### PR TITLE
ci: require license field in all SKILL.md files

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -52,3 +52,44 @@ jobs:
           fi
 
           echo "All skill directories are covered in CODEOWNERS."
+
+
+  license-field:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check SKILL.md files have license field in frontmatter
+        run: |
+          missing=()
+          for file in $(find skills -name SKILL.md); do
+            # Extract frontmatter (between first two --- delimiters) and check for license field
+            if ! awk '/^---$/{n++; next} n==1{print} n>=2{exit}' "$file" | grep -q "^license:"; then
+              missing+=("$file")
+            fi
+          done
+
+          # Write GitHub Step Summary
+          echo "## License Field Check" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Skill | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|--------|" >> "$GITHUB_STEP_SUMMARY"
+
+          for file in $(find skills -name SKILL.md | sort); do
+            if printf '%s\n' "${missing[@]}" | grep -qx "$file"; then
+              echo "| $file | ❌ Missing |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| $file | ✅ Pass |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo ""
+            echo "::error::The following SKILL.md files are missing a 'license:' field in their frontmatter:"
+            for f in "${missing[@]}"; do
+              echo "  $f"
+            done
+            exit 1
+          fi
+
+          echo "All SKILL.md files have a license field."

--- a/skills/aem/edge-delivery-services/skills/analyze-and-plan/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/analyze-and-plan/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: analyze-and-plan
 description: Analyze development requirements and define acceptance criteria for AEM Edge Delivery Services tasks. Handles new blocks, variants, modifications, bug fixes, and styling changes with task-specific guidance.
+license: Apache-2.0
 ---
 
 # Analyze & Plan

--- a/skills/aem/edge-delivery-services/skills/authoring-analysis/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/authoring-analysis/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: authoring-analysis
 description: Analyze content sequences and determine authoring approach (default content vs blocks). Validates block selection and section styling for import/migration to AEM Edge Delivery Services.
+license: Apache-2.0
 ---
 
 # Authoring Analysis

--- a/skills/aem/edge-delivery-services/skills/block-collection-and-party/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/block-collection-and-party/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: block-collection-and-party
 description: The Block Collection and Block Party are repositories for existing AEM blocks, build tools, code snippets, integration patterns, plugins, and more. Use this skill anytime you are developing something and want to find a reference to use as a starting point.
+license: Apache-2.0
 ---
 
 # Using the Block Collection and Block Party

--- a/skills/aem/edge-delivery-services/skills/block-inventory/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/block-inventory/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: block-inventory
 description: Survey available blocks from local AEM Edge Delivery Services project and Block Collection to understand the block palette available for authoring. Returns block inventory with purposes to inform content modeling decisions.
+license: Apache-2.0
 ---
 
 # Block Inventory

--- a/skills/aem/edge-delivery-services/skills/building-blocks/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/building-blocks/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: building-blocks
 description: Guide for implementing code changes in AEM Edge Delivery Services. Handles block development (new or modified), core functionality changes (scripts.js, styles, delayed.js, etc.), or both. Use this skill for all implementation work guided by the content-driven-development workflow.
+license: Apache-2.0
 ---
 
 # Building Blocks

--- a/skills/aem/edge-delivery-services/skills/code-review/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/code-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: code-review
 description: Review code for AEM Edge Delivery Services projects. Use at the end of development (before PR) for self-review, or to review pull requests. Validates code quality, performance, accessibility, and adherence to EDS best practices.
+license: Apache-2.0
 ---
 
 # Code Review

--- a/skills/aem/edge-delivery-services/skills/content-driven-development/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/content-driven-development/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: content-driven-development
 description: Apply a Content Driven Development process to AEM Edge Delivery Services development. Use for ALL code changes - new blocks, block modifications, CSS styling, bug fixes, core functionality (scripts.js, styles, etc.), or any JavaScript/CSS work that needs validation.
+license: Apache-2.0
 ---
 
 # Content Driven Development (CDD)

--- a/skills/aem/edge-delivery-services/skills/content-modeling/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/content-modeling/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: content-modeling
 description: Create effective content models for your blocks that are easy for authors to work with. Use this skill anytime you are building new blocks, making changes to existing blocks that modify the initial structure authors work with.
+license: Apache-2.0
 ---
 
 # Content Modeling for AEM Edge Delivery Blocks

