### PR TITLE
Add Tessl skill review GitHub Action for PRs

### DIFF
--- a/.github/workflows/tessl-review.yml
+++ b/.github/workflows/tessl-review.yml
@@ -11,17 +11,58 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: tesslio/setup-tessl@v2
 
-      - name: Review all skills
+      - name: Detect changed skills
+        id: detect
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+            CHANGED_SKILLS=$(echo "$CHANGED_FILES" | grep -oE '^skills/[^/]+' | sort -u || true)
+            if [ -z "$CHANGED_SKILLS" ]; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "No skill files changed."
+            else
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+              DIRS=""
+              for skill_path in $CHANGED_SKILLS; do
+                if [ -f "$skill_path/SKILL.md" ]; then
+                  DIRS="$DIRS $skill_path"
+                fi
+              done
+              echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "dirs=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post skip summary
+        if: steps.detect.outputs.skip == 'true'
+        run: |
+          echo "## Skill Review" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "No skills changed — review skipped." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Review skills
+        if: steps.detect.outputs.skip != 'true'
         run: |
           THRESHOLD=50
           PASS=0
           FAIL=0
+          SUMMARY_ROWS=""
           ERRORS=""
 
-          for dir in $(find skills -name SKILL.md -exec dirname {} \;); do
+          SKILL_DIRS="${{ steps.detect.outputs.dirs }}"
+          if [ -z "$SKILL_DIRS" ]; then
+            # Push to main or no filter: review all skills
+            SKILL_DIRS=$(find skills -name SKILL.md -exec dirname {} \;)
+          fi
+
+          for dir in $SKILL_DIRS; do
             SKILL_NAME=$(basename "$dir")
             echo "::group::Reviewing $SKILL_NAME"
             OUTPUT=$(tessl skill review "$dir" 2>&1) || true
@@ -37,12 +78,26 @@ jobs:
             if [ "$SCORE" -lt "$THRESHOLD" ]; then
               FAIL=$((FAIL + 1))
               ERRORS="$ERRORS\n  ❌ $SKILL_NAME: ${SCORE}% (below ${THRESHOLD}%)"
+              SUMMARY_ROWS="$SUMMARY_ROWS| $SKILL_NAME | ${SCORE}% | ❌ |\n"
             else
               PASS=$((PASS + 1))
+              SUMMARY_ROWS="$SUMMARY_ROWS| $SKILL_NAME | ${SCORE}% | ✅ |\n"
             fi
           done
 
           TOTAL=$((PASS + FAIL))
