### PR TITLE
Project Management plugin updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,15 +92,17 @@ gh upskill adobe/skills --path skills/aem/edge-delivery-services --list
 
 Project lifecycle management for AEM Edge Delivery Services including handover documentation, PDF generation, and authentication.
 
-> **Usage Note:** This plugin is designed to run at the root of an AEM Edge Delivery Services project in an isolated workspace. Clone your Edge Delivery Services repository and run the plugin from the project root to ensure the PDF lifecycle hooks correctly track only your project's documentation files.
+> **Requirement:** This plugin is exclusively for AEM Edge Delivery Services projects. It validates projects by checking for `scripts/aem.js`. For non-Edge Delivery projects, the plugin exits early — use standard documentation approaches instead.
 
 **Quick Start:**
 ```bash
-cd your-eds-project
-# Say: "create documentation or guides for this project"
+cd your-edge-delivery-project   # or any subdirectory within it
+# Say: "create handover documentation for this project"
 ```
 
-**Setup:** You will be prompted for your Config Service organization name (the `{org}` in `https://main--site--{org}.aem.page`). A browser window will then open for authentication - sign in and **close the browser window** to continue. The org name and auth token are saved locally for guide generation.
+**Setup:** You will be prompted for your Config Service organization name (the `{org}` in `https://main--site--{org}.aem.page`). A browser window will open for authentication — sign in and **close the browser window** to continue.
+
+**Permissions:** Admin access to the project organization is required. The plugin queries the Config Service API to gather project configuration, site settings, and access controls for comprehensive documentation.
 
 **Output:** Professional PDFs generated in `project-guides/` folder:
 - `project-guides/AUTHOR-GUIDE.pdf` - For content authors
@@ -109,7 +111,7 @@ cd your-eds-project
 
 | Skill | Description |
 |-------|-------------|
-| `handover` | Orchestrates project handover documentation generation |
+| `handover` | Orchestrates project documentation generation |
 | `authoring` | Generate comprehensive authoring guide for content authors |
 | `development` | Generate technical documentation for developers |
 | `admin` | Generate admin guide for site administrators |

--- a/skills/aem/project-management/hooks/pdf-lifecycle.js
+++ b/skills/aem/project-management/hooks/pdf-lifecycle.js
@@ -15,6 +15,32 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
+/**
+ * Check if current directory is the root of an AEM Edge Delivery Services project.
+ * Returns: { isRoot: boolean, foundInParent: boolean, projectRoot: string|null }
+ */
+function checkEdgeDeliveryProject() {
+  const cwd = process.cwd();
+
+  // Check if at project root
+  if (fs.existsSync(path.join(cwd, 'scripts/aem.js'))) {
+    return { isRoot: true, foundInParent: false, projectRoot: cwd };
+  }
+
+  // Walk up to see if we're in a nested folder of an Edge Delivery project
+  let dir = path.dirname(cwd);
+  const root = path.parse(dir).root;
+
+  while (dir !== root) {
+    if (fs.existsSync(path.join(dir, 'scripts/aem.js'))) {
+      return { isRoot: false, foundInParent: true, projectRoot: dir };
+    }
+    dir = path.dirname(dir);
+  }
+
+  return { isRoot: false, foundInParent: false, projectRoot: null };
+}
+
 // Session-scoped file paths
 let sessionId = 'default';
 let TRACKING_FILE = path.join(os.tmpdir(), `project-mgmt-pdf-tracking-${sessionId}.txt`);
