### PR TITLE
feat(create-site): add create-site onboarding skill for AEM EDS

### DIFF
--- a/skills/aem/edge-delivery-services/evals/create-site-onboarding/criteria.json
+++ b/skills/aem/edge-delivery-services/evals/create-site-onboarding/criteria.json
@@ -1,0 +1,56 @@
+{
+  "context": "Tests whether the agent correctly executes the full AEM EDS site creation flow: collecting inputs, creating the GitHub repo from the boilerplate template, handling the aem-code-sync human handoff with verification, authenticating with DA using a cache-first approach, creating nav/footer/index content via DA API, and triggering preview with the required Bearer auth. Covers the non-obvious DA-specific behaviours that trip up agents without this skill.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Inputs collected before any API call",
+      "max_score": 5,
+      "description": "Agent collects GitHub org, repo name, and site name from the user before attempting any automated step"
+    },
+    {
+      "name": "GitHub repo created from aem-boilerplate template",
+      "max_score": 12,
+      "description": "Agent uses gh CLI or GitHub API to create the repo specifically from the adobe/aem-boilerplate template, not a blank repo"
+    },
+    {
+      "name": "aem-code-sync handoff correctly signalled",
+      "max_score": 12,
+      "description": "Agent provides the GitHub App installation URL, instructs the user to select only the new repo, and explicitly waits for user confirmation before continuing"
+    },
+    {
+      "name": "aem-code-sync installation verified programmatically",
+      "max_score": 8,
+      "description": "After user confirmation, agent checks admin.hlx.page/status/{org}/{repo}/main/ returns a valid JSON response before proceeding to DA steps"
+    },
+    {
+      "name": "DA auth uses cache-first approach",
+      "max_score": 10,
+      "description": "Agent checks ~/.aem/da-token.json for a valid cached token and its expiry before attempting a new OAuth flow or asking the user for a token"
+    },
+    {
+      "name": "All three mandatory pages created in DA",
+      "max_score": 15,
+      "description": "Agent creates nav.html, footer.html, and index.html in DA (admin.da.live/source/{org}/{repo}/) with structurally correct HTML and the site name substituted"
+    },
+    {
+      "name": "DA API calls use temp files, not inline multiline content",
+      "max_score": 8,
+      "description": "Agent writes HTML to temp files and uses the @ syntax for the curl -F flag rather than passing multiline content inline (inline multiline causes curl exit 26)"
+    },
+    {
+      "name": "Preview requests include Bearer auth",
+      "max_score": 15,
+      "description": "Agent sends POST requests to admin.hlx.page/preview for nav, footer, and index — all with an Authorization: Bearer header. DA-sourced content returns 401 without it even on public repos."
+    },
+    {
+      "name": "Complete hand-off delivered",
+      "max_score": 10,
+      "description": "Agent provides the preview URL (https://main--{repo}--{org}.aem.page/), DA content browser link, individual page edit links, and GitHub repo URL"
+    },
+    {
+      "name": "Human handoff points clearly distinguished from automated steps",
+      "max_score": 5,
+      "description": "Agent clearly labels which steps require human action versus which it executes automatically, and does not proceed past handoff points without confirmation"
+    }
+  ]
+}

--- a/skills/aem/edge-delivery-services/evals/create-site-onboarding/task.md
+++ b/skills/aem/edge-delivery-services/evals/create-site-onboarding/task.md
@@ -1,0 +1,9 @@
+# Create a New AEM Edge Delivery Site
+
+## Problem/Feature Description
+
+A developer wants to create a brand-new AEM Edge Delivery Services site. They have a GitHub account under the organization `acme-org` and want the repository to be named `acme-site`, with a site display name of "Acme Site". They have an Adobe IMS account with access to DA (da.live).
+
+## Output Specification
+
+Walk through the complete site creation flow using the create-site skill. Execute each automated step directly — do not stop to explain what you would do. Clearly signal the two steps that require human action (aem-code-sync installation and DA authentication if no cached token is available), and wait for confirmation before continuing past each. Deliver a live preview URL and DA editing links at the end.

--- a/skills/aem/edge-delivery-services/skills/create-site/.releaserc.json
+++ b/skills/aem/edge-delivery-services/skills/create-site/.releaserc.json
@@ -1,0 +1,1 @@
+{"extends": "../../../../../release.config.cjs"}

