### PR TITLE
docs: add beta skill convention to cloud-service and 6.5-lts CLAUDE.md

### DIFF
--- a/skills/aem/6.5-lts/CLAUDE.md
+++ b/skills/aem/6.5-lts/CLAUDE.md
@@ -1,0 +1,21 @@
+# Conventions for this skill tree
+
+## Beta skills
+
+Skills that are not yet production-ready are marked with beta status using three mechanisms.
+All three must be applied together. To check whether a skill is beta, look for `status: beta`
+in its SKILL.md frontmatter.
+
+1. **Frontmatter `status: beta`** -- machine-readable field for tooling
+2. **`[BETA]` prefix in `description`** -- visible to the LLM during skill selection,
+   followed by a caveat line: "This skill is in beta. Verify all outputs before
+   applying them to production projects."
+3. **Blockquote in body** -- visible to the LLM during skill execution:
+   ```
+   > **Beta Skill**: This skill is in beta and under active development.
+   > Results should be reviewed carefully before use in production.
+   > Report issues at https://github.com/adobe/skills/issues
+   ```
+
+When creating or modifying skills, preserve these markers. Do not remove beta
+status without explicit instruction.

--- a/skills/aem/cloud-service/CLAUDE.md
+++ b/skills/aem/cloud-service/CLAUDE.md
@@ -1,0 +1,21 @@
+# Conventions for this skill tree
+
+## Beta skills
+
+Skills that are not yet production-ready are marked with beta status using three mechanisms.
+All three must be applied together. To check whether a skill is beta, look for `status: beta`
+in its SKILL.md frontmatter.
+
+1. **Frontmatter `status: beta`** -- machine-readable field for tooling
+2. **`[BETA]` prefix in `description`** -- visible to the LLM during skill selection,
+   followed by a caveat line: "This skill is in beta. Verify all outputs before
+   applying them to production projects."
+3. **Blockquote in body** -- visible to the LLM during skill execution:
+   ```
+   > **Beta Skill**: This skill is in beta and under active development.
+   > Results should be reviewed carefully before use in production.
+   > Report issues at https://github.com/adobe/skills/issues
+   ```
+
+When creating or modifying skills, preserve these markers. Do not remove beta
+status without explicit instruction.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Document the three-mechanism convention for marking skills as beta (frontmatter status field, [BETA] description prefix, body blockquote) so coding agents working in these subtrees automatically pick it up.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Prepares migration of cloud-service and 6.5-lts skills to main while clearly marking which skills are ready for general usage and which ones are still in beta.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manual testing with prompt `Mark @skills/aem/cloud-service/...` as beta.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