+
+          # Write GitHub Step Summary
+          {
+            echo "## Skill Review"
+            echo ""
+            echo "| Skill | Score | Status |"
+            echo "|-------|-------|--------|"
+            echo -e "$SUMMARY_ROWS"
+            echo "| **Total** | **$PASS/$TOTAL passed** | $([ "$FAIL" -eq 0 ] && echo '✅' || echo '❌') |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Stdout summary for logs
           echo ""
           echo "============================="
           echo "  Skill Review Summary"

--- a/.github/workflows/tessl-review.yml
+++ b/.github/workflows/tessl-review.yml
@@ -1,0 +1,64 @@
+name: Tessl Skill Review
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  tessl-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: tesslio/setup-tessl@v2
+
+      - name: Review all skills
+        run: |
+          THRESHOLD=50
+          PASS=0
+          FAIL=0
+          ERRORS=""
+
+          for dir in $(find skills -name SKILL.md -exec dirname {} \;); do
+            SKILL_NAME=$(basename "$dir")
+            echo "::group::Reviewing $SKILL_NAME"
+            OUTPUT=$(tessl skill review "$dir" 2>&1) || true
+            echo "$OUTPUT"
+            echo "::endgroup::"
+
+            SCORE=$(echo "$OUTPUT" | grep -oE '[0-9]+%' | tail -1 | tr -d '%')
+            if [ -z "$SCORE" ]; then
+              echo "::warning::Could not parse score for $SKILL_NAME"
+              SCORE=0
+            fi
+
+            if [ "$SCORE" -lt "$THRESHOLD" ]; then
+              FAIL=$((FAIL + 1))
+              ERRORS="$ERRORS\n  ❌ $SKILL_NAME: ${SCORE}% (below ${THRESHOLD}%)"
+            else
+              PASS=$((PASS + 1))
+            fi
+          done
+
+          TOTAL=$((PASS + FAIL))
+          echo ""
+          echo "============================="
+          echo "  Skill Review Summary"
+          echo "============================="
+          echo "  Total:  $TOTAL"
+          echo "  Passed: $PASS"
+          echo "  Failed: $FAIL"
+          if [ -n "$ERRORS" ]; then
+            echo ""
+            echo "  Failed skills:"
+            echo -e "$ERRORS"
+          fi
+          echo "============================="
+
+          if [ "$FAIL" -gt 0 ]; then
+            echo "::error::$FAIL skill(s) scored below ${THRESHOLD}%"
+            exit 1
+          fi
+

--- a/.github/workflows/tessl-review.yml
+++ b/.github/workflows/tessl-review.yml
@@ -56,18 +56,34 @@ jobs:
           SUMMARY_ROWS=""
           ERRORS=""
 
-          SKILL_DIRS="${{ steps.detect.outputs.dirs }}"
-          if [ -z "$SKILL_DIRS" ]; then
+          SKILL_DIRS_INPUT="${{ steps.detect.outputs.dirs }}"
+          SKILL_LIST_FILE=$(mktemp)
+          trap 'rm -f "$SKILL_LIST_FILE"' EXIT
+
+          if [ -z "$SKILL_DIRS_INPUT" ]; then
             # Push to main or no filter: review all skills
-            SKILL_DIRS=$(find skills -name SKILL.md -exec dirname {} \;)
+            find skills -name SKILL.md -exec dirname {} \; > "$SKILL_LIST_FILE"
+          else
+            # PR mode: use detected skill dirs
+            printf '%s\n' $SKILL_DIRS_INPUT > "$SKILL_LIST_FILE"
           fi
 
-          for dir in $SKILL_DIRS; do
+          while IFS= read -r dir; do
+            [ -z "$dir" ] && continue
             SKILL_NAME=$(basename "$dir")
             echo "::group::Reviewing $SKILL_NAME"
-            OUTPUT=$(tessl skill review "$dir" 2>&1) || true
+
+            EXIT_CODE=0
+            OUTPUT=$(tessl skill review "$dir" 2>&1) || EXIT_CODE=$?
             echo "$OUTPUT"
             echo "::endgroup::"
+
+            if [ "$EXIT_CODE" -ne 0 ]; then
+              echo "::warning::tessl skill review failed for $SKILL_NAME (exit code $EXIT_CODE)"
+              FAIL=$((FAIL + 1))
+              SUMMARY_ROWS="$SUMMARY_ROWS| $SKILL_NAME | error | ❌ |\n"
+              continue
+            fi
 
             SCORE=$(echo "$OUTPUT" | grep -oE '[0-9]+%' | tail -1 | tr -d '%')
             if [ -z "$SCORE" ]; then
@@ -83,9 +99,15 @@ jobs:
               PASS=$((PASS + 1))
               SUMMARY_ROWS="$SUMMARY_ROWS| $SKILL_NAME | ${SCORE}% | ✅ |\n"
             fi
-          done
+          done < "$SKILL_LIST_FILE"
 
           TOTAL=$((PASS + FAIL))
+
+          # Fail if no skills were reviewed (push to main only)
+          if [ "$TOTAL" -eq 0 ] && [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "::error::No skills were reviewed — expected at least one"
+            exit 1
+          fi
 
           # Write GitHub Step Summary
           {


### PR DESCRIPTION
Adds a new GitHub Action workflow that runs Tessl skill quality reviews on every PR and push to main. Uses tesslio/setup-tessl@v2, discovers all 23 skills automatically, enforces a 50% quality threshold (current average is ~74%), and prints a per-skill summary. No secrets required. Existing validate.yml is unchanged.