### PR TITLE
README update for AEM Project Management Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ gh upskill adobe/skills --all
 | `generate-import-html` | Generate structured HTML |
 | `preview-import` | Preview imported content |
 
+##### Managing Projects
+
+Handover documentation and PDF guides generation for AEM Edge Delivery Services projects. Available via the `aem-project-management` plugin.
+
+| Skill | Description |
+|-------|-------------|
+| `handover` | Orchestrates project documentation generation |
+| `authoring` | Generate comprehensive authoring guide for content authors |
+| `development` | Generate technical documentation for developers |
+| `admin` | Generate admin guide for site administrators |
+| `whitepaper` | Create professional PDF whitepapers from Markdown |
+| `auth` | Authenticate with AEM Config Service API |
+
 ### AEM as a Cloud Service — Create Component
 
 The `create-component` skill creates complete AEM components following Adobe best practices for AEM Cloud Service and AEM 6.5. It covers:
@@ -154,19 +167,6 @@ Under `plugins/aem/cloud-service/skills/`, **`best-practices/`** is the **genera
 **Key features:**
 - **Best practices:** one skill for patterns, SCR→OSGi DS, and resolver/logging — applicable to Cloud Service projects generally, not only migration
 - **Migration:** orchestration-only; pattern and transformation content lives in **`best-practices`**
-
-##### Managing Projects
-
-Handover documentation and PDF generation for AEM Edge Delivery Services projects.
-
-| Skill | Description |
-|-------|-------------|
-| `handover` | Orchestrates project documentation generation |
-| `authoring` | Generate comprehensive authoring guide for content authors |
-| `development` | Generate technical documentation for developers |
-| `admin` | Generate admin guide for site administrators |
-| `whitepaper` | Create professional PDF whitepapers from Markdown |
-| `auth` | Authenticate with AEM Config Service API |
 
 ### App Builder
 


### PR DESCRIPTION
Moved the Managing Projects section from its misplaced position into the correct location under AEM Edge Delivery Services, alongside the other Edge Delivery Services skill groups (Developing, Discovering Blocks, Migrating Content..)