### PR TITLE
Post eval results URL as PR comment

### DIFF
--- a/.github/workflows/tessl-eval.yml
+++ b/.github/workflows/tessl-eval.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   tessl-eval:
     runs-on: ubuntu-latest
@@ -123,6 +127,7 @@ jobs:
           token: ${{ secrets.TESSL_TOKEN }}
 
       - name: Run evals
+        id: run-evals
         if: steps.trigger.outputs.skip != 'true' && steps.detect.outputs.skip != 'true'
         run: |
           PASS=0
@@ -131,7 +136,8 @@ jobs:
           ERRORS_FILE=$(mktemp)
           STDOUT_TMP=$(mktemp)
           STDERR_TMP=$(mktemp)
-          trap 'rm -f "$SUMMARY_FILE" "$ERRORS_FILE" "$STDOUT_TMP" "$STDERR_TMP"' EXIT
+          EVAL_URLS_FILE=$(mktemp)
+          trap 'rm -f "$SUMMARY_FILE" "$ERRORS_FILE" "$STDOUT_TMP" "$STDERR_TMP" "$EVAL_URLS_FILE"' EXIT
 
           POLL_INTERVAL=30
           TIMEOUT=900
@@ -164,6 +170,7 @@ jobs:
             fi
 
             echo "Eval run started for $TILE_NAME with run ID: $RUN_ID"
+            echo "- **$TILE_NAME**: [View results](https://tessl.io/eval-runs/$RUN_ID)" >> "$EVAL_URLS_FILE"
 
             # Poll for completion
             ELAPSED=0
@@ -248,8 +255,32 @@ jobs:
           fi
           echo "============================="
 
+          # Export eval URLs for PR comment step
+          if [ -s "$EVAL_URLS_FILE" ]; then
+            echo "has_results=true" >> "$GITHUB_OUTPUT"
+            {
+              echo 'eval_urls<<EVAL_URLS_EOF'
+              cat "$EVAL_URLS_FILE"
+              echo 'EVAL_URLS_EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "has_results=false" >> "$GITHUB_OUTPUT"
+          fi
+
           if [ "$FAIL" -gt 0 ]; then
             echo "::error::$FAIL tile(s) failed evaluation"
             exit 1
           fi
+
+      - name: Comment eval results on PR
+        if: always() && github.event_name == 'pull_request' && steps.run-evals.outputs.has_results == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          COMMENT="## Tessl Eval Results"
+          COMMENT="$COMMENT"$'\n\n'
+          COMMENT="$COMMENT${{ steps.run-evals.outputs.eval_urls }}"
+          COMMENT="$COMMENT"$'\n\n'
+          COMMENT="${COMMENT}_Triggered by commit $(git log -1 --format=%s)_"
+          gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT"
 

--- a/.github/workflows/tessl-eval.yml
+++ b/.github/workflows/tessl-eval.yml
@@ -276,10 +276,11 @@ jobs:
         if: always() && github.event_name == 'pull_request' && steps.run-evals.outputs.has_results == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          EVAL_URLS: ${{ steps.run-evals.outputs.eval_urls }}
         run: |
           COMMENT="## Tessl Eval Results"
           COMMENT="$COMMENT"$'\n\n'
-          COMMENT="$COMMENT${{ steps.run-evals.outputs.eval_urls }}"
+          COMMENT="$COMMENT$EVAL_URLS"
           COMMENT="$COMMENT"$'\n\n'
           COMMENT="${COMMENT}_Triggered by commit $(git log -1 --format=%s)_"
           gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT"


### PR DESCRIPTION
After the eval workflow completes, posts a PR comment with clickable links to tessl.io eval run results for each evaluated tile.

## Changes
- Added `permissions: pull-requests: write` to the workflow
- Added `id: run-evals` to the eval step and collect eval URLs into a temp file
- Export eval URLs as step output using heredoc syntax
- Added new "Comment eval results on PR" step that uses `gh pr comment` to post results
- Comment step runs with `always()` so it posts even when some evals fail
- No comment posted if no evals ran (`has_results` guard)
