### PR TITLE
docs: fix marketplace description typo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Adobe"
   },
   "metadata": {
-    "description": "Official Adobe skills for AI coding agents"
+    "description": "Official Adobe Skills for AI Agents"
   },
   "plugins": [
     {


### PR DESCRIPTION
Fix the description in .claude-plugin/marketplace.json to read "Official Adobe Skills for AI Agents" (capitalization and removed "coding").