### PR TITLE
feat: add HTL data-sly-test lint reference to best-practices

### DIFF
--- a/skills/aem/cloud-service/skills/best-practices/README.md
+++ b/skills/aem/cloud-service/skills/best-practices/README.md
@@ -1,6 +1,6 @@
 # AEM as a Cloud Service — Best practices
 
-Source: `skills/aem/cloud-service/skills/best-practices/`. **`SKILL.md`** and **`references/`** (patterns: scheduler, replication, events, assets; Java baseline: `scr-to-osgi-ds.md`, `resource-resolver-logging.md`, prerequisites hub).
+Source: `skills/aem/cloud-service/skills/best-practices/`. **`SKILL.md`** and **`references/`** (patterns: scheduler, replication, events, assets; Java baseline: `scr-to-osgi-ds.md`, `resource-resolver-logging.md`, prerequisites hub; **HTL:** `data-sly-test-redundant-constant.md` and proactive `rg` discovery in `SKILL.md`).
 
 These files ship with the **AEM as a Cloud Service** plugin (`aem-cloud-service` in the marketplace). Install that umbrella package once; the agent selects this skill when the task matches.
 

--- a/skills/aem/cloud-service/skills/best-practices/SKILL.md
+++ b/skills/aem/cloud-service/skills/best-practices/SKILL.md
@@ -1,23 +1,24 @@
 ---
 name: best-practices
-description: AEM as a Cloud Service Java/OSGi best practices, guardrails, and legacy-to-cloud pattern transformations. Use for Cloud Service–correct bundles, deprecated APIs, schedulers, ResourceChangeListener, replication, Replicator, JCR observation (javax.jcr.observation.EventListener), OSGi Event Admin (org.osgi.service.event.EventHandler), DAM AssetManager, BPA-style fixes, or any time you need the detailed pattern reference modules under this skill.
+description: AEM as a Cloud Service Java/OSGi best practices, guardrails, and legacy-to-cloud pattern transformations. Use for Cloud Service–correct bundles, deprecated APIs, schedulers, ResourceChangeListener, replication, Replicator, JCR observation (javax.jcr.observation.EventListener), OSGi Event Admin (org.osgi.service.event.EventHandler), DAM AssetManager, BPA-style fixes, HTL (Sightly) Cloud SDK lint warnings (data-sly-test redundant constant value comparison), or any time you need the detailed pattern reference modules under this skill.
 ---
 
 # AEM as a Cloud Service — Best Practices
 
-Platform guidance for **AEM as a Cloud Service** backend code: what to use, what to avoid, and **how to refactor** known legacy patterns into Cloud-compatible implementations.
+Platform guidance for **AEM as a Cloud Service**: **Java/OSGi** (what to use, what to avoid, how to refactor legacy patterns) and **HTL** (component `.html` templates, Cloud SDK HTL lint).
 
 This skill holds the **pattern transformation modules** (`references/*.md`). They ship with the **`aem-cloud-service`** plugin; use this skill **without** the **migration** skill for greenfield or maintenance work that only needs these references. Use **migration** when you need BPA/CAM orchestration on top.
 
-**Quick pick:** Open the **Pattern Reference Modules** table below → jump to the matching `references/<file>.md` → read it fully before editing Java. For Felix SCR, resolvers, or logging, use **Java / OSGi baseline** links in this file first when those appear in the same change set.
+**Quick pick:** Open the **Pattern Reference Modules** table below → jump to the matching `references/<file>.md` → read it fully before editing. For Java: Felix SCR, resolvers, or logging, use **Java / OSGi baseline** links first when those appear in the same change set.
 
 ## When to Use This Skill
 
 Use this skill when you need to:
 
-- Apply **AEM as a Cloud Service** constraints to Java/OSGi code (new or existing)
-- Refactor **legacy patterns** into supported APIs (same modules migration uses)
+- Apply **AEM as a Cloud Service** constraints to **Java/OSGi** code (new or existing)
+- Refactor **legacy Java patterns** into supported APIs (same modules migration uses)
 - Follow **consistent rules** across schedulers, replication, **JCR observation listeners** (`eventListener`), **OSGi event handlers** (`eventHandler`), and DAM assets
