### PR TITLE
ci: add conventional commits check for PRs

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,47 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  conventional-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for conventional commits
+        run: |
+          PATTERN='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-zA-Z0-9_-]+\))?!?: .+'
+
+          COMMITS=$(git log origin/${{ github.base_ref }}..HEAD --pretty=format:"%h %s")
+          if [ -z "$COMMITS" ]; then
+            echo "No commits found in this PR."
+            exit 1
+          fi
+
+          echo "Checking commits for conventional commit format..."
+          echo ""
+
+          FOUND=0
+          while IFS= read -r line; do
+            HASH=$(echo "$line" | cut -d' ' -f1)
+            MSG=$(echo "$line" | cut -d' ' -f2-)
+            if echo "$MSG" | grep -qE "$PATTERN"; then
+              echo "✅ $HASH $MSG"
+              FOUND=1
+            else
+              echo "❌ $HASH $MSG"
+            fi
+          done <<< "$COMMITS"
+
+          echo ""
+          if [ "$FOUND" -eq 1 ]; then
+            echo "✅ At least one conventional commit found."
+          else
+            echo "❌ No conventional commits found. Please use the format: type(scope): description"
+            exit 1
+          fi
+

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,4 +1,4 @@
-name: Conventional Commits
+name: Conventional Commits (at least one)
 
 on:
   pull_request:
@@ -16,7 +16,10 @@ jobs:
         run: |
           PATTERN='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-zA-Z0-9_-]+\))?!?: .+'
 
-          COMMITS=$(git log origin/${{ github.base_ref }}..HEAD --pretty=format:"%h %s")
+          COMMITS=$(git log ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} --pretty=format:"%h %s" 2>&1) || {
+            echo "::error::Failed to retrieve commits: $COMMITS"
+            exit 1
+          }
           if [ -z "$COMMITS" ]; then
             echo "No commits found in this PR."
             exit 1
@@ -39,9 +42,9 @@ jobs:
 
           echo ""
           if [ "$FOUND" -eq 1 ]; then
-            echo "✅ At least one conventional commit found."
+            echo "✅ Pass: at least one commit follows the Conventional Commits format."
           else
-            echo "❌ No conventional commits found. Please use the format: type(scope): description"
+            echo "❌ Fail: no commits follow the Conventional Commits format. At least one is required. Please use: type(scope): description"
             exit 1
           fi
 


### PR DESCRIPTION
Adds a GitHub Action workflow that enforces conventional commit messages on pull requests.

## What it does
- Checks all commits in a PR against the conventional commit format
- **Passes** if at least one commit follows the format (e.g. \, \, \)
- **Fails** with a clear message if no commits are conventional
- Supports optional scopes (\) and breaking change indicator (\)

## Supported types
\, \, \, \, \, \, \, \, \, \, \

No external dependencies — just bash and git.