--- a/skills/aem/edge-delivery-services/skills/create-site/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/create-site/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-site
-description: Zero-knowledge onboarding skill for AEM Edge Delivery Services. Creates a new GitHub repo from the boilerplate, sets up aem-code-sync, creates initial content in DA (Document Authoring), and delivers a live preview URL. Use this skill whenever a user wants to create a new AEM Edge Delivery site from scratch.
+description: Creates a new AEM Edge Delivery site from scratch — GitHub repo from the boilerplate, aem-code-sync installation, initial DA content (nav, footer, homepage), and a live preview URL. Use this skill whenever a user wants to create a new AEM Edge Delivery site and no repository or DA content exists yet.
 license: Apache-2.0
 metadata:
   version: "1.0.0"
@@ -26,7 +26,7 @@ Use this skill when:
 - A GitHub account with permission to create repositories in the target org
 - An Adobe IMS account with access to DA (da.live)
 - `gh` CLI authenticated (`gh auth status`) or a GitHub personal access token with `repo` scope
-- Node.js 18+ (for DA token management)
+- Node.js (for DA token management via da-auth-helper)
 
 ## Related Skills
 
@@ -38,7 +38,7 @@ Use this skill when:
 
 ## Step 0: Create TodoList
 
-Use the TodoWrite tool to create a todo list:
+Create a checklist to track progress (use your agent's task-tracking tool if available):
 
 1. **Gather inputs** — org, repo name, site name collected
 2. **Create GitHub repository** — repo created from boilerplate template

--- a/skills/aem/edge-delivery-services/skills/create-site/SKILL.md
+++ b/skills/aem/edge-delivery-services/skills/create-site/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: create-site
+description: Zero-knowledge onboarding skill for AEM Edge Delivery Services. Creates a new GitHub repo from the boilerplate, sets up aem-code-sync, creates initial content in DA (Document Authoring), and delivers a live preview URL. Use this skill whenever a user wants to create a new AEM Edge Delivery site from scratch.
+license: Apache-2.0
+metadata:
+  version: "1.0.0"
+---
+
+# Create a New AEM Edge Delivery Site
+
+This skill walks through the full onboarding flow for a new AEM Edge Delivery site. It handles everything that can be automated and clearly signals the steps that require human action.
+
+## When to Use This Skill
+
+Use this skill when:
+- A user wants to create a brand-new AEM Edge Delivery site from scratch
+- A user asks to "set up a new site", "create a new EDS project", or "onboard a new site"
+- No GitHub repository or DA content exists yet for the project
+
+**Do NOT use this skill for:**
+- Importing or migrating existing pages (use **page-import** skill)
+- Building or modifying blocks on an existing site (use **content-driven-development** skill)
+
+## Prerequisites
+
+- A GitHub account with permission to create repositories in the target org
+- An Adobe IMS account with access to DA (da.live)
+- `gh` CLI authenticated (`gh auth status`) or a GitHub personal access token with `repo` scope
+- Node.js 18+ (for DA token management)
+
+## Related Skills
+
+- **page-import** — Import existing pages into the newly created site
+- **content-driven-development** — Build and modify blocks once the site exists
+- **building-blocks** — Implement new block code
+
+---
+
+## Step 0: Create TodoList
+
+Use the TodoWrite tool to create a todo list:
+
+1. **Gather inputs** — org, repo name, site name collected
+2. **Create GitHub repository** — repo created from boilerplate template
+3. **Install aem-code-sync** *(human action)* — GitHub App installed on repo
+4. **Authenticate with DA** — valid IMS token obtained
+5. **Create initial content in DA** — nav, footer, index created
+6. **Trigger preview** — all three paths return 200/201
+7. **Hand off** — preview URL and DA links delivered to user
+
+---
+
+## Step 1: Gather Inputs
+
+Ask the user for the following. Do not proceed until all required inputs are provided.
+
+1. **GitHub org** — the GitHub organization or username where the repo will be created (e.g. `my-org`)
+2. **Project name** — the repository name, lowercase, hyphens only (e.g. `my-site`)
+3. **Site name** — the human-readable name used in content (e.g. `My Site`). If not provided, derive it from the project name.
+
+Store as: `{{ORG}}`, `{{REPO}}`, `{{SITE_NAME}}`
+
+---
+
+## Step 2: Create GitHub Repository
+
+Create a new repository using the `adobe/aem-boilerplate` template.
+
+**Option A — GitHub CLI (preferred, handles auth automatically):**
+```bash
+gh repo create {{ORG}}/{{REPO}} \
+  --template adobe/aem-boilerplate \
+  --description "{{SITE_NAME}} — AEM Edge Delivery site" \
+  --public
+```
+
+Check if `gh` is available with `gh auth status`. If not authenticated, run `gh auth login` first.
+
+**Option B — GitHub API (if `gh` CLI is not available):**
+```
+POST https://api.github.com/repos/adobe/aem-boilerplate/generate
+Authorization: Bearer {{GITHUB_TOKEN}}
+Content-Type: application/json
+
+{
+  "owner": "{{ORG}}",
+  "name": "{{REPO}}",
+  "description": "{{SITE_NAME}} — AEM Edge Delivery site",
+  "private": false,
+  "include_all_branches": false
+}
+```
+
+To obtain a token: https://github.com/settings/tokens/new — scope: `repo`.
+
+**Success:** HTTP 201 (API) or exit code 0 (CLI). The repo is now live at `https://github.com/{{ORG}}/{{REPO}}`.
+
+---
+
+## Step 3: Install aem-code-sync *(human action required)*
+
+The aem-code-sync GitHub App connects the repository to AEM's content delivery pipeline. This step cannot be automated — the user must complete it in the browser.
+
+Tell the user:
+
+> **Action required:** Install the AEM Code Sync app on your new repository.
+>
+> 1. Open this URL: https://github.com/apps/aem-code-sync/installations/new
+> 2. Under "Repository access", select **Only select repositories**
+> 3. Choose **{{ORG}}/{{REPO}}** from the list
+> 4. Click **Save**
+>
+> Reply "done" when complete.
+
+Wait for confirmation before proceeding.
+
+**Verify:** After confirmation, check that `https://admin.hlx.page/status/{{ORG}}/{{REPO}}/main/` returns a valid JSON response (not 404). If it does, the app is correctly installed.
+
+---
+
+## Step 4: Authenticate with DA
+
+DA requires Adobe IMS authentication. Choose the appropriate path:
+
+**Option A — da-auth-helper (preferred)**
+
+`da-auth-helper` (https://github.com/adobe-rnd/da-auth-helper) caches IMS tokens at `~/.aem/da-token.json`. Always check the cache first before triggering a new OAuth flow.
+
+1. Check for a valid cached token:
+```bash
+node -e "
+  const fs = require('fs');
+  const p = process.env.HOME + '/.aem/da-token.json';
+  if (!fs.existsSync(p)) { console.log('No cache'); process.exit(1); }
+  const t = JSON.parse(fs.readFileSync(p));
+  console.log('Valid:', t.expires_at > Date.now());
+  console.log('Expires:', new Date(t.expires_at).toISOString());
+"
+```
+
+2. If valid, capture the token and skip to Step 5:
+```bash
+DA_TOKEN=$(node -e "const t = require(process.env.HOME + '/.aem/da-token.json'); process.stdout.write(t.access_token);")
+```
+
+3. If missing or expired, install da-auth-helper from GitHub (it is not published to npm) and refresh:
+```bash
+npm install -g github:adobe-rnd/da-auth-helper
+da-auth-helper token
+```
+This opens a browser for Adobe IMS login and writes the new token to `~/.aem/da-token.json`. Then capture it as in step 2.
+
+**Option B — DA MCP is configured**
+
+If the DA MCP server is available, trigger the authentication tool to start the OAuth flow and share the authorization URL with the user.
+
+**Option C — Manual token**
+
+Ask the user to obtain an IMS token from their browser (e.g. from the DA network tab or an existing session) and paste it. Store as `{{DA_TOKEN}}`.
+
+---
+
+## Step 5: Create Initial Content in DA
+
+Create the three mandatory pages every EDS site requires. Use the templates below exactly — they are pre-validated for EDS compliance.
+
+**Option A — DA MCP:**
+Call the DA create source tool three times with the content below.
+
+**Option B — DA API:**
+
+Write each file to a temp file first, then POST using `@` syntax. Inline multiline content with `-F 'data=...'` causes curl to fail (exit 26). Use `/usr/bin/curl` explicitly to avoid PATH resolution issues in subshells.
+
+```bash
+cat > /tmp/nav.html << 'EOF'
+<nav content>
+EOF
+/usr/bin/curl -s -o /dev/null -w "%{http_code}" -X POST "https://admin.da.live/source/{{ORG}}/{{REPO}}/nav.html" \
+  -H "Authorization: Bearer {{DA_TOKEN}}" \
+  -F "data=@/tmp/nav.html;type=text/html"
+```
+
+Repeat for `footer.html` and `index.html`.
+
+**Verify:** After each POST, expect HTTP 201. If you get 401, the token has expired — return to Step 4.
+
+---
+
+### nav.html
+
+```html
+<main>
+  <div>
+    <p><a href="/">{{SITE_NAME}}</a></p>
+  </div>
+  <div>
+    <ul>
+      <li><a href="/">Home</a></li>
+    </ul>
+  </div>
+  <div></div>
+</main>
+```
+
+### footer.html
+
+```html
+<main>
+  <div>
+    <p>© 2024 {{SITE_NAME}}. All rights reserved.</p>
+  </div>
+</main>
+```
+
+### index.html
+
+```html
+<main>
+  <div>
+    <h1>Welcome to {{SITE_NAME}}</h1>
+    <p>Your new site is ready. Start editing this page in DA.</p>
+  </div>
+</main>
+```
+
+---
+
+## Step 6: Trigger Preview
+
+Preview pulls the DA content into the AEM delivery pipeline and makes it accessible on the `.aem.page` domain.
+
+DA-sourced content requires the Bearer token on preview requests — even for public repos. Use `/usr/bin/curl` explicitly.
+
+```bash
+/usr/bin/curl -s -o /dev/null -w "%{http_code}" -X POST "https://admin.hlx.page/preview/{{ORG}}/{{REPO}}/main/nav" \
+  -H "Authorization: Bearer {{DA_TOKEN}}"
+/usr/bin/curl -s -o /dev/null -w "%{http_code}" -X POST "https://admin.hlx.page/preview/{{ORG}}/{{REPO}}/main/footer" \
+  -H "Authorization: Bearer {{DA_TOKEN}}"
+/usr/bin/curl -s -o /dev/null -w "%{http_code}" -X POST "https://admin.hlx.page/preview/{{ORG}}/{{REPO}}/main/" \
+  -H "Authorization: Bearer {{DA_TOKEN}}"
+```
+
+**Success:** HTTP 200 or 201 for each. The homepage is now live at:
+```
+https://main--{{REPO}}--{{ORG}}.aem.page/
+```
+
+---
+
+## Step 7: Confirm and Hand Off
+
+Tell the user:
+
+> **Your site is ready!**
+>
+> - **Preview:** `https://main--{{REPO}}--{{ORG}}.aem.page/`
+> - **Browse content in DA:** `https://da.live/#/{{ORG}}/{{REPO}}/`
+> - **Edit homepage:** `https://da.live/edit#/{{ORG}}/{{REPO}}/index`
+> - **Edit nav:** `https://da.live/edit#/{{ORG}}/{{REPO}}/nav`
+> - **Edit footer:** `https://da.live/edit#/{{ORG}}/{{REPO}}/footer`
+> - **GitHub repo:** `https://github.com/{{ORG}}/{{REPO}}`
+>
+> To start developing locally:
+> ```bash
+> git clone https://github.com/{{ORG}}/{{REPO}}.git
+> cd {{REPO}}
+> npm install
+> aem up
+> ```
+>
+> What would you like to do next — add more pages, customize a block, or set up a custom domain?
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Step 2 returns 422 | Repo name already exists | Ask user for a different name |
+| Step 3 verify returns 404 | aem-code-sync not installed | Re-send the installation URL |
+| Step 4 cached token missing/expired | No prior DA session on this machine | Install da-auth-helper from GitHub (`npm install -g github:adobe-rnd/da-auth-helper`) and run `da-auth-helper token` |
+| Step 5 curl exits with code 26 | Inline multiline content in `-F` flag | Write content to a temp file and use `@/tmp/file.html` syntax |
+| Step 5 returns 401 | Expired or missing IMS token | Re-check `~/.aem/da-token.json` expiry; ask user for a fresh token |
+| Step 5 returns 403 | Token lacks permission for this org/repo | Confirm the user has write access to `{{ORG}}/{{REPO}}` in DA |
+| Step 6 returns 401 | DA-sourced content requires auth on preview | Add `-H "Authorization: Bearer {{DA_TOKEN}}"` to preview requests |
+| Step 6 returns 404 | aem-code-sync not installed correctly | Verify Step 3, then retry |
+| `curl: command not found` in scripts | PATH not resolved in subshell | Use `/usr/bin/curl` explicitly |
+| Preview URL shows blank page | nav or index not previewed | Re-run Step 6 for the failing path |
+
+---
+
+## Reference
+
+- Boilerplate: https://github.com/adobe/aem-boilerplate
+- aem-code-sync app: https://github.com/apps/aem-code-sync
+- DA docs: https://da.live/docs
+- DA Admin API: https://opensource.adobe.com/da-admin/
+- DA Auth (IMS token helper): https://github.com/adobe-rnd/da-auth-helper
+- AEM Admin API: https://www.aem.live/docs/admin.html
+- Full onboarding guide: https://www.aem.live/developer/create-site.md
+
+### DA URL patterns
+
+- Browse folder: `https://da.live/#/{{org}}/{{repo}}{{folder-path}}`
+- Edit HTML document: `https://da.live/edit#/{{org}}/{{repo}}{{path-without-extension}}`
+- Edit JSON/sheet: `https://da.live/sheet#/{{org}}/{{repo}}{{path-without-extension}}`

--- a/skills/aem/edge-delivery-services/skills/create-site/package.json
+++ b/skills/aem/edge-delivery-services/skills/create-site/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "create-site",
+  "version": "0.0.0-semantically-released",
+  "private": true
+}

--- a/skills/aem/edge-delivery-services/tile.json
+++ b/skills/aem/edge-delivery-services/tile.json
@@ -1,10 +1,11 @@
 {
   "name": "adobe/aem-edge-delivery-services",
   "version": "0.1.0",
-  "summary": "Skills for building AEM Edge Delivery Services sites — block development, content modeling, code review, testing, and page import.",
+  "summary": "Skills for building AEM Edge Delivery Services sites — site creation, block development, content modeling, code review, testing, and page import.",
   "private": false,
   "skills": {
     "analyze-and-plan": { "path": "skills/analyze-and-plan/SKILL.md" },
+    "create-site": { "path": "skills/create-site/SKILL.md" },
     "authoring-analysis": { "path": "skills/authoring-analysis/SKILL.md" },
     "block-collection-and-party": { "path": "skills/block-collection-and-party/SKILL.md" },
     "block-inventory": { "path": "skills/block-inventory/SKILL.md" },


### PR DESCRIPTION
## What this PR does

Adds a new `create-site` skill that automates the full zero-to-site onboarding flow for AEM Edge Delivery Services — from nothing to a live `.aem.page` preview URL.

## Steps covered

1. Gather inputs (GitHub org, repo name, site name)
2. Create GitHub repo from `adobe/aem-boilerplate` template via `gh` CLI or GitHub API
3. Install aem-code-sync GitHub App *(human action + automated verification)*
4. Authenticate with DA via cached token, `da-auth-helper`, DA MCP, or manual token
5. Create initial content in DA (nav, footer, index) via DA MCP or DA Admin API
6. Trigger preview via `admin.hlx.page` for all three paths
7. Hand off with live URLs and DA editing links

## Learnings from a real end-to-end run

This skill was validated against a live site creation and updated with fixes for issues discovered during execution:

- **`da-auth-helper` is not on npm** — must be installed from GitHub (`npm install -g github:adobe-rnd/da-auth-helper`); the tool caches tokens at `~/.aem/da-token.json` which should be checked first
- **DA-sourced content requires Bearer auth on preview requests** — even for public repos, `admin.hlx.page/preview` returns 401 without a token when content comes from DA
- **curl inline multiline content fails** — `-F 'data=...'` with multiline strings causes exit code 26; temp files + `@/tmp/file.html` syntax is required
- **`/usr/bin/curl` needed explicitly** — bare `curl` can fail with "command not found" in subshells on macOS

## Validation

```
npm run validate
# → Valid skill: skills/aem/edge-delivery-services/skills/create-site ✅
```

## Related skills

This skill fills a gap not covered by existing skills. Once the site exists, users continue with `content-driven-development`, `building-blocks`, or `page-import`.

> **Note:** Please apply the `ai-generated` label per CONTRIBUTING.md — it cannot be set from a fork PR.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)