+- Fix **HTL (Sightly)** issues from the **AEM Cloud SDK build**, especially `data-sly-test: redundant constant value comparison`
 - Read **step-by-step transformation** and validation checklists for a specific pattern
 
 For **BPA/CAM orchestration** (collections, CSV, MCP project selection), use the **`migration`** skill (`skills/aem/cloud-service/skills/migration/`).
@@ -36,6 +37,7 @@ Each supported pattern has a dedicated module under `references/` relative to th
 | Asset Manager | `assetApi` | `references/asset-manager.md` | Ready |
 | Felix SCR → OSGi DS | — | `references/scr-to-osgi-ds.md` | Ready |
 | ResourceResolver + SLF4J | — | `references/resource-resolver-logging.md` | Ready |
+| HTL: `data-sly-test` redundant constant | — (HTL lint) | `references/data-sly-test-redundant-constant.md` | Ready |
 | *(Prerequisites hub)* | — | `references/aem-cloud-service-pattern-prerequisites.md` | — |
 
 **Event listener vs event handler (not the same):** **`eventListener`** is **JCR observation** — the JCR API for repository change callbacks (`javax.jcr.observation.EventListener`, `onEvent`). **`eventHandler`** is **OSGi Event Admin** — whiteboard-style OSGi events (`org.osgi.service.event.EventHandler`, `handleEvent`). Both migrate via **`references/event-migration.md`** (Path A vs Path B). **`resourceChangeListener`** is separate: Sling **`ResourceChangeListener`**, module **`references/resource-change-listener.md`**.