--- a/skills/aem/edge-delivery-services/skills/docs-search/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/docs-search/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: docs-search
 description: Searches the aem.live documentation for information on AEM Edge Delivery Services features. Use this skill when you need more information about a feature, want guidance on how to implement a feature, and using existing tools you have to search the web isn't turning up relevant results.
+license: Apache-2.0
 ---
 
 # Searching AEM Documentation

--- a/skills/aem/edge-delivery-services/skills/find-test-content/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/find-test-content/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: find-test-content
 description: Search for existing content pages containing a specific block in AEM Edge Delivery Services. Reports URLs with occurrences and variants to help identify test content during development.
+license: Apache-2.0
 ---
 
 # Find Test Content

--- a/skills/aem/edge-delivery-services/skills/generate-import-html/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/generate-import-html/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: generate-import-html
 description: Generate structured HTML from authoring analysis for AEM Edge Delivery Services. Creates section structure, applies block tables, handles metadata, and manages images folder.
+license: Apache-2.0
 ---
 
 # Generate Import HTML

--- a/skills/aem/edge-delivery-services/skills/identify-page-structure/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/identify-page-structure/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: identify-page-structure
 description: Identify section boundaries and content sequences within a scraped webpage for AEM Edge Delivery Services import. Performs two-level analysis (sections, then sequences per section) and surveys available blocks.
+license: Apache-2.0
 ---
 
 # Identify Page Structure

--- a/skills/aem/edge-delivery-services/skills/page-decomposition/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/page-decomposition/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: page-decomposition
 description: Analyze content sequences within a section and provide neutral descriptions for AEM Edge Delivery Services. Invoked per section during page import to identify breaking points between default content and blocks.
+license: Apache-2.0
 ---
 
 # Page Decomposition

--- a/skills/aem/edge-delivery-services/skills/page-import/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/page-import/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: page-import
 description: Import a single webpage from any URL to structured HTML content for authoring in AEM Edge Delivery Services. Scrapes the page, analyzes structure, maps to existing blocks, and generates HTML for immediate local preview. Also triggered by terms like "migrate", "migration", or "migrating".
+license: Apache-2.0
 ---
 
 # Page Import Orchestrator

--- a/skills/aem/edge-delivery-services/skills/preview-import/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/preview-import/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: preview-import
 description: Preview and verify imported content in local AEM Edge Delivery Services dev server. Validates rendering, compares with original page, and troubleshoots common issues.
+license: Apache-2.0
 ---
 
 # Preview Import

--- a/skills/aem/edge-delivery-services/skills/scrape-webpage/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/scrape-webpage/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: scrape-webpage
 description: Scrape webpage content, extract metadata, download images, and prepare for import/migration to AEM Edge Delivery Services. Returns analysis JSON with paths, metadata, cleaned HTML, and local images.
+license: Apache-2.0
 ---
 
 # Scrape Webpage

--- a/skills/aem/edge-delivery-services/skills/testing-blocks/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/testing-blocks/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: testing-blocks
 description: Guide for testing code changes in AEM Edge Delivery projects including blocks, scripts, and styles. Use this skill after making code changes and before opening a pull request to validate functionality. Covers unit testing for utilities and logic, browser testing with Playwright, linting, and guidance on what to test and how
+license: Apache-2.0
 ---
 
 # Testing Blocks

--- a/skills/aem/project-management/skills/admin/SKILL.md
+++ b/skills/aem/project-management/skills/admin/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: admin
 description: Generate comprehensive admin documentation for AEM Edge Delivery Services project handover. Creates admin guide covering Config Service setup, permissions, access control, Admin API operations, cache management, and code sync. Use for "admin guide", "admin documentation", "admin handover".
+license: Apache-2.0
 allowed-tools: Read, Write, Edit, Bash, AskUserQuestion, Skill
 ---
 

--- a/skills/aem/project-management/skills/auth/SKILL.md
+++ b/skills/aem/project-management/skills/auth/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth
 description: Authenticate with AEM Edge Delivery Services Config Service API. Opens a browser window for Adobe ID login and captures the auth token when browser is closed. Use when generating guides/documentation that require API access.
+license: Apache-2.0
 allowed-tools: Read, Write, Edit, Bash, AskUserQuestion
 ---
 

--- a/skills/aem/project-management/skills/authoring/SKILL.md
+++ b/skills/aem/project-management/skills/authoring/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: authoring
 description: Generate comprehensive documentation for content authors taking over an AEM Edge Delivery Services project. Analyzes the project structure and produces a complete authoring guide with blocks, templates, configurations, and publishing workflows.