@@ -75,11 +101,11 @@ function isTrackableMarkdownFile(filePath) {
   const allowedFiles = ['AUTHOR-GUIDE.md', 'DEVELOPER-GUIDE.md', 'ADMIN-GUIDE.md'];
   if (!allowedFiles.includes(basename)) return false;
 
-  // Only match project-guides/ at project root (first or second segment)
-  const normalized = path.normalize(filePath);
-  const segments = normalized.split(path.sep);
-  const guidesIndex = segments.indexOf('project-guides');
-  return guidesIndex !== -1 && guidesIndex <= 1;
+  // Check if file is in project-guides/ relative to project root
+  const cwd = process.cwd();
+  const relativePath = path.relative(cwd, filePath);
+  return relativePath.startsWith('project-guides' + path.sep) ||
+         relativePath.startsWith('project-guides/');
 }
 
 /**
@@ -249,7 +275,16 @@ function handleSessionEnd() {
       }
     }
 
-    // Keep .html file (needed for UI download)
+    // Delete .html file (PDF is the only deliverable)
+    const htmlFile = mdFile.replace(/\.md$/, '.html');
+    if (fs.existsSync(htmlFile)) {
+      try {
+        fs.unlinkSync(htmlFile);
+        debugLog(`Deleted: ${htmlFile}`);
+      } catch (err) {
+        debugLog(`Error deleting ${htmlFile}: ${err.message}`);
+      }
+    }
   }
 
   clearTrackedFiles();
@@ -267,6 +302,18 @@ function handleSessionEnd() {
  * Main hook logic
  */
 async function main() {
+  const projectCheck = checkEdgeDeliveryProject();
+
+  // Silent no-op for non-Edge Delivery projects (good citizen in multi-plugin environments)
+  if (!projectCheck.isRoot && !projectCheck.foundInParent) {
+    process.exit(0);
+  }
+
+  // Nested folder - auto-navigate to project root
+  if (!projectCheck.isRoot && projectCheck.foundInParent) {
+    process.chdir(projectCheck.projectRoot);
+  }
+
   try {
     const hookInput = await readStdin();
     initSessionFiles(hookInput);

--- a/skills/aem/project-management/package.json
+++ b/skills/aem/project-management/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/skills/aem/project-management/skills/admin/SKILL.md
+++ b/skills/aem/project-management/skills/admin/SKILL.md
@@ -19,6 +19,38 @@ Generate comprehensive documentation for administrators taking over an AEM Edge 
 
 ---
 
+## Step 0: Navigate to Project Root and Verify Edge Delivery Services Project (CONDITIONAL)
+
+**Skip this step if `allGuides` flag is set** (orchestrator already validated and navigated).
+
+**CRITICAL: If NOT skipped, you MUST execute the `cd` command. Do NOT use absolute paths — actually change directory.**
+
+```bash
+ALL_GUIDES=$(cat .claude-plugin/project-config.json 2>/dev/null | grep -o '"allGuides"[[:space:]]*:[[:space:]]*true')
+if [ -z "$ALL_GUIDES" ]; then
+  # Navigate to git project root (works from any subdirectory)
+  cd "$(git rev-parse --show-toplevel)"
+  # Verify it's an Edge Delivery Services project
+  ls scripts/aem.js
+fi
+```
+
+**IMPORTANT:**
+- You MUST run the `cd` command above using the Bash tool
+- All subsequent steps operate from project root
+- Do NOT use absolute paths to verify — actually navigate
+- Guides will be created at `project-root/project-guides/`
+
+**If NOT skipped AND `scripts/aem.js` does NOT exist**, respond:
+
+> "This skill is designed for AEM Edge Delivery Services projects. The current directory does not appear to be an Edge Delivery Services project (`scripts/aem.js` not found).
+>
+> Please navigate to an Edge Delivery Services project and try again."
+
+**STOP if check fails. Otherwise proceed — you are now at project root.**
+
+---
+
 ## Execution Checklist
 
 ```markdown
@@ -64,6 +96,7 @@ project-guides/ADMIN-GUIDE.md
 **MANDATORY OUTPUT:** `project-guides/ADMIN-GUIDE.pdf`
 
 **STRICTLY FORBIDDEN:**
+- ❌ Do NOT read or analyze `fstab.yaml` — it does NOT exist in most projects and does NOT show all sites
 - ❌ Do NOT create `.plain.html` files
 - ❌ Do NOT use `convert_markdown_to_html` tool — this converts the FULL guide to HTML with raw frontmatter visible, which is NOT what we want
 - ❌ Do NOT tell user to "convert markdown to PDF manually"
@@ -256,13 +289,36 @@ The response is a JSON object with a `sites` array (each entry has a `name` fiel
 
 Multiple sites = **repoless** setup. Single site = **standard** setup.
 
-**Then fetch individual site config to get the code repository:**
+**Then fetch individual site config for code and content details:**
 
 ```bash
-curl -s -H "Accept: application/json" "https://admin.hlx.page/config/${ORG}/sites/{site-name}.json"
+AUTH_TOKEN=$(cat .claude-plugin/project-config.json | grep -o '"authToken"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/"authToken"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
+curl -s -H "x-auth-token: ${AUTH_TOKEN}" "https://admin.hlx.page/config/${ORG}/sites/{site-name}.json"
 ```
 
-The `code` object in the response contains `owner` and `repo` — this may point to a GitHub repo or a Cloud Manager program.
+**Example response:**
+```json
+{
+  "code": {
+    "owner": "github-owner",
+    "repo": "repo-name",
+    "source": { "type": "github", "url": "https://github.com/owner/repo" }
+  },
+  "content": {
+    "source": {
+      "url": "https://content.da.live/org-name/site-name/",
+      "type": "markup"
+    }
+  }
+}
+```
+
+**Extract from response:**
+- `code.owner` / `code.repo` — GitHub repository
+- `content.source.url` — Content mountpath (e.g., `https://content.da.live/org/site/`)
+- `content.source.type` — Content source type (markup, onedrive, google)
+
+**⚠️ Do NOT use `fstab.yaml`** — use Config Service API instead.
 
 ### 1.2 Build Context
 

--- a/skills/aem/project-management/skills/authoring/SKILL.md
+++ b/skills/aem/project-management/skills/authoring/SKILL.md
@@ -17,6 +17,38 @@ Generate a complete authoring guide for content authors and content managers. Th
 
 ---
 
+## Step 0: Navigate to Project Root and Verify Edge Delivery Services Project (CONDITIONAL)
+
+**Skip this step if `allGuides` flag is set** (orchestrator already validated and navigated).
+
+**CRITICAL: If NOT skipped, you MUST execute the `cd` command. Do NOT use absolute paths — actually change directory.**
+
+```bash
+ALL_GUIDES=$(cat .claude-plugin/project-config.json 2>/dev/null | grep -o '"allGuides"[[:space:]]*:[[:space:]]*true')
+if [ -z "$ALL_GUIDES" ]; then
+  # Navigate to git project root (works from any subdirectory)
+  cd "$(git rev-parse --show-toplevel)"
+  # Verify it's an Edge Delivery Services project
+  ls scripts/aem.js
+fi
+```
+
+**IMPORTANT:**
+- You MUST run the `cd` command above using the Bash tool
+- All subsequent steps operate from project root
+- Do NOT use absolute paths to verify — actually navigate
+- Guides will be created at `project-root/project-guides/`
+
+**If NOT skipped AND `scripts/aem.js` does NOT exist**, respond:
+
+> "This skill is designed for AEM Edge Delivery Services projects. The current directory does not appear to be an Edge Delivery Services project (`scripts/aem.js` not found).
+>
+> Please navigate to an Edge Delivery Services project and try again."
+
+**STOP if check fails. Otherwise proceed — you are now at project root.**
+
+---
+
 ## Communication Guidelines
 
 - **NEVER use "EDS"** as an acronym for Edge Delivery Services in any generated documentation or chat responses
@@ -51,6 +83,7 @@ project-guides/AUTHOR-GUIDE.md
 **MANDATORY OUTPUT:** `project-guides/AUTHOR-GUIDE.pdf`
 
 **STRICTLY FORBIDDEN:**
+- ❌ Do NOT read or analyze `fstab.yaml` — it does NOT exist in most projects and does NOT show all sites
 - ❌ Do NOT create `.plain.html` files
 - ❌ Do NOT use `convert_markdown_to_html` tool — this converts the FULL guide to HTML with raw frontmatter visible, which is NOT what we want
 - ❌ Do NOT tell user to "convert markdown to PDF manually"
@@ -160,18 +193,41 @@ The response is a JSON object with a `sites` array (each entry has a `name` fiel
 
 Multiple sites = **repoless** setup. Single site = **standard** setup.
 
-**Then fetch individual site config to get the code repository:**
+**Then fetch individual site config for code and content details:**
 
 ```bash
-curl -s -H "Accept: application/json" "https://admin.hlx.page/config/${ORG}/sites/{site-name}.json"
+AUTH_TOKEN=$(cat .claude-plugin/project-config.json | grep -o '"authToken"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/"authToken"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
+curl -s -H "x-auth-token: ${AUTH_TOKEN}" "https://admin.hlx.page/config/${ORG}/sites/{site-name}.json"
 ```
 
-The site config may include a **content** object or **content source** (e.g. `content.da.live/audemars-piguet/arbres-fondationsaudemarspiguet/`). **DA and Block Library URLs must be built from this content path**, not from code.owner/code.repo — the path can differ per project/site.
+**Example response:**
+```json
+{
+  "code": {
+    "owner": "github-owner",
+    "repo": "repo-name",
+    "source": { "type": "github", "url": "https://github.com/owner/repo" }
+  },
+  "content": {
+    "source": {
+      "url": "https://content.da.live/org-name/site-name/",
+      "type": "markup"
+    },
+    "contentBusId": "..."
+  }
+}
+```
 
-- **DA URL:** `https://da.live/#/{content-owner}/{content-path}/` (from content source in site config; e.g. `content.da.live/org/site/` → `https://da.live/#/org/site/`)
-- **Block Library URL:** `https://da.live/#/{content-owner}/{content-path}/.da/library`
+**Extract from response:**
+- `code.owner` / `code.repo` — GitHub repository
+- `content.source.url` — Content mountpath (e.g., `https://content.da.live/org/site/`)
+- `content.source.type` — Content source type (markup, onedrive, google)
 
-If the API does not expose content source, document that authors should get the correct DA/library path from their admin or from the Config Service UI. Do not assume code.owner/code.repo equals the DA path.
+**Build URLs from content source:**
+- **DA URL:** `https://da.live/#/{org}/{site}/` (derived from `content.source.url`)
+- **Block Library:** `https://da.live/#/{org}/{site}/.da/library`
+
+**⚠️ Do NOT use `fstab.yaml`** — use Config Service API instead.
 
 ### 1.2 Check Multi-Language Support
 

--- a/skills/aem/project-management/skills/development/SKILL.md
+++ b/skills/aem/project-management/skills/development/SKILL.md
@@ -17,6 +17,38 @@ Generate a complete technical guide for developers. This skill analyzes the code
 
 ---
 
+## Step 0: Navigate to Project Root and Verify Edge Delivery Services Project (CONDITIONAL)
+
+**Skip this step if `allGuides` flag is set** (orchestrator already validated and navigated).
+
+**CRITICAL: If NOT skipped, you MUST execute the `cd` command. Do NOT use absolute paths — actually change directory.**
+
+```bash
+ALL_GUIDES=$(cat .claude-plugin/project-config.json 2>/dev/null | grep -o '"allGuides"[[:space:]]*:[[:space:]]*true')
+if [ -z "$ALL_GUIDES" ]; then
+  # Navigate to git project root (works from any subdirectory)
+  cd "$(git rev-parse --show-toplevel)"
+  # Verify it's an Edge Delivery Services project
+  ls scripts/aem.js
+fi
+```
+
+**IMPORTANT:**
+- You MUST run the `cd` command above using the Bash tool
+- All subsequent steps operate from project root
+- Do NOT use absolute paths to verify — actually navigate
+- Guides will be created at `project-root/project-guides/`
+
+**If NOT skipped AND `scripts/aem.js` does NOT exist**, respond:
+
+> "This skill is designed for AEM Edge Delivery Services projects. The current directory does not appear to be an Edge Delivery Services project (`scripts/aem.js` not found).
+>
+> Please navigate to an Edge Delivery Services project and try again."
+
+**STOP if check fails. Otherwise proceed — you are now at project root.**
+
+---
+
 ## Communication Guidelines
 
 - **NEVER use "EDS"** as an acronym for Edge Delivery Services in any generated documentation or chat responses
@@ -51,6 +83,7 @@ project-guides/DEVELOPER-GUIDE.md
 **MANDATORY OUTPUT:** `project-guides/DEVELOPER-GUIDE.pdf`
 
 **STRICTLY FORBIDDEN:**
+- ❌ Do NOT read or analyze `fstab.yaml` — it does NOT exist in most projects and does NOT show all sites
 - ❌ Do NOT create `.plain.html` files
 - ❌ Do NOT use `convert_markdown_to_html` tool — this converts the FULL guide to HTML with raw frontmatter visible, which is NOT what we want
 - ❌ Do NOT tell user to "convert markdown to PDF manually"
@@ -183,13 +216,36 @@ The response is a JSON object with a `sites` array (each entry has a `name` fiel
 
 Multiple sites = **repoless** setup. Single site = **standard** setup.
 
-**Then fetch individual site config to get the code repository:**
+**Then fetch individual site config for code and content details:**
 
 ```bash
-curl -s -H "Accept: application/json" "https://admin.hlx.page/config/${ORG}/sites/{site-name}.json"
+AUTH_TOKEN=$(cat .claude-plugin/project-config.json | grep -o '"authToken"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/"authToken"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
+curl -s -H "x-auth-token: ${AUTH_TOKEN}" "https://admin.hlx.page/config/${ORG}/sites/{site-name}.json"
 ```
 
-The response includes a `code` object with `owner` and `repo` fields. This tells you where the code lives — it may be a GitHub repo or a Cloud Manager program (not always GitHub).
+**Example response:**
+```json
+{
+  "code": {
+    "owner": "github-owner",
+    "repo": "repo-name",
+    "source": { "type": "github", "url": "https://github.com/owner/repo" }
+  },
+  "content": {
+    "source": {
+      "url": "https://content.da.live/org-name/site-name/",
+      "type": "markup"
+    }
+  }
+}
+```
+
+**Extract from response:**
+- `code.owner` / `code.repo` — GitHub repository
+- `content.source.url` — Content mountpath (e.g., `https://content.da.live/org/site/`)
+- `content.source.type` — Content source type (markup, onedrive, google)
+
+**⚠️ Do NOT use `fstab.yaml`** — use Config Service API instead.
 
 **Record the result** (repoless or standard) — it is used in the Local Development Setup section to decide whether to include the `--pages-url` flag for `aem up`.
 

--- a/skills/aem/project-management/skills/handover/SKILL.md
+++ b/skills/aem/project-management/skills/handover/SKILL.md
@@ -30,6 +30,44 @@ Generate comprehensive handover documentation for Edge Delivery Services project
 
 ## Execution Flow
 
+### Step 0: Navigate to Project Root and Verify Edge Delivery Services Project (MANDATORY FIRST STEP)
+
+**CRITICAL: You MUST execute this `cd` command before anything else. Do NOT use absolute paths — actually change directory.**
+
+```bash
+# Navigate to git project root (works from any subdirectory)
+cd "$(git rev-parse --show-toplevel)"
+
+# Verify it's an Edge Delivery Services project
+ls scripts/aem.js
+```
+
+**IMPORTANT:**
+- You MUST run the `cd` command above using the Bash tool
+- All subsequent steps operate from project root
+- Do NOT use absolute paths to verify — actually navigate
+- Guides will be created at `project-root/project-guides/`
+
+**If `scripts/aem.js` does NOT exist**, respond:
+
+> "This skill is designed for AEM Edge Delivery Services projects. The current directory does not appear to be an Edge Delivery Services project (`scripts/aem.js` not found).
+>
+> Please navigate to an Edge Delivery Services project and try again."
+
+**STOP if check fails. Otherwise proceed — you are now at project root.**
+
+---
+
+### Step 0.5: Clean Up Stale Config
+
+Remove any existing config to ensure fresh org and authentication for this project:
+
+```bash
+rm -f .claude-plugin/project-config.json
+```
+
+---
+
 ### Step 1: Ask User for Documentation Type
 
 **MANDATORY:** Use the `AskUserQuestion` tool with EXACTLY these 4 options:
@@ -86,8 +124,13 @@ mkdir -p .claude-plugin
 grep -qxF '.claude-plugin/' .gitignore 2>/dev/null || echo '.claude-plugin/' >> .gitignore
 
 # Save org name to config file
+# If "All" was selected, include allGuides flag to skip step 0 in sub-skills
 echo '{"org": "{ORG_NAME}"}' > .claude-plugin/project-config.json
+# OR if "All (Recommended)" was selected:
+echo '{"org": "{ORG_NAME}", "allGuides": true}' > .claude-plugin/project-config.json
 ```
+
+**Note:** Include `"allGuides": true` ONLY when user selected "All (Recommended)". This signals sub-skills to skip step 0 validation (orchestrator already validated).
 
 Replace `{ORG_NAME}` with the actual organization name provided by the user.
 
@@ -119,23 +162,26 @@ ORG=$(cat .claude-plugin/project-config.json | grep -o '"org"[[:space:]]*:[[:spa
 SITE=$(curl -s "https://admin.hlx.page/config/${ORG}/sites.json" | grep -o '"name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/"name"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
 ```
 
-3. **Display clear instructions and open browser**:
-```bash
-echo ""
-echo "╔════════════════════════════════════════════════════════════════╗"
-echo "║                                                                ║"
-echo "║   BROWSER WINDOW OPENING FOR ADOBE ID LOGIN                    ║"
-echo "║                                                                ║"
-echo "║   1. Sign in with your Adobe ID credentials                   ║"
-echo "║   2. After successful login, CLOSE THE BROWSER WINDOW         ║"
-echo "║                                                                ║"
-echo "║   >>> CLOSE THE BROWSER TO CONTINUE <<<                       ║"
-echo "║                                                                ║"
-echo "╚════════════════════════════════════════════════════════════════╝"
-echo ""
+3. **Get user acknowledgment before opening browser**:
 
-mkdir -p .claude-plugin
-npx playwright open --save-storage=.claude-plugin/auth-storage.json "https://admin.hlx.page/login/${ORG}/${SITE}/main"
+Use `AskUserQuestion` to ensure user is ready:
+
+```json
+AskUserQuestion({
+  "questions": [{
+    "question": "A browser window will open for authentication. After signing in, CLOSE THE BROWSER WINDOW to continue. Ready?",
+    "header": "Authentication Required",
+    "options": [
+      {"label": "Open Browser", "description": "I understand - open the browser for login"}
+    ],
+    "multiSelect": false
+  }]
+})
+```
+
+**After user confirms**, run:
+```bash
+mkdir -p .claude-plugin && npx playwright open --save-storage=.claude-plugin/auth-storage.json "https://admin.hlx.page/login/${ORG}/${SITE}/main"
 ```
 
 #### 1.6.3 Extract and Save Auth Token
@@ -187,35 +233,32 @@ Based on user selection:
 You'll see progress updates as each guide moves through its phases."
 ```
 
-**Launch all three skills simultaneously using parallel Task tool calls (NO background mode):**
+**Launch all three skills simultaneously using parallel Agent tool calls (foreground mode):**
 
-In a SINGLE message, invoke three Task tools in parallel WITHOUT `run_in_background`. This allows streaming progress updates while still running concurrently:
+In a SINGLE message, invoke three Agent tools in parallel. Foreground agents have full tool permissions and run concurrently:
 
 ```javascript
-// All three in ONE message - they run concurrently WITH streaming progress
-Task({
-  subagent_type: "general-purpose",
+// All three in ONE message - runs in parallel with full permissions
+Agent({
   description: "Generate authoring guide",
   prompt: "Invoke skill project-management:authoring to generate the authoring guide PDF. Show progress as you complete each phase."
 })
 
-Task({
-  subagent_type: "general-purpose",
+Agent({
   description: "Generate developer guide",
   prompt: "Invoke skill project-management:development to generate the developer guide PDF. Show progress as you complete each phase."
 })
 
-Task({
-  subagent_type: "general-purpose",
+Agent({
   description: "Generate admin guide",
   prompt: "Invoke skill project-management:admin to generate the admin guide PDF. Show progress as you complete each phase."
 })
 ```
 
-**Progress updates stream automatically** as each task works through phases:
-- User sees which guide is at which phase
-- Completions appear as they happen
-- No polling required
+**Why foreground agents:**
+- Run all 3 in parallel (~3x faster than sequential)
+- Full tool permissions (Bash, Read, Write, Glob, Skill)
+- Progress updates stream as each agent works
 
 **When all three complete, report final summary:**
 
@@ -269,6 +312,7 @@ project-guides/ADMIN-GUIDE.md
 ## MANDATORY RULES
 
 **STRICTLY FORBIDDEN:**
+- ❌ Do NOT read or analyze `fstab.yaml` — it does NOT exist in most projects and does NOT show all sites
 - ❌ Do NOT create `.plain.html` files
 - ❌ Do NOT use `convert_markdown_to_html` tool
 - ❌ Do NOT tell user to "convert markdown to PDF manually"

--- a/skills/aem/project-management/skills/whitepaper/SKILL.md
+++ b/skills/aem/project-management/skills/whitepaper/SKILL.md
@@ -129,34 +129,23 @@ TYPST_FONT_PATHS="$PLUGIN_ROOT/fonts" pandoc ADMIN-GUIDE.md -o ADMIN-GUIDE.pdf -
 
 Note: Do **not** pass `--toc` — the template generates its own table of contents page with proper styling.
 
-### 5. Clean Up (MANDATORY)
+### 5. Clean Up (MANDATORY - DO NOT SKIP)
 
-**After successful PDF generation, perform ALL cleanup steps:**
+**CRITICAL: You MUST execute cleanup immediately after PDF generation. Only PDF should remain.**
 
 ```bash
-# Remove copied template file
-rm -f <output-directory>/whitepaper.typ
-
-# Remove source markdown file (PDF is the deliverable)
-rm -f <input.md>
-
-# Remove any .plain.html file with same base name
-rm -f <input-without-extension>.plain.html
-
-# Remove any .html file with same base name
-rm -f <input-without-extension>.html
+# Remove ALL intermediate files in one command
+rm -f <output-directory>/whitepaper.typ <input.md> <input-without-extension>.plain.html <input-without-extension>.html
 ```
 
 **Example cleanup for `project-guides/AUTHOR-GUIDE.md`:**
 ```bash
-rm -f project-guides/whitepaper.typ
-rm -f project-guides/AUTHOR-GUIDE.md project-guides/AUTHOR-GUIDE.plain.html project-guides/AUTHOR-GUIDE.html
-# Keep: project-guides/AUTHOR-GUIDE.pdf (deliverable)
+rm -f project-guides/whitepaper.typ project-guides/AUTHOR-GUIDE.md project-guides/AUTHOR-GUIDE.plain.html project-guides/AUTHOR-GUIDE.html
 ```
 
-### 6. Report Result
+**After cleanup, only `project-guides/AUTHOR-GUIDE.pdf` should exist. No .md, .html, or .plain.html files.**
 
-Tell the user the PDF was created and its path. Confirm cleanup was performed.
+### 6. Report Result
 
 ```
 "PDF created: [output.pdf]"


### PR DESCRIPTION
Enhancements to the AEM Project Management plugin for improved reliability, user experience, and Edge Delivery Services project validation.

## Description
  - Step 0 validation — Skills now auto-navigate to project root before verifying Edge Delivery project
  - Conditional validation — Sub-skills skip Step 0 when invoked via orchestrator with allGuides flag (parallel execution
  optimization)
  - Config cleanup — Fresh org/auth required per handover run (Step 0.5 removes stale config)
  - Parallel execution fix — Changed from Task to foreground Agent for full tool permissions
  - Config Service API — Explicit instructions to fetch site config from API
  - Authentication UX — Added AskUserQuestion prompt before opening browser for login
  - README update — Clarified plugin requirements and permissions

## Motivation and Context
Based on tests on various Edge Delivery and Non-Edge Delivery projects

## How Has This Been Tested?
- If plugin is executed from any sub-folder of project repo, it auto-navigate to root
- For non-Edge Delivery project - should exit early with message.
- Select "All" guides - should run 3 agents in parallel with full permissions
- Verify only PDFs remain in project-guides
- Verify Config Service API is used 

## Screenshots (if appropriate):
<img width="1352" height="345" alt="Screenshot 2026-03-30 at 15 16 58" src="https://github.com/user-attachments/assets/66cf5958-d082-4755-b253-565268cb857c" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