@@ -56,11 +58,11 @@ SCR→DS and `ResourceResolver`/logging are **reference modules** under `referen
 - **READ THE PATTERN MODULE FIRST** — never transform code without reading the module
 - **READ** [`scr-to-osgi-ds.md`](references/scr-to-osgi-ds.md) and [`resource-resolver-logging.md`](references/resource-resolver-logging.md) when SCR, `ResourceResolver`, or logging are in scope (pattern modules link via the [prerequisites hub](references/aem-cloud-service-pattern-prerequisites.md); do not duplicate long guides inline)
 - **DO** preserve environment-specific guards (e.g. `isAuthor()` run mode checks)
-- **DO NOT** change business logic inside methods
+- **DO NOT** change business logic inside methods (Java) or **logical show/hide intent** (HTL) unless the module explicitly allows it
 - **DO NOT** rename classes unless the pattern module explicitly says to
 - **DO NOT** invent values — extract from existing code
 - **DO NOT** edit files outside the scope agreed with the user (e.g. only BPA targets or paths they named)
-- **DO** keep **searches, discovery, and edits** for the customer’s AEM sources inside the **IDE workspace root(s)** currently open; **DO NOT** grep or walk directories outside that boundary to find Java unless the user explicitly points there
+- **DO** keep **searches, discovery, and edits** for the customer's AEM sources inside the **IDE workspace root(s)** currently open; **DO NOT** grep or walk directories outside that boundary to find Java unless the user explicitly points there
 
 ## Manual Pattern Hints (Classification)
 
@@ -76,9 +78,10 @@ When no BPA list exists, scan imports and types to pick a module:
 | `com.day.cq.dam.api.AssetManager` create/remove asset APIs | `assetApi` |
 | `org.apache.felix.scr.annotations` | read `references/scr-to-osgi-ds.md` (often combined with a BPA pattern) |
 | `getAdministrativeResourceResolver`, `System.out` / `printStackTrace` | read `references/resource-resolver-logging.md` |
+| **HTL:** build warning `data-sly-test: redundant constant value comparison`, or `.html` under `ui.apps` / `jcr_root` with bad `data-sly-test` | read `references/data-sly-test-redundant-constant.md` |
 
 If multiple patterns match, ask which to fix first.
 
 ## Relationship to Migration
 
-The **`migration`** skill defines **one-pattern-per-session** workflow, BPA/CAM/MCP flows, and user messaging. It **delegates** all detailed transformation steps to this skill’s `references/` modules. It uses a **`{best-practices}`** repo-root path alias to this folder (see its `SKILL.md`). Keep platform truth here; keep orchestration there.
+The **`migration`** skill defines **one-pattern-per-session** workflow, BPA/CAM/MCP flows, and user messaging. It **delegates** all detailed transformation steps to this skill's `references/` modules. It uses a **`{best-practices}`** repo-root path alias to this folder (see its `SKILL.md`). Keep platform truth here; keep orchestration there.

--- a/skills/aem/cloud-service/skills/best-practices/references/data-sly-test-redundant-constant.md
+++ b/skills/aem/cloud-service/skills/best-practices/references/data-sly-test-redundant-constant.md
@@ -1,0 +1,294 @@
+# data-sly-test: Redundant Constant Value Comparison
+
+Fixes for the AEM Cloud SDK HTL lint warning **"data-sly-test: redundant constant value comparison"**.
+
+**Rule:** In HTL, `data-sly-test` should always receive a variable or expression that evaluates to boolean — never a raw string literal, raw `true`/`false`, or a number directly.
+
+---
+
+## Workflow
+
+When the user pastes **HTL lint warnings** or asks to fix **`data-sly-test`** issues:
+
+1. **Group warnings by file** (de-duplicate repeated lines from the build).
+2. **Classify** each warning using the flagged value (`true`/`false`, path string, number, split `${} || ${}`) — see patterns below.
+3. **Read the matching pattern section** before editing `.html` files.
+4. **Preserve logical intent** — only fix expression shape, not authoring behavior.
+
+## Proactive Discovery (find candidates without Maven)
+
+When the user wants to **find and fix** redundant `data-sly-test` issues but has **no build log yet**, run a **heuristic scan** on HTL templates, then fix hits using the patterns below.
+
+**Limits:** Grep is **not** the HTL compiler. It can **miss** issues (multiline attributes, unusual quoting) and **false-positive** on expressions that are fine. After edits, **`mvn … generate-sources`** (or the Cloud Manager build) is still the **authoritative** check.
+
+**Scope:** Prefer `ui.apps/**/jcr_root/**/*.html` and any other content packages that ship component HTL.
+
+From the **repository root**, use **ripgrep** (`rg`):
+
+| Pattern class | What to search | Example `rg` (run from repo root) |
+|---------------|----------------|-------------------------------------|
+| Boolean literal | `== true`, `== false`, `!= true`, `!= false` inside `data-sly-test` | `rg -n 'data-sly-test="[^"]*==\s*(true|false)' --glob '*.html' ui.apps` and `rg -n 'data-sly-test="[^"]*!=\s*(true|false)' --glob '*.html' ui.apps` |
+| Raw `/apps/…` string as test | HTL string literal starting with `/apps/` inside the attribute (common anti-pattern) | `rg -n "data-sly-test=.*'/apps/" --glob '*.html' ui.apps` (then confirm it is a useless string-as-test, not a legitimate comparison) |
+| Split `\|\|` / `&&` across `${}` | Literal `} || ${` or `} && ${` in one attribute | `rg -n 'data-sly-test="[^"]*\}\s*\|\|\s*\$\{' --glob '*.html' ui.apps` and the same pattern with `&&` instead of `\|\|` |
+| Numeric literal comparison | `== <digits>` inside a `data-sly-test` line (review each hit) | `rg -n 'data-sly-test="[^"]*==\s*[0-9]+\s*}' --glob '*.html' ui.apps` |
+
+**Agent workflow:**
+
+1. Run the `rg` lines above (adjust `ui.apps` to the user's module paths if different).
+2. Open each file at the reported lines; confirm the match is really a `data-sly-test` problem per the patterns below (skip unrelated `== 1` in other attributes if any).
+3. Apply fixes from the matching pattern section.
+4. Tell the user to run **HTL validate** / full module build so compiler warnings confirm nothing was missed.
+
+---
+
+## Pattern 1: Boolean Constant Comparison (`== true` / `== false`)
+
+### What the linter flags
+
+The warning value is `true` or `false`. The HTL expression compares a variable against a boolean literal.
+
+### Before (warns)
+
+```html
+<div data-sly-test="${someVar == true}">visible when someVar is truthy</div>
+<div data-sly-test="${someVar == false}">visible when someVar is falsy</div>
+```
+
+### After (clean)
+
+```html
+<div data-sly-test="${someVar}">visible when someVar is truthy</div>
+<div data-sly-test="${!someVar}">visible when someVar is falsy</div>
+```
+
+### Rules
+
+- `== true` → remove the comparison; HTL treats the variable as boolean by default
+- `== false` → negate with `!`
+- If the original uses `data-sly-test.varName`, preserve the variable name:
+
+```html
+<!-- Before -->
+<div data-sly-test.isActive="${model.active == true}">
+
+<!-- After -->
+<div data-sly-test.isActive="${model.active}">
+```
+
+### Edge case: `!= true` / `!= false`
+
+```html
+<!-- != true is the same as == false -->
+<div data-sly-test="${someVar != true}">  →  <div data-sly-test="${!someVar}">
+
+<!-- != false is the same as == true -->
+<div data-sly-test="${someVar != false}">  →  <div data-sly-test="${someVar}">
+```
+
+---
+
+## Pattern 2: Hardcoded String/Path as Test Value
+
+### What the linter flags
+
+The warning value is a string like `/apps/bcbsmgeneral/components/content/container`. A raw string literal inside `data-sly-test` is always truthy (non-empty string), so the condition is meaningless.
+
+### Diagnosis
+
+The author almost always **meant** to compare a variable against that string. Common cases:
+
+| Intent | Variable to compare |
+|--------|---------------------|
+| Check current resource type | `resource.resourceType` |
+| Check a child resource type | `childResource.resourceType` |
+| Check a property value | `properties.someProperty` |
+| Check a `data-sly-resource` path | a variable holding the resource type |
+
+### Before (warns)
+
+```html
+<!-- Always truthy — the string itself is the test -->
+<div data-sly-test="${'/apps/bcbsmgeneral/components/content/container'}">
+    ...
+</div>
+```
+
+### After (clean)
+
+Determine **what variable** should be compared. The most common fix:
+
+```html
+<!-- Compare resource type (strip /apps/ prefix for sling:resourceType) -->
+<div data-sly-test="${resource.resourceType == 'bcbsmgeneral/components/content/container'}">
+    ...
+</div>
+```
+
+Or if the path was being passed to `data-sly-resource`:
+
+```html
+<!-- The test was guarding a data-sly-resource include -->
+<sly data-sly-set.containerType="${'bcbsmgeneral/components/content/container'}"/>
+<div data-sly-test="${containerType}"
+     data-sly-resource="${resource @ resourceType=containerType}">
+</div>
+```
+
+### Rules
+
+- **Never** leave a raw string as the sole `data-sly-test` value
+- Strip the `/apps/` prefix when comparing against `resource.resourceType` (Sling stores relative resource types)
+- If you cannot determine the intended variable, wrap in `data-sly-set` and add a `TODO` comment:
+
+```html
+<!-- TODO: verify the correct variable for this comparison -->
+<sly data-sly-set.expectedType="${'bcbsmgeneral/components/content/container'}"/>
+<div data-sly-test="${resource.resourceType == expectedType}">
+```
+
+### Nested resource iteration
+
+When iterating child resources (e.g. `data-sly-list`), the comparison often belongs on the child:
+
+```html
+<!-- Before (warns — raw path string) -->
+<sly data-sly-list.child="${resource.children}">
+    <div data-sly-test="${'/apps/bcbsmgeneral/components/content/container'}">
+        <sly data-sly-resource="${child}"/>
+    </div>
+</sly>
+
+<!-- After -->
+<sly data-sly-list.child="${resource.children}">
+    <div data-sly-test="${child.resourceType == 'bcbsmgeneral/components/content/container'}">
+        <sly data-sly-resource="${child}"/>
+    </div>
+</sly>
+```
+
+---
+
+## Pattern 3: Numeric Constant Comparison
+
+### What the linter flags
+
+The warning value is a number like `1` or `2`. HTL's linter flags numeric literals in comparisons even when the logic is correct.
+
+### Before (warns)
+
+```html
+<div data-sly-test="${properties.columnCount == 1}">one column</div>
+<div data-sly-test="${properties.columnCount == 2}">two columns</div>
+```
+
+### After (clean)
+
+Extract the comparison into a `data-sly-set` variable:
+
+```html
+<sly data-sly-set.isOneColumn="${properties.columnCount == 1}"/>
+<sly data-sly-set.isTwoColumn="${properties.columnCount == 2}"/>
+
+<div data-sly-test="${isOneColumn}">one column</div>
+<div data-sly-test="${isTwoColumn}">two columns</div>
+```
+
+### Rules
+
+- Move the numeric comparison into `data-sly-set` so `data-sly-test` only sees a boolean variable
+- Choose descriptive variable names (`isOneColumn`, `isTypeTwo`, etc.)
+- Place `data-sly-set` on a `<sly>` element **before** the element that uses `data-sly-test`
+- If many numeric comparisons exist (e.g. a switch-like block), group all `data-sly-set` declarations together at the top
+
+### Alternative: Use a Sling Model
+
+For complex switch logic, expose a method from the model:
+
+```java
+public boolean isOneColumn() {
+    return getColumnCount() == 1;
+}
+```
+
+```html
+<div data-sly-test="${model.oneColumn}">one column</div>
+```
+
+---
+
+## Pattern 4: Split-Expression Logical OR/AND
+
+### What the linter flags
+
+The warning value is something like `${properties.videoUrl} || ${properties.videoUrl1}`. HTL does **not** support `||` or `&&` operators **across** separate `${}` expression blocks.
+
+When you write:
+
+```html
+<div data-sly-test="${properties.videoUrl} || ${properties.videoUrl1}">
+```
+
+HTL evaluates `${properties.videoUrl}` as one expression and treats the literal string ` || ` and `${properties.videoUrl1}` as separate tokens. The result is unpredictable and always flagged.
+
+### Before (warns)
+
+```html
+<div data-sly-test="${properties.videoUrl} || ${properties.videoUrl1}">
+    video content
+</div>
+```
+
+### After (clean)
+
+Combine into a **single** `${}` block:
+
+```html
+<sly data-sly-set.hasVideo="${properties.videoUrl || properties.videoUrl1}"/>
+<div data-sly-test="${hasVideo}">
+    video content
+</div>
+```
+
+Or inline if the expression is short:
+
+```html
+<div data-sly-test="${properties.videoUrl || properties.videoUrl1}">
+    video content
+</div>
+```
+
+### Rules
+
+- **All** logical operators (`||`, `&&`, ternary `? :`) must be inside a **single** `${}` block
+- If the combined expression is long, use `data-sly-set` for readability
+- The same applies to `&&`:
+
+```html
+<!-- BAD -->
+<div data-sly-test="${properties.a} && ${properties.b}">
+
+<!-- GOOD -->
+<div data-sly-test="${properties.a && properties.b}">
+```
+
+---
+
+## Validation Checklist
+
+After fixing all warnings in a file:
+
+- [ ] **Build passes** — re-run `mvn clean install` and confirm no `redundant constant value comparison` warnings remain for this file
+- [ ] **Logical intent preserved** — the element still shows/hides under the same conditions as before
+- [ ] **No broken references** — if `data-sly-test.varName` was changed, all downstream `${varName}` references still work
+- [ ] **No orphaned `data-sly-set`** — every `data-sly-set` variable is used by at least one `data-sly-test`
+- [ ] **Authoring still works** — component dialog values still drive the correct rendering in author and publish mode
+
+## Files That Cannot Be Auto-Fixed
+
+Some warnings require **human judgment**:
+
+- **Pattern 2** when the intended comparison variable is ambiguous (no obvious `resource.resourceType` or `properties.*` candidate)
+- **Expressions inside `data-sly-include` or `data-sly-template`** — the scope of variables may differ
+- **Third-party / ACS Commons overlays** — changing shared component HTL may break other sites on the same instance
+
+Flag these to the user with a `TODO` comment and move on.

--- a/skills/aem/cloud-service/skills/migration/SKILL.md
+++ b/skills/aem/cloud-service/skills/migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: migration
-description: Orchestrates legacy AEM Java (6.x, AMS, on-prem) to AEM as a Cloud Service migration using BPA CSV or cache, CAM/MCP target discovery, and one-pattern-per-session workflow. Use for BPA/CAM findings, Cloud Service blockers, or fixes for scheduler, ResourceChangeListener, replication, EventListener, OSGi EventHandler, DAM AssetManager. Java transformation steps live in the best-practices skill—read it and the right references/ modules before editing code.
+description: Orchestrates legacy AEM (6.x, AMS, on-prem) to AEM as a Cloud Service migration using BPA CSV or cache, CAM/MCP target discovery, and one-pattern-per-session workflow. Use for BPA/CAM findings, Cloud Service blockers, or fixes for scheduler, ResourceChangeListener, replication, EventListener, OSGi EventHandler, DAM AssetManager, HTL data-sly-test lint. Transformation steps live in the best-practices skill—read it and the right references/ modules before editing code.
 ---
 
 # AEM as a Cloud Service — Code Migration
@@ -13,19 +13,21 @@ This skill is **orchestration**: BPA data, CAM/MCP, **one pattern per session**,
 
 ## Quick start (for the person driving the agent)
 
-**One pattern per chat/session** — if you ask to “fix everything,” the skill will ask you to pick first (e.g. scheduler vs replication).
+**One pattern per chat/session** — if you ask to "fix everything," the skill will ask you to pick first (e.g. scheduler vs replication vs htlLint).
 
 | You have… | Say something like… | What happens |
 |-----------|---------------------|--------------|
-| A **BPA CSV** | *“Fix **scheduler** findings using `./path/to/bpa.csv`”* | Fastest path: CSV → cached collection → files |
-| **CAM + MCP** only | *“Get **scheduler** findings from CAM; I’ll pick the project when you list them.”* | Agent lists projects → you confirm → MCP fetch ([cam-mcp.md](references/cam-mcp.md)) |
-| **Just a few files** | *“Migrate **scheduler** in `core/.../MyJob.java`”* | Manual flow: no BPA required |
+| A **BPA CSV** | *"Fix **scheduler** findings using `./path/to/bpa.csv`"* | Fastest path: CSV → cached collection → files |
+| **CAM + MCP** only | *"Get **scheduler** findings from CAM; I'll pick the project when you list them."* | Agent lists projects → you confirm → MCP fetch ([cam-mcp.md](references/cam-mcp.md)) |
+| **Just a few files** | *"Migrate **scheduler** in `core/.../MyJob.java`"* | Manual flow: no BPA required |
+| **HTL lint warnings** | *"Fix **htlLint** issues in `ui.apps`"* | Proactive discovery via `rg` → fix per reference module |
 
 **Starter prompts (copy-paste):**
 
-- *“Use the migration skill: **scheduler** only, BPA CSV at `./reports/bpa.csv`, then apply best-practices reference modules before editing.”*
-- *“**Replication** only from CAM; list projects first, I’ll pick one.”*
-- *“**Manual:** **event listener** migration for `.../Listener.java` — read best-practices module first.”*
+- *"Use the migration skill: **scheduler** only, BPA CSV at `./reports/bpa.csv`, then apply best-practices reference modules before editing."*
+- *"**Replication** only from CAM; list projects first, I'll pick one."*
+- *"**Manual:** **event listener** migration for `.../Listener.java` — read best-practices module first."*
+- *"Fix **htlLint** in `ui.apps` — scan for `data-sly-test` redundant constant warnings and fix them."*
 
 
 ## Path convention (Adobe Skills monorepo)
@@ -40,17 +42,17 @@ Examples: `{best-practices}/SKILL.md`, `{best-practices}/references/scheduler.md
 
 ## Workspace scope (IDE) — user code only
 
-Applies to **finding and editing the user’s AEM project** (Java, bundles, config), not to reading installed skill files under `{best-practices}`.
+Applies to **finding and editing the user's AEM project** (Java, bundles, config, HTL), not to reading installed skill files under `{best-practices}`.
 
 - Treat the **current IDE workspace root folder(s)** (single- or multi-root) as the **only** boundary for searches, globs, `grep`, and file reads/writes for migration targets.
-- **Do not** search parent directories, sibling folders on disk, `~`, other clones, or arbitrary absolute paths to “discover” sources unless the user **explicitly** names those paths or asks you to include them.
+- **Do not** search parent directories, sibling folders on disk, `~`, other clones, or arbitrary absolute paths to "discover" sources unless the user **explicitly** names those paths or asks you to include them.
 - **BPA CSV / CAM targets:** If a `filePath` or class-to-file mapping does not resolve under a workspace root, **stop** and tell the user which paths are missing — do not hunt elsewhere on the filesystem. Ask them to open the correct project in the IDE or adjust paths.
 - **Manual flow:** Only migrate files the user named that live under the workspace (or paths they explicitly provided). Do not expand scope by searching outside the workspace.
 
 ## Required delegation (do this first)
 
 1. Read **`{best-practices}/SKILL.md`** — critical rules, Java baseline links, **Pattern Reference Modules** table, **Manual Pattern Hints**.
-2. Read **`{best-practices}/references/<module>.md`** for the **single** active BPA pattern (see table in that `SKILL.md`).
+2. Read **`{best-practices}/references/<module>.md`** for the **single** active pattern (see table in that `SKILL.md`).
 3. When code uses SCR, `ResourceResolver`, or console logging, read **`{best-practices}/references/scr-to-osgi-ds.md`** and **`{best-practices}/references/resource-resolver-logging.md`** (or the hub **`{best-practices}/references/aem-cloud-service-pattern-prerequisites.md`**).
 
 Do not transform code until the pattern module is read.
@@ -58,6 +60,7 @@ Do not transform code until the pattern module is read.
 ## When to Use This Skill
 
 - Migrate legacy AEM Java toward **Cloud Service–compatible** patterns
+- Fix **HTL (Sightly)** lint warnings (`data-sly-test: redundant constant value comparison`) across component templates
 - Drive work from **BPA** (CSV or cached collection) or **CAM via MCP**
 - Enforce **one pattern type per session**
 
@@ -65,6 +68,7 @@ Do not transform code until the pattern module is read.
 
 - Project source and Maven/Gradle build
 - BPA CSV or MCP access optional but recommended
+- For **htlLint**: `ui.apps` or equivalent content package with `.html` HTL templates
 
 ## BPA findings — flow
 
@@ -75,6 +79,8 @@ Scripts run via **`getBpaFindings`** (see **Calling the helper**); do not reimpl
 3. **No CSV; MCP available** → follow [references/cam-mcp.md](references/cam-mcp.md): `list-projects`, user confirms project, then `fetch-cam-bpa-findings`.
 4. **Nothing works** → ask for CSV path or explicit Java files (manual flow).
 
+**Note:** `htlLint` does **not** appear in BPA CSV — it uses proactive `rg` discovery instead. See **htlLint flow** below.
+
 ### CAM via MCP (summary)
 
 Use **`fetch-cam-bpa-findings`** only after **`list-projects`** and **explicit user confirmation** of which project row to use (prefer **`projectId`** from that list). Do not pass an unconfirmed project name string. **Full tool schemas, REST notes, retries, and error handling:** [references/cam-mcp.md](references/cam-mcp.md).
@@ -84,6 +90,7 @@ Use **`fetch-cam-bpa-findings`** only after **`list-projects`** and **explicit u
 - *"Fix scheduler using ./reports/bpa.csv"* → CSV path known
 - *"Fix scheduler"* → collection → MCP → ask for CSV
 - *"Migrate `core/.../Foo.java`"* → manual flow
+- *"Fix htlLint in ui.apps"* → proactive discovery flow
 
 ### Calling the helper
 
@@ -112,7 +119,7 @@ Filter rows where **`pattern`** matches the session pattern. Typical columns: `p
 
 ### MCP errors and fallback
 
-**Critical:** On MCP failure, **stop the workflow immediately** and give the user the **exact tool error message** (verbatim), including “not found” / 404-style project errors. **Do not** continue with migration steps, infer a different CAM project from the workspace, or switch to manual/local migration on your own.
+**Critical:** On MCP failure, **stop the workflow immediately** and give the user the **exact tool error message** (verbatim), including "not found" / 404-style project errors. **Do not** continue with migration steps, infer a different CAM project from the workspace, or switch to manual/local migration on your own.
 
 **Exception:** enablement restriction errors (prefix documented in [references/cam-mcp.md](references/cam-mcp.md)) must be shown **verbatim** with no paraphrase and no automatic fallback until the user addresses them.
 
@@ -134,15 +141,17 @@ If the user asks to fix everything or BPA mixes patterns, **ask which pattern fi
 
 ### Step 1: Pattern id
 
-Map the request to a BPA id: `scheduler`, `resourceChangeListener`, `replication`, `eventListener`, `eventHandler`, `assetApi`. If unclear, use **Manual Pattern Hints** in **`{best-practices}/SKILL.md`** or ask the user to pick one of those.
+Map the request to a pattern id: `scheduler`, `resourceChangeListener`, `replication`, `eventListener`, `eventHandler`, `assetApi`, `htlLint`. If unclear, use **Manual Pattern Hints** in **`{best-practices}/SKILL.md`** or ask the user to pick one of those.
 
 ### Step 2: Availability
 
 If the id is missing from the best-practices table, say the pattern is not supported yet.
 
-### Step 3: BPA targets
+### Step 3: Targets
 
-Run **`getBpaFindings`** (with `bpaFilePath` when provided). Internally: cache → CSV → MCP → manual **only when each step is applicable and succeeds**; if MCP fails, obey **MCP errors and fallback** (stop; no silent chain). For MCP details, [references/cam-mcp.md](references/cam-mcp.md).
+**For BPA patterns** (`scheduler`, `resourceChangeListener`, `replication`, `eventListener`, `eventHandler`, `assetApi`): Run **`getBpaFindings`** (with `bpaFilePath` when provided). Internally: cache → CSV → MCP → manual **only when each step is applicable and succeeds**; if MCP fails, obey **MCP errors and fallback** (stop; no silent chain). For MCP details, [references/cam-mcp.md](references/cam-mcp.md).
+
+**For `htlLint`**: Skip BPA/CSV/MCP — targets come from proactive `rg` discovery. See **htlLint flow** below.
 
 ### Step 4: Read before edits
 
@@ -160,15 +169,25 @@ Summarize files touched, sub-paths, failures.
 
 User-named files → classify (best-practices hints or ask) → confirm module exists → read **`{best-practices}/SKILL.md`** + module → transform → report.
 
+### htlLint flow
+
+`htlLint` does not use BPA CSV or CAM/MCP. Instead:
+
+1. **Read** `{best-practices}/references/data-sly-test-redundant-constant.md` — it contains the **Workflow**, **Proactive Discovery** `rg` patterns, and all 4 fix patterns.
+2. **Discover** targets using the `rg` commands from the module's **Proactive Discovery** table (scope: `ui.apps/**/jcr_root/**/*.html` or the user's content package paths).
+3. **Group** hits by file, classify each by pattern (boolean literal, raw string, numeric, split expression).
+4. **Fix** each hit per the matching pattern section in the module.
+5. **Report** and recommend the user run `mvn clean install` or HTL validate to confirm no warnings remain.
+
 ## Quick reference
 
-**Source priority (when choosing how to obtain targets):** unified collection → BPA CSV → MCP → manual paths. **Not** an automatic cascade after MCP errors — if MCP fails, stop and wait for user direction (see **MCP errors and fallback**).
+**Source priority (when choosing how to obtain targets):** unified collection → BPA CSV → MCP → manual paths. **Not** an automatic cascade after MCP errors — if MCP fails, stop and wait for user direction (see **MCP errors and fallback**). For `htlLint`, use proactive `rg` discovery (no BPA/MCP).
 
-**User-facing snippets:** *"Using existing BPA collection (N findings)…"* / *"Processing your BPA report…"* / *"Fetched findings from CAM."* / optional prompt after MCP stop above.
+**User-facing snippets:** *"Using existing BPA collection (N findings)…"* / *"Processing your BPA report…"* / *"Fetched findings from CAM."* / *"Scanning HTL templates for data-sly-test lint issues…"* / optional prompt after MCP stop above.
 
 ### CLI (development only)
 
-From this skill’s directory:
+From this skill's directory:
 
 ```bash
 node scripts/bpa-findings-helper.js scheduler ./unified-collections


### PR DESCRIPTION
## Description

Adds an HTL `data-sly-test` lint reference module to the `aem-cloud-service` best-practices skill. This provides pattern-based fix guidance for the AEM Cloud SDK HTL lint warning *"data-sly-test: redundant constant value comparison"* and a proactive ripgrep discovery workflow to find candidates without a Maven build.

Changes across 3 files:
- **New:** `references/data-sly-test-redundant-constant.md` (259 lines) — covers boolean literal, raw path string, numeric, and split-expression patterns with before/after examples
- **Modified:** `SKILL.md` — adds HTL (Sightly) workflow section, proactive `rg` discovery patterns, and a pattern table entry for HTL lint
- **Modified:** `README.md` — mentions the new HTL reference module in the skill summary

## Motivation and Context

The AEM Cloud SDK build emits HTL lint warnings for redundant constant value comparisons in `data-sly-test` attributes. Without a reference module, the agent has no structured guidance for classifying and fixing these warnings. This change gives the best-practices skill full HTL lint coverage alongside its existing Java/OSGi patterns.

## How Has This Been Tested?

- Verified `data-sly-test-redundant-constant.md` exists under `skills/aem/cloud-service/skills/best-practices/references/`
- Confirmed `SKILL.md` contains the HTL workflow section, proactive discovery table, and pattern table entry
- Confirmed `README.md` mentions the HTL reference
- Checked all 3 files for merge conflict markers — none present

## Screenshots (if appropriate):

N/A — documentation/skill reference changes only.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.