+license: Apache-2.0
 allowed-tools: Read, Write, Edit, Bash, Skill, Glob, Grep
 ---
 

--- a/skills/aem/project-management/skills/development/SKILL.md
+++ b/skills/aem/project-management/skills/development/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: development
 description: Generate comprehensive technical documentation for developers taking over an AEM Edge Delivery Services project. Analyzes codebase structure, custom implementations, design tokens, and produces a complete developer guide.
+license: Apache-2.0
 allowed-tools: Read, Write, Edit, Bash, Skill, Glob, Grep
 ---
 

--- a/skills/aem/project-management/skills/handover/SKILL.md
+++ b/skills/aem/project-management/skills/handover/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: handover
 description: Generate project handover documentation for AEM Edge Delivery Services projects. Creates comprehensive guides for content authors, developers, and administrators. Use for "handover docs", "project documentation", "generate handover", "create guides".
+license: Apache-2.0
 allowed-tools: Read, Write, Edit, Bash, AskUserQuestion, Skill, Agent
 ---
 

--- a/skills/aem/project-management/skills/whitepaper/SKILL.md
+++ b/skills/aem/project-management/skills/whitepaper/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: whitepaper
 description: Creates professional PDF whitepapers from Markdown files. Use when the user wants to create a whitepaper, technical document, or PDF with professional formatting and typography.
+license: Apache-2.0
 allowed-tools: Read, Write, Edit, Bash
 metadata:
   argument-hint: "[input.md] [output.pdf]"


### PR DESCRIPTION
## Summary

Adds a CI check requiring every SKILL.md to have a \ field in its YAML frontmatter, and adds \ to all 23 existing skills.

### Changes

1. **New \ CI job** in \
   - Finds all SKILL.md files under \
   - Parses YAML frontmatter and checks for \ field
   - Fails with clear error listing any files missing the field
   - Writes a GitHub Step Summary table showing pass/fail per skill

2. **Added \** to all 23 SKILL.md frontmatter blocks
   - Matches the repo-level LICENSE file (Apache-2.0)
   - Inserted after the \ field in each frontmatter

### Why

Neither \ nor \ enforce the presence of a license field. Per the [Agent Skills spec](https://agentskills.io/specification#license-field), \ is optional but recommended. This repo requires it for all contributed skills.

### Verification

- \
> @anthropic-ai/skills@0.1.0 validate
> find skills -name SKILL.md -exec dirname {} \; | xargs -I {} skills-ref validate {}

Valid skill: skills/aem/edge-delivery-services/skills/generate-import-html
Valid skill: skills/aem/edge-delivery-services/skills/identify-page-structure
Valid skill: skills/aem/edge-delivery-services/skills/find-test-content
Valid skill: skills/aem/edge-delivery-services/skills/analyze-and-plan
Valid skill: skills/aem/edge-delivery-services/skills/code-review
Valid skill: skills/aem/edge-delivery-services/skills/page-decomposition
Valid skill: skills/aem/edge-delivery-services/skills/block-collection-and-party
Valid skill: skills/aem/edge-delivery-services/skills/content-driven-development
Valid skill: skills/aem/edge-delivery-services/skills/authoring-analysis
Valid skill: skills/aem/edge-delivery-services/skills/page-import
Valid skill: skills/aem/edge-delivery-services/skills/block-inventory
Valid skill: skills/aem/edge-delivery-services/skills/docs-search
Valid skill: skills/aem/edge-delivery-services/skills/scrape-webpage
Valid skill: skills/aem/edge-delivery-services/skills/testing-blocks
Valid skill: skills/aem/edge-delivery-services/skills/preview-import
Valid skill: skills/aem/edge-delivery-services/skills/content-modeling
Valid skill: skills/aem/edge-delivery-services/skills/building-blocks
Valid skill: skills/aem/project-management/skills/auth
Valid skill: skills/aem/project-management/skills/development
Valid skill: skills/aem/project-management/skills/handover
Valid skill: skills/aem/project-management/skills/admin
Valid skill: skills/aem/project-management/skills/whitepaper
Valid skill: skills/aem/project-management/skills/authoring passes for all 23 skills
- Zero SKILL.md files missing license field
- Existing \ and \ jobs unchanged