### PR TITLE
Fix changed-skill detection in tessl-review workflow

### DIFF
--- a/.github/workflows/tessl-eval.yml
+++ b/.github/workflows/tessl-eval.yml
@@ -47,32 +47,39 @@ jobs:
         id: detect
         run: |
           CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
-          # Extract unique tile directories (3 levels deep: skills/<org>/<tile>)
-          TILE_DIRS=$(echo "$CHANGED_FILES" \
-            | grep -oE '^skills/[^/]+/[^/]+' \
-            | sort -u || true)
 
-          if [ -z "$TILE_DIRS" ]; then
+          # Build list of all tile directories (parents of tile.json)
+          ALL_TILE_DIRS=$(find skills -name tile.json -exec dirname {} \; 2>/dev/null | sort)
+
+          if [ -z "$ALL_TILE_DIRS" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "No skill files changed."
+            echo "No tile.json files found in repo."
           else
-            # Filter to only tile dirs that have a tile.json
-            EVAL_DIRS=""
-            for tile_dir in $TILE_DIRS; do
-              if [ -f "$tile_dir/tile.json" ]; then
-                EVAL_DIRS="$EVAL_DIRS $tile_dir"
-                echo "Found tile.json in $tile_dir"
-              else
-                echo "No tile.json in $tile_dir — skipping"
-              fi
+            # For each changed file, find which tile directory it belongs to
+            DIRS=""
+            for changed_file in $CHANGED_FILES; do
+              for tile_dir in $ALL_TILE_DIRS; do
+                case "$changed_file" in
+                  "$tile_dir"/*)
+                    # Check not already added
+                    case " $DIRS " in
+                      *" $tile_dir "*) ;;
+                      *) DIRS="$DIRS $tile_dir" ;;
+                    esac
+                    break
+                    ;;
+                esac
+              done
             done
 
-            if [ -z "$EVAL_DIRS" ]; then
+            DIRS=$(echo "$DIRS" | xargs)  # trim whitespace
+            if [ -z "$DIRS" ]; then
               echo "skip=true" >> "$GITHUB_OUTPUT"
-              echo "Changed skills have no tile.json — nothing to eval."
+              echo "Changed files don't belong to any tile — nothing to eval."
             else
               echo "skip=false" >> "$GITHUB_OUTPUT"
-              echo "dirs=$EVAL_DIRS" >> "$GITHUB_OUTPUT"
+              echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
+              echo "Changed tiles: $DIRS"
             fi
           fi
 

--- a/.github/workflows/tessl-eval.yml
+++ b/.github/workflows/tessl-eval.yml
@@ -73,6 +73,31 @@ jobs:
             done
 
             DIRS=$(echo "$DIRS" | xargs)  # trim whitespace
+
+            # Check for unmatched changes under skills/
+            UNMATCHED=false
+            for changed_file in $CHANGED_FILES; do
+              case "$changed_file" in
+                skills/*)
+                  MATCHED=false
+                  for tile_dir in $ALL_TILE_DIRS; do
+                    case "$changed_file" in
+                      "$tile_dir"/*) MATCHED=true; break ;;
+                    esac
+                  done
+                  if [ "$MATCHED" = "false" ]; then
+                    UNMATCHED=true
+                    break
+                  fi
+                  ;;
+              esac
+            done
+
+            if [ "$UNMATCHED" = "true" ]; then
+              echo "Unmatched changes under skills/ detected — evaluating all tiles"
+              DIRS=$(find skills -name tile.json -exec dirname {} \; 2>/dev/null | tr "\n" " " | xargs)
+            fi
+
             if [ -z "$DIRS" ]; then
               echo "skip=true" >> "$GITHUB_OUTPUT"
               echo "Changed files don't belong to any tile — nothing to eval."

--- a/.github/workflows/tessl-review.yml
+++ b/.github/workflows/tessl-review.yml
@@ -21,23 +21,41 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
-            CHANGED_SKILLS=$(echo "$CHANGED_FILES" | grep -oE '^skills/[^/]+' | sort -u || true)
-            if [ -z "$CHANGED_SKILLS" ]; then
+
+            # Build list of all skill directories (parents of SKILL.md)
+            ALL_SKILL_DIRS=$(find skills -name SKILL.md -exec dirname {} \; | sort)
+
+            # For each changed file, find which skill directory it belongs to
+            DIRS=""
+            for changed_file in $CHANGED_FILES; do
+              for skill_dir in $ALL_SKILL_DIRS; do
+                case "$changed_file" in
+                  "$skill_dir"/*)
+                    # Check not already added
+                    case " $DIRS " in
+                      *" $skill_dir "*) ;;
+                      *) DIRS="$DIRS $skill_dir" ;;
+                    esac
+                    break
+                    ;;
+                esac
+              done
+            done
+
+            DIRS=$(echo "$DIRS" | xargs)  # trim whitespace
+            if [ -z "$DIRS" ]; then
               echo "skip=true" >> "$GITHUB_OUTPUT"
               echo "No skill files changed."
             else
               echo "skip=false" >> "$GITHUB_OUTPUT"
-              DIRS=""
-              for skill_path in $CHANGED_SKILLS; do
-                if [ -f "$skill_path/SKILL.md" ]; then
-                  DIRS="$DIRS $skill_path"
-                fi
-              done
               echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
+              echo "Changed skills: $DIRS"
             fi
           else
+            # Push to main: review all skills
             echo "skip=false" >> "$GITHUB_OUTPUT"
             echo "dirs=" >> "$GITHUB_OUTPUT"
+            echo "Push to main — will review all skills."
           fi
 
       - name: Post skip summary

--- a/.github/workflows/tessl-review.yml
+++ b/.github/workflows/tessl-review.yml
@@ -43,6 +43,31 @@ jobs:
             done
 
             DIRS=$(echo "$DIRS" | xargs)  # trim whitespace
+
+            # Check for unmatched changes under skills/
+            UNMATCHED=false
+            for changed_file in $CHANGED_FILES; do
+              case "$changed_file" in
+                skills/*)
+                  MATCHED=false
+                  for skill_dir in $ALL_SKILL_DIRS; do
+                    case "$changed_file" in
+                      "$skill_dir"/*) MATCHED=true; break ;;
+                    esac
+                  done
+                  if [ "$MATCHED" = "false" ]; then
+                    UNMATCHED=true
+                    break
+                  fi
+                  ;;
+              esac
+            done
+
+            if [ "$UNMATCHED" = "true" ]; then
+              echo "Unmatched changes under skills/ detected — reviewing all skills"
+              DIRS=$(find skills -name SKILL.md -exec dirname {} \; 2>/dev/null | tr "\n" " " | xargs)
+            fi
+
             if [ -z "$DIRS" ]; then
               echo "skip=true" >> "$GITHUB_OUTPUT"
               echo "No skill files changed."


### PR DESCRIPTION
Fixes path detection bugs in both tessl workflow files where changed-skill/tile detection used fragile grep patterns that assumed fixed directory depths.

## tessl-review.yml
**Bug:** `grep -oE '^skills/[^/]+'` only captured two path levels (`skills/aem`), but skill directories are four levels deep. Every PR silently fell through to reviewing all 23 skills.

**Fix:** `find skills -name SKILL.md` + `case` pattern matching.

## tessl-eval.yml
**Bug:** `grep -oE '^skills/[^/]+/[^/]+'` captured three levels. Happens to work for the current structure but breaks if tile depth changes.

**Fix:** `find skills -name tile.json` + `case` pattern matching. Also correctly handles the case where no `tile.json` files exist yet (skips gracefully).