### PR TITLE
Add Tessl eval workflow and document quality checks

### DIFF
--- a/.github/workflows/tessl-eval.yml
+++ b/.github/workflows/tessl-eval.yml
@@ -1,0 +1,144 @@
+name: Tessl Skill Eval
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  tessl-eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check eval trigger
+        id: trigger
+        run: |
+          LAST_MSG=$(git log -1 --format=%s)
+          echo "commit_message=$LAST_MSG"
+          if [[ ! "$LAST_MSG" =~ ^eval: ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Last commit does not start with 'eval:' — skipping eval."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Eval triggered by commit: $LAST_MSG"
+          fi
+
+      - name: Post skip summary (no eval trigger)
+        if: steps.trigger.outputs.skip == 'true'
+        run: |
+          {
+            echo "## Skill Eval"
+            echo ""
+            echo "Eval not requested — last commit message does not start with \`eval:\`."
+            echo "To trigger evals, create a commit with a message like:"
+            echo "\`\`\`"
+            echo 'git commit --allow-empty -m "eval: test building-blocks changes"'
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Detect changed skills with tiles
+        if: steps.trigger.outputs.skip != 'true'
+        id: detect
+        run: |
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          # Extract unique tile directories (3 levels deep: skills/<org>/<tile>)
+          TILE_DIRS=$(echo "$CHANGED_FILES" \
+            | grep -oE '^skills/[^/]+/[^/]+' \
+            | sort -u || true)
+
+          if [ -z "$TILE_DIRS" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No skill files changed."
+          else
+            # Filter to only tile dirs that have a tile.json
+            EVAL_DIRS=""
+            for tile_dir in $TILE_DIRS; do
+              if [ -f "$tile_dir/tile.json" ]; then
+                EVAL_DIRS="$EVAL_DIRS $tile_dir"
+                echo "Found tile.json in $tile_dir"
+              else
+                echo "No tile.json in $tile_dir — skipping"
+              fi
+            done
+
+            if [ -z "$EVAL_DIRS" ]; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "Changed skills have no tile.json — nothing to eval."
+            else
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+              echo "dirs=$EVAL_DIRS" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Post skip summary (no qualifying tiles)
+        if: steps.trigger.outputs.skip != 'true' && steps.detect.outputs.skip == 'true'
+        run: |
+          {
+            echo "## Skill Eval"
+            echo ""
+            echo "No qualifying skills to evaluate — either no skill files were changed or changed skills have no \`tile.json\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: tesslio/setup-tessl@v2
+        if: steps.trigger.outputs.skip != 'true' && steps.detect.outputs.skip != 'true'
+        with:
+          token: ${{ secrets.TESSL_TOKEN }}
+
+      - name: Run evals
+        if: steps.trigger.outputs.skip != 'true' && steps.detect.outputs.skip != 'true'
+        run: |
+          PASS=0
+          FAIL=0
+          SUMMARY_ROWS=""
+
+          for tile_dir in ${{ steps.detect.outputs.dirs }}; do
+            TILE_NAME=$(basename "$tile_dir")
+            echo "::group::Evaluating $TILE_NAME ($tile_dir)"
+
+            EXIT_CODE=0
+            OUTPUT=$(tessl eval run "$tile_dir" 2>&1) || EXIT_CODE=$?
+            echo "$OUTPUT"
+            echo "::endgroup::"
+
+            if [ "$EXIT_CODE" -ne 0 ]; then
+              echo "::warning::tessl eval run failed for $TILE_NAME (exit code $EXIT_CODE)"
+              FAIL=$((FAIL + 1))
+              SUMMARY_ROWS="$SUMMARY_ROWS| $TILE_NAME | error | ❌ |\n"
+            else
+              PASS=$((PASS + 1))
+              SUMMARY_ROWS="$SUMMARY_ROWS| $TILE_NAME | passed | ✅ |\n"
+            fi
+
+            # Show detailed results
+            echo "::group::Eval results for $TILE_NAME"
+            tessl eval view --last 2>&1 || true
+            echo "::endgroup::"
+          done
+
+          TOTAL=$((PASS + FAIL))
+
+          {
+            echo "## Skill Eval"
+            echo ""
+            echo "| Tile | Result | Status |"
+            echo "|------|--------|--------|"
+            echo -e "$SUMMARY_ROWS"
+            echo "| **Total** | **$PASS/$TOTAL passed** | $([ "$FAIL" -eq 0 ] && echo '✅' || echo '❌') |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo ""
+          echo "============================="
+          echo "  Skill Eval Summary"
+          echo "============================="
+          echo "  Total:  $TOTAL"
+          echo "  Passed: $PASS"
+          echo "  Failed: $FAIL"
+          echo "============================="
+
+          if [ "$FAIL" -gt 0 ]; then
+            echo "::error::$FAIL tile(s) failed evaluation"
+            exit 1
+          fi
+

--- a/.github/workflows/tessl-eval.yml
+++ b/.github/workflows/tessl-eval.yml
@@ -7,10 +7,14 @@ on:
 jobs:
   tessl-eval:
     runs-on: ubuntu-latest
+    # Uses the "eval" environment for protection rules (e.g. reviewer approval)
+    # to guard the TESSL_TOKEN secret against exfiltration via same-repo branches.
+    environment: eval
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Check eval trigger
         id: trigger
@@ -109,12 +113,11 @@ jobs:
             else
               PASS=$((PASS + 1))
               SUMMARY_ROWS="$SUMMARY_ROWS| $TILE_NAME | passed | ✅ |\n"
+              # Show detailed results only for successful eval
+              echo "::group::Eval results for $TILE_NAME"
+              tessl eval view --last 2>&1 || true
+              echo "::endgroup::"
             fi
-
-            # Show detailed results
-            echo "::group::Eval results for $TILE_NAME"
-            tessl eval view --last 2>&1 || true
-            echo "::endgroup::"
           done
 
           TOTAL=$((PASS + FAIL))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,33 @@ For other contributors, a maintainer of the project has to approve the pull requ
 
 To contribute a new skill, follow the format described in the [Agent Skills specification](https://agentskills.io). When your skill is ready, open a pull request and ping [#agentskills](https://adobe.enterprise.slack.com/archives/C0APTKDNPEY) on Slack to get a review.
 
+## Quality Checks
+
+PRs go through three tiers of quality checks:
+
+1. **Validation** (`npm run validate`) — checks skill structure against the [agentskills.io](https://agentskills.io) spec. Runs automatically on every PR.
+
+2. **Tessl Skill Review** (`tessl skill review`) — LLM-based scoring of content quality, activation quality, and security. Runs automatically on every PR for changed skills. Must score above 50%.
+
+3. **Tessl Evals** (`tessl eval run`) — end-to-end agent evaluation that measures whether the skill actually improves agent behavior. Runs only when explicitly requested and only for skills that include a `tile.json`.
+
+## Requesting Evals
+
+To trigger evals, push an empty commit with an `eval:` prefix:
+
+```bash
+git commit --allow-empty -m "eval: describe what you're testing"
+git push
+```
+
+Things to know:
+
+- Evals only run for skills that have a `tile.json` in their tile directory
+- Evals require the `TESSL_TOKEN` secret (maintainers only, or auto-available in CI)
+- Evals take several minutes per skill — be patient
+- Results appear in the GitHub Actions step summary
+- Evals measure the "impact score" — the gap between agent performance with vs. without the skill
+
 # How to Contribute
 
 1. Fork the repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ PRs go through three tiers of quality checks:
 
 1. **Validation** (`npm run validate`) — checks skill structure against the [agentskills.io](https://agentskills.io) spec. Runs automatically on every PR.
 
-2. **Tessl Skill Review** (`tessl skill review`) — LLM-based scoring of content quality, activation quality, and security. Runs automatically on every PR for changed skills. Must score above 50%.
+2. **Tessl Skill Review** (`tessl skill review`) — LLM-based scoring of content quality, activation quality, and security. Runs automatically on every PR for changed skills. Must score at least 50%.
 
 3. **Tessl Evals** (`tessl eval run`) — end-to-end agent evaluation that measures whether the skill actually improves agent behavior. Runs only when explicitly requested and only for skills that include a `tile.json`.
 
@@ -53,7 +53,9 @@ git push
 Things to know:
 
 - Evals only run for skills that have a `tile.json` in their tile directory
-- Evals require the `TESSL_TOKEN` secret (maintainers only, or auto-available in CI)
+- Evals require the `TESSL_TOKEN` GitHub Actions secret
+- GitHub Actions secrets are not available to PRs from forks, so external contributors cannot run evals directly
+- If you need evals for a fork-based PR, ask a maintainer to run them from a branch in the main repo
 - Evals take several minutes per skill — be patient
 - Results appear in the GitHub Actions step summary
 - Evals measure the "impact score" — the gap between agent performance with vs. without the skill


### PR DESCRIPTION
Adds on-demand Tessl eval support and documents all quality check tiers in CONTRIBUTING.md.

## Changes

### New: \
On-demand eval workflow that runs only when ALL conditions are met:
- PR targeting main
- Last commit message starts with \ (e.g. \)
- Changed skills have a \ in their tile directory

Uses \ secret for authenticated eval runs. Posts results to GitHub Step Summary.

### Updated: \
New sections documenting the three-tier quality check system:
1. **Validation** — structural checks (automatic)
2. **Tessl Skill Review** — LLM quality scoring (automatic)
3. **Tessl Evals** — end-to-end agent evaluation (on-demand via \ commits)

Includes instructions for requesting evals.