### PR TITLE
Add CODEOWNERS file and CI coverage check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# CODEOWNERS for adobe/skills
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Rules are evaluated top-to-bottom; the LAST matching pattern takes precedence.
+# Order: general → specific so that specific paths override the default.
+
+# Default owner (repo admin)
+*                                                     @trieloff
+
+# CI/CD and GitHub workflows
+/.github/                                             @trieloff @ssteimer
+
+# Claude plugin marketplace config
+/.claude-plugin/                                      @ssteimer @trieloff
+
+# AEM Edge Delivery Services (Sean Steimer is primary author of all skills)
+/skills/aem/edge-delivery-services/                   @ssteimer
+
+# AEM Project Management (Astha Bhargava is sole author)
+/skills/aem/project-management/                       @asthabhargava
+
+# AEM Cloud Service (in-flight, contributors: abhigarg, pkumargaddam, Himanich, akankshajain18, rombert)
+/skills/aem/cloud-service/                            @abhigarg @pkumargaddam @Himanich @akankshajain18 @rombert
+
+# AEM 6.5 LTS (in-flight, contributors: abhigarg, akankshajain18, rombert)
+/skills/aem/6.5-lts/                                  @abhigarg @akankshajain18 @rombert

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,3 +20,35 @@ jobs:
       - run: npm ci
 
       - run: npm run validate
+
+  codeowners-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check CODEOWNERS covers all skill directories
+        run: |
+          codeowners=".github/CODEOWNERS"
+          if [ ! -f "$codeowners" ]; then
+            echo "::error::CODEOWNERS file not found at $codeowners"
+            exit 1
+          fi
+
+          missing=()
+          for dir in skills/*/*/; do
+            # Remove trailing slash for the lookup path
+            path="/${dir%/}"
+            if ! grep -q "^${path}[/ ]" "$codeowners"; then
+              missing+=("$path")
+            fi
+          done
+
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::The following skill directories are not covered in CODEOWNERS:"
+            for p in "${missing[@]}"; do
+              echo "  $p"
+            done
+            exit 1
+          fi
+
+          echo "All skill directories are covered in CODEOWNERS."


### PR DESCRIPTION
## Summary

Adds a `.github/CODEOWNERS` file that assigns mandated reviewers based on subpath ownership derived from past contribution patterns, plus a CI check to ensure new skill directories always have a code owner assigned.

## Changes

### `.github/CODEOWNERS` (new)
Ownership rules derived from git history analysis:

| Path | Reviewer(s) | Rationale |
|---|---|---|
| `*` (default) | @trieloff | Repo admin |
| `/.github/` | @trieloff @ssteimer | CI/CD authors |
| `/.claude-plugin/` | @ssteimer @trieloff | Plugin config authors |
| `/skills/aem/edge-delivery-services/` | @ssteimer | Primary author of all 17 skills |
| `/skills/aem/project-management/` | @asthabhargava | Sole author |
| `/skills/aem/cloud-service/` | @abhigarg @pkumargaddam @Himanich @akankshajain18 @rombert | Combined contributors |
| `/skills/aem/6.5-lts/` | @abhigarg @akankshajain18 @rombert | Combined contributors |

Rules are kept at max 2 subdirectory depth (e.g. `/skills/aem/cloud-service/` but nothing below).

### `.github/workflows/validate.yml` (modified)
Added a `codeowners-coverage` CI job that:
- Finds all `skills/*/*/` directories
- Verifies each has a matching CODEOWNERS entry
- Fails with a clear error listing uncovered paths

This ensures that when a new skill subdirectory is added, a code owner must be assigned.

## Note
GitHub usernames were inferred from git commit emails. Please verify the following mappings are correct:
- Robert Munteanu → `@rombert`
- Astha Bhargava → `@asthabhargava`
- Abhishek Garg → `@abhigarg`
