### PR TITLE
fix: correct GitHub usernames in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,19 +8,19 @@
 *                                                     @trieloff
 
 # CI/CD and GitHub workflows
-/.github/                                             @trieloff @ssteimer
+/.github/                                             @trieloff @shsteimer
 
 # Claude plugin marketplace config
-/.claude-plugin/                                      @ssteimer @trieloff
+/.claude-plugin/                                      @shsteimer @trieloff
 
 # AEM Edge Delivery Services (Sean Steimer is primary author of all skills)
-/skills/aem/edge-delivery-services/                   @ssteimer
+/skills/aem/edge-delivery-services/                   @shsteimer
 
 # AEM Project Management (Astha Bhargava is sole author)
-/skills/aem/project-management/                       @asthabhargava
+/skills/aem/project-management/                       @AsthaBhargava
 
-# AEM Cloud Service (in-flight, contributors: abhigarg, pkumargaddam, Himanich, akankshajain18, rombert)
-/skills/aem/cloud-service/                            @abhigarg @pkumargaddam @Himanich @akankshajain18 @rombert
+# AEM Cloud Service (in-flight, contributors: abhishekgarg18, pkumargaddam, Himanich, akankshajain18, rombert)
+/skills/aem/cloud-service/                            @abhishekgarg18 @pkumargaddam @Himanich @akankshajain18 @rombert
 
-# AEM 6.5 LTS (in-flight, contributors: abhigarg, akankshajain18, rombert)
-/skills/aem/6.5-lts/                                  @abhigarg @akankshajain18 @rombert
+# AEM 6.5 LTS (in-flight, contributors: abhishekgarg18, akankshajain18, rombert)
+/skills/aem/6.5-lts/                                  @abhishekgarg18 @akankshajain18 @rombert


### PR DESCRIPTION
## Summary

Fixes incorrect GitHub usernames in CODEOWNERS that prevented automatic review requests (e.g. PR #56 didn't request Sean's review).

## Changes

| Old (wrong) | New (correct) | Affected rules |
|---|---|---|
| `@ssteimer` | `@shsteimer` | `.github/`, `.claude-plugin/`, `edge-delivery-services/` |
| `@asthabhargava` | `@AsthaBhargava` | `project-management/` |
| `@abhigarg` | `@abhishekgarg18` | `cloud-service/`, `6.5-lts/` |

Fixes #56 not requesting @shsteimer's review.
