### PR TITLE
docs: add upskill path filter examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,18 @@ npx skills add adobe/skills --list
 
 ```bash
 gh extension install trieloff/gh-upskill
+
+# Install all skills from this repo
 gh upskill adobe/skills
+
+# Install only AEM Edge Delivery Services skills
+gh upskill adobe/skills --path skills/aem/edge-delivery-services --all
+
+# Install a specific skill
+gh upskill adobe/skills --path skills/aem/edge-delivery-services --skill content-driven-development
+
+# List available skills in a subfolder
+gh upskill adobe/skills --path skills/aem/edge-delivery-services --list
 ```
 
 ## Available Skills


### PR DESCRIPTION
## Summary
- Adds examples to the README showing how to use `gh upskill`'s `--path` flag to install only specific skill subsets (e.g., AEM Edge Delivery Services skills)
- Documents `--path` combined with `--all`, `--skill`, and `--list` options

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Confirm example commands match `gh-upskill` CLI usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>