### PR TITLE
migration(docs): batch BPA findings with paging and unified helper behavior

### DIFF
--- a/plugins/aem/cloud-service/skills/best-practices/references/asset-manager-create.md
+++ b/plugins/aem/cloud-service/skills/best-practices/references/asset-manager-create.md
@@ -1,14 +1,34 @@
-# Asset Manager Path A: Create/Upload → Direct Binary Access
+# Asset Manager Path A: Create / Upload
 
-For files using deprecated `createAsset()`, `createAssetForBinary()`, or `getAssetForBinary()`.
+For files using the `AssetManager` create / upload APIs.
 
-These deprecated APIs are replaced with **Direct Binary Access** via the `@adobe/aem-upload` SDK (client-side) or HTTP API (server-side).
+**Scope:**
+
+- `AssetManager.createAssetForBinary(binaryFilePath, doSave)` — **removed on AEMaaCS** → Direct Binary Access.
+- `AssetManager.getAssetForBinary(binaryFilePath)` — **removed on AEMaaCS** → path-based lookup via `resolver.getResource(...).adaptTo(Asset.class)`.
+- `AssetManager.createAsset(path, InputStream, mimeType, doSave)` — **still supported** for in-JVM use, but client-facing servlets that accept uploads must move to Direct Binary Access.
+
+---
+
+## When does `createAsset` need to change?
+
+| Caller | Keep `createAsset(path, is, mimeType, doSave)`? |
+|--------|--------------------------------------------------|
+| Client-facing servlet accepting `multipart` / `InputStream` from a browser or external caller | **No** — migrate to Direct Binary Access. |
+| Back-office utility creating small assets from a bundled resource or another already-in-JVM stream (fixtures, reports, migration imports) | **Yes, still supported.** Use a service-user resolver and close the stream. |
+| Scheduled asset ingestion pulling from an external source | **Prefer** Direct Binary Access through the HTTP API; the job acts as an external client. |
+
+When you keep `createAsset`, apply [resource-resolver-logging.md](resource-resolver-logging.md)
+and make sure the `InputStream` is closed in try-with-resources.
+
+`createAssetForBinary` and `getAssetForBinary` are always replaced — those APIs do not exist on
+AEMaaCS.
 
 ---
 
 ## Complete Example: Before and After
 
-### Before (Legacy AssetManager API)
+### Before (client-facing upload via `AssetManager.createAsset`)
 
 ```java
 package com.example.servlets;
@@ -34,11 +54,11 @@ public class CreateAssetServlet extends SlingAllMethodsServlet {
     @Override
     protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {
-        
+
         String assetPath = request.getParameter("path");
         String mimeType = request.getParameter("mimeType");
         InputStream inputStream = request.getInputStream();
-        
+
         try {
             Asset asset = assetManager.createAsset(assetPath, inputStream, mimeType, true);
             response.setContentType("text/plain");
@@ -53,11 +73,12 @@ public class CreateAssetServlet extends SlingAllMethodsServlet {
 }
 ```
 
-### After (Cloud Service Compatible - Client-Side Upload)
+### After — Cloud Service compatible (client-side Direct Binary Access)
 
-**Note:** In AEM Cloud Service, asset creation from InputStream in servlets is deprecated. Migrate to client-side upload using Direct Binary Access.
+On AEMaaCS the upload must happen **directly between the client and the binary store**; the AEM
+JVM orchestrates the upload but does not carry the bytes. Delete the servlet; replace it with a
+client-side upload:
 
-**Client-side JavaScript (replaces servlet):**
 ```javascript
 import DirectBinary from '@adobe/aem-upload';
 
@@ -65,33 +86,28 @@ async function uploadAsset(file, assetPath, host, token) {
     const upload = new DirectBinary.DirectBinaryUpload();
     const options = new DirectBinary.DirectBinaryUploadOptions()
         .withUrl(`${host}/api/assets${assetPath}`)
-        .withUploadFiles([file])
-        .withHttpOptions({ 
-            headers: { 
-                Authorization: `Bearer ${token}`,
-                'Content-Type': file.type
-            } 
+        .withUploadFiles([{ fileName: file.name, blob: file, fileSize: file.size }])
+        .withHttpOptions({
+            headers: {
+                Authorization: `Bearer ${token}`   // IMS / dev-console token — never a static password
+            }
         });
-    
-    try {
-        const result = await upload.uploadFiles(options);
-        return result;
-    } catch (error) {
-        console.error('Upload failed:', error);
-        throw error;
-    }
+
+    return upload.uploadFiles(options);
 }
 ```
 
-**If servlet must remain (redirects to client-side):**
+If the servlet **must** remain (for example, routing / ACL reasons), return a clear error
+instead of accepting the upload — do **not** silently call a removed API:
+
 ```java
 package com.example.servlets;
 
-import org.osgi.service.component.annotations.Component;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.apache.sling.api.servlets.ServletResolverConstants;
+import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,7 +116,7 @@ import javax.servlet.ServletException;
 import java.io.IOException;
 
 @Component(service = Servlet.class, property = {
-    ServletResolverConstants.SLING_SERVLET_PATHS + "=/bin/createasset"
+        ServletResolverConstants.SLING_SERVLET_PATHS + "=/bin/createasset"
 })
 public class CreateAssetServlet extends SlingAllMethodsServlet {
 
@@ -109,130 +125,133 @@ public class CreateAssetServlet extends SlingAllMethodsServlet {
     @Override
     protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {
-        
-        // In Cloud Service, asset creation must use Direct Binary Access
-        // Redirect client to use @adobe/aem-upload SDK
+        LOG.warn("Legacy upload endpoint hit — clients must use Direct Binary Access.");
+        response.setStatus(410);   // 410 Gone — the operation moved
         response.setContentType("application/json");
-        response.setStatus(400);
-        response.getWriter().write("{\"error\":\"Asset creation must use Direct Binary Access. " +
-            "Use @adobe/aem-upload SDK client-side or HTTP API.\"}");
-        LOG.warn("Deprecated createAsset API called - redirecting to Direct Binary Access");
+        response.getWriter().write(
+                "{\"error\":\"Use Direct Binary Access (/api/assets + @adobe/aem-upload) to upload assets.\"}");
     }
 }
 ```
 
-**Key Changes:**
-- ✅ Removed `AssetManager.createAsset()` calls
-- ✅ Migrated to Direct Binary Access pattern (`@adobe/aem-upload`)
-- ✅ Removed Felix SCR → OSGi DS annotations
-- ✅ Replaced `System.out/err` → SLF4J Logger
-- ✅ Servlet redirects to client-side upload pattern
+**Key changes:**
+
+- Removed client-facing use of `AssetManager.createAsset(path, InputStream, mimeType, boolean)` —
+  replaced with Direct Binary Access.
+- No more `createAssetForBinary` / `getAssetForBinary` — these APIs are not available on AEMaaCS.
+- Removed Felix SCR → OSGi DS.
+- Replaced `System.out` / `System.err` with SLF4J.
 
 ---
 
 ## Pattern prerequisites
 
-Read [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md) for Java/OSGi hygiene. Asset creation/upload scope follows **this file** and `asset-manager.md` only.
+Read [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md)
+for Java/OSGi hygiene (SCR → DS, service-user resolvers, SLF4J). Asset creation/upload scope
+follows this file and [`asset-manager.md`](asset-manager.md) only.
 
-## C1: Replace createAssetForBinary / getAssetForBinary with Direct Binary Access
+## C1: Replace `createAssetForBinary` / `getAssetForBinary`
 
-**Remove deprecated API usage:**
+These APIs do not exist on AEMaaCS. Remove every call.
 
 ```java
-// BEFORE (deprecated)
+// BEFORE (removed API)
 assetManager.createAssetForBinary(binaryFilePath, doSave);
 Asset asset = assetManager.getAssetForBinary(binaryFilePath);
-if (asset != null) {
-    response.getWriter().write("Asset created successfully: " + asset.getPath());
-} else {
-    response.getWriter().write("Failed to create asset.");
-}
-
-// AFTER (Cloud Service — use Direct Binary Access)
-// In AEM as a Cloud Service, asset creation must use Direct Binary Access.
-// Migrate to client-side upload using @adobe/aem-upload SDK:
-//   const DirectBinary = require('@adobe/aem-upload');
-//   const upload = new DirectBinary.DirectBinaryUpload();
-//   const options = new DirectBinary.DirectBinaryUploadOptions()
-//       .withUrl(targetUrl)
-//       .withUploadFiles(uploadFiles)
-//       .withHttpOptions({ headers: { Authorization: ... } });
-//   upload.uploadFiles(options).then(...)
-// See: https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/assets/admin/direct-binary-access.html
 ```
 
-**For Java servlets that must remain:** Redirect to client-side upload flow or return instructions. Do not retain deprecated calls.
+**Replacements:**
 
-## C2: Replace createAsset(path, is, mimeType, overwrite) with Direct Binary Access
+| Legacy call | AEMaaCS replacement |
+|-------------|----------------------|
+| `createAssetForBinary(binaryFilePath, doSave)` | **Direct Binary Access** (`@adobe/aem-upload` or HTTP `POST /api/assets`). The binary never sits on the AEM filesystem. |
+| `getAssetForBinary(binaryFilePath)` | `resolver.getResource(repoPath).adaptTo(Asset.class)` using the repository path of the asset — not a filesystem path. |
 
-**Remove deprecated API usage:**
+```javascript
+// Direct Binary Access upload (client-side)
+const DirectBinary = require('@adobe/aem-upload');
+const upload = new DirectBinary.DirectBinaryUpload();
+const options = new DirectBinary.DirectBinaryUploadOptions()
+    .withUrl(targetUrl)
+    .withUploadFiles(uploadFiles)
+    .withHttpOptions({ headers: { Authorization: `Bearer ${token}` } });
+await upload.uploadFiles(options);
+```
+
+If the caller used `getAssetForBinary` to locate an existing asset, switch to the repository path:
 
 ```java
-// BEFORE (deprecated)
-AssetManager assetManager = req.getResourceResolver().adaptTo(AssetManager.class);
-Asset imageAsset = assetManager.createAsset("/content/dam/mysite/test." + fileExt, is, mimeType, true);
-resp.setContentType("text/plain");
-resp.getWriter().write("Image Uploaded = " + imageAsset.getName() + " to path = " + imageAsset.getPath());
-
-// AFTER (Cloud Service — use Direct Binary Access)
-// In AEM as a Cloud Service, asset creation from InputStream is deprecated.
-// Migrate to client-side upload using @adobe/aem-upload:
-//   fetch(sourceUrl).then(r => r.blob()).then(blob => {
-//       const upload = new DirectBinary.DirectBinaryUpload();
-//       const options = new DirectBinary.DirectBinaryUploadOptions()
-//           .withUrl(targetUrl)
-//           .withUploadFiles(blob)
-//           .withHttpOptions({ headers: { Authorization: ... } });
-//       upload.uploadFiles(options).then(...);
-//   });
+Resource r = resolver.getResource("/content/dam/my-site/report.pdf");
+Asset asset = r != null ? r.adaptTo(Asset.class) : null;
 ```
 
-**InputStream handling:** Ensure any `InputStream` is closed in try-with-resources or `finally` block. If migrating away from Java entirely, remove the InputStream logic.
+## C2: Decide whether `createAsset(path, InputStream, mimeType, overwrite)` needs to change
 
-**ResourceResolver + logging:** Apply [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md) for any remaining servlet or service code that opens a resolver or logs errors.
+Apply the decision table at the top of this file:
+
+- **Client-facing servlet** receiving `request.getInputStream()` or a multipart part from a
+  browser / external caller → replace with Direct Binary Access. Remove the servlet or convert
+  it to a `410 Gone` redirect.
+- **In-JVM utility** creating an asset from a bundled resource / fixture stream → keep
+  `createAsset`, but harden the surrounding code:
+  - Open the resolver via `getServiceResourceResolver(SUBSERVICE)` (see
+    [resource-resolver-logging.md](resource-resolver-logging.md)).
+  - Close the `InputStream` in try-with-resources.
+  - Call `resolver.commit()` only if `doSave=false` was used (AEM usually auto-commits when
+    `doSave=true`).
+
+```java
+try (ResourceResolver resolver = resolverFactory.getServiceResourceResolver(
+        Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "asset-admin-service"));
+     InputStream stream = bundleContext.getBundle().getResource(bundledPath).openStream()) {
+
+    AssetManager assetManager = resolver.adaptTo(AssetManager.class);
+    Asset asset = assetManager.createAsset(dest, stream, mimeType, true);
+    LOG.info("Seeded asset at {}", asset.getPath());
+
+} catch (LoginException e) {
+    LOG.error("Could not open service resolver for subservice 'asset-admin-service'", e);
+} catch (IOException e) {
+    LOG.error("Failed to read bundled asset {}", bundledPath, e);
+}
+```
+
+This is legitimate on AEMaaCS — it does not hit the removed binary APIs and does not accept
+arbitrary client uploads.
 
 ## C3: Update imports
 
-**Remove (when deprecated AssetManager usage is removed):**
+**Remove** (when `createAssetForBinary` / `getAssetForBinary` are removed):
+
 ```java
-import com.day.cq.dam.api.Asset;
-import com.day.cq.dam.api.AssetManager;
 import com.day.cq.dam.api.metadata.MetaDataMap;  // if only used for deprecated flow
 ```
 
-**Keep (if AssetManager still used for read-only operations):**
-```java
-import com.day.cq.dam.api.Asset;
-import com.day.cq.dam.api.AssetManager;
-```
+Keep `com.day.cq.dam.api.Asset` / `com.day.cq.dam.api.AssetManager` when `createAsset` /
+`getAsset` are still in use.
 
-**Add (for logging):**
-```java
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-```
+**Add** (for logging and OSGi DS):
 
-**Remove (Felix SCR, if migrated):**
-```java
-import org.apache.felix.scr.annotations.*;
-```
-
-**Add (OSGi DS, if migrated):**
 ```java
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.apache.sling.api.servlets.ServletResolverConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import javax.servlet.Servlet;
 ```
 
+Remove Felix SCR imports per [scr-to-osgi-ds.md](scr-to-osgi-ds.md).
+
 ---
 
-# Validation
+## Validation
 
-- [ ] No `createAssetForBinary(binaryFilePath, doSave)` or `getAssetForBinary(binaryFilePath)` calls remain
-- [ ] No `createAsset(path, is, mimeType, overwrite)` calls remain
-- [ ] Direct Binary Access pattern documented or implemented (client-side `@adobe/aem-upload` or equivalent)
-- [ ] [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md) satisfied for SCR, resolver, logging
-- [ ] InputStream resources closed in try-with-resources or `finally` (if any remain)
-- [ ] `@Reference` AssetManager removed if no longer needed for create flows
-- [ ] Code compiles: `mvn clean compile`
+- [ ] No `createAssetForBinary(` or `getAssetForBinary(` calls remain.
+- [ ] Client-facing upload endpoints moved to Direct Binary Access; any residual Java endpoint returns 410 Gone (or equivalent) with a documented replacement path.
+- [ ] `createAsset(path, InputStream, mimeType, overwrite)` only remains in in-JVM utilities where the stream is trusted and small; the stream is closed in try-with-resources.
+- [ ] Service-user resolver + `SUBSERVICE` used (Repoinit-provisioned) where `AssetManager.adaptTo` is still called.
+- [ ] [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md) satisfied for SCR, resolver, logging.
+- [ ] No hardcoded credentials (`":password"`, literal bearer tokens) anywhere in the sample flow.
+- [ ] `@Reference AssetManager` removed if no longer needed.
+- [ ] Code compiles: `mvn clean compile`.

--- a/plugins/aem/cloud-service/skills/best-practices/references/asset-manager-delete.md
+++ b/plugins/aem/cloud-service/skills/best-practices/references/asset-manager-delete.md
@@ -1,14 +1,20 @@
-# Asset Manager Path B: Delete → HTTP Assets API
+# Asset Manager Path B: Delete
 
-For files using deprecated `removeAssetForBinary()`.
+For files using `AssetManager.removeAssetForBinary(binaryFilePath, doSave)` — an API that
+**does not exist on AEM as a Cloud Service**.
 
-This deprecated API is replaced with the **HTTP Assets API** `DELETE /api/assets{path}`.
+On AEMaaCS, asset deletion splits two ways:
+
+| Where is the deleter running? | Use |
+|------------------------------|-----|
+| **Inside the AEM JVM** (servlet, Sling job, scheduler, workflow step) | Service-user `ResourceResolver` + `resolver.delete(resource)` + `resolver.commit()`. **Never** call AEM's own HTTP API from inside the JVM. |
+| **Outside AEM** (ingestion worker, integration backend, CLI) | HTTP Assets API `DELETE /api/assets{path}` with an **IMS / dev-console bearer token** (never a static password). |
 
 ---
 
 ## Complete Example: Before and After
 
-### Before (Legacy AssetManager API)
+### Before (removed API)
 
 ```java
 package com.example.servlets;
@@ -32,9 +38,9 @@ public class DeleteAssetServlet extends SlingAllMethodsServlet {
     @Override
     protected void doDelete(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {
-        
+
         String binaryFilePath = request.getParameter("path");
-        
+
         try {
             boolean isDeleted = assetManager.removeAssetForBinary(binaryFilePath, true);
             response.setContentType("text/plain");
@@ -54,125 +60,144 @@ public class DeleteAssetServlet extends SlingAllMethodsServlet {
 }
 ```
 
-### After (Cloud Service Compatible - Client-Side)
+### After — in-JVM delete with a service-user resolver (recommended)
 
-**Client-side JavaScript:**
-```javascript
-async function deleteAsset(assetPath, host, credentials) {
-    try {
-        const response = await axios.delete(`${host}/api/assets${assetPath}`, {
-            auth: {
-                username: credentials.username,
-                password: credentials.password
-            }
-        });
-        return response.status === 200 || response.status === 204;
-    } catch (error) {
-        if (error.response?.status === 404) {
-            return false; // Asset not found
-        }
-        throw error;
-    }
-}
-```
+Server-side code that already has a trusted `ResourceResolver` should delete assets directly.
+No HTTP, no credentials, no self-loopback.
 
-### After (Cloud Service Compatible - Server-Side Java)
-
-**If servlet must remain:**
 ```java
 package com.example.servlets;
 
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.osgi.service.component.annotations.Component;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
-import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.api.servlets.ServletResolverConstants;
+import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 import java.io.IOException;
-import java.util.Base64;
+import java.util.Collections;
 
 @Component(service = Servlet.class, property = {
-    ServletResolverConstants.SLING_SERVLET_PATHS + "=/bin/deleteasset"
+        ServletResolverConstants.SLING_SERVLET_PATHS + "=/bin/deleteasset"
 })
 public class DeleteAssetServlet extends SlingAllMethodsServlet {
 
     private static final Logger LOG = LoggerFactory.getLogger(DeleteAssetServlet.class);
 
+    @Reference
+    private ResourceResolverFactory resolverFactory;
+
     @Override
     protected void doDelete(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {
-        
+
         String assetPath = request.getParameter("path");
-        if (assetPath == null || assetPath.isEmpty()) {
+        if (assetPath == null || assetPath.isEmpty() || !assetPath.startsWith("/content/dam/")) {
             response.setStatus(400);
-            response.getWriter().write("{\"error\":\"path parameter required\"}");
+            response.setContentType("application/json");
+            response.getWriter().write("{\"error\":\"valid /content/dam path parameter required\"}");
             return;
         }
 
-        try {
-            // Use HTTP Assets API
-            String host = request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort();
-            String apiUrl = host + "/api/assets" + assetPath;
-            
-            HttpClient client = HttpClientBuilder.create().build();
-            HttpDelete deleteRequest = new HttpDelete(apiUrl);
-            
-            // Add authentication header (use service user credentials)
-            String auth = Base64.getEncoder().encodeToString(
-                (request.getUserPrincipal().getName() + ":password").getBytes()
-            );
-            deleteRequest.setHeader("Authorization", "Basic " + auth);
-            
-            org.apache.http.HttpResponse httpResponse = client.execute(deleteRequest);
-            int statusCode = httpResponse.getStatusLine().getStatusCode();
-            
-            response.setContentType("application/json");
-            if (statusCode == 200 || statusCode == 204) {
-                response.getWriter().write("{\"success\":true,\"message\":\"Asset deleted: " + assetPath + "\"}");
-            } else if (statusCode == 404) {
+        try (ResourceResolver resolver = resolverFactory.getServiceResourceResolver(
+                Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "asset-admin-service"))) {
+
+            Resource resource = resolver.getResource(assetPath);
+            if (resource == null) {
                 response.setStatus(404);
-                response.getWriter().write("{\"error\":\"Asset not found: " + assetPath + "\"}");
-            } else {
-                response.setStatus(statusCode);
-                response.getWriter().write("{\"error\":\"Delete failed with status: " + statusCode + "\"}");
+                response.setContentType("application/json");
+                response.getWriter().write("{\"error\":\"asset not found\"}");
+                return;
             }
-            
-        } catch (Exception e) {
-            LOG.error("Error deleting asset: {}", assetPath, e);
+
+            resolver.delete(resource);
+            resolver.commit();
+
+            response.setContentType("application/json");
+            response.getWriter().write("{\"success\":true}");
+            LOG.info("Deleted asset at {}", assetPath);
+
+        } catch (LoginException e) {
+            LOG.error("Could not open service resolver for subservice 'asset-admin-service'", e);
             response.setStatus(500);
-            response.getWriter().write("{\"error\":\"Internal server error\"}");
+            response.setContentType("application/json");
+            response.getWriter().write("{\"error\":\"internal error\"}");
+        } catch (PersistenceException e) {
+            LOG.error("Commit failed while deleting asset {}", assetPath, e);
+            response.setStatus(500);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"error\":\"internal error\"}");
         }
     }
 }
 ```
 
-**Key Changes:**
-- ✅ Removed `AssetManager.removeAssetForBinary()` calls
-- ✅ Migrated to HTTP Assets API `DELETE /api/assets{path}`
-- ✅ Removed Felix SCR → OSGi DS annotations
-- ✅ Replaced `System.out/err` → SLF4J Logger
-- ✅ Used HttpClient for server-side API calls
-- ✅ Proper error handling and status codes
+Supporting Repoinit / service-user mapping (in `ui.config`):
+
+```
+create service user asset-admin-service
+
+set ACL for asset-admin-service
+    allow jcr:read,rep:write,jcr:removeNode,jcr:removeChildNodes on /content/dam
+end
+```
+
+```json
+{
+  "user.mapping": [
+    "com.example.mybundle:asset-admin-service=[asset-admin-service]"
+  ]
+}
+```
+
+### After — external-caller delete via the HTTP Assets API
+
+If the deleter is **outside** the AEM JVM (integration backend, CLI, worker), call the HTTP API
+with an IMS or dev-console bearer token — not with a hardcoded password.
+
+```javascript
+import axios from 'axios';
+
+export async function deleteAsset({ host, assetPath, bearerToken }) {
+    const response = await axios.delete(`${host}/api/assets${assetPath}`, {
+        headers: { Authorization: `Bearer ${bearerToken}` },
+        validateStatus: s => s === 200 || s === 204 || s === 404
+    });
+    return response.status !== 404;
+}
+```
+
+**Key changes:**
+
+- Removed use of `AssetManager.removeAssetForBinary()` (the API is gone on AEMaaCS).
+- Server-side deletion goes through `ResourceResolver#delete` + `commit`, using a service user
+  provisioned via Repoinit.
+- No hardcoded `":password"` anywhere. External callers use an IMS / dev-console token.
+- Removed Felix SCR → OSGi DS.
+- Replaced `System.out` / `System.err` / `printStackTrace` with SLF4J.
 
 ---
 
 ## Pattern prerequisites
 
-Read [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md) for Java/OSGi hygiene. Asset delete scope follows **this file** and `asset-manager.md` only.
+Read [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md)
+for Java/OSGi hygiene. Asset delete scope follows this file and
+[`asset-manager.md`](asset-manager.md) only.
 
-## D1: Replace removeAssetForBinary with HTTP Assets API
-
-**Remove deprecated API usage:**
+## D1: Replace `removeAssetForBinary` with `ResourceResolver#delete` (in-JVM)
 
 ```java
-// BEFORE (deprecated)
+// BEFORE (removed API)
 boolean isAssetDeleted = assetManager.removeAssetForBinary(binaryFilePath, doSave);
 if (isAssetDeleted) {
     response.getWriter().write("Asset deleted successfully: " + binaryFilePath);
@@ -180,63 +205,84 @@ if (isAssetDeleted) {
     response.getWriter().write("Failed to delete asset.");
 }
 
-// AFTER (Cloud Service — use HTTP Assets API)
-// Option A: Call HTTP API from Java (requires HttpClient/HttpURLConnection)
-//   DELETE {host}/api/assets{path}
-//   with basic auth
-//
-// Option B: Migrate to client-side delete using HTTP API:
-//   const response = await axios.delete(`${host}/api/assets${assetPath}`, {
-//       auth: { username, password }
-//   });
+// AFTER — in-JVM
+try (ResourceResolver resolver = resolverFactory.getServiceResourceResolver(
+        Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "asset-admin-service"))) {
+
+    Resource resource = resolver.getResource(assetPath);   // repository path, not binary path
+    if (resource == null) {
+        // asset already gone
+        return;
+    }
+    resolver.delete(resource);
+    resolver.commit();
+} catch (LoginException e) {
+    LOG.error("Could not open service resolver for subservice 'asset-admin-service'", e);
+} catch (PersistenceException e) {
+    LOG.error("Commit failed while deleting asset {}", assetPath, e);
+}
 ```
 
-**HTTP API delete example (client-side):**
+Notes:
+
+- `assetPath` must be the **repository path** (e.g. `/content/dam/site/file.jpg`) — the old
+  "binary path" concept does not exist on AEMaaCS.
+- The service user behind the `SUBSERVICE` name must have
+  `jcr:removeNode` / `jcr:removeChildNodes` on the asset tree (Repoinit rule above).
+- Do not call AEM's own HTTP API (`/api/assets`) from inside the JVM — it adds an extra hop,
+  requires credentials you shouldn't store, and breaks idempotency.
+
+## D2: For external callers, use the HTTP Assets API with a bearer token
+
 ```javascript
-const response = await axios.delete(`${host}/api/assets${assetPath}`, {
-    auth: { username, password }
+await axios.delete(`${host}/api/assets${assetPath}`, {
+    headers: { Authorization: `Bearer ${bearerToken}` }
 });
 ```
 
-**ResourceResolver + logging:** Apply [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md) for any remaining servlet or service code.
+Where `bearerToken` comes from:
 
-## D2: Update imports
+- **Adobe Developer Console / IMS** service credentials (server-to-server), **or**
+- A short-lived user token obtained via the AEM login flow.
 
-**Remove (when deprecated AssetManager delete usage is removed):**
-```java
-import com.day.cq.dam.api.AssetManager;  // if no longer needed
-```
+**Never** hardcode usernames and passwords in source or pass `":password"` strings.
 
-**Keep (if AssetManager still used for other operations):**
+## D3: Update imports
+
+**Remove** (when all `AssetManager` delete calls are gone):
+
 ```java
 import com.day.cq.dam.api.AssetManager;
 ```
 
-**Add (for logging):**
-```java
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-```
+**Keep** if the file still uses `AssetManager.getAsset(...)` for reads.
 
-**Remove (Felix SCR, if migrated):**
-```java
-import org.apache.felix.scr.annotations.*;
-```
+**Add** (for the in-JVM delete path):
 
-**Add (OSGi DS, if migrated):**
 ```java
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.apache.sling.api.servlets.ServletResolverConstants;
-import javax.servlet.Servlet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.Collections;
 ```
+
+Remove Felix SCR imports per [scr-to-osgi-ds.md](scr-to-osgi-ds.md).
 
 ---
 
-# Validation
+## Validation
 
-- [ ] No `removeAssetForBinary(binaryFilePath, doSave)` calls remain
-- [ ] HTTP Assets API `DELETE /api/assets{path}` used (client or server)
-- [ ] [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md) satisfied for SCR, resolver, logging
-- [ ] `@Reference` AssetManager removed if no longer needed for delete flows
-- [ ] Code compiles: `mvn clean compile`
+- [ ] No `removeAssetForBinary(` calls remain.
+- [ ] In-JVM deletes use `resolver.delete(resource)` + `resolver.commit()` with a service-user resolver; the servlet no longer calls AEM's own HTTP API.
+- [ ] Service user + mapping provisioned via Repoinit in `ui.config`, with ACLs granting `jcr:removeNode` / `jcr:removeChildNodes` on the asset tree.
+- [ ] No hardcoded credentials (`":password"`, plain-text basic auth strings) anywhere.
+- [ ] External-caller examples use a bearer token — not basic auth with a literal password.
+- [ ] [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md) satisfied for SCR, resolver, logging.
+- [ ] `@Reference AssetManager` removed if no longer needed for delete flows.
+- [ ] Code compiles: `mvn clean compile`.

--- a/plugins/aem/cloud-service/skills/best-practices/references/asset-manager.md
+++ b/plugins/aem/cloud-service/skills/best-practices/references/asset-manager.md
@@ -1,26 +1,54 @@
 # Asset Manager API Migration Pattern
 
-Migrates legacy AEM Asset Manager API usage to Cloud Service compatible patterns.
+Covers how to handle `com.day.cq.dam.api.AssetManager` usage so it is safe and idiomatic on
+**AEM as a Cloud Service**.
 
-**Before you start:** Java baseline ([scr-to-osgi-ds.md](scr-to-osgi-ds.md), [resource-resolver-logging.md](resource-resolver-logging.md)) via [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md). This file **classifies** deprecated `AssetManager` usage and routes to path modules (`asset-manager-create.md`, `asset-manager-delete.md`); asset API scope stays limited to that pattern.
+**Before you start:** Java baseline ([scr-to-osgi-ds.md](scr-to-osgi-ds.md),
+[resource-resolver-logging.md](resource-resolver-logging.md)) via
+[aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md).
+This file **classifies** the usage and routes to path modules
+(`asset-manager-create.md`, `asset-manager-delete.md`).
 
-**Two paths based on operation type:**
-- **Path A (Create/Upload):** Uses deprecated `createAsset()`, `createAssetForBinary()`, or `getAssetForBinary()` — migrates to **Direct Binary Access** via `@adobe/aem-upload` SDK
-- **Path B (Delete):** Uses deprecated `removeAssetForBinary()` — migrates to **HTTP Assets API** `DELETE /api/assets{path}`
+---
+
+## What changed on AEM as a Cloud Service
+
+`com.day.cq.dam.api.AssetManager` itself is **not removed**; several of its operations *are*
+removed or strongly discouraged because binary I/O no longer flows through the AEM JVM the way
+it did on AEM 6.x.
+
+| API | Status on AEMaaCS | What to use instead |
+|-----|-------------------|---------------------|
+| `AssetManager.getAsset(path)` | Supported — read-only use | No change |
+| `AssetManager.createAsset(path, InputStream, mimeType, doSave)` | **Strongly discouraged at runtime** for client-driven uploads (performance, 2 GB binary limit, asset-processing pipeline expects Direct Binary Access). Still callable in bulk import / back-office utilities where the binary is already local to the AEM JVM and small. | **Direct Binary Access** via `@adobe/aem-upload` (HTTP clients) for client uploads. In-JVM small-file creation from bundled resources is still OK. |
+| `AssetManager.createAssetForBinary(binaryFilePath, doSave)` | **Removed on AEMaaCS** — relied on direct filesystem access that the cloud runtime does not expose. | **Direct Binary Access** (`@adobe/aem-upload` or the HTTP Assets API). |
+| `AssetManager.getAssetForBinary(binaryFilePath)` | **Removed on AEMaaCS** — same reason. | Look up the `Asset` by repository path via `resolver.getResource(path).adaptTo(Asset.class)`. |
+| `AssetManager.removeAssetForBinary(binaryFilePath, doSave)` | **Removed on AEMaaCS** — same reason. | For server-side (in-JVM) deletes: `resolver.delete(resource); resolver.commit();`. For external callers: HTTP Assets API `DELETE /api/assets{path}`. |
+
+**Bottom line:**
+
+- **Uploads from outside AEM (browser, integration, ingestion worker)** → Direct Binary Access.
+- **Server-side (inside the AEM JVM) delete** → service-user `ResourceResolver` +
+  `resolver.delete(resource)` + `resolver.commit()`. Do not call AEM's own HTTP API from inside
+  the JVM.
+- **External callers deleting assets** → HTTP Assets API `DELETE /api/assets{path}`.
+- Read access via `AssetManager.getAsset` / `resolver.adaptTo(Asset.class)` is unchanged.
 
 ---
 
 ## Quick Examples
 
-### Path A Example (Create/Upload)
+### Path A Example (create / upload)
 
-**Before:**
+**Before (deprecated binary-path API):**
+
 ```java
 AssetManager assetManager = resolver.adaptTo(AssetManager.class);
 Asset asset = assetManager.createAssetForBinary(binaryFilePath, true);
 ```
 
-**After (Client-side):**
+**After — client-side Direct Binary Access:**
+
 ```javascript
 const DirectBinary = require('@adobe/aem-upload');
 const upload = new DirectBinary.DirectBinaryUpload();
@@ -31,28 +59,41 @@ const options = new DirectBinary.DirectBinaryUploadOptions()
 await upload.uploadFiles(options);
 ```
 
-### Path B Example (Delete)
+### Path B Example (delete)
 
-**Before:**
+**Before (removed on AEMaaCS):**
+
 ```java
 AssetManager assetManager = resolver.adaptTo(AssetManager.class);
 boolean deleted = assetManager.removeAssetForBinary(binaryFilePath, true);
 ```
 
-**After (Client-side):**
-```javascript
-await axios.delete(`${host}/api/assets${assetPath}`, {
-    auth: { username, password }
-});
+**After — server-side delete with a service-user resolver:**
+
+```java
+try (ResourceResolver resolver = resolverFactory.getServiceResourceResolver(
+        Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "asset-admin-service"))) {
+    Resource resource = resolver.getResource(assetPath);
+    if (resource == null) {
+        LOG.info("Asset already gone at {}", assetPath);
+        return;
+    }
+    resolver.delete(resource);
+    resolver.commit();
+    LOG.info("Deleted asset at {}", assetPath);
+} catch (LoginException e) {
+    LOG.error("Could not open service resolver for subservice 'asset-admin-service'", e);
+} catch (PersistenceException e) {
+    LOG.error("Failed to commit asset delete at {}", assetPath, e);
+}
 ```
 
-**After (Server-side Java):**
-```java
-// Use HttpClient to call DELETE /api/assets{path}
-HttpClient client = HttpClientBuilder.create().build();
-HttpDelete delete = new HttpDelete(host + "/api/assets" + assetPath);
-delete.setHeader("Authorization", "Basic " + base64Credentials);
-HttpResponse response = client.execute(delete);
+**After — external-caller delete via the HTTP Assets API:**
+
+```javascript
+await axios.delete(`${host}/api/assets${assetPath}`, {
+    headers: { Authorization: `Bearer ${token}` }    // IMS / dev-console token — never a static "password"
+});
 ```
 
 ---
@@ -62,35 +103,44 @@ HttpResponse response = client.execute(delete);
 **Classify BEFORE making any changes.**
 
 ### Use Path A when ANY of these are true:
-- File calls `assetManager.createAsset(path, inputStream, mimeType, overwrite)`
-- File calls `assetManager.createAssetForBinary(binaryFilePath, doSave)`
-- File calls `assetManager.getAssetForBinary(binaryFilePath)`
-- File uses `resourceResolver.adaptTo(AssetManager.class)` for asset creation or upload
+- File calls `assetManager.createAssetForBinary(binaryFilePath, doSave)`.
+- File calls `assetManager.getAssetForBinary(binaryFilePath)`.
+- File calls `assetManager.createAsset(path, InputStream, mimeType, overwrite)` from a client-facing
+  servlet (accepts uploads from browsers or external callers).
 
-**If Path A → read `asset-manager-create.md` and follow its steps.**
+**If Path A → read [`asset-manager-create.md`](asset-manager-create.md) and follow its steps.**
 
 ### Use Path B when ANY of these are true:
-- File calls `assetManager.removeAssetForBinary(binaryFilePath, doSave)`
-- File uses `AssetManager` exclusively for delete operations
+- File calls `assetManager.removeAssetForBinary(binaryFilePath, doSave)`.
+- File deletes assets via a public HTTP endpoint and relies on `AssetManager`.
 
-**If Path B → read `asset-manager-delete.md` and follow its steps.**
+**If Path B → read [`asset-manager-delete.md`](asset-manager-delete.md) and follow its steps.**
 
-### Mixed operations (both create and delete):
-If the file uses BOTH create/upload AND delete operations, process **Path A first**, then **Path B**. Read both path files sequentially.
+### Mixed operations (both create and delete)
 
-### Already compliant — skip migration:
-- File only uses `AssetManager.getAsset(path)` for read operations (metadata, renditions) — no migration needed
+If the file uses BOTH a removed create API AND a removed delete API, process **Path A first**,
+then **Path B**. Read both path files sequentially.
 
-## Asset-Specific Rules
+### Already compliant — skip migration
 
-- **CLASSIFY FIRST** — determine Path A, Path B, or Mixed before making any changes
-- **DO** replace deprecated `createAssetForBinary` / `getAssetForBinary` with Direct Binary Access
-- **DO** replace deprecated `removeAssetForBinary` with HTTP Assets API DELETE
-- **DO** replace deprecated `createAsset(path, is, mimeType, overwrite)` with Direct Binary Access
-- **DO** use `@adobe/aem-upload` SDK for client-side uploads
-- **DO** use HTTP API for server-side delete operations when migrating servlets
-- **DO NOT** call deprecated AssetManager methods for create/remove
-- **DO NOT** keep inline asset creation from InputStream in Java servlets
+- File only uses `AssetManager.getAsset(path)` for read operations (metadata, renditions).
+- File uses `AssetManager.createAsset(path, InputStream, mimeType, overwrite)` **internally** in
+  a back-office utility (scheduled import, test fixture, asset post-processing) where the binary
+  is already inside the AEM JVM and is small. This is still supported — flag and move on.
+
+## Asset-specific rules
+
+- **CLASSIFY FIRST** — Path A, Path B, or Mixed — before making any changes.
+- **Do** replace `createAssetForBinary` / `getAssetForBinary` / `removeAssetForBinary` — these do
+  not exist on AEMaaCS.
+- **Do** migrate client-facing uploads (servlets that accept `multipart` or `InputStream` from
+  external callers) to Direct Binary Access.
+- **Do** replace server-side HTTP `DELETE /api/assets` loops with in-JVM
+  `resolver.delete(resource)` + `resolver.commit()` — AEM should never call its own HTTP API.
+- **Do not** hardcode credentials. Never use a literal `":password"` string; external callers
+  authenticate with an IMS / dev-console bearer token, internal JVM code uses a service-user
+  resolver.
+- **Do not** rewrite perfectly valid internal `AssetManager.getAsset()` reads — they still work.
 
 ## IMPORTANT
 

--- a/plugins/aem/cloud-service/skills/best-practices/references/event-migration-path-a.md
+++ b/plugins/aem/cloud-service/skills/best-practices/references/event-migration-path-a.md
@@ -1,8 +1,21 @@
-# Event Migration Path A: JCR EventListener → EventHandler + JobConsumer
+# Event Migration Path A: JCR `EventListener` → `JobConsumer`
 
 For classes that implement `javax.jcr.observation.EventListener` with `onEvent(EventIterator)`.
 
-This path converts the JCR observation listener to an OSGi EventHandler, then offloads business logic to a Sling JobConsumer.
+> **Stop first.** If the `onEvent` body inspects JCR paths / properties / types — i.e. it is
+> observing **repository content** — the target API on AEM as a Cloud Service is
+> **`org.apache.sling.api.resource.observation.ResourceChangeListener`**, not an OSGi
+> `EventHandler`. Follow [resource-change-listener.md](resource-change-listener.md) instead of
+> this file. The OSGi resource topics
+> (`org/apache/sling/api/resource/Resource/ADDED|CHANGED|REMOVED`) are deprecated as an
+> application API and should not be used as a migration target.
+>
+> Continue below only if the legacy `EventListener` observes something that genuinely cannot be
+> expressed as a `ResourceChangeListener` (rare — e.g. a custom JCR concern that the Sling
+> resource layer does not surface).
+
+This path converts the JCR observation listener into an OSGi `EventHandler` for a non-resource
+topic, then offloads business logic to a Sling `JobConsumer`.
 
 ---
 
@@ -183,7 +196,10 @@ public class ACLModificationJobConsumer implements JobConsumer {
 
 Read [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md) before the steps below.
 
-## A1: Convert JCR EventListener to OSGi EventHandler
+## A1: Convert JCR EventListener to OSGi EventHandler (non-resource topic)
+
+> Only apply A1 when the source cannot migrate to `ResourceChangeListener`. See the warning at
+> the top of this file.
 
 Replace JCR observation API with OSGi event API:
 
@@ -228,15 +244,28 @@ public class ACLModificationEventHandler implements EventHandler {
 }
 ```
 
-**JCR event type to OSGi resource topic mapping:**
+**JCR event type → `ChangeType` on `ResourceChangeListener`** (preferred):
 
-| JCR Event Type | OSGi Resource Event Topic |
-|---------------|---------------------------|
+| JCR Event Type | `ResourceChange.ChangeType` |
+|----------------|-----------------------------|
+| `Event.NODE_ADDED` | `ADDED` |
+| `Event.NODE_REMOVED` | `REMOVED` |
+| `Event.PROPERTY_ADDED` | `CHANGED` |
+| `Event.PROPERTY_CHANGED` | `CHANGED` |
+| `Event.PROPERTY_REMOVED` | `CHANGED` |
+
+If you are one of the rare cases that truly cannot use `ResourceChangeListener` and needs the
+raw OSGi resource topics, the legacy mapping is:
+
+| JCR Event Type | OSGi Resource Event Topic (deprecated as app API) |
+|----------------|----------------------------------------------------|
 | `Event.NODE_ADDED` | `org/apache/sling/api/resource/Resource/ADDED` |
 | `Event.NODE_REMOVED` | `org/apache/sling/api/resource/Resource/REMOVED` |
 | `Event.PROPERTY_CHANGED` | `org/apache/sling/api/resource/Resource/CHANGED` |
 | `Event.PROPERTY_ADDED` | `org/apache/sling/api/resource/Resource/CHANGED` |
 | `Event.PROPERTY_REMOVED` | `org/apache/sling/api/resource/Resource/CHANGED` |
+
+Prefer the `ResourceChangeListener` route.
 
 **JCR event data to OSGi event property mapping:**
 

--- a/plugins/aem/cloud-service/skills/best-practices/references/event-migration-path-b.md
+++ b/plugins/aem/cloud-service/skills/best-practices/references/event-migration-path-b.md
@@ -215,6 +215,9 @@ The `handleEvent()` method should ONLY:
 **Replication event example:**
 ```java
 // BEFORE (inline business logic in handler)
+private static final Map<String, Object> AUTH_INFO =
+        Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "replication-service");
+
 @Override
 public void handleEvent(Event event) {
     if (ReplicationEvent.fromEvent(event).getReplicationAction().getType().equals(ReplicationActionType.ACTIVATE)) {
@@ -223,7 +226,7 @@ public void handleEvent(Event event) {
             if (resource != null) {
                 ModifiableValueMap map = resource.adaptTo(ModifiableValueMap.class);
                 map.put("cq:lastReplicated", Calendar.getInstance());
-                resource.getResourceResolver().commit();
+                resourceResolver.commit();
             }
         } catch (LoginException | PersistenceException ex) {
             LOG.error("Error", ex);

--- a/plugins/aem/cloud-service/skills/best-practices/references/event-migration.md
+++ b/plugins/aem/cloud-service/skills/best-practices/references/event-migration.md
@@ -1,21 +1,51 @@
 # Event Migration Pattern
 
-Migrates two legacy styles into one Cloud Service–compatible pattern — **lightweight OSGi `EventHandler` + Sling `JobConsumer`**:
+Covers two legacy event-listening styles on AEM as a Cloud Service:
 
 1. **JCR observation (`eventListener` / BPA):** `javax.jcr.observation.EventListener` listening to **repository** changes via `onEvent(EventIterator)`.
 2. **OSGi Event Admin (`eventHandler` / BPA):** `org.osgi.service.event.EventHandler` with **`handleEvent`** — often already OSGi, but must not hold heavy JCR/resolver work inline.
 
-**Before path files:** [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md) (SCR→DS, resolver, logging).
+**Before path files:** [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md) (SCR → DS, service-user resolvers, SLF4J).
 
-**Two paths based on source pattern:**
-- **Path A (JCR observation → OSGi):** Source uses **`javax.jcr.observation.EventListener`** — replace JCR observation with OSGi topics + offload work to JobConsumer.
-- **Path B (OSGi `EventHandler` with inline logic):** Source already uses **`org.osgi.service.event.EventHandler`** but runs resolver/session/node code inside **`handleEvent()`** — offload to JobConsumer only.
+## First — pick the right target API
+
+Not every legacy listener should become an OSGi `EventHandler`. Use this table:
+
+| Legacy source is reacting to… | Cloud Service target | Reference |
+|-------------------------------|----------------------|-----------|
+| **Repository changes** (page, asset, property added / changed / removed) | **`org.apache.sling.api.resource.observation.ResourceChangeListener`** | [resource-change-listener.md](resource-change-listener.md) |
+| External (cluster) repository changes | **`ExternalResourceChangeListener`** | [resource-change-listener.md](resource-change-listener.md) |
+| `com.day.cq.replication.ReplicationEvent.EVENT_TOPIC` | OSGi `EventHandler` + `JobConsumer` | **this file** (Path B) |
+| Workflow topics (`com/adobe/granite/workflow/*`) | OSGi `EventHandler` + `JobConsumer` | **this file** (Path B) |
+| Custom OSGi Event Admin topic posted by another bundle | OSGi `EventHandler` + `JobConsumer` | **this file** (Path B) |
+| Any other non-resource OSGi event | OSGi `EventHandler` + `JobConsumer` | **this file** (Path B) |
+
+**Rule of thumb:** repository content events → `ResourceChangeListener`. Non-content OSGi events
+(replication, workflow, custom) → OSGi `EventHandler`.
+
+> The OSGi resource topics `org/apache/sling/api/resource/Resource/ADDED|CHANGED|REMOVED` are
+> an internal Sling dispatcher detail that is now deprecated as an application-level API. Do not
+> make a new `EventHandler` subscribe to them — use `ResourceChangeListener` for that.
+> Legacy code that already does this and only needs minor cleanup can still be migrated per
+> Path B; but for **new** work or major refactors, move it to `ResourceChangeListener`.
+
+**Two paths based on source pattern (within this file):**
+- **Path A (JCR observation → `ResourceChangeListener` when the source observes resources; OSGi `EventHandler` otherwise):** Source uses **`javax.jcr.observation.EventListener`** — replace JCR observation with the appropriate Sling API and offload work to a `JobConsumer`.
+- **Path B (OSGi `EventHandler` with inline logic):** Source already uses **`org.osgi.service.event.EventHandler`** (correctly scoped to a non-resource topic) but runs resolver/session/node code inside **`handleEvent()`** — offload to a `JobConsumer`.
 
 ---
 
 ## Quick Examples
 
-### Path A Example (JCR EventListener)
+> Reminder: if the source watches **resources**, do not follow the examples below; route to
+> [resource-change-listener.md](resource-change-listener.md) and use `ResourceChangeListener`
+> as the target.
+
+### Path A Example (JCR EventListener for a non-resource concern)
+
+> **If the legacy listener observes repository content, stop — go to
+> [resource-change-listener.md](resource-change-listener.md).** The example below shows a
+> residual non-resource JCR use case that still needs migration through this module.
 
 **Before:**
 ```java
@@ -36,11 +66,11 @@ public class MyListener implements EventListener {
 **EventHandler.java:**
 ```java
 @Component(service = EventHandler.class, property = {
-    EventConstants.EVENT_TOPIC + "=org/apache/sling/api/resource/Resource/CHANGED"
+    EventConstants.EVENT_TOPIC + "=com/example/custom/topic"
 })
 public class MyEventHandler implements EventHandler {
     @Reference private JobManager jobManager;
-    
+
     @Override
     public void handleEvent(Event event) {
         Map<String, Object> props = Map.of("path", event.getProperty("path"));
@@ -113,36 +143,49 @@ public class MyJobConsumer implements JobConsumer {
 
 **Classify BEFORE making any changes.**
 
-### Use Path A when ALL of these are true:
-- Class implements `javax.jcr.observation.EventListener`
-- Has `onEvent(EventIterator)` method
-- Uses `import javax.jcr.observation.*`
+### Route to [resource-change-listener.md](resource-change-listener.md) when the source observes *resources*
 
-**If Path A → read `resources/event-migration-path-a.md` and follow its steps.**
+- Class implements `javax.jcr.observation.EventListener` **and** the `onEvent` body inspects
+  JCR node / property paths (i.e. it is observing repository content).
+- Class implements `EventHandler` and subscribes to `org/apache/sling/api/resource/Resource/*`
+  (ADDED / CHANGED / REMOVED / PROVIDER_*).
 
-### Use Path B when ANY of these are true:
-- Class already implements `org.osgi.service.event.EventHandler`
-- Has `handleEvent(Event)` with inline business logic (ResourceResolver, JCR Session, Node operations)
-- Replication event handler using `ReplicationEvent.EVENT_TOPIC` with inline processing
-- Workflow event handler using `WorkflowEvent` with Session/Node operations in handler
+In both cases the Cloud Service target is **`ResourceChangeListener`**, not an OSGi
+`EventHandler`. Use the [resource-change-listener.md](resource-change-listener.md) module.
 
-**If Path B → read `resources/event-migration-path-b.md` and follow its steps.**
+### Use Path A (this file) when ALL of these are true:
+- Class implements `javax.jcr.observation.EventListener`.
+- The `onEvent` body observes something that **cannot** be expressed through
+  `ResourceChangeListener` (e.g. a JCR-level concern that has no resource-layer equivalent — rare).
+
+**If Path A → read [`event-migration-path-a.md`](event-migration-path-a.md) and follow its steps.**
+
+### Use Path B (this file) when ANY of these are true:
+- Class already implements `org.osgi.service.event.EventHandler` subscribed to a
+  **non-resource topic** (`ReplicationEvent.EVENT_TOPIC`, workflow topics, custom topics).
+- `handleEvent(Event)` has inline business logic (ResourceResolver, JCR Session, Node operations).
+
+**If Path B → read [`event-migration-path-b.md`](event-migration-path-b.md) and follow its steps.**
 
 ### Already compliant — skip migration:
-- Class implements `EventHandler` and `handleEvent()` ONLY calls `jobManager.addJob()` — already uses the correct pattern
+- Class implements `EventHandler` for a non-resource topic and `handleEvent()` ONLY calls `jobManager.addJob()` — already the correct pattern.
+- Class implements `ResourceChangeListener` correctly — confirm against [resource-change-listener.md](resource-change-listener.md).
 
 ## Event-Specific Rules
 
-- **CLASSIFY FIRST** — determine Path A or Path B before making any changes
-- **DO** convert JCR `EventListener` to OSGi `EventHandler` (Path A only)
-- **DO** offload ALL business logic from `handleEvent()` / `onEvent()` to a `JobConsumer`
-- **DO** keep `handleEvent()` lightweight — only extract event data and create a job
-- **DO** map JCR event types to OSGi resource event topics (Path A only)
-- **DO** preserve event filtering logic (paths, property names, event types)
-- **DO** add `TopologyEventListener` for replication handlers that should only run on leader node
-- **DO** distribute `@Reference` fields: infrastructure services (e.g., `JobManager`) stay in EventHandler, business logic services (e.g., `ResourceResolverFactory`) move to JobConsumer
-- **DO NOT** put ResourceResolver, JCR Session, or Node operations in the EventHandler
-- **DO NOT** change the business logic — move it as-is to the JobConsumer
+- **ROUTE FIRST** — resource-content observers go to [resource-change-listener.md](resource-change-listener.md), not this file.
+- **CLASSIFY SECOND** — determine Path A or Path B before making any changes.
+- **DO** offload ALL business logic from `handleEvent()` / `onEvent()` to a `JobConsumer`.
+- **DO** keep `handleEvent()` lightweight — only extract event data and create a job.
+- **DO NOT** subscribe a new `EventHandler` to `org/apache/sling/api/resource/Resource/*` —
+  those topics are deprecated as an application API; use `ResourceChangeListener` instead.
+- **DO** preserve event filtering logic (paths, property names, event types).
+- **DO** add `TopologyEventListener` for handlers that should only run on the leader node.
+- **DO** distribute `@Reference` fields: infrastructure services (e.g. `JobManager`) stay in the
+  `EventHandler`; business logic services (e.g. `ResourceResolverFactory`) move to the
+  `JobConsumer`.
+- **DO NOT** put `ResourceResolver`, JCR `Session`, or `Node` operations in the `EventHandler`.
+- **DO NOT** change the business logic — move it as-is to the `JobConsumer`.
 
 ## IMPORTANT
 

--- a/plugins/aem/cloud-service/skills/best-practices/references/replication.md
+++ b/plugins/aem/cloud-service/skills/best-practices/references/replication.md
@@ -135,14 +135,22 @@ public class PropertyNodeReplicationService {
                 false,
                 propertyNodePath
             );
-            DistributionResponse distributionResponse = distributor.distribute("publish", resolver, distributionRequest);
+            DistributionResponse distributionResponse =
+                distributor.distribute("publish", resolver, distributionRequest);
 
-            LOG.info("Property Node Distribution successful for path: {}", propertyNodePath);
+            if (distributionResponse.isSuccessful()) {
+                LOG.info("Property node distribution queued for path: {}", propertyNodePath);
+            } else {
+                LOG.warn("Property node distribution not queued for path: {} (state={}, message={})",
+                        propertyNodePath,
+                        distributionResponse.getState(),
+                        distributionResponse.getMessage());
+            }
 
         } catch (LoginException e) {
-            LOG.error("Failed to get resource resolver", e);
-        } catch (Exception e) {
-            LOG.error("Error during distribution", e);
+            LOG.error("Could not open service resolver for subservice 'property-node-distribution-service'", e);
+        } catch (DistributionException e) {
+            LOG.error("Distribution failed for {}", propertyNodePath, e);
         }
     }
 }
@@ -244,27 +252,37 @@ public class ContentReplicationService {
                 false,
                 contentPath
             );
-            DistributionResponse distributionResponse = distributor.distribute("publish", resolver, distributionRequest);
-            LOG.info("Forward Distribution successful for path: {}", contentPath);
+            DistributionResponse distributionResponse =
+                distributor.distribute("publish", resolver, distributionRequest);
+
+            if (distributionResponse.isSuccessful()) {
+                LOG.info("Content distribution queued for path: {}", contentPath);
+            } else {
+                LOG.warn("Content distribution not queued for path: {} (state={}, message={})",
+                        contentPath,
+                        distributionResponse.getState(),
+                        distributionResponse.getMessage());
+            }
 
         } catch (LoginException e) {
-            LOG.error("Failed to get resource resolver", e);
-        } catch (Exception e) {
-            LOG.error("Error during distribution", e);
+            LOG.error("Could not open service resolver for subservice 'content-distribution-service'", e);
+        } catch (DistributionException e) {
+            LOG.error("Distribution failed for {}", contentPath, e);
         }
     }
 }
 ```
 
 **Key Changes:**
-- ✅ Replaced `Replicator`/`ReplicationAgent` → `Distributor`
-- ✅ Replaced `ReplicationAction`/`ReplicationResult` → `DistributionRequest`/`DistributionResponse`
-- ✅ Mapped `ReplicationActionType.ACTIVATE` → `DistributionRequestType.ADD`
-- ✅ Used correct `publish`/`preview` agent
-- ✅ Replaced `getAdministrativeResourceResolver()` → `getServiceResourceResolver()` with SUBSERVICE
-- ✅ Removed USER/PASSWORD from authInfo (Cloud Service uses SUBSERVICE only)
-- ✅ Replaced `System.out/err` → SLF4J Logger
-- ✅ Used try-with-resources for ResourceResolver
+- Replaced `Replicator` / `ReplicationAgent` → `Distributor`.
+- Replaced `ReplicationAction` / `ReplicationResult` → `DistributionRequest` / `DistributionResponse`.
+- Mapped `ReplicationActionType.ACTIVATE` → `DistributionRequestType.ADD`.
+- Targets the correct agent name (`publish` or `preview`) — legacy `Replicator.replicate` implicitly targeted every configured replication agent; `Distributor.distribute` is explicit.
+- Inspects `DistributionResponse.isSuccessful()` instead of assuming the call succeeded.
+- Replaced `getAdministrativeResourceResolver()` → `getServiceResourceResolver(SUBSERVICE)`.
+- Removed `USER` / `PASSWORD` from `authInfo` — AEM as a Cloud Service uses subservice mappings (Repoinit + `ServiceUserMapperImpl.amended`) only.
+- Replaced `System.out` / `System.err` / `printStackTrace` → SLF4J.
+- Resolver opened in try-with-resources.
 
 ---
 
@@ -360,18 +378,17 @@ import org.apache.felix.scr.annotations.*;  // must be gone when done
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
-import org.apache.sling.distribution.Distributor;
+import org.apache.sling.distribution.DistributionException;
 import org.apache.sling.distribution.DistributionRequest;
-import org.apache.sling.distribution.DistributionResponse;
 import org.apache.sling.distribution.DistributionRequestType;
+import org.apache.sling.distribution.DistributionResponse;
+import org.apache.sling.distribution.Distributor;
 import org.apache.sling.distribution.SimpleDistributionRequest;
-import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.Collections;
-import java.util.Map;
 ```
 
 ---
@@ -380,10 +397,12 @@ import java.util.Map;
 
 ## Replication/Distribution Checklist
 
-- [ ] No `ReplicationAgent`, `Replicator`, `ReplicationAction`, or `ReplicationResult` remains
-- [ ] Uses `Distributor` (`org.apache.sling.distribution`)
-- [ ] Uses `SimpleDistributionRequest` with `DistributionRequestType` from `org.apache.sling.distribution`
-- [ ] Calls `distributor.distribute("publish", resolver, distributionRequest)` with the service-user resolver
-- [ ] [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md) satisfied (SCR→DS, resolver/logging, auth maps)
-- [ ] `scheduler.concurrent=false` is set (if using scheduler)
-- [ ] Code compiles: `mvn clean compile`
+- [ ] No `ReplicationAgent`, `Replicator`, `ReplicationAction`, or `ReplicationResult` remains.
+- [ ] No imports from `com.day.cq.replication.*` or `org.apache.sling.replication.*` remain.
+- [ ] Uses `Distributor` (`org.apache.sling.distribution`).
+- [ ] Uses `SimpleDistributionRequest` with `DistributionRequestType` from `org.apache.sling.distribution`.
+- [ ] Calls `distributor.distribute("publish", resolver, distributionRequest)` with a service-user resolver (opened via `getServiceResourceResolver` with a `SUBSERVICE`, closed in try-with-resources).
+- [ ] Inspects `distributionResponse.isSuccessful()` (and `getState()` / `getMessage()` on failure) instead of assuming success.
+- [ ] Targets the correct agent — `"publish"` for live distribution, `"preview"` for the preview tier; both (in two calls) if you replicate to both tiers.
+- [ ] [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md) satisfied (SCR → DS, service-user resolver, SLF4J, no `USER` / `PASSWORD` auth maps).
+- [ ] Code compiles: `mvn clean compile`.

--- a/plugins/aem/cloud-service/skills/best-practices/references/resource-change-listener.md
+++ b/plugins/aem/cloud-service/skills/best-practices/references/resource-change-listener.md
@@ -1,44 +1,89 @@
-# Resource Change Listener / Event Listener Migration Pattern
+# Sling `ResourceChangeListener` (AEM as a Cloud Service)
 
-Migrates legacy JCR observation listeners and OSGi event handlers with inline business logic to Cloud Service compatible pattern: **lightweight EventHandler + Sling JobConsumer**.
+BPA pattern id: **`resourceChangeListener`**.
 
-**Source patterns handled:**
-- JCR `javax.jcr.observation.EventListener` with `onEvent(EventIterator)`
-- OSGi `org.osgi.service.event.EventHandler` with inline business logic in `handleEvent(Event)`
+Covers existing or newly authored `org.apache.sling.api.resource.observation.ResourceChangeListener`
+implementations and how they must be shaped for **AEM as a Cloud Service** — a lightweight listener
+that offloads all business logic to a Sling **`JobConsumer`**.
 
-**Target pattern:**
-- OSGi `EventHandler` (lightweight — receives event, creates Sling Job)
-- Sling `JobConsumer` (handles business logic asynchronously)
-
-**Before transformation steps:** [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md).
-
-## Classification
-
-No sub-paths — all source patterns transform to the same target (EventHandler + JobConsumer split).
-
-Identify which source pattern the file uses:
-- **JCR EventListener:** Has `implements EventListener`, `import javax.jcr.observation.*`, `onEvent(EventIterator)`
-- **OSGi EventHandler with inline logic:** Has `implements EventHandler`, `handleEvent(Event)`, and business logic (ResourceResolver, JCR Session, etc.) directly inside `handleEvent()`
-
-If the file already has `implements EventHandler` and already offloads to a Sling Job (i.e., `handleEvent()` only calls `jobManager.addJob()`), it may not need migration — verify and skip if already compliant.
-
-## Pattern-Specific Rules
-
-- **DO** convert JCR `EventListener` to OSGi `EventHandler`
-- **DO** offload ALL business logic from `handleEvent()` to a `JobConsumer`
-- **DO** keep `handleEvent()` lightweight — it should only extract event data and create a job
-- **DO** map JCR event types to OSGi resource event topics
-- **DO** preserve event filtering logic (paths, property names, event types)
-- **DO NOT** put ResourceResolver, JCR Session, or Node operations in the EventHandler
-- **DO NOT** change the business logic — move it as-is to the JobConsumer
+**Before transformation steps:** [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md)
+(SCR → OSGi DS, service-user resolvers, SLF4J).
 
 ---
 
-## Complete Example: Before and After
+## Why `ResourceChangeListener` is the target API
 
-### Example 1: JCR EventListener → OSGi EventHandler + JobConsumer
+On AEM as a Cloud Service, Sling **`ResourceChangeListener`** is the preferred API for reacting
+to repository changes:
 
-#### Before (Legacy JCR EventListener)
+- First-class Sling API with typed **`ResourceChange`** events and a typed **`ChangeType`** enum.
+- **Cluster-aware**: external (remote-node) vs local changes are flagged via `change.isExternal()`.
+- **Path-prefix** and **change-type** filtering are native OSGi component properties — no LDAP filter required.
+- No JCR `Session` handling in the listener itself.
+
+**Do not** use the following as a replacement:
+
+| Legacy / discouraged on AEMaaCS | Reason |
+|---------------------------------|--------|
+| `javax.jcr.observation.EventListener` (`onEvent(EventIterator)`) | Requires a `Session`, is not cluster-aware, not recommended by Adobe for AEMaaCS. Migrate to `ResourceChangeListener`. |
+| `org.osgi.service.event.EventHandler` subscribed to `org/apache/sling/api/resource/Resource/*` topics | The OSGi resource topics are an internal dispatcher detail and are deprecated as an application-facing API. Use `ResourceChangeListener` instead. |
+| `org.osgi.service.event.EventHandler` for **non-resource** topics (replication, workflow, custom) | Still valid — see [event-migration.md](event-migration.md). |
+
+## Decision table — which API for which event
+
+| Reacting to… | Use |
+|--------------|-----|
+| Resource (page/asset/property) added, changed, removed | **`ResourceChangeListener`** |
+| External (remote-node) change to content | **`ResourceChangeListener`** — implement **`ExternalResourceChangeListener`** |
+| Sling resource provider added/removed | **`ResourceChangeListener`** with `CHANGES=PROVIDER_ADDED/PROVIDER_REMOVED` |
+| Replication action (`com.day.cq.replication.ReplicationEvent.EVENT_TOPIC`) | OSGi `EventHandler` — see [event-migration.md](event-migration.md) |
+| Workflow completion (`com/adobe/granite/workflow/*`) | OSGi `EventHandler` — see [event-migration.md](event-migration.md) |
+| Custom OSGi Event Admin topic posted by another bundle | OSGi `EventHandler` — see [event-migration.md](event-migration.md) |
+| JCR-level events that `ResourceChangeListener` cannot express (rare) | **Avoid custom JCR listeners on AEMaaCS**; file an Adobe support case before adding one. |
+
+## `ResourceChangeListener` vs `ExternalResourceChangeListener`
+
+| Interface | Receives | When to use |
+|-----------|----------|-------------|
+| `ResourceChangeListener` | Only **local** changes (same JVM) | Most write-triggers (e.g. post-process what *this* pod just wrote) |
+| `ExternalResourceChangeListener` **extends** `ResourceChangeListener` | **Local** *and* **external** (cluster / replicated) changes | Cluster-wide reactions (e.g. cache invalidation on publish, replication follow-ups) |
+
+Choose based on whether the reaction must fire **on every node** when any node writes
+(`ExternalResourceChangeListener`), or **only where the write happened** (`ResourceChangeListener`).
+
+## Critical rules for Cloud Service
+
+- **Listener must be lightweight.** `onChange(List<ResourceChange>)` runs on a shared Sling thread;
+  blocking it delays **every other** registered listener. Do only:
+  1. Filter changes you care about (by path, `ChangeType`, or property names).
+  2. Extract the data you need (paths, user id, external flag).
+  3. Enqueue a Sling job via `JobManager.addJob(topic, props)`.
+- **Never** open a `ResourceResolver`, `Session`, or perform JCR / repository reads or writes inside `onChange`.
+- **Never** call `ResourceResolverFactory.getAdministrativeResourceResolver(...)` — replace with `getServiceResourceResolver(SUBSERVICE)` per [resource-resolver-logging.md](resource-resolver-logging.md). The resolver belongs in the **`JobConsumer`**, not the listener.
+- **Filter at registration, not in code.** Use the `paths`, `changes`, and (optionally) `propertyNamesHint`
+  OSGi properties so the Sling framework delivers only relevant events.
+- Business `@Reference` fields (`ResourceResolverFactory`, domain services) live on the **`JobConsumer`**.
+  Only `JobManager` lives on the listener.
+- Choose `ResourceChangeListener` vs `ExternalResourceChangeListener` **deliberately** — see the table above.
+- Paths **must** start with `/` (e.g. `/content/dam`). A leading `glob:` or a path with `.` globs is allowed — see the Sling API Javadoc.
+- On AEMaaCS, service-user mappings referenced via `SUBSERVICE` must be provisioned in **Repoinit**; creating users through the UI is not available. See [resource-resolver-logging.md](resource-resolver-logging.md).
+
+---
+
+## Classification
+
+1. **File already implements `ResourceChangeListener`** and `onChange` contains business logic
+   (resolver acquire, JCR/Session ops, heavy processing) → **apply steps R1–R5** below.
+2. **File implements `ResourceChangeListener`** and `onChange` only enqueues jobs → **already compliant**; verify only.
+3. **File implements `javax.jcr.observation.EventListener`** or **`org.osgi.service.event.EventHandler`
+   subscribed to `org/apache/sling/api/resource/Resource/*`** → **this module still applies** (new target is `ResourceChangeListener`); apply **R0** (convert to `ResourceChangeListener`) then R1–R5. For
+   non-resource `EventHandler` topics (ReplicationEvent, WorkflowEvent, custom) use [event-migration.md](event-migration.md) instead.
+
+---
+
+## Complete example — before and after
+
+### Before (legacy JCR `EventListener` with inline logic and admin resolver)
 
 ```java
 package com.example.listeners;
@@ -52,96 +97,94 @@ import org.apache.sling.api.resource.ResourceResolverFactory;
 import javax.jcr.observation.Event;
 import javax.jcr.observation.EventIterator;
 import javax.jcr.observation.EventListener;
-import java.util.Calendar;
 
 @Component(immediate = true)
 @Service
-public class ACLModificationListener implements EventListener {
+public class ACLPolicyListener implements EventListener {
 
     @Reference
-    private ResourceResolverFactory resourceResolverFactory;
+    private ResourceResolverFactory resolverFactory;
 
     @Override
     public void onEvent(EventIterator events) {
         try {
-            ResourceResolver resolver = resourceResolverFactory.getAdministrativeResourceResolver(null);
-            if (resolver != null) {
-                while (events.hasNext()) {
-                    Event event = events.nextEvent();
-                    if (event.getType() == Event.PROPERTY_CHANGED) {
-                        String path = event.getPath();
-                        if (path.contains("/rep:policy")) {
-                            // Business logic: update replication date
-                            System.out.println("ACL modified at: " + path);
-                            // ... update replication date logic ...
-                        }
-                    }
+            ResourceResolver resolver = resolverFactory.getAdministrativeResourceResolver(null);
+            while (events.hasNext()) {
+                Event event = events.nextEvent();
+                if (event.getType() == Event.PROPERTY_CHANGED
+                        && event.getPath().contains("/rep:policy")) {
+                    // heavy work: recompute ACL audit record, replicate, etc.
+                    System.out.println("ACL modified: " + event.getPath());
                 }
-                resolver.close();
             }
+            resolver.close();
         } catch (Exception e) {
-            System.err.println("Error handling ACL modification: " + e.getMessage());
+            System.err.println("ACL listener failed: " + e.getMessage());
             e.printStackTrace();
         }
     }
 }
 ```
 
-#### After (Cloud Service Compatible)
+### After — Cloud Service compatible
 
-**File 1: ACLModificationEventHandler.java** (EventHandler)
+**File 1 — `ACLPolicyChangeListener.java`** (lightweight `ResourceChangeListener`)
 
 ```java
 package com.example.listeners;
 
-import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.observation.ResourceChange;
+import org.apache.sling.api.resource.observation.ResourceChangeListener;
+import org.apache.sling.event.jobs.JobManager;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.event.Event;
-import org.osgi.service.event.EventConstants;
-import org.osgi.service.event.EventHandler;
-import org.apache.sling.event.jobs.JobManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Component(
-    service = EventHandler.class,
-    immediate = true,
-    property = {
-        Constants.SERVICE_DESCRIPTION + "=Event Handler for ACL modifications",
-        EventConstants.EVENT_TOPIC + "=org/apache/sling/api/resource/Resource/CHANGED",
-        EventConstants.EVENT_FILTER + "=(path=/*/rep:policy)"
-    }
+        service = ResourceChangeListener.class,
+        property = {
+                Constants.SERVICE_DESCRIPTION + "=ACL policy change listener",
+                ResourceChangeListener.PATHS + "=glob:/**/rep:policy",
+                ResourceChangeListener.CHANGES + "=ADDED",
+                ResourceChangeListener.CHANGES + "=CHANGED",
+                ResourceChangeListener.CHANGES + "=REMOVED"
+        }
 )
-public class ACLModificationEventHandler implements EventHandler {
+public class ACLPolicyChangeListener implements ResourceChangeListener {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ACLModificationEventHandler.class);
-    private static final String JOB_TOPIC = "com/example/acl/modification/job";
+    private static final Logger LOG = LoggerFactory.getLogger(ACLPolicyChangeListener.class);
+    static final String JOB_TOPIC = "com/example/acl/policy/changed";
 
     @Reference
     private JobManager jobManager;
 
     @Override
-    public void handleEvent(Event event) {
-        try {
-            String path = (String) event.getProperty("path");
-            LOG.debug("Resource event: {} for path: {}", event.getTopic(), path);
-
-            Map<String, Object> jobProperties = new HashMap<>();
-            jobProperties.put("path", path);
-            jobManager.addJob(JOB_TOPIC, jobProperties);
-        } catch (Exception e) {
-            LOG.error("Error handling event", e);
+    public void onChange(List<ResourceChange> changes) {
+        for (ResourceChange change : changes) {
+            try {
+                Map<String, Object> props = new HashMap<>();
+                props.put("path", change.getPath());
+                props.put("type", change.getType().name());
+                props.put("external", change.isExternal());
+                if (change.getUserId() != null) {
+                    props.put("userId", change.getUserId());
+                }
+                jobManager.addJob(JOB_TOPIC, props);
+            } catch (Exception e) {
+                LOG.error("Failed to enqueue ACL change job for {}", change.getPath(), e);
+            }
         }
     }
 }
 ```
 
-**File 2: ACLModificationJobConsumer.java** (JobConsumer)
+**File 2 — `ACLPolicyJobConsumer.java`** (business logic runs here, with a service-user resolver)
 
 ```java
 package com.example.listeners;
@@ -151,7 +194,6 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.event.jobs.Job;
 import org.apache.sling.event.jobs.consumer.JobConsumer;
-import org.apache.sling.event.jobs.consumer.JobResult;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -160,500 +202,261 @@ import org.slf4j.LoggerFactory;
 import java.util.Collections;
 
 @Component(
-    service = JobConsumer.class,
-    immediate = true,
-    property = {
-        JobConsumer.PROPERTY_TOPICS + "=" + "com/example/acl/modification/job"
-    }
+        service = JobConsumer.class,
+        property = {
+                JobConsumer.PROPERTY_TOPICS + "=com/example/acl/policy/changed"
+        }
 )
-public class ACLModificationJobConsumer implements JobConsumer {
+public class ACLPolicyJobConsumer implements JobConsumer {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ACLModificationJobConsumer.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ACLPolicyJobConsumer.class);
 
     @Reference
     private ResourceResolverFactory resolverFactory;
 
     @Override
     public JobResult process(final Job job) {
-        String path = (String) job.getProperty("path");
-        LOG.info("Processing ACL modification job for path: {}", path);
+        final String path = job.getProperty("path", String.class);
+        final String type = job.getProperty("type", String.class);
 
         try (ResourceResolver resolver = resolverFactory.getServiceResourceResolver(
-                Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "event-handler-service"))) {
+                Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "acl-audit-service"))) {
 
-            if (resolver == null) {
-                LOG.warn("Could not acquire resource resolver");
-                return JobResult.FAILED;
-            }
-
-            // Business logic: update replication date
-            LOG.info("ACL modified at: {}", path);
-            // ... existing business logic from onEvent() goes here ...
+            // ==== existing business logic from onEvent() moves here ====
+            LOG.info("Processing ACL {} at {}", type, path);
+            // read resource, update audit record, etc.
 
             return JobResult.OK;
-
         } catch (LoginException e) {
-            LOG.error("Failed to get resource resolver", e);
+            LOG.error("Could not open service resolver for subservice 'acl-audit-service'", e);
             return JobResult.FAILED;
         } catch (Exception e) {
-            LOG.error("Error processing job", e);
+            LOG.error("ACL policy job failed for {}", path, e);
             return JobResult.FAILED;
         }
     }
 }
 ```
 
-### Example 2: OSGi EventHandler with Inline Logic → Lightweight EventHandler + JobConsumer
+**Required Repoinit** (provision the service user and ACLs — goes in your `ui.config` Repoinit OSGi config):
 
-#### Before (Legacy OSGi EventHandler with Inline Logic)
+```
+create service user acl-audit-service
 
-```java
-package com.example.listeners;
-
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.sling.api.resource.LoginException;
-import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ResourceResolverFactory;
-import org.osgi.service.event.Event;
-import org.osgi.service.event.EventConstants;
-import org.osgi.service.event.EventHandler;
-
-import java.util.Calendar;
-import java.util.Collections;
-
-@Component(
-    immediate = true,
-    property = {
-        EventConstants.EVENT_TOPIC + "=org/apache/sling/api/resource/Resource/CHANGED"
-    }
-)
-public class ReplicationDateEventHandler implements EventHandler {
-
-    @Reference
-    private ResourceResolverFactory resourceResolverFactory;
-
-    @Override
-    public void handleEvent(Event event) {
-        String path = (String) event.getProperty("path");
-        try {
-            ResourceResolver resolver = resourceResolverFactory.getServiceResourceResolver(
-                Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "replication-service"));
-            
-            if (resolver != null) {
-                // Business logic: update replication date
-                Resource resource = resolver.getResource(path + "/jcr:content");
-                if (resource != null) {
-                    ModifiableValueMap map = resource.adaptTo(ModifiableValueMap.class);
-                    map.put("cq:lastReplicated", Calendar.getInstance());
-                    resolver.commit();
-                }
-                resolver.close();
-            }
-        } catch (Exception e) {
-            System.err.println("Error updating replication date: " + e.getMessage());
-            e.printStackTrace();
-        }
-    }
-}
+set ACL for acl-audit-service
+    allow jcr:read on /content
+    allow jcr:read,rep:write on /var/acl-audit
+end
 ```
 
-#### After (Cloud Service Compatible)
+**Required service-user mapping** (`ui.config`, file named e.g.
+`org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-acl-audit.cfg.json`):
 
-**File 1: ReplicationDateEventHandler.java** (Lightweight EventHandler)
-
-```java
-package com.example.listeners;
-
-import org.osgi.framework.Constants;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.event.Event;
-import org.osgi.service.event.EventConstants;
-import org.osgi.service.event.EventHandler;
-import org.apache.sling.event.jobs.JobManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.Map;
-
-@Component(
-    service = EventHandler.class,
-    immediate = true,
-    property = {
-        Constants.SERVICE_DESCRIPTION + "=Event Handler for replication date updates",
-        EventConstants.EVENT_TOPIC + "=org/apache/sling/api/resource/Resource/CHANGED"
-    }
-)
-public class ReplicationDateEventHandler implements EventHandler {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ReplicationDateEventHandler.class);
-    private static final String JOB_TOPIC = "com/example/replication/date/update";
-
-    @Reference
-    private JobManager jobManager;
-
-    @Override
-    public void handleEvent(Event event) {
-        try {
-            String path = (String) event.getProperty("path");
-            LOG.debug("Resource event: {} for path: {}", event.getTopic(), path);
-
-            Map<String, Object> jobProperties = new HashMap<>();
-            jobProperties.put("path", path);
-            jobManager.addJob(JOB_TOPIC, jobProperties);
-        } catch (Exception e) {
-            LOG.error("Error handling event", e);
-        }
-    }
+```json
+{
+  "user.mapping": [
+    "com.example.mybundle:acl-audit-service=[acl-audit-service]"
+  ]
 }
 ```
-
-**File 2: ReplicationDateJobConsumer.java** (JobConsumer)
-
-```java
-package com.example.listeners;
-
-import org.apache.sling.api.resource.LoginException;
-import org.apache.sling.api.resource.ModifiableValueMap;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ResourceResolverFactory;
-import org.apache.sling.api.resource.PersistenceException;
-import org.apache.sling.event.jobs.Job;
-import org.apache.sling.event.jobs.consumer.JobConsumer;
-import org.apache.sling.event.jobs.consumer.JobResult;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.Calendar;
-import java.util.Collections;
-
-@Component(
-    service = JobConsumer.class,
-    immediate = true,
-    property = {
-        JobConsumer.PROPERTY_TOPICS + "=" + "com/example/replication/date/update"
-    }
-)
-public class ReplicationDateJobConsumer implements JobConsumer {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ReplicationDateJobConsumer.class);
-
-    @Reference
-    private ResourceResolverFactory resolverFactory;
-
-    @Override
-    public JobResult process(final Job job) {
-        String path = (String) job.getProperty("path");
-        LOG.info("Processing replication date update job for path: {}", path);
-
-        try (ResourceResolver resolver = resolverFactory.getServiceResourceResolver(
-                Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "event-handler-service"))) {
-
-            if (resolver == null) {
-                LOG.warn("Could not acquire resource resolver");
-                return JobResult.FAILED;
-            }
-
-            // Business logic: update replication date
-            Resource resource = resolver.getResource(path + "/jcr:content");
-            if (resource != null) {
-                ModifiableValueMap map = resource.adaptTo(ModifiableValueMap.class);
-                map.put("cq:lastReplicated", Calendar.getInstance());
-                resolver.commit();
-                LOG.debug("Updated replication date for: {}", path);
-            }
-
-            return JobResult.OK;
-
-        } catch (LoginException e) {
-            LOG.error("Failed to get resource resolver", e);
-            return JobResult.FAILED;
-        } catch (PersistenceException e) {
-            LOG.error("Failed to commit changes", e);
-            return JobResult.FAILED;
-        } catch (Exception e) {
-            LOG.error("Error processing job", e);
-            return JobResult.FAILED;
-        }
-    }
-}
-```
-
-**Key Changes:**
-- ✅ Converted JCR `EventListener` → OSGi `EventHandler` (Example 1)
-- ✅ Split EventHandler + JobConsumer (both examples)
-- ✅ EventHandler is lightweight — only creates jobs
-- ✅ Business logic moved to JobConsumer `process()` method
-- ✅ Replaced `getAdministrativeResourceResolver()` → `getServiceResourceResolver()` with SUBSERVICE
-- ✅ Replaced `System.out/err` → SLF4J Logger
-- ✅ Event topics correctly mapped (JCR → OSGi)
-- ✅ Preserved business logic unchanged
 
 ---
 
-# Transformation Steps
+## Transformation steps
 
-## Pattern prerequisites
+### R0 — (only if source is JCR `EventListener` or resource-topic OSGi `EventHandler`) convert to `ResourceChangeListener`
 
-Read [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md) before the steps below.
-
-## R1: Convert JCR EventListener to OSGi EventHandler (if applicable)
-
-**Skip this step if the file already implements `EventHandler`.**
-
-If the file implements JCR `EventListener`, convert to OSGi `EventHandler`:
+Replace the legacy registration/implementation scaffolding with an OSGi DS
+`ResourceChangeListener` component:
 
 ```java
-// BEFORE (JCR Observation)
-import javax.jcr.observation.Event;
-import javax.jcr.observation.EventListener;
-import javax.jcr.observation.EventIterator;
-
-public class ACLModificationListener implements EventListener {
-    @Override
-    public void onEvent(EventIterator events) {
-        while (events.hasNext()) {
-            Event event = events.nextEvent();
-            if (event.getType() == Event.PROPERTY_CHANGED) {
-                String path = event.getPath();
-                // business logic...
-            }
-        }
-    }
-}
-
-// AFTER (OSGi EventHandler — lightweight)
-import org.osgi.service.event.Event;
-import org.osgi.service.event.EventHandler;
-import org.osgi.service.event.EventConstants;
-
-@Component(service = EventHandler.class, immediate = true, property = {
-    Constants.SERVICE_DESCRIPTION + "=Event Handler for ACL modifications",
-    EventConstants.EVENT_TOPIC + "=org/apache/sling/api/resource/Resource/CHANGED",
-    EventConstants.EVENT_FILTER + "=(path=/*/rep:policy)"
-})
-public class ACLModificationEventHandler implements EventHandler {
-    @Reference
-    private JobManager jobManager;
-
-    @Override
-    public void handleEvent(Event event) {
-        String path = (String) event.getProperty("path");
-        // offload to job (business logic goes to JobConsumer)
-    }
-}
-```
-
-**JCR event type to OSGi resource topic mapping:**
-
-| JCR Event Type | OSGi Resource Event Topic |
-|---------------|--------------------------|
-| `Event.NODE_ADDED` | `org/apache/sling/api/resource/Resource/ADDED` |
-| `Event.NODE_REMOVED` | `org/apache/sling/api/resource/Resource/REMOVED` |
-| `Event.PROPERTY_CHANGED` | `org/apache/sling/api/resource/Resource/CHANGED` |
-| `Event.PROPERTY_ADDED` | `org/apache/sling/api/resource/Resource/CHANGED` |
-| `Event.PROPERTY_REMOVED` | `org/apache/sling/api/resource/Resource/CHANGED` |
-
-**JCR event data to OSGi event property mapping:**
-
-| JCR Event API | OSGi Event API |
-|--------------|----------------|
-| `event.getPath()` | `(String) event.getProperty("path")` |
-| `event.getIdentifier()` | `(String) event.getProperty("resourceType")` |
-| `event.getType()` | Determined by topic (no need to check type) |
-
-## R2: Make EventHandler lightweight — offload to Sling Job
-
-The `handleEvent()` method should ONLY:
-1. Extract event data (path, properties, etc.)
-2. Create a Sling Job with those properties
-3. Return immediately
-
-**Move ALL business logic out of handleEvent():**
-
-```java
-// BEFORE (inline business logic in handler)
-@Override
-public void handleEvent(Event event) {
-    String path = (String) event.getProperty("path");
-    try (ResourceResolver resolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO)) {
-        Resource resource = resolver.getResource(path + "/jcr:content");
-        if (resource != null) {
-            ModifiableValueMap map = resource.adaptTo(ModifiableValueMap.class);
-            map.put("cq:lastReplicated", Calendar.getInstance());
-            resolver.commit();
-        }
-    } catch (LoginException | PersistenceException ex) {
-        LOG.error("Error", ex);
-    }
-}
-
-// AFTER (lightweight — just creates a job)
-@Override
-public void handleEvent(Event event) {
-    try {
-        String path = ReplicationEvent.fromEvent(event).getReplicationAction().getPath();
-        LOG.debug("Resource event: {} for path: {}", event.getTopic(), path);
-
-        Map<String, Object> jobProperties = new HashMap<>();
-        jobProperties.put("path", path);
-        jobManager.addJob(JOB_TOPIC, jobProperties);
-    } catch (Exception e) {
-        LOG.error("Error handling event", e);
-    }
-}
-```
-
-**Add JobManager injection:**
-```java
-@Reference
-private JobManager jobManager;
-
-private static final String JOB_TOPIC = "com/example/acl/modification/job";
-```
-
-**Remove ResourceResolverFactory from EventHandler** — it moves to the JobConsumer.
-
-## R3: Create the JobConsumer class
-
-Create a NEW class that implements `JobConsumer` to handle the business logic:
-
-```java
-package com.example.listeners;
-
-import org.apache.sling.api.resource.LoginException;
-import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ResourceResolverFactory;
-import org.apache.sling.event.jobs.Job;
-import org.apache.sling.event.jobs.consumer.JobConsumer;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import java.util.Collections;
-
+// AFTER
 @Component(
-    service = JobConsumer.class,
-    immediate = true,
-    property = {
-        JobConsumer.PROPERTY_TOPICS + "=" + "com/example/acl/modification/job"
-    }
+        service = ResourceChangeListener.class,
+        property = {
+                ResourceChangeListener.PATHS   + "=/content/dam",
+                ResourceChangeListener.CHANGES + "=ADDED",
+                ResourceChangeListener.CHANGES + "=CHANGED",
+                ResourceChangeListener.CHANGES + "=REMOVED"
+        }
 )
-public class ACLModificationJobConsumer implements JobConsumer {
+public class MyChangeListener implements ResourceChangeListener {
+    @Override
+    public void onChange(List<ResourceChange> changes) { /* enqueue jobs */ }
+}
+```
 
-    private static final Logger LOG = LoggerFactory.getLogger(ACLModificationJobConsumer.class);
+**Filter options** (OSGi component properties — use the constants on `ResourceChangeListener`):
+
+| Property | Purpose | Values |
+|----------|---------|--------|
+| `ResourceChangeListener.PATHS` | Path prefixes or globs to observe | `/content/dam`, `glob:/**/jcr:content/*`, `.` (all) |
+| `ResourceChangeListener.CHANGES` | Change types | `ADDED`, `CHANGED`, `REMOVED`, `PROVIDER_ADDED`, `PROVIDER_REMOVED` |
+| `ResourceChangeListener.PROPERTY_NAMES_HINT` | Hint: only these property names are relevant for CHANGED events | `cq:lastReplicated`, `status` |
+
+**Legacy JCR event type → `ChangeType` mapping:**
+
+| JCR (`javax.jcr.observation.Event.*`) | `ResourceChange.ChangeType` |
+|---------------------------------------|-----------------------------|
+| `NODE_ADDED` | `ADDED` |
+| `NODE_REMOVED` | `REMOVED` |
+| `PROPERTY_ADDED` | `CHANGED` |
+| `PROPERTY_CHANGED` | `CHANGED` |
+| `PROPERTY_REMOVED` | `CHANGED` |
+| `NODE_MOVED` | Expressed as `REMOVED` + `ADDED` |
+
+**Legacy JCR `Event` → `ResourceChange` data:**
+
+| JCR | `ResourceChange` |
+|-----|------------------|
+| `event.getPath()` | `change.getPath()` |
+| `event.getType()` | `change.getType()` |
+| `event.getUserID()` | `change.getUserId()` |
+| `event.getInfo()` / heuristics for clustered events | `change.isExternal()` |
+| `event.getIdentifier()` | Not directly available — use path + `getAddedPropertyNames()` / `getChangedPropertyNames()` / `getRemovedPropertyNames()` for property-level detail |
+
+### R1 — Keep `onChange` lightweight; offload to Sling Job
+
+`onChange` must only:
+
+1. Inspect each `ResourceChange` for path, type, and (optionally) property names.
+2. Build a job `Map<String, Object>`.
+3. Call `jobManager.addJob(JOB_TOPIC, props)`.
+4. Return.
+
+Do **not** open resolvers, call `adaptTo(Session.class)`, read child resources, or do I/O here.
+
+```java
+@Override
+public void onChange(List<ResourceChange> changes) {
+    for (ResourceChange change : changes) {
+        Map<String, Object> props = new HashMap<>();
+        props.put("path", change.getPath());
+        props.put("type", change.getType().name());
+        props.put("external", change.isExternal());
+        jobManager.addJob(JOB_TOPIC, props);
+    }
+}
+```
+
+### R2 — Create the `JobConsumer` (business logic)
+
+Create a **new** class that moves *all* the business logic from the legacy `onEvent` / inline
+`handleEvent` / heavy `onChange` into `process(Job)`:
+
+```java
+@Component(
+        service = JobConsumer.class,
+        property = {
+                JobConsumer.PROPERTY_TOPICS + "=com/example/your/topic"
+        }
+)
+public class YourJobConsumer implements JobConsumer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(YourJobConsumer.class);
 
     @Reference
     private ResourceResolverFactory resolverFactory;
 
     @Override
     public JobResult process(final Job job) {
-        String path = (String) job.getProperty("path");
-        LOG.info("Processing job for path: {}", path);
+        final String path = job.getProperty("path", String.class);
 
         try (ResourceResolver resolver = resolverFactory.getServiceResourceResolver(
-                Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "event-handler-service"))) {
-
-            if (resolver == null) {
-                LOG.warn("Could not acquire resource resolver");
-                return JobResult.FAILED;
-            }
-
-            // === EXISTING BUSINESS LOGIC FROM onEvent()/handleEvent() GOES HERE ===
-
+                Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "my-service-user"))) {
+            // business logic
             return JobResult.OK;
-
         } catch (LoginException e) {
-            LOG.error("Failed to get resource resolver", e);
-            return JobResult.FAILED;
-        } catch (Exception e) {
-            LOG.error("Error processing job", e);
+            LOG.error("Could not open service resolver for 'my-service-user'", e);
             return JobResult.FAILED;
         }
     }
 }
 ```
 
-**Key rules for JobConsumer:**
-- Job topic MUST match the topic used in the EventHandler
-- Move ALL business logic from `onEvent()`/`handleEvent()` into `process(Job)`
-- Move business-logic `@Reference` fields here (e.g., `ResourceResolverFactory`)
-- Extract job properties via `job.getProperty("key")` or `(Type) job.getProperty("key")`
-- Return `JobResult.OK` on success, `JobResult.FAILED` on failure
-- Resolver + logging per [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md)
+Rules:
 
-## R4: Add TopologyEventListener for leader election (if applicable)
+- Topic on the `JobConsumer` component **must** match the topic used in `jobManager.addJob`.
+- Move **all** business `@Reference` fields (`ResourceResolverFactory`, domain services, etc.) to the `JobConsumer`.
+- Extract job data via `job.getProperty("key", Type.class)` — **do not** use the deprecated `JobUtil.getProperty(...)`.
+- Return `JobResult.OK` on success, `JobResult.FAILED` on failure (will be retried per the queue config), `JobResult.CANCEL` for unrecoverable failures.
 
-If the event handler should only run on one instance in a cluster (e.g., replication handlers), add `TopologyEventListener`:
+### R3 — Deciding between `ResourceChangeListener` and `ExternalResourceChangeListener`
+
+Default to **`ResourceChangeListener`** (local only). Use
+`ExternalResourceChangeListener` **only** if the reaction must run even for changes that happened
+on a different cluster node (e.g. a publish tier reacting to a replicated update).
 
 ```java
-@Component(service = { EventHandler.class, TopologyEventListener.class }, immediate = true, property = {
-    EventConstants.EVENT_TOPIC + "=" + ReplicationEvent.EVENT_TOPIC
-})
-public class PublishDateEventHandler implements EventHandler, TopologyEventListener {
+import org.apache.sling.api.resource.observation.ExternalResourceChangeListener;
 
-    private volatile boolean isLeader = false;
-
-    @Override
-    public void handleTopologyEvent(TopologyEvent event) {
-        if (event.getType() == TopologyEvent.Type.TOPOLOGY_CHANGED
-                || event.getType() == TopologyEvent.Type.TOPOLOGY_INIT) {
-            isLeader = event.getNewView().getLocalInstance().isLeader();
+@Component(
+        service = ExternalResourceChangeListener.class,
+        property = {
+                ResourceChangeListener.PATHS   + "=/content",
+                ResourceChangeListener.CHANGES + "=CHANGED"
         }
-    }
-
+)
+public class PublishedContentListener implements ExternalResourceChangeListener {
     @Override
-    public void handleEvent(Event event) {
-        if (isLeader) {
-            // create job...
-        }
-    }
+    public void onChange(List<ResourceChange> changes) { /* ... */ }
 }
 ```
 
-**Only add this if:**
-- The handler processes replication events
-- The handler should only fire on one node in the cluster
-- The original code had leader-check logic
+`ExternalResourceChangeListener` **extends** `ResourceChangeListener`; both interfaces expose the same `onChange`.
 
-## R5: Update imports
+Inside `onChange`, you can still branch on origin:
 
-**EventHandler class — Remove:**
+```java
+if (change.isExternal()) {
+    // happened elsewhere in the cluster
+}
+```
+
+### R4 — Update imports
+
+**Remove** (when source was JCR `EventListener`):
+
 ```java
 import javax.jcr.observation.Event;
-import javax.jcr.observation.EventListener;
 import javax.jcr.observation.EventIterator;
+import javax.jcr.observation.EventListener;
+```
+
+**Remove** (when source was `EventHandler` on `org/apache/sling/api/resource/Resource/*`):
+
+```java
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventConstants;
+import org.osgi.service.event.EventHandler;
+```
+
+**Remove** (SCR → DS per [scr-to-osgi-ds.md](scr-to-osgi-ds.md)):
+
+```java
 import org.apache.felix.scr.annotations.*;
-import org.apache.sling.api.resource.ResourceResolverFactory;  // moves to JobConsumer
 ```
 
-**EventHandler class — Add:**
+**Add** — listener class:
+
 ```java
-import org.osgi.service.event.Event;
-import org.osgi.service.event.EventConstants;
-import org.osgi.service.event.EventHandler;
+import org.apache.sling.api.resource.observation.ResourceChange;
+import org.apache.sling.api.resource.observation.ResourceChangeListener;
+// If reacting to external changes too:
+import org.apache.sling.api.resource.observation.ExternalResourceChangeListener;
+import org.apache.sling.event.jobs.JobManager;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.apache.sling.event.jobs.JobManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 ```
 
-**If using TopologyEventListener, also add:**
-```java
-import org.apache.sling.discovery.TopologyEvent;
-import org.apache.sling.discovery.TopologyEventListener;
-```
+**Add** — job consumer class:
 
-**JobConsumer class — Add:**
 ```java
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -667,29 +470,69 @@ import org.slf4j.LoggerFactory;
 import java.util.Collections;
 ```
 
+### R5 — Repoinit and service-user mapping (must be in `ui.config`)
+
+The `JobConsumer` acquires a resolver via `SUBSERVICE`. On AEM as a Cloud Service, the backing
+system user **must** be created through **Repoinit** (the `repo-init` OSGi factory config) and
+mapped through `ServiceUserMapperImpl.amended`. The classic UI-based user admin is not available.
+
+```
+create service user my-service-user
+
+set ACL for my-service-user
+    allow jcr:read on /content
+    allow jcr:read,rep:write on /var/my-app
+end
+```
+
+`org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-<bundle>.cfg.json`:
+
+```json
+{
+  "user.mapping": [
+    "com.example.mybundle:my-service-user=[my-service-user]"
+  ]
+}
+```
+
+See [resource-resolver-logging.md](resource-resolver-logging.md) for the full Repoinit workflow.
+
 ---
 
-# Validation
+## Validation checklist
 
-## EventHandler Checklist
+**Listener class**
 
-- [ ] No `import javax.jcr.observation.*` remains (if converted from JCR EventListener)
-- [ ] SCR→DS per [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md)
-- [ ] No business logic in `handleEvent()` — only event data extraction + job creation
-- [ ] No `ResourceResolver`, `Session`, or `Node` operations in `handleEvent()`
-- [ ] `@Component(service = EventHandler.class, property = { EVENT_TOPIC... })` is present
-- [ ] `@Reference JobManager` is present
-- [ ] `jobManager.addJob(TOPIC, properties)` is called
-- [ ] Event topics are correctly mapped (JCR → OSGi)
-- [ ] Event filtering preserves original filter logic (paths, types)
-- [ ] Logging per [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md)
+- [ ] Implements `org.apache.sling.api.resource.observation.ResourceChangeListener`
+      (or `ExternalResourceChangeListener` if external changes are needed — justified in a code comment).
+- [ ] Component registers via `@Component(service = ResourceChangeListener.class, property = { PATHS..., CHANGES... })`.
+- [ ] No `import javax.jcr.observation.*` remains.
+- [ ] No OSGi resource-topic `EventHandler` subscription remains (`org/apache/sling/api/resource/Resource/*`).
+- [ ] No `ResourceResolverFactory`, `ResourceResolver`, `Session`, or `Node` operation inside `onChange`.
+- [ ] `onChange` body only extracts data and calls `jobManager.addJob(...)`.
+- [ ] `@Reference JobManager` present; business `@Reference` fields moved to the `JobConsumer`.
+- [ ] SLF4J used (no `System.out` / `System.err` / `printStackTrace`).
+- [ ] SCR → DS complete — no `org.apache.felix.scr.annotations.*` imports.
 
-## JobConsumer Checklist
+**`JobConsumer` class**
 
-- [ ] Implements `JobConsumer`
-- [ ] Has `@Component(service = JobConsumer.class, property = { PROPERTY_TOPICS... })`
-- [ ] Job topic matches the EventHandler topic
-- [ ] Business logic from original `onEvent()`/`handleEvent()` is preserved
-- [ ] Returns `JobResult.OK` or `JobResult.FAILED`
-- [ ] Resolver + logging per [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md)
-- [ ] Code compiles: `mvn clean compile`
+- [ ] Implements `JobConsumer`.
+- [ ] `@Component(service = JobConsumer.class, property = { PROPERTY_TOPICS = ... })` with the **same** topic used by the listener.
+- [ ] Resolver opened via `getServiceResourceResolver` with a `SUBSERVICE` mapping, in try-with-resources.
+- [ ] All business logic from the legacy listener lives here.
+- [ ] Extracts job data via `job.getProperty(..., Type.class)` — not `JobUtil.getProperty`.
+- [ ] Returns `JobResult.OK` / `FAILED` / `CANCEL`; never swallows errors.
+
+**Configuration**
+
+- [ ] Service user created via Repoinit in `ui.config`.
+- [ ] `ServiceUserMapperImpl.amended-*.cfg.json` maps `<bundle>:<subservice>` → the service user.
+- [ ] `mvn clean install` succeeds and produces no SCR-related or deprecated-API warnings.
+
+---
+
+## See also
+
+- [event-migration.md](event-migration.md) — for non-resource OSGi Event Admin handlers (replication, workflow, custom topics).
+- [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md) — SCR → DS, service-user resolvers, SLF4J.
+- [`../SKILL.md`](../SKILL.md) — pattern index.

--- a/plugins/aem/cloud-service/skills/best-practices/references/resource-resolver-logging.md
+++ b/plugins/aem/cloud-service/skills/best-practices/references/resource-resolver-logging.md
@@ -1,19 +1,27 @@
 # ResourceResolver & logging (AEM as a Cloud Service)
 
-**Part of the `best-practices` skill.** Read this module when fixing Sling resource access or logging; pattern files link here instead of repeating the same rules.
+**Part of the `best-practices` skill.** Read this module when fixing Sling resource access or
+logging; pattern files link here instead of repeating the same rules.
 
 **Expectations** for backend Java on **AEM as a Cloud Service**:
 
 1. Do **not** use `ResourceResolverFactory.getAdministrativeResourceResolver(...)`.
-2. Use **`getServiceResourceResolver`** with a **`SUBSERVICE`** mapping to an OSGi service user with the right ACLs.
-3. Close resolvers predictably — prefer **try-with-resources**.
-4. Use **SLF4J**; do **not** use `System.out`, `System.err`, or `e.printStackTrace()`.
+2. Use **`getServiceResourceResolver`** with a **`SUBSERVICE`** mapping to an OSGi service user
+   with the right ACLs.
+3. The service user and its ACLs must be provisioned through **Repoinit** (the Apache Sling
+   Repoinit OSGi factory config), because AEM as a Cloud Service does **not** provide an
+   interactive user-admin UI for creating users or adjusting their ACLs at runtime.
+4. The `<bundle>:<subservice>` → service-user mapping must be declared in a
+   `org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-*.cfg.json` file under
+   the appropriate `ui.config` runmode folder.
+5. Close resolvers predictably — prefer **try-with-resources**.
+6. Use **SLF4J**; do **not** use `System.out`, `System.err`, or `e.printStackTrace()`.
 
 ## When to Use
 
-- Migration or review touching `ResourceResolver` or `ResourceResolverFactory`
-- Replacing legacy auth maps (`USER`/`PASSWORD`) with service users
-- OSGi components, servlets, jobs, listeners
+- Migration or review touching `ResourceResolver` or `ResourceResolverFactory`.
+- Replacing legacy auth maps (`USER` / `PASSWORD`) with service users.
+- OSGi components, servlets, jobs, listeners.
 
 ## ResourceResolver: service user (not administrative)
 
@@ -26,21 +34,82 @@ import java.util.Collections;
 
 try (ResourceResolver resolver = factory.getServiceResourceResolver(
         Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "my-service-user"))) {
-    if (resolver == null) {
-        LOG.warn("Could not acquire resource resolver");
-        return;
-    }
     // work with resolver
 } catch (LoginException e) {
-    LOG.error("Failed to open resource resolver", e);
+    LOG.error("Could not open service resolver for subservice 'my-service-user'", e);
 }
 ```
 
-**Notes:**
+### `LoginException` vs. `null` — what to check
 
-- **`SUBSERVICE`** must match a **service user** in your project. Reuse an existing subservice name when one exists for the same concern.
-- If you see `getWriteResourceResolver()` or similar deprecated APIs, replace with the **service resolver** pattern where supported by your SDK.
-- Prefer **subservice only** for Cloud Service patterns; remove **`USER` / `PASSWORD`** from `authInfo` unless a pattern module documents an exception.
+`getServiceResourceResolver` signals failure by **throwing `LoginException`**; it does **not**
+normally return `null`. Catch `LoginException` and log. You do **not** need a defensive
+`resolver == null` branch unless a downstream wrapper in your codebase can legitimately return
+`null` (rare).
+
+The same applies to `getResourceResolver(authInfo)`.
+
+### Notes
+
+- **`SUBSERVICE`** must match a **service user** in your project that is provisioned through
+  Repoinit and mapped through `ServiceUserMapperImpl.amended` (see below). Reuse an existing
+  subservice name when one exists for the same concern.
+- If you see `getWriteResourceResolver()` or similar deprecated APIs, replace with the
+  **service resolver** pattern.
+- Prefer **subservice only** for Cloud Service patterns; remove **`USER` / `PASSWORD`** from
+  `authInfo` unless a pattern module documents an explicit exception (there are none at the
+  moment).
+
+## Provisioning the service user with Repoinit
+
+On AEM as a Cloud Service, service users, system users, and their ACLs must be created through
+the **Apache Sling Repoinit** OSGi factory configuration. The classic `/useradmin` UI and
+ad-hoc ACL editing through CRXDE are not available.
+
+Place the Repoinit config in a `ui.config` package under a runmode folder that matches where
+the service user is needed (`osgiconfig/config`, `osgiconfig/config.author`,
+`osgiconfig/config.publish`, etc.).
+
+**File name:** `org.apache.sling.jcr.repoinit.RepositoryInitializer~my-service-user.cfg.json`
+
+```json
+{
+  "scripts": [
+    "create service user my-service-user",
+    "set ACL for my-service-user",
+    "  allow jcr:read on /content",
+    "  allow jcr:read,rep:write on /var/my-app",
+    "end"
+  ]
+}
+```
+
+Repoinit idempotency: the `create service user` / `set ACL` statements are safe to run on every
+deployment. They create the user if missing and re-apply ACLs; they never drop other users or
+other grants.
+
+See Adobe's documentation for the full Repoinit grammar (node creation, group membership,
+principal-based ACLs, path globs, etc.).
+
+## Mapping the bundle subservice to the service user
+
+Without a mapping, `SUBSERVICE = "my-service-user"` resolves to nothing and
+`getServiceResourceResolver` throws `LoginException`. Declare the mapping in a
+`ServiceUserMapperImpl.amended-*.cfg.json` file in the same `ui.config` module.
+
+**File name:** `org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-my-app.cfg.json`
+
+```json
+{
+  "user.mapping": [
+    "com.example.mybundle:my-service-user=[my-service-user]"
+  ]
+}
+```
+
+The entry format is `<bundle-symbolic-name>:<subservice-name>=[<system-user>]`. The bundle
+symbolic name must match the Maven `<artifactId>` / `Bundle-SymbolicName` of the bundle doing
+the `getServiceResourceResolver(SUBSERVICE=...)` call.
 
 ## try-with-resources
 
@@ -60,11 +129,12 @@ try {
 try (ResourceResolver resolver = factory.getServiceResourceResolver(authInfo)) {
     // ...
 } catch (LoginException e) {
-    LOG.error("Failed to get resource resolver", e);
+    LOG.error("Could not open service resolver for subservice '...'", e);
 }
 ```
 
-Also close other closeables (`InputStream`, `Session` where applicable) with try-with-resources or `finally`.
+Also close other closeables (`InputStream`, `Session` where applicable) with try-with-resources
+or `finally`.
 
 ## Logging: SLF4J
 
@@ -83,11 +153,17 @@ Log exceptions as the last argument: `LOG.error("msg", e)`.
 
 ## Validation checklist
 
-- [ ] No `getAdministrativeResourceResolver(` (unless an approved exception exists elsewhere)
-- [ ] `ResourceResolver` closed via try-with-resources or equivalent
-- [ ] `SUBSERVICE` / service user valid for the operation
-- [ ] `private static final Logger LOG = LoggerFactory.getLogger(...)` where logging is needed
-- [ ] No `System.out`, `System.err`, or `printStackTrace()` in production paths
+- [ ] No `getAdministrativeResourceResolver(` remains.
+- [ ] `ResourceResolver` closed via try-with-resources (or equivalent for non-trivial flows).
+- [ ] `SUBSERVICE` / service user matches a Repoinit-provisioned system user.
+- [ ] `org.apache.sling.jcr.repoinit.RepositoryInitializer~*.cfg.json` under `ui.config`
+      creates the service user and grants the minimum required ACLs.
+- [ ] `org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-*.cfg.json` maps
+      `<bundle-symbolic-name>:<subservice>` → the service user.
+- [ ] `LoginException` is caught (not left unchecked) where
+      `getServiceResourceResolver` is called; no defensive `== null` branch unless justified.
+- [ ] `private static final Logger LOG = LoggerFactory.getLogger(...)` where logging is needed.
+- [ ] No `System.out`, `System.err`, or `printStackTrace()` in production paths.
 
 ## See also
 

--- a/plugins/aem/cloud-service/skills/best-practices/references/scheduler-path-a.md
+++ b/plugins/aem/cloud-service/skills/best-practices/references/scheduler-path-a.md
@@ -1,6 +1,12 @@
-# Scheduler Path A: @SlingScheduled (Simple Schedulers)
+# Scheduler Path A — OSGi scheduler properties (simple schedulers)
 
-For schedulers with hardcoded cron, single schedule, and `implements Runnable`.
+For schedulers with a hardcoded cron, a single schedule, and `implements Runnable`.
+
+The target pattern is a `Runnable` component whose schedule is declared through the
+**Apache Sling Commons Scheduler OSGi component properties**
+(`scheduler.expression`, `scheduler.concurrent`, `scheduler.runOn`). No `Scheduler` reference,
+no `schedule()` call, no `@SlingScheduled` annotation (that annotation does **not** exist in the
+Cloud Service SDK).
 
 ---
 
@@ -8,33 +14,71 @@ For schedulers with hardcoded cron, single schedule, and `implements Runnable`.
 
 Read [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md) and apply the linked prerequisite modules before the scheduler-specific steps below.
 
-## A1: Update @Component annotation
+## A1: Update `@Component` to declare the schedule via properties
+
+Register the component as a `Runnable` service and push the cron expression, concurrency guard,
+and cluster-role setting into the component's `property` list. These three properties are the
+public contract between `org.apache.sling.commons.scheduler.Scheduler` and any `Runnable` service.
 
 ```java
-// BEFORE
+// BEFORE (legacy)
 @Component(immediate = true)
 // OR
 @Component(service = Job.class, immediate = true)
 
-// AFTER
-@Component(service = Runnable.class)
+// AFTER — Cloud Service compatible
+import org.osgi.service.component.annotations.Component;
+
+@Component(
+        service = Runnable.class,
+        immediate = true,
+        property = {
+                "scheduler.expression=0 0 2 * * ?",          // hardcoded cron, keep your existing value
+                "scheduler.concurrent:Boolean=false",        // never run two overlapping invocations
+                "scheduler.runOn=SINGLE"                     // only one JVM in the topology runs it
+        }
+)
+public class MyScheduler implements Runnable { /* ... */ }
 ```
 
-Only change the `@Component` parameters. Do NOT remove the import for `@Component`.
+**Property reference:**
 
-## A2: Remove Scheduler injection
+| Property | Type | Purpose | Typical value on AEMaaCS |
+|----------|------|---------|--------------------------|
+| `scheduler.expression` | `String` | Quartz cron expression | Your existing cron |
+| `scheduler.concurrent` | `Boolean` | Allow overlapping runs? | **`false`** (set by `:Boolean=false`) |
+| `scheduler.runOn` | `String` | Which topology members execute it | `SINGLE` (leader only) or `LEADER`; omit only when every publish must run it independently |
+| `scheduler.period` | `Long` | Fixed-interval scheduling (seconds) | Only if you are migrating a periodic scheduler (not cron) — use `scheduler.expression` instead |
+| `scheduler.name` | `String` | Human-readable name / registry key | Optional |
 
-Remove the `@Reference` Scheduler field entirely:
+**AEM as a Cloud Service caveat:** publish runs multiple pods; without `scheduler.runOn=SINGLE`
+(or `LEADER`), a cron `Runnable` will fire **on every pod**. Pick deliberately:
+
+- Writes to the repository / external systems → `SINGLE`.
+- Per-pod bookkeeping (local cache warm-up, etc.) → omit `scheduler.runOn`.
+
+Do **not** remove the `@Component` import — it is still needed.
+
+## A2: Remove the `Scheduler` `@Reference` field
+
+Remove the `@Reference` `Scheduler` field entirely:
 
 ```java
-// REMOVE these lines
+// REMOVE
+import org.apache.sling.commons.scheduler.Scheduler;
+...
 @Reference
 private Scheduler scheduler;
 ```
 
-## A3: Remove scheduler.schedule() and scheduler.unschedule() calls
+The Sling framework calls `run()` directly based on the `scheduler.expression` property — there
+is no `Scheduler` API call anywhere in your class.
 
-Remove all `scheduler.schedule(...)`, `scheduler.unschedule(...)`, `scheduler.EXPR(...)` calls. Remove helper methods that only exist for scheduling (e.g., `addScheduler()`, `removeScheduler()`). Keep the `@Activate` annotation and method, but remove the scheduling calls inside it.
+## A3: Remove every `scheduler.schedule(...)` / `unschedule(...)` / `EXPR(...)` call
+
+Remove all `scheduler.schedule(...)`, `scheduler.unschedule(...)`, and `scheduler.EXPR(...)`
+calls. Remove helper methods that only exist for scheduling (`addScheduler()`, `removeScheduler()`,
+etc.). Keep `@Activate` / `@Deactivate`, but remove their scheduling calls.
 
 ```java
 // BEFORE
@@ -51,14 +95,16 @@ protected void activate() {
 }
 ```
 
-(Apply **logging** changes per [resource-resolver-logging.md](resource-resolver-logging.md), not ad hoc.)
+Apply **logging** changes per [resource-resolver-logging.md](resource-resolver-logging.md).
 
-## A4: Remove @Modified method (if it only re-registers schedules)
+## A4: Remove `@Modified` when it only re-registers schedules
 
-If the `@Modified` method only calls `removeScheduler()` + `addScheduler()` (or equivalent), remove it entirely since `@SlingScheduled` handles scheduling automatically.
+If `@Modified` only calls `removeScheduler()` + `addScheduler()` (or equivalent), remove it
+entirely — the Sling framework re-reads the `scheduler.expression` property automatically on
+config change.
 
 ```java
-// REMOVE if it only re-registers schedules
+// REMOVE — framework handles reschedule on property change
 @Modified
 protected void modified(Config config) {
     removeScheduler();
@@ -66,10 +112,10 @@ protected void modified(Config config) {
 }
 ```
 
-If `@Modified` has other business logic (e.g., updating config fields), keep the method but remove the scheduling calls:
+If `@Modified` carries other business logic (updating cached config fields), keep it but drop
+the scheduling calls:
 
 ```java
-// KEEP but simplify
 @Modified
 protected void modified(Config config) {
     this.myParameter = config.myParameter();
@@ -77,68 +123,95 @@ protected void modified(Config config) {
 }
 ```
 
-## A5: Extract cron expression and add @SlingScheduled
+## A5: Extract the cron expression and put it on the `@Component`
 
-Find the existing cron expression in the code. Look for:
-- String constants or inline cron strings used in `scheduler.schedule()` calls
-- `@Property(name = "scheduler.expression", value = "...")` annotations (legacy SCR — may already be migrated via DS metatype)
-- Any scheduler configuration properties with hardcoded defaults
+Find the existing cron in the code:
+
+- String constants or inline cron strings passed to `scheduler.schedule(...)`.
+- Legacy `@Property(name = "scheduler.expression", value = "...")` SCR annotations.
+- Any scheduler configuration properties with hardcoded defaults.
+
+Move the **exact** cron you extract into the `scheduler.expression` entry of `@Component.property`
+(see A1). Examples:
+
+| Found in legacy code | Put in `@Component.property` |
+|---|---|
+| `scheduler.schedule(this, ..., "0 0 2 * * ?")` | `"scheduler.expression=0 0 2 * * ?"` |
+| `@Property(name="scheduler.expression", value="*/30 * * * * ?")` | `"scheduler.expression=*/30 * * * * ?"` |
+| `scheduler.EXPR("0 * * * * ?")` | `"scheduler.expression=0 * * * * ?"` |
+
+**Do not invent a cron.** If you cannot find one, ask the user.
+
+### Making the cron configurable (metatype, still Cloud Service compatible)
+
+If the legacy code sourced the cron from metatype / config, keep it configurable by backing the
+three properties with an `@ObjectClassDefinition`. The framework still schedules from the
+resulting component properties:
 
 ```java
-// BEFORE
-@Override
-public void run() {
-    // existing logic
+@ObjectClassDefinition(name = "My Scheduler")
+public @interface Config {
+    @AttributeDefinition(name = "Cron expression")
+    String scheduler_expression() default "0 0 2 * * ?";
+
+    @AttributeDefinition(name = "Concurrent")
+    boolean scheduler_concurrent() default false;
+
+    @AttributeDefinition(name = "Run on")
+    String scheduler_runOn() default "SINGLE";
 }
 
-// AFTER
-@Override
-@SlingScheduled(expression = "*/30 * * * * ?")  // use the EXISTING cron from the code
-public void run() {
-    // existing logic (will be wrapped in A6)
-}
+@Component(service = Runnable.class, immediate = true)
+@Designate(ocd = MyScheduler.Config.class)
+public class MyScheduler implements Runnable { /* ... */ }
 ```
 
-**Extract the exact cron expression from the code:**
-- From `scheduler.schedule(this, ..., "0 0 2 * * ?")` -> use `"0 0 2 * * ?"`
-- From `@Property(name = "scheduler.expression", value = "*/30 * * * * ?")` -> use `"*/30 * * * * ?"`
-- From `scheduler.EXPR("0 * * * * ?")` -> use `"0 * * * * ?"`
+Prefer the direct `property = { ... }` form (A1) for **hardcoded** Path-A schedulers; use the
+OCD form when the cron truly needs to be admin-configurable.
 
-## A6: Add ResourceResolver handling
+> If the cron value **must** come from runtime OSGi configuration with arbitrary values, this is
+> actually a **Path B** scheduler — see [scheduler-path-b.md](scheduler-path-b.md) and use the
+> Sling Jobs flow instead.
 
-Follow [resource-resolver-logging.md](resource-resolver-logging.md) for resolver acquisition and try-with-resources. Wrap the `run()` method body:
+## A6: Add `ResourceResolver` handling inside `run()`
+
+Follow [resource-resolver-logging.md](resource-resolver-logging.md) for resolver acquisition and
+try-with-resources. `run()` becomes:
 
 ```java
-// AFTER
 @Override
-@SlingScheduled(expression = "*/30 * * * * ?")
 public void run() {
     try (ResourceResolver resolver = resolverFactory.getServiceResourceResolver(
             Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "scheduler-service"))) {
 
-        if (resolver == null) {
-            LOG.warn("Could not acquire resource resolver, skipping execution");
-            return;
-        }
-
         LOG.debug("Running scheduled job");
         // existing job logic here
-
     } catch (LoginException e) {
-        LOG.error("Failed to get resource resolver", e);
+        LOG.error("Could not open service resolver for subservice 'scheduler-service'", e);
     }
 }
 ```
 
-**Add ResourceResolverFactory injection (if not already present):**
+Notes:
+
+- `getServiceResourceResolver` throws `LoginException` on failure — it does **not** normally
+  return `null`. Catch `LoginException` and log; do not add a `resolver == null` branch unless
+  you have a specific reason (e.g. a wrapper that returns `null`).
+- The `SUBSERVICE` name must be backed by a Repoinit service user plus a
+  `ServiceUserMapperImpl.amended-*.cfg.json` mapping — see
+  [resource-resolver-logging.md](resource-resolver-logging.md).
+
+Add the factory field if not already present:
+
 ```java
 @Reference
 private ResourceResolverFactory resolverFactory;
 ```
 
-## A7: Update @Activate method
+## A7: Update `@Activate`
 
-Remove all scheduling logic. If using `@Designate`, change parameter from `Map<String, Object>` to the Config interface:
+Remove all scheduling logic from `@Activate`. If using `@Designate`, change the parameter from
+`Map<String, Object>` to the typed `Config`:
 
 ```java
 // BEFORE
@@ -148,10 +221,10 @@ protected void activate(final Map<String, Object> config) {
     addScheduler(config);
 }
 
-// AFTER (OSGi DS)
+// AFTER
 @Activate
 protected void activate(final Config config) {
-    myParameter = config.myParameter();
+    this.myParameter = config.myParameter();
     LOG.info("Scheduler activated, myParameter='{}'", myParameter);
 }
 ```
@@ -159,26 +232,32 @@ protected void activate(final Config config) {
 ## A8: Update imports
 
 **Remove:**
+
 ```java
 import org.apache.sling.commons.scheduler.Scheduler;
 import org.apache.sling.commons.scheduler.ScheduleOptions;
 import org.apache.sling.commons.scheduler.Job;
 import org.apache.sling.commons.scheduler.JobContext;
-import org.apache.sling.commons.osgi.PropertiesUtil;  // if no longer needed
+import org.apache.sling.commons.osgi.PropertiesUtil;  // if no longer used
 ```
 
-(Remove Felix SCR imports per **SCR→DS** skill.)
+Remove Felix SCR imports per [scr-to-osgi-ds.md](scr-to-osgi-ds.md).
+
+**Do NOT** add `org.apache.sling.commons.scheduler.SlingScheduled` — that class does not exist
+in the AEM Cloud Service SDK. The scheduling is entirely driven by the component properties in
+A1.
 
 **Add (if not already present):**
+
 ```java
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
-import org.apache.sling.commons.scheduler.SlingScheduled;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+// Only if you keep a typed Config via OCD:
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
@@ -187,9 +266,9 @@ import org.slf4j.LoggerFactory;
 import java.util.Collections;
 ```
 
-**DO NOT** remove or change any other imports that are still used.
+**Do not** remove or change any other imports that are still used.
 
-## A9: Add @Deactivate method (if missing)
+## A9: Add `@Deactivate` (if missing)
 
 ```java
 @Deactivate
@@ -200,17 +279,76 @@ protected void deactivate() {
 
 ---
 
-# Validation Checklist
+## Complete Path-A example (after)
 
-- [ ] No `import org.apache.sling.commons.scheduler.Scheduler;` remains
-- [ ] No `import org.apache.sling.commons.scheduler.ScheduleOptions;` remains
-- [ ] No Felix SCR annotations remain (`org.apache.felix.scr.annotations.*`) — per SCR→DS skill
-- [ ] No `scheduler.schedule(` calls remain
-- [ ] No `scheduler.unschedule(` calls remain
-- [ ] No `scheduler.EXPR(` calls remain
-- [ ] Resolver + logging checklist satisfied — per [resource-resolver-logging.md](resource-resolver-logging.md)
-- [ ] `@Component(service = Runnable.class)` is present
-- [ ] `@SlingScheduled(expression = "...")` is on `run()` method
-- [ ] `ResourceResolverFactory` injected via `@Reference` if `run()` uses a resolver
-- [ ] `@Deactivate` method is present
-- [ ] Code compiles: `mvn clean compile`
+```java
+package com.example.scheduling;
+
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+
+@Component(
+        service = Runnable.class,
+        immediate = true,
+        property = {
+                "scheduler.expression=0 0 2 * * ?",
+                "scheduler.concurrent:Boolean=false",
+                "scheduler.runOn=SINGLE"
+        }
+)
+public class NightlyCleanupScheduler implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NightlyCleanupScheduler.class);
+
+    @Reference
+    private ResourceResolverFactory resolverFactory;
+
+    @Activate
+    protected void activate() {
+        LOG.info("NightlyCleanupScheduler activated");
+    }
+
+    @Deactivate
+    protected void deactivate() {
+        LOG.info("NightlyCleanupScheduler deactivated");
+    }
+
+    @Override
+    public void run() {
+        try (ResourceResolver resolver = resolverFactory.getServiceResourceResolver(
+                Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "scheduler-service"))) {
+            // business logic
+            LOG.debug("Nightly cleanup completed");
+        } catch (LoginException e) {
+            LOG.error("Could not open service resolver for subservice 'scheduler-service'", e);
+        }
+    }
+}
+```
+
+---
+
+## Validation checklist
+
+- [ ] No `import org.apache.sling.commons.scheduler.Scheduler;` remains.
+- [ ] No `import org.apache.sling.commons.scheduler.ScheduleOptions;` remains.
+- [ ] **No `@SlingScheduled` annotation** (it does not exist in the AEMaaCS SDK).
+- [ ] No Felix SCR annotations remain (`org.apache.felix.scr.annotations.*`) — per [scr-to-osgi-ds.md](scr-to-osgi-ds.md).
+- [ ] No `scheduler.schedule(`, `scheduler.unschedule(`, `scheduler.EXPR(` calls remain.
+- [ ] Resolver + logging checklist satisfied — per [resource-resolver-logging.md](resource-resolver-logging.md).
+- [ ] `@Component(service = Runnable.class, property = { "scheduler.expression=...", "scheduler.concurrent:Boolean=false", "scheduler.runOn=SINGLE" })` is present, with the exact cron extracted from the legacy code.
+- [ ] `scheduler.concurrent:Boolean=false` is set (or `scheduler.concurrent=false` with a matching OCD method).
+- [ ] `scheduler.runOn=SINGLE` (or `LEADER`) is set — unless every publish pod must run the job.
+- [ ] `ResourceResolverFactory` injected via `@Reference` if `run()` uses a resolver.
+- [ ] `@Deactivate` method is present.
+- [ ] Service user + mapping exists in Repoinit / `ui.config` (see [resource-resolver-logging.md](resource-resolver-logging.md)).
+- [ ] Code compiles: `mvn clean compile`.

--- a/plugins/aem/cloud-service/skills/best-practices/references/scheduler-path-b.md
+++ b/plugins/aem/cloud-service/skills/best-practices/references/scheduler-path-b.md
@@ -389,7 +389,6 @@ import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.event.jobs.Job;
 import org.apache.sling.event.jobs.consumer.JobConsumer;
 import org.apache.sling.event.jobs.consumer.JobResult;
-import org.apache.sling.event.jobs.consumer.JobUtil;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -441,7 +440,7 @@ public class AssetPurgeJobConsumer implements JobConsumer {
 - Job topic MUST match the topic used in the Scheduler class
 - Move ALL business logic from `run()` or `execute(JobContext)` into `process(Job)`
 - Move business-logic `@Reference` fields here (e.g., `ExampleService`, `ResourceResolverFactory`)
-- Extract job properties via `job.getProperty("key", Type.class)` or `JobUtil.getProperty(job, "key", Type.class)` (both valid)
+- Extract job properties via `job.getProperty("key", Type.class)`. Do **not** use `org.apache.sling.event.jobs.consumer.JobUtil.getProperty(...)` — it is deprecated.
 - Map `jobContext.getConfiguration().get("key")` (old) to `job.getProperty("key", Type.class)` (new)
 - Return `JobResult.OK` on success, `JobResult.FAILED` on failure
 - Resolver + logging per [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md)
@@ -516,7 +515,6 @@ import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.event.jobs.Job;
 import org.apache.sling.event.jobs.consumer.JobConsumer;
 import org.apache.sling.event.jobs.consumer.JobResult;
-import org.apache.sling.event.jobs.consumer.JobUtil;  // optional, for JobUtil.getProperty()
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -525,6 +523,11 @@ import java.util.Collections;
 ```
 
 ## B5: Verify @Activate, @Modified, @Deactivate lifecycle
+
+OSGi Declarative Services allows `@Activate` and `@Modified` on the **same** method; the method
+is called both at component start and whenever bound configuration changes. This is the
+simplest pattern when activation and reconfiguration need the exact same logic (unschedule then
+reschedule):
 
 ```java
 @Activate
@@ -541,6 +544,33 @@ protected void deactivate() {
     unscheduleExistingJobs();
 }
 ```
+
+**Alternative — separate `modified` method.** If you prefer the classic OSGi DS style (two
+distinct methods), annotate each independently and let `modified` delegate to `activate`. No
+extra `@Component(modified = ...)` attribute is needed on modern bnd / Felix SCR generators —
+the annotations alone are sufficient:
+
+```java
+@Activate
+protected void activate(SchedulerConfig config) {
+    unscheduleExistingJobs();
+    if (config.enabled()) {
+        scheduleJob(config);
+    }
+}
+
+@Modified
+protected void modified(SchedulerConfig config) {
+    activate(config);
+}
+
+@Deactivate
+protected void deactivate() {
+    unscheduleExistingJobs();
+}
+```
+
+Pick whichever style the surrounding bundle already uses. Do **not** mix both in the same class.
 
 ---
 

--- a/plugins/aem/cloud-service/skills/best-practices/references/scheduler.md
+++ b/plugins/aem/cloud-service/skills/best-practices/references/scheduler.md
@@ -5,8 +5,12 @@ Migrates AEM schedulers from legacy patterns to Cloud Service compatible pattern
 **Before path-specific steps:** [aem-cloud-service-pattern-prerequisites.md](aem-cloud-service-pattern-prerequisites.md) (SCR→DS, resolver, logging).
 
 **Two paths based on complexity:**
-- **Path A (@SlingScheduled):** Simple schedulers — hardcoded cron, single schedule, `implements Runnable`
-- **Path B (Sling Job):** Complex schedulers — config-driven crons, multiple schedules, `implements Job`
+- **Path A (Runnable with OSGi scheduler properties):** Simple schedulers — hardcoded cron, single schedule, `implements Runnable`; registered via `scheduler.expression` / `scheduler.concurrent` / `scheduler.runOn` component properties.
+- **Path B (Sling Job):** Complex schedulers — config-driven crons, multiple schedules, business logic that belongs on a `JobConsumer`.
+
+> **Note:** There is **no `@SlingScheduled` annotation** in the AEM as a Cloud Service SDK.
+> Schedules on a `Runnable` service are always declared through the
+> `scheduler.expression` / `scheduler.concurrent` / `scheduler.runOn` OSGi component properties.
 
 ---
 
@@ -35,16 +39,25 @@ public class MyScheduler implements Runnable {
 
 **After:**
 ```java
-@Component(service = Runnable.class)
+@Component(
+        service = Runnable.class,
+        immediate = true,
+        property = {
+                "scheduler.expression=*/30 * * * * ?",
+                "scheduler.concurrent:Boolean=false",
+                "scheduler.runOn=SINGLE"
+        }
+)
 public class MyScheduler implements Runnable {
     @Reference private ResourceResolverFactory resolverFactory;
-    
+
     @Override
-    @SlingScheduled(expression = "*/30 * * * * ?")
     public void run() {
         try (ResourceResolver resolver = resolverFactory.getServiceResourceResolver(
                 Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "scheduler-service"))) {
             // business logic
+        } catch (LoginException e) {
+            // log and return
         }
     }
 }
@@ -108,12 +121,14 @@ public class MyJobConsumer implements JobConsumer {
 **Classify BEFORE making any changes.**
 
 ### Use Path A when ALL of these are true:
-- Cron expression is a hardcoded string constant (not from runtime configuration)
+- Cron expression is a hardcoded string constant (or a simple `@AttributeDefinition`-backed
+  `scheduler.expression` config value)
 - Only one schedule/cron per class
 - Class implements `Runnable` (not `Job`)
-- No complex scheduling logic (no `ScheduleOptions.config()`, no job properties)
+- No complex scheduling logic (no `ScheduleOptions.config()`, no job properties, no per-execution
+  job payload)
 
-**If Path A → read `resources/scheduler-path-a.md` and follow its steps.**
+**If Path A → read [`scheduler-path-a.md`](scheduler-path-a.md) and follow its steps.**
 
 ### Use Path B when ANY of these are true:
 - Cron expression comes from runtime configuration (e.g., `config.cronExpression()`)
@@ -123,14 +138,22 @@ public class MyJobConsumer implements JobConsumer {
 - Business logic needs access to job context/properties at execution time
 - `@Modified` method re-registers schedules with new config values
 
-**If Path B → read `resources/scheduler-path-b.md` and follow its steps.**
+**If Path B → read [`scheduler-path-b.md`](scheduler-path-b.md) and follow its steps.**
 
 ## Scheduler-Specific Rules
 
-- **CLASSIFY FIRST** — determine Path A or Path B before making any changes
-- **DO NOT** invent cron expressions — extract from existing code or @Property annotations
-- **DO NOT** use `@SlingScheduled` with runtime config values — it requires compile-time constants
-- **DO** distribute `@Reference` fields correctly in Path B: business logic services (e.g., `ExampleService`, `ResourceResolverFactory`) go to JobConsumer, infrastructure services (e.g., `SlingSettingsService`, `JobManager`) stay in Scheduler class
+- **CLASSIFY FIRST** — determine Path A or Path B before making any changes.
+- **DO NOT** invent cron expressions — extract the exact value from existing code,
+  legacy `@Property` annotations, or legacy metatype.
+- **DO NOT** use `@SlingScheduled` — the annotation does **not** exist in the AEMaaCS SDK;
+  schedules on a `Runnable` service are always declared via the
+  `scheduler.expression` / `scheduler.concurrent` / `scheduler.runOn` OSGi component properties.
+- **DO** set `scheduler.concurrent:Boolean=false` unless overlapping runs are explicitly desired.
+- **DO** set `scheduler.runOn=SINGLE` (or `LEADER`) when the job writes to the repository or
+  calls external systems — otherwise it will fire on **every publish pod**.
+- **DO** distribute `@Reference` fields correctly in Path B: business logic services
+  (e.g. `ExampleService`, `ResourceResolverFactory`) go to the `JobConsumer`; infrastructure
+  services (e.g. `SlingSettingsService`, `JobManager`) stay in the Scheduler class.
 
 ## IMPORTANT
 

--- a/plugins/aem/cloud-service/skills/migration/SKILL.md
+++ b/plugins/aem/cloud-service/skills/migration/SKILL.md
@@ -86,10 +86,29 @@ Sleek user prompts are enough (see Quick start). **Agent:** **Branch A** → rea
 
 Scripts run via **`getBpaFindings`** (see **Calling the helper**); do not reimplement collection logic by hand unless the helper is unavailable.
 
-1. **Collection exists** → reuse; tell the user counts/age when useful.
-2. **User gave BPA CSV path** → parse, build collection, then use targets.
-3. **No CSV; MCP available** → follow [references/cam-mcp.md](references/cam-mcp.md): `list-projects`, user confirms project, then `fetch-cam-bpa-findings`.
-4. **Nothing works** → ask for CSV path or explicit Java files (manual flow).
+The helper has **two independent paths**, chosen by what the caller configures:
+
+1. **MCP configured** (`mcpFetcher` + `projectId` passed) → first call fetches all findings
+   from MCP and caches them to `<collectionsDir>/mcp/<projectId>/<pattern>.json`.
+   Every call (first and subsequent) reads from the MCP cache and returns one batch.
+2. **MCP not configured, BPA CSV provided** → first call parses the CSV and writes the
+   unified-collection JSON to `<collectionsDir>/unified-collection.json`.
+   Every call reads from the CSV cache and returns one batch.
+
+The two caches are disjoint — MCP sessions and CSV sessions never shadow each other. If
+neither is configured, the helper reports `no-source` and the agent asks for one.
+
+**Batching is mandatory on every path.** `getBpaFindings` returns findings **in batches of 5
+by default** with a `paging` envelope:
+
+```ts
+result.targets   // this batch (length <= limit)
+result.paging    // { total, returned, offset, limit, nextOffset, hasMore }
+```
+
+Process one batch at a time; stop after each batch and report progress to the user; resume on
+the user's go-ahead by re-calling the helper with `offset: paging.nextOffset`. See
+**Batched processing (batch size 5)** below.
 
 **Note:** `htlLint` does **not** appear in BPA CSV — it uses proactive `rg` discovery instead. See **htlLint flow** below.
 
@@ -111,15 +130,37 @@ Scripts live under **`./scripts/`** (next to this `SKILL.md`).
 ```javascript
 const { getBpaFindings } = require('./scripts/bpa-findings-helper.js');
 
+// First batch (defaults: limit=5, offset=0)
 const result = await getBpaFindings(pattern, {
   bpaFilePath: './cleaned_file6.csv',
   collectionsDir: './unified-collections',
   projectId: '...',
   mcpFetcher: mcpFunction
+  // limit: 5,   // implicit default
+  // offset: 0,  // implicit default
 });
+
+// Next batch — only after the user says to continue
+if (result.paging?.hasMore) {
+  const next = await getBpaFindings(pattern, {
+    bpaFilePath: './cleaned_file6.csv',
+    collectionsDir: './unified-collections',
+    projectId: '...',
+    mcpFetcher: mcpFunction,
+    offset: result.paging.nextOffset
+  });
+}
 ```
 
-**`result`:** `success`, `source` (`'unified-collection' | 'bpa-file' | 'mcp-server' | …`), `message`, `targets` (when successful).
+**`result`:**
+- `success`, `source` (`'unified-collection' | 'bpa-file' | 'mcp-server' | …`)
+- `message` (includes a human-readable batch status)
+- `targets` — the **current batch** (length `<= limit`)
+- `paging: { total, returned, offset, limit, nextOffset, hasMore }` — always present on
+  successful calls
+
+To disable batching for a one-off programmatic caller, pass `limit: null`. The
+skill workflow itself **never** does this.
 
 ### Collection caching
 
@@ -165,19 +206,39 @@ If the id is missing from the best-practices table, say the pattern is not suppo
 
 **For BPA patterns** (`scheduler`, `resourceChangeListener`, `replication`, `eventListener`, `eventHandler`, `assetApi`): Run **`getBpaFindings`** (with `bpaFilePath` when provided). Internally: cache → CSV → MCP → manual **only when each step is applicable and succeeds**; if MCP fails, obey **MCP errors and fallback** (stop; no silent chain). For MCP details, [references/cam-mcp.md](references/cam-mcp.md).
 
+`getBpaFindings` returns **a batch of 5 findings** (default `limit=5`) along with a `paging`
+envelope. The agent processes that batch only; it does **not** request the next batch until
+the user says to continue. See **Batched processing (batch size 5)** below.
+
 **For `htlLint`**: Skip BPA/CSV/MCP — targets come from proactive `rg` discovery. See **htlLint flow** below.
 
 ### Step 4: Read before edits
 
 **STOP.** Read **`{best-practices}/SKILL.md`** and **`{best-practices}/references/<module>.md`** for the active pattern.
 
-### Step 5: Process each file
+### Step 5: Process the batch
 
-Resolve each target **only inside the IDE workspace** (see **Workspace scope (IDE)**). Read source → classify with the module → apply steps **in order** → check lints → next file.
+For **each finding in the returned batch only** (up to 5):
 
-### Step 6: Report
+1. Resolve the target **inside the IDE workspace** (see **Workspace scope (IDE)**).
+2. Read source → classify with the module → apply steps **in order** → check lints → next file.
 
-Summarize files touched, sub-paths, failures.
+Do **not** request the next batch mid-processing. Never hold more than one batch of findings in working memory at a time.
+
+### Step 6: Report batch and wait
+
+After finishing the batch, summarise **for this batch only**:
+
+- `paging.returned` findings processed (of `paging.total`), with class names.
+- Any files touched, plus any skips / failures.
+- If `paging.hasMore === true`, tell the user:
+  *"Processed batch of N (offset {offset}–{offset + returned − 1} of {total}). Reply
+  `continue` to process the next batch, or name specific classes to focus on."*
+- If `paging.hasMore === false`, say the pattern is done and move to the overall session report.
+
+**Stop and wait for the user.** Do not automatically start the next batch. Only call
+`getBpaFindings` (or `fetch-cam-bpa-findings`) again when the user explicitly requests it,
+and pass `offset: paging.nextOffset` unchanged.
 
 ### Manual flow (no BPA)
 
@@ -197,9 +258,80 @@ Does **not** use BPA CSV, CAM/MCP, or best-practices pattern modules for collect
 4. **Fix** each hit per the matching pattern section in the module.
 5. **Report** and recommend the user run `mvn clean install` or HTL validate to confirm no warnings remain.
 
+## Batched processing (batch size 5)
+
+Findings are served to the agent in batches of **5** by default, regardless of source (MCP
+or CSV). Batching happens **client-side** — the heavy fetch (MCP call or CSV parse) happens
+once and is materialized to a local JSON cache; every subsequent batch is a cheap slice of
+that cache.
+
+### Rules
+
+1. **Default `limit` is 5.** Pass `limit: 5` (or accept the helper default). The skill never
+   requests a larger batch unless the user has explicitly asked for one.
+2. **Offset starts at 0** and advances by `result.paging.nextOffset` from the previous call.
+   Do not compute offsets from `offset + limit` — read `nextOffset` from the previous
+   response; it is authoritative.
+3. **Stable ordering.** Each cache file is written once with a deterministic order; every
+   slice from it is therefore stable and contiguous.
+4. **One batch per call. One batch in memory at a time.** Process, report, stop. No
+   pre-fetching, no merging across batches.
+5. **Resume is stateless.** The skill does not maintain its own progress file. Resuming means
+   "call the helper again with `offset: previous.paging.nextOffset`". If the session ends, a
+   later session calls with the same `pattern` and `offset` and gets the same batch.
+6. **Done when `paging.hasMore === false`** (or `paging.nextOffset === null`).
+7. **To refresh source data**, delete the relevant cache file:
+   - CSV: `<collectionsDir>/unified-collection.json`
+   - MCP: `<collectionsDir>/mcp/<projectId>/<pattern>.json`
+
+### Agent-visible flow (CSV path)
+
+```
+[User] "Fix scheduler findings using ./reports/bpa.csv"
+[Agent] getBpaFindings('scheduler', { bpaFilePath, limit: 5, offset: 0 })
+        // first call parses CSV → writes <dir>/unified-collection.json → slices
+        → paging: { total: 137, returned: 5, offset: 0, nextOffset: 5, hasMore: true }
+        Processes 5 findings.
+        Reports: "Processed 5 of 137 (offset 0–4). Reply `continue` for the next batch."
+[User] "continue"
+[Agent] getBpaFindings('scheduler', { bpaFilePath, limit: 5, offset: 5 })
+        // reads cached JSON — no CSV re-parse
+        → paging: { ..., offset: 5, nextOffset: 10, hasMore: true }
+        Processes next 5.
+...
+```
+
+### Agent-visible flow (MCP path)
+
+```
+[User] "Fix scheduler findings from CAM project <id>"
+[Agent] getBpaFindings('scheduler', { mcpFetcher, projectId, limit: 5, offset: 0 })
+        // first call: one MCP fetch → writes <dir>/mcp/<projectId>/scheduler.json → slices
+        → paging: { total: 137, returned: 5, offset: 0, nextOffset: 5, hasMore: true }
+        Processes 5 findings.
+        Reports and stops.
+[User] "continue"
+[Agent] getBpaFindings('scheduler', { mcpFetcher, projectId, limit: 5, offset: 5 })
+        // reads cached MCP JSON — NO additional MCP call
+        → paging: { ..., offset: 5, nextOffset: 10, hasMore: true }
+...
+```
+
+### Do not
+
+- Do not call `getBpaFindings` with `limit: null` inside the skill flow. That option exists
+  only for programmatic callers that deliberately want the full list.
+- Do not invent a next batch offset. Always read `paging.nextOffset` from the previous
+  response.
+- Do not accumulate `targets` across batches in memory.
+- Do not call the MCP tool for every batch; the first call caches, subsequent batches read
+  the cache.
+
 ## Quick reference
 
 **Source priority (when choosing how to obtain targets):** unified collection → BPA CSV → MCP → manual paths. **Not** an automatic cascade after MCP errors — if MCP fails, stop and wait for user direction (see **MCP errors and fallback**). For `htlLint`, use proactive `rg` discovery (no BPA/MCP). For **OSGi → Cloud Manager**, use [references/osgi-cfg-json-cloud-manager.md](references/osgi-cfg-json-cloud-manager.md) only (no BPA/MCP).
+
+**Batch size:** 5 (default) on every BPA source. See **Batched processing** above.
 
 **User-facing snippets:** *"Using existing BPA collection (N findings)…"* / *"Processing your BPA report…"* / *"Fetched findings from CAM."* / *"Scanning HTL templates for data-sly-test lint issues…"* / optional prompt after MCP stop above.
 
@@ -208,7 +340,16 @@ Does **not** use BPA CSV, CAM/MCP, or best-practices pattern modules for collect
 From this skill's directory:
 
 ```bash
+# First batch (default offset=0, limit=5)
 node scripts/bpa-findings-helper.js scheduler ./unified-collections
 node scripts/bpa-findings-helper.js scheduler ./unified-collections ./cleaned_file6.csv
-node scripts/unified-collection-reader.js all ./unified-collections
+
+# Next batch: offset=5, limit=5
+node scripts/bpa-findings-helper.js scheduler ./unified-collections ./cleaned_file6.csv 5 5
+
+# Full unbounded listing (development / debugging only — skill never does this)
+node scripts/bpa-findings-helper.js scheduler ./unified-collections ./cleaned_file6.csv 0 all
+
+# Same batching on the low-level reader
+node scripts/unified-collection-reader.js all ./unified-collections 0 5
 ```

--- a/plugins/aem/cloud-service/skills/migration/references/cam-mcp.md
+++ b/plugins/aem/cloud-service/skills/migration/references/cam-mcp.md
@@ -6,8 +6,13 @@ Read this file when **fetching BPA targets via MCP** instead of a CSV or cached 
 
 1. Agent asks the user for their **CAM project name or ID**.
 2. **You confirm** the project name or ID (the agent should not guess or infer it).
-3. Agent calls **`fetch-cam-bpa-findings`** with the confirmed project and the **one pattern** for this session (`scheduler`, `assetApi`, etc., or `all` then filtered).
-4. Agent maps returned targets to Java files and continues the migration workflow in `../SKILL.md`.
+3. Agent calls **`fetch-cam-bpa-findings`** **once** with the confirmed project and the **one pattern** for this session (`scheduler`, `assetApi`, etc., or `all` then filtered). The MCP server returns all findings for that pattern.
+4. `bpa-findings-helper.js` caches the response to
+   `<collectionsDir>/mcp/<projectId>/<pattern>.json` and applies the batch slice (default 5) client-side.
+5. Agent processes that batch, reports progress (`returned / total`), then stops. The user says whether to continue.
+6. On continue, the agent re-invokes `getBpaFindings` with `offset = paging.nextOffset`; the helper reads the cached MCP fetch — **no additional MCP calls** — and returns the next batch.
+
+See [Batching](#batching) below for the full contract.
 
 ### Project name and ID — non-negotiable
 
@@ -66,6 +71,8 @@ The only MCP tool registered by the server. It can also resolve a project name t
 }
 ```
 
+The MCP server is **not** required to implement paging; the helper batches client-side.
+
 **Success response (shape may vary by server version):**
 
 ```typescript
@@ -99,12 +106,49 @@ The only MCP tool registered by the server. It can also resolve a project name t
 **Example:**
 
 ```javascript
-const result = await fetchCamBpaFindings({
+// One-shot fetch per (projectId, pattern). The helper caches this and pages
+// subsequent batches from the cache — do not call the MCP tool for every batch.
+const resp = await fetchCamBpaFindings({
   projectId: "<user-confirmed-cam-project-id>",
   pattern: "scheduler",
   environment: "prod"
 });
+// resp.targets — full list for this pattern
 ```
+
+---
+
+## Batching
+
+The migration skill processes BPA findings in **batches of 5** by default. Batching is
+**entirely client-side** — the MCP server is called once per `(projectId, pattern)`; the
+helper caches the response to disk and slices from the cache on subsequent calls.
+
+### Contract
+
+- **The MCP tool does not need to support `limit` or `offset`.** It is called once and
+  returns the full list for the requested pattern.
+- **Ordering should be stable across calls.** If the underlying BPA run changes between
+  fetches and the user wants fresh data, they (or the agent) delete
+  `<collectionsDir>/mcp/<projectId>/<pattern>.json` to trigger a re-fetch.
+- **No severity filtering.** Within a single pattern all findings are equal rank; the server
+  must not silently reorder or filter by severity.
+- **Cache location:** `<collectionsDir>/mcp/<projectId>/<pattern>.json`. Disjoint from the
+  CSV path's cache at `<collectionsDir>/unified-collection.json`, so MCP and CSV cannot
+  shadow each other.
+
+### Agent rules
+
+1. Call `fetch-cam-bpa-findings` **once** per `(projectId, pattern)` — the helper does this
+   the first time the agent invokes `getBpaFindings` on the MCP path.
+2. After each batch the helper returns, process **only** those findings, then **stop**:
+   *"Processed 5 of 137 scheduler findings. Reply `continue` for the next batch, or name
+   specific classes to focus on."*
+3. On continue, re-invoke `getBpaFindings` with `offset = paging.nextOffset`. The helper
+   reads the local cache — **no** additional MCP call.
+4. Stop when `paging.hasMore === false` (or `paging.nextOffset === null`).
+5. Never accumulate more than one batch in working memory. Each batch is independent.
+6. To refresh MCP data, delete the cache file for that `(projectId, pattern)` and re-invoke.
 
 ---
 

--- a/plugins/aem/cloud-service/skills/migration/scripts/bpa-findings-helper.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/bpa-findings-helper.js
@@ -1,39 +1,75 @@
 /**
  * BPA Findings Helper
- * 
- * Provides a seamless interface for getting BPA findings. The skill calls this
- * helper and it handles everything automatically:
- * 
- * 1. Check if unified collection already exists → use it
- * 2. If not, and BPA CSV path provided → parse it, create collection, then use it
- * 3. If no BPA path → try MCP server
- * 4. If nothing available → return guidance for manual flow
+ *
+ * Two independent execution paths — the helper picks one based on what the
+ * caller configured, never mixes them, and applies the same batching to both:
+ *
+ *   1. MCP configured (mcpFetcher + projectId)
+ *        → first call: fetch all findings from MCP, cache to
+ *          `<collectionsDir>/mcp/<projectId>/<pattern>.json`.
+ *        → subsequent calls: read that cache.
+ *        → every call applies `paginate(...)` and returns one batch.
+ *
+ *   2. MCP not configured, CSV path provided (or cached CSV collection exists)
+ *        → first call: parse CSV, write the unified-collection JSON to
+ *          `<collectionsDir>/unified-collection.json`.
+ *        → subsequent calls: read that cache.
+ *        → every call applies `paginate(...)` and returns one batch.
+ *
+ * The two cache locations are disjoint so the paths never shadow each other.
+ * Batch size defaults to `DEFAULT_BATCH_SIZE` (5); pass `limit: null` to
+ * disable batching.
  */
 
 const path = require('path');
 const fs = require('fs');
-const { hasUnifiedCollection, fetchUnifiedBpaFindings, getAvailablePatterns, getUnifiedCollectionSummary } = require('./unified-collection-reader.js');
+const {
+  hasUnifiedCollection,
+  fetchUnifiedBpaFindings,
+  getAvailablePatterns,
+  getUnifiedCollectionSummary,
+  paginate,
+  DEFAULT_BATCH_SIZE
+} = require('./unified-collection-reader.js');
 const { validateBpaFile, parseBpaFile, createUnifiedCollection } = require('./bpa-local-parser.js');
 
 const DEFAULT_COLLECTIONS_DIR = './unified-collections';
 
+/** Path to the MCP cache file for (projectId, pattern). */
+function mcpCachePath(collectionsDir, projectId, pattern) {
+  return path.join(collectionsDir, 'mcp', projectId, `${pattern}.json`);
+}
+
+/** Read a cached MCP fetch from disk; returns `null` if absent or invalid. */
+function readMcpCache(collectionsDir, projectId, pattern) {
+  const file = mcpCachePath(collectionsDir, projectId, pattern);
+  if (!fs.existsSync(file)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/** Persist an MCP fetch to disk as the read model for subsequent paging. */
+function writeMcpCache(collectionsDir, projectId, pattern, environment, targets) {
+  const file = mcpCachePath(collectionsDir, projectId, pattern);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify({
+    source: 'mcp',
+    projectId,
+    pattern,
+    environment,
+    fetchedAt: new Date().toISOString(),
+    targets
+  }, null, 2));
+}
+
 /**
- * Get BPA findings with automatic collection management.
- * 
- * Flow:
- *   1. Unified collection exists? → Use it directly
- *   2. BPA CSV file provided? → Create collection, then use it
- *   3. MCP server available? → Fetch from MCP
- *   4. Nothing available → Return manual flow guidance
- * 
- * @param {string} pattern - Pattern to fetch ('scheduler', 'assetApi', 'all', etc.)
- * @param {Object} options
- * @param {string} [options.bpaFilePath] - Path to BPA CSV file
- * @param {string} [options.collectionsDir] - Where to store/read unified collections
- * @param {string} [options.projectId] - Cloud Manager project ID (for MCP fallback)
- * @param {string} [options.environment] - Environment (for MCP)
- * @param {Function} [options.mcpFetcher] - MCP fetcher function
- * @returns {Object} BPA findings result with `source` and `message` fields
+ * Get BPA findings, batched. See module header for the two-path contract.
+ *
+ * Returns `{ success, source, message, targets, paging, … }` where
+ * `paging = { total, returned, offset, limit, nextOffset, hasMore }`.
  */
 async function getBpaFindings(pattern = 'all', options = {}) {
   const {
@@ -41,75 +77,60 @@ async function getBpaFindings(pattern = 'all', options = {}) {
     collectionsDir = DEFAULT_COLLECTIONS_DIR,
     projectId,
     environment = 'prod',
-    mcpFetcher
+    mcpFetcher,
+    offset = 0,
+    limit = DEFAULT_BATCH_SIZE
   } = options;
 
-  // ── 1. Check for existing unified collection ──
-  if (hasUnifiedCollection(collectionsDir)) {
-    const availablePatterns = getAvailablePatterns(collectionsDir);
-    const hasPattern = pattern === 'all'
-      ? availablePatterns.length > 0
-      : availablePatterns.includes(pattern);
-
-    if (hasPattern) {
-      const summary = getUnifiedCollectionSummary(collectionsDir);
-      const result = fetchUnifiedBpaFindings(pattern, collectionsDir);
-      result.source = 'unified-collection';
-      result.message = `Using existing BPA collection (${summary?.totalFindings || result.targets.length} findings across ${availablePatterns.length} patterns, created ${formatTimestamp(summary?.timestamp)})`;
-      return result;
-    }
+  // ── Path A: MCP (one fetch per (projectId, pattern), cached, then paged) ──
+  if (mcpFetcher && projectId) {
+    return getFromMcp({
+      pattern, projectId, environment, mcpFetcher, collectionsDir, offset, limit
+    });
   }
 
-  // ── 2. BPA CSV file provided → parse and create collection ──
-  if (bpaFilePath) {
+  // ── Path B: CSV / cached CSV collection ──
+  if (bpaFilePath || hasUnifiedCollection(collectionsDir)) {
+    return getFromCsvOrCache({
+      pattern, bpaFilePath, collectionsDir, offset, limit
+    });
+  }
+
+  // ── Nothing configured ──
+  return {
+    success: false,
+    source: 'no-source',
+    error: 'No BPA findings source available',
+    message: 'No BPA data found. Configure MCP (mcpFetcher + projectId) or provide a BPA CSV file path.',
+    troubleshooting: [
+      'Configure MCP access with mcpFetcher and projectId',
+      'Or provide the path to your BPA CSV report',
+      'Or point to specific Java files for manual migration'
+    ]
+  };
+}
+
+/**
+ * MCP path: first call fetches & caches; subsequent calls read cache.
+ * Every call returns exactly one batch.
+ */
+async function getFromMcp({ pattern, projectId, environment, mcpFetcher, collectionsDir, offset, limit }) {
+  let cache = readMcpCache(collectionsDir, projectId, pattern);
+
+  if (!cache) {
     try {
-      validateBpaFile(bpaFilePath);
-
-      const bpaData = parseBpaFile(bpaFilePath);
-      const summary = createUnifiedCollection(bpaData, collectionsDir);
-
-      const availablePatterns = getAvailablePatterns(collectionsDir);
-      const hasPattern = pattern === 'all'
-        ? availablePatterns.length > 0
-        : availablePatterns.includes(pattern);
-
-      if (!hasPattern) {
+      const mcp = await mcpFetcher({ projectId, pattern, environment });
+      if (!mcp || mcp.success === false) {
         return {
+          ...(mcp || {}),
           success: false,
-          source: 'bpa-file',
-          error: `Pattern '${pattern}' not found in BPA report`,
-          message: `Processed BPA report but pattern '${pattern}' was not found. Available patterns: ${availablePatterns.join(', ')}`,
-          availablePatterns
+          source: 'mcp-server',
+          message: `MCP fetch did not succeed (project: ${projectId}).`
         };
       }
-
-      const result = fetchUnifiedBpaFindings(pattern, collectionsDir);
-      result.source = 'bpa-file';
-      result.message = `Processed BPA report (${summary?.totalFindings || 0} findings across ${summary?.subtypes?.length || 0} patterns). Collection saved for future use.`;
-      return result;
-    } catch (error) {
-      return {
-        success: false,
-        source: 'bpa-file-error',
-        error: `Failed to process BPA file: ${error.message}`,
-        message: `Could not process BPA file at ${bpaFilePath}: ${error.message}`,
-        troubleshooting: [
-          'Verify the file exists and is a valid BPA CSV',
-          'Expected CSV headers: code, type, subtype, importance, identifier, message, context'
-        ]
-      };
-    }
-  }
-
-  // ── 3. Try MCP server ──
-  if (mcpFetcher && projectId) {
-    try {
-      const result = await mcpFetcher({ projectId, pattern, environment });
-      if (result) {
-        result.source = 'mcp-server';
-        result.message = `Fetched findings from MCP server (project: ${projectId})`;
-        return result;
-      }
+      const targets = Array.isArray(mcp.targets) ? mcp.targets : [];
+      writeMcpCache(collectionsDir, projectId, pattern, environment, targets);
+      cache = readMcpCache(collectionsDir, projectId, pattern);
     } catch (error) {
       return {
         success: false,
@@ -125,18 +146,67 @@ async function getBpaFindings(pattern = 'all', options = {}) {
     }
   }
 
-  // ── 4. Nothing available → guide the user ──
+  const { targets, paging } = paginate(cache.targets, { offset, limit });
   return {
-    success: false,
-    source: 'no-source',
-    error: 'No BPA findings source available',
-    message: 'No BPA data found. Please provide a BPA CSV file path, or use the manual flow for specific files.',
-    troubleshooting: [
-      'Provide the path to your BPA CSV report',
-      'Or provide MCP server access with projectId',
-      'Or point to specific Java files for manual migration'
-    ]
+    success: true,
+    source: 'mcp-server',
+    projectId,
+    environment,
+    message: `Using MCP cache for project ${projectId} (fetched ${formatTimestamp(cache.fetchedAt)}).`,
+    targets,
+    paging
   };
+}
+
+/**
+ * CSV / cached-collection path: first call parses CSV and writes the unified
+ * collection; subsequent calls read it. Every call returns exactly one batch.
+ */
+function getFromCsvOrCache({ pattern, bpaFilePath, collectionsDir, offset, limit }) {
+  // Create the cache on first invocation if it doesn't exist yet.
+  if (!hasUnifiedCollection(collectionsDir)) {
+    if (!bpaFilePath) {
+      return {
+        success: false,
+        source: 'bpa-file',
+        error: 'No BPA CSV path provided and no cached collection exists',
+        message: `No cached collection at ${collectionsDir}; provide bpaFilePath to create one.`
+      };
+    }
+    try {
+      validateBpaFile(bpaFilePath);
+      createUnifiedCollection(parseBpaFile(bpaFilePath), collectionsDir);
+    } catch (error) {
+      return {
+        success: false,
+        source: 'bpa-file-error',
+        error: `Failed to process BPA file: ${error.message}`,
+        message: `Could not process BPA file at ${bpaFilePath}: ${error.message}`,
+        troubleshooting: [
+          'Verify the file exists and is a valid BPA CSV',
+          'Expected CSV headers: code, type, subtype, importance, identifier, message, context'
+        ]
+      };
+    }
+  }
+
+  const patterns = getAvailablePatterns(collectionsDir);
+  const hasPattern = pattern === 'all' ? patterns.length > 0 : patterns.includes(pattern);
+  if (!hasPattern) {
+    return {
+      success: false,
+      source: 'bpa-file',
+      error: `Pattern '${pattern}' not found in BPA report`,
+      message: `Pattern '${pattern}' not found. Available patterns: ${patterns.join(', ')}`,
+      availablePatterns: patterns
+    };
+  }
+
+  const summary = getUnifiedCollectionSummary(collectionsDir);
+  const result = fetchUnifiedBpaFindings(pattern, collectionsDir, { offset, limit });
+  result.source = 'bpa-file';
+  result.message = `Using CSV collection (${summary?.totalFindings ?? result.paging.total} findings, ${formatTimestamp(summary?.timestamp)}).`;
+  return result;
 }
 
 /**
@@ -163,7 +233,8 @@ function checkAvailableSources(options = {}) {
     },
     mcpServer: {
       available: !!(mcpFetcher && projectId),
-      projectId: projectId || null
+      projectId: projectId || null,
+      cached: !!(projectId && readMcpCache(collectionsDir, projectId, 'all'))
     }
   };
 
@@ -209,18 +280,28 @@ function formatTimestamp(isoTimestamp) {
 
 /**
  * CLI interface for testing
+ *
+ * Usage: node bpa-findings-helper.js <pattern> [collectionsDir] [bpaFilePath] [offset] [limit]
+ *   offset defaults to 0
+ *   limit  defaults to 5 (use 'all' to disable batching)
  */
 async function main() {
   const args = process.argv.slice(2);
   const pattern = args[0] || 'all';
   const collectionsDir = args[1] || DEFAULT_COLLECTIONS_DIR;
   const bpaFilePath = args[2];
+  const offset = args[3] !== undefined ? Number(args[3]) : 0;
+  const limit = args[4] === 'all' ? null
+    : args[4] !== undefined ? Number(args[4])
+    : DEFAULT_BATCH_SIZE;
 
   console.log('BPA Findings Helper');
   console.log('==================');
   console.log(`Pattern: ${pattern}`);
   console.log(`Collections Dir: ${collectionsDir}`);
   if (bpaFilePath) console.log(`BPA File: ${bpaFilePath}`);
+  console.log(`Offset: ${offset}`);
+  console.log(`Limit:  ${limit === null ? 'all' : limit}`);
   console.log('');
 
   const sources = checkAvailableSources({ collectionsDir, bpaFilePath });
@@ -235,14 +316,17 @@ async function main() {
   console.log(`  MCP Server: ${sources.mcpServer.available ? '✅' : '❌'}`);
   console.log('');
 
-  const result = await getBpaFindings(pattern, { collectionsDir, bpaFilePath });
+  const result = await getBpaFindings(pattern, { collectionsDir, bpaFilePath, offset, limit });
 
   console.log(`Source: ${result.source}`);
   console.log(`Message: ${result.message}`);
   console.log('');
 
   if (result.success) {
-    console.log(`✅ Loaded ${result.targets.length} findings`);
+    const p = result.paging;
+    console.log(p
+      ? `✅ Batch ${p.returned}/${p.total} (offset ${p.offset}, next ${p.nextOffset ?? 'none'}, hasMore=${p.hasMore})`
+      : `✅ Loaded ${result.targets.length} findings`);
     if (result.summary) {
       Object.entries(result.summary).forEach(([key, value]) => {
         console.log(`   ${key}: ${value}`);

--- a/plugins/aem/cloud-service/skills/migration/scripts/bpa-findings-helper.test.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/bpa-findings-helper.test.js
@@ -9,10 +9,14 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { getBpaFindings, checkAvailableSources } = require('./bpa-findings-helper.js');
+const { paginate, DEFAULT_BATCH_SIZE } = require('./unified-collection-reader.js');
 
 function tempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'bpa-helper-test-'));
 }
+
+const MANY_CSV = path.join(__dirname, 'fixtures', 'many-scheduler-bpa.csv');
+const MANY_CSV_TOTAL = 12; // classes in many-scheduler-bpa.csv
 
 test('getBpaFindings with no CSV, collection, or MCP returns no-source', async () => {
   const dir = tempDir();
@@ -74,4 +78,280 @@ test('checkAvailableSources reflects MCP only when fetcher and projectId present
     projectId: 'p'
   });
   assert.equal(withMcp.mcpServer.available, true);
+});
+
+// ─────────────────────────────────────────────────────────────
+// Batching: pure paginate()
+// ─────────────────────────────────────────────────────────────
+
+test('paginate() returns a batch of DEFAULT_BATCH_SIZE by default', () => {
+  assert.equal(DEFAULT_BATCH_SIZE, 5);
+  const items = Array.from({ length: 12 }, (_, i) => ({ i }));
+  const { targets, paging } = paginate(items);
+  assert.equal(targets.length, 5);
+  assert.deepEqual(paging, {
+    total: 12, returned: 5, offset: 0, limit: 5, nextOffset: 5, hasMore: true
+  });
+});
+
+test('paginate() advances via nextOffset contiguously', () => {
+  const items = Array.from({ length: 12 }, (_, i) => ({ i }));
+  const seen = [];
+  let offset = 0;
+  for (let safety = 0; safety < 10; safety++) {
+    const { targets, paging } = paginate(items, { offset, limit: 5 });
+    for (const it of targets) seen.push(it.i);
+    if (!paging.hasMore) break;
+    offset = paging.nextOffset;
+  }
+  assert.deepEqual(seen, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+});
+
+test('paginate() handles offset past end without error', () => {
+  const { targets, paging } = paginate([{ i: 0 }, { i: 1 }], { offset: 5 });
+  assert.equal(targets.length, 0);
+  assert.equal(paging.hasMore, false);
+  assert.equal(paging.nextOffset, null);
+});
+
+test('paginate() with limit=null returns everything', () => {
+  const items = Array.from({ length: 12 }, (_, i) => ({ i }));
+  const { targets, paging } = paginate(items, { limit: null });
+  assert.equal(targets.length, 12);
+  assert.equal(paging.hasMore, false);
+  assert.equal(paging.limit, null);
+});
+
+// ─────────────────────────────────────────────────────────────
+// Batching: local BPA CSV path end-to-end
+// ─────────────────────────────────────────────────────────────
+
+test('getBpaFindings (CSV path) returns a batch of 5 by default', async () => {
+  const dir = tempDir();
+  const r = await getBpaFindings('scheduler', {
+    collectionsDir: dir,
+    bpaFilePath: MANY_CSV
+  });
+  assert.equal(r.success, true);
+  assert.equal(r.source, 'bpa-file');
+  assert.equal(r.targets.length, 5);
+  assert.ok(r.paging);
+  assert.equal(r.paging.total, MANY_CSV_TOTAL);
+  assert.equal(r.paging.returned, 5);
+  assert.equal(r.paging.offset, 0);
+  assert.equal(r.paging.limit, 5);
+  assert.equal(r.paging.nextOffset, 5);
+  assert.equal(r.paging.hasMore, true);
+});
+
+test('CSV path advances by nextOffset with stable contiguous order', async () => {
+  const dir = tempDir();
+
+  // First call parses CSV → writes cache → returns first batch.
+  const first = await getBpaFindings('scheduler', {
+    collectionsDir: dir,
+    bpaFilePath: MANY_CSV
+  });
+  assert.equal(first.source, 'bpa-file');
+  assert.equal(first.targets.length, 5);
+
+  // Subsequent calls read the cache — same source, no re-parse.
+  const second = await getBpaFindings('scheduler', {
+    collectionsDir: dir,
+    offset: first.paging.nextOffset
+  });
+  assert.equal(second.source, 'bpa-file');
+  assert.equal(second.targets.length, 5);
+  assert.equal(second.paging.offset, 5);
+  assert.equal(second.paging.nextOffset, 10);
+  assert.equal(second.paging.hasMore, true);
+
+  const third = await getBpaFindings('scheduler', {
+    collectionsDir: dir,
+    offset: second.paging.nextOffset
+  });
+  assert.equal(third.source, 'bpa-file');
+  assert.equal(third.targets.length, 2);
+  assert.equal(third.paging.total, MANY_CSV_TOTAL);
+  assert.equal(third.paging.offset, 10);
+  assert.equal(third.paging.nextOffset, null);
+  assert.equal(third.paging.hasMore, false);
+
+  // No overlap, no gap.
+  const allClassNames = [
+    ...first.targets,
+    ...second.targets,
+    ...third.targets
+  ].map((t) => t.className);
+  assert.equal(new Set(allClassNames).size, allClassNames.length, 'batches must not overlap');
+  assert.equal(allClassNames.length, MANY_CSV_TOTAL);
+});
+
+test('getBpaFindings (collection path) re-issuing the same offset returns the same batch', async () => {
+  const dir = tempDir();
+  await getBpaFindings('scheduler', { collectionsDir: dir, bpaFilePath: MANY_CSV });
+
+  const a = await getBpaFindings('scheduler', { collectionsDir: dir, offset: 5 });
+  const b = await getBpaFindings('scheduler', { collectionsDir: dir, offset: 5 });
+  assert.deepEqual(
+    a.targets.map((t) => t.className),
+    b.targets.map((t) => t.className),
+    'stable ordering: same offset, same batch'
+  );
+});
+
+test('getBpaFindings (collection path) with limit=null returns every finding', async () => {
+  const dir = tempDir();
+  await getBpaFindings('scheduler', { collectionsDir: dir, bpaFilePath: MANY_CSV });
+  const r = await getBpaFindings('scheduler', { collectionsDir: dir, limit: null });
+  assert.equal(r.targets.length, MANY_CSV_TOTAL);
+  assert.equal(r.paging.hasMore, false);
+  assert.equal(r.paging.limit, null);
+});
+
+// ─────────────────────────────────────────────────────────────
+// Batching: MCP path (one-shot fetch, cached to disk, paged client-side)
+// ─────────────────────────────────────────────────────────────
+
+/** MCP fetcher that returns `total` findings and counts how many times it was called. */
+function mkCountingMcpFetcher(total) {
+  const fetcher = async (args) => {
+    fetcher.calls.push(args);
+    return {
+      success: true,
+      targets: Array.from({ length: total }, (_, i) => ({
+        pattern: 'scheduler',
+        className: `com.example.Job${String(i).padStart(3, '0')}`,
+        identifier: 'org.apache.sling.commons.scheduler',
+        issue: 'mcp-test'
+      }))
+    };
+  };
+  fetcher.calls = [];
+  return fetcher;
+}
+
+test('MCP path: first call fetches + caches + returns a batch of 5', async () => {
+  const dir = tempDir();
+  const mcpFetcher = mkCountingMcpFetcher(12);
+  const r = await getBpaFindings('scheduler', {
+    collectionsDir: dir,
+    projectId: 'proj-A',
+    mcpFetcher
+  });
+  assert.equal(r.success, true);
+  assert.equal(r.source, 'mcp-server');
+  assert.equal(r.targets.length, 5);
+  assert.equal(r.paging.total, 12);
+  assert.equal(r.paging.offset, 0);
+  assert.equal(r.paging.nextOffset, 5);
+  assert.equal(r.paging.hasMore, true);
+
+  // Cache file written in the expected location.
+  const cacheFile = path.join(dir, 'mcp', 'proj-A', 'scheduler.json');
+  assert.ok(fs.existsSync(cacheFile), 'MCP cache file should exist after first call');
+});
+
+test('MCP path: subsequent batches read the cache — mcpFetcher is called once', async () => {
+  const dir = tempDir();
+  const mcpFetcher = mkCountingMcpFetcher(12);
+
+  // Drive three batches: 5 + 5 + 2.
+  const seen = [];
+  let offset = 0;
+  for (let safety = 0; safety < 10; safety++) {
+    const r = await getBpaFindings('scheduler', {
+      collectionsDir: dir,
+      projectId: 'proj-A',
+      mcpFetcher,
+      offset
+    });
+    for (const t of r.targets) seen.push(t.className);
+    if (!r.paging.hasMore) break;
+    offset = r.paging.nextOffset;
+  }
+
+  assert.equal(seen.length, 12);
+  assert.equal(new Set(seen).size, 12, 'no duplicates across batches');
+  assert.equal(mcpFetcher.calls.length, 1, 'mcpFetcher must be called only once');
+});
+
+test('MCP path: mcpFetcher receives projectId/pattern/environment only (no limit/offset)', async () => {
+  const dir = tempDir();
+  const mcpFetcher = mkCountingMcpFetcher(3);
+  await getBpaFindings('scheduler', {
+    collectionsDir: dir,
+    projectId: 'proj-A',
+    environment: 'stage',
+    mcpFetcher,
+    offset: 10      // user-supplied offset must NOT be forwarded
+  });
+  assert.equal(mcpFetcher.calls.length, 1);
+  const args = mcpFetcher.calls[0];
+  assert.equal(args.projectId, 'proj-A');
+  assert.equal(args.pattern, 'scheduler');
+  assert.equal(args.environment, 'stage');
+  assert.equal(args.limit, undefined, 'limit must not be sent to MCP');
+  assert.equal(args.offset, undefined, 'offset must not be sent to MCP');
+});
+
+test('MCP path is preferred over a pre-existing CSV-derived cache', async () => {
+  const dir = tempDir();
+
+  // Seed a CSV-derived cache — simulates a previous CSV session.
+  await getBpaFindings('scheduler', { collectionsDir: dir, bpaFilePath: MANY_CSV });
+
+  // Now call with MCP configured; the CSV cache must NOT shadow MCP.
+  const mcpFetcher = mkCountingMcpFetcher(3);
+  const r = await getBpaFindings('scheduler', {
+    collectionsDir: dir,
+    projectId: 'proj-A',
+    mcpFetcher
+  });
+
+  assert.equal(r.source, 'mcp-server');
+  assert.equal(r.paging.total, 3, 'must read MCP count, not CSV count');
+  assert.equal(mcpFetcher.calls.length, 1);
+});
+
+test('MCP cache files are keyed by (projectId, pattern) — different keys do not collide', async () => {
+  const dir = tempDir();
+  const fA = mkCountingMcpFetcher(3);
+  const fB = mkCountingMcpFetcher(7);
+
+  const ra = await getBpaFindings('scheduler', {
+    collectionsDir: dir, projectId: 'proj-A', mcpFetcher: fA
+  });
+  const rb = await getBpaFindings('scheduler', {
+    collectionsDir: dir, projectId: 'proj-B', mcpFetcher: fB
+  });
+
+  assert.equal(ra.paging.total, 3);
+  assert.equal(rb.paging.total, 7);
+
+  // Both caches present.
+  assert.ok(fs.existsSync(path.join(dir, 'mcp', 'proj-A', 'scheduler.json')));
+  assert.ok(fs.existsSync(path.join(dir, 'mcp', 'proj-B', 'scheduler.json')));
+});
+
+test('MCP path: second session reuses the cache across processes (no fetch)', async () => {
+  const dir = tempDir();
+  const fA = mkCountingMcpFetcher(8);
+
+  // First session — populates the cache.
+  await getBpaFindings('scheduler', {
+    collectionsDir: dir, projectId: 'proj-A', mcpFetcher: fA
+  });
+  assert.equal(fA.calls.length, 1);
+
+  // Second session with a "dead" fetcher that should never be called.
+  const fDead = async () => {
+    throw new Error('mcp fetcher must not be called when cache exists');
+  };
+  const r = await getBpaFindings('scheduler', {
+    collectionsDir: dir, projectId: 'proj-A', mcpFetcher: fDead, offset: 5
+  });
+  assert.equal(r.success, true);
+  assert.equal(r.source, 'mcp-server');
+  assert.equal(r.paging.offset, 5);
 });

--- a/plugins/aem/cloud-service/skills/migration/scripts/fixtures/many-scheduler-bpa.csv
+++ b/plugins/aem/cloud-service/skills/migration/scripts/fixtures/many-scheduler-bpa.csv
@@ -1,0 +1,13 @@
+code,type,subtype,importance,identifier,message,context
+BPA-001,issue,sling.commons.scheduler,high,com.example.jobs.Alpha,Uses Apache Sling scheduler in Alpha,
+BPA-002,issue,sling.commons.scheduler,high,com.example.jobs.Bravo,Uses Apache Sling scheduler in Bravo,
+BPA-003,issue,sling.commons.scheduler,high,com.example.jobs.Charlie,Uses Apache Sling scheduler in Charlie,
+BPA-004,issue,sling.commons.scheduler,high,com.example.jobs.Delta,Uses Apache Sling scheduler in Delta,
+BPA-005,issue,sling.commons.scheduler,high,com.example.jobs.Echo,Uses Apache Sling scheduler in Echo,
+BPA-006,issue,sling.commons.scheduler,high,com.example.jobs.Foxtrot,Uses Apache Sling scheduler in Foxtrot,
+BPA-007,issue,sling.commons.scheduler,high,com.example.jobs.Golf,Uses Apache Sling scheduler in Golf,
+BPA-008,issue,sling.commons.scheduler,high,com.example.jobs.Hotel,Uses Apache Sling scheduler in Hotel,
+BPA-009,issue,sling.commons.scheduler,high,com.example.jobs.India,Uses Apache Sling scheduler in India,
+BPA-010,issue,sling.commons.scheduler,high,com.example.jobs.Juliet,Uses Apache Sling scheduler in Juliet,
+BPA-011,issue,sling.commons.scheduler,high,com.example.jobs.Kilo,Uses Apache Sling scheduler in Kilo,
+BPA-012,issue,sling.commons.scheduler,high,com.example.jobs.Lima,Uses Apache Sling scheduler in Lima,

--- a/plugins/aem/cloud-service/skills/migration/scripts/unified-collection-reader.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/unified-collection-reader.js
@@ -8,6 +8,10 @@
 const fs = require('fs');
 const path = require('path');
 
+// Default batch size for paged access to findings. Keep this in sync with
+// the documented batch size in migration/SKILL.md and cam-mcp.md.
+const DEFAULT_BATCH_SIZE = 5;
+
 // Pattern to subtype mapping (matching cam-bpa-fetcher.ts)
 const PATTERN_TO_SUBTYPE = {
   scheduler: "sling.commons.scheduler",
@@ -64,6 +68,35 @@ class BpaResult {
  */
 function fromMongoSafeFieldName(mongoSafeFieldName) {
   return mongoSafeFieldName ? mongoSafeFieldName.replace(/_/g, '.') : null;
+}
+
+/**
+ * Slice a flat array of findings and return `{ targets, paging }`.
+ *
+ * Caller must produce `items` in a stable, deterministic order so that
+ * incrementing `offset` across calls yields contiguous, non-overlapping batches.
+ * `limit: null` disables batching (returns everything).
+ */
+function paginate(items, { offset = 0, limit = DEFAULT_BATCH_SIZE } = {}) {
+  const list = Array.isArray(items) ? items : [];
+  const total = list.length;
+  const start = Math.max(0, Math.floor(Number(offset)) || 0);
+  const unbounded = limit === null;
+  const size = unbounded ? total : Math.max(1, Math.floor(Number(limit)) || DEFAULT_BATCH_SIZE);
+  const targets = list.slice(start, unbounded ? total : start + size);
+  const reached = start + targets.length;
+  const nextOffset = reached < total ? reached : null;
+  return {
+    targets,
+    paging: {
+      total,
+      returned: targets.length,
+      offset: start,
+      limit: unbounded ? null : size,
+      nextOffset,
+      hasMore: nextOffset !== null
+    }
+  };
 }
 
 /**
@@ -128,7 +161,10 @@ function readUnifiedCollection(collectionsDir = './unified-collections') {
 function processSchedulerFromUnified(subtypeData, targets) {
   let count = 0;
   
-  for (const mongoSafeIdentifier of Object.keys(subtypeData || {})) {
+  // Sort identifiers alphabetically so the iteration order is deterministic
+  // across runs, independent of how the unified-collection JSON was written.
+  const identifierKeys = Object.keys(subtypeData || {}).sort();
+  for (const mongoSafeIdentifier of identifierKeys) {
     const classNames = subtypeData[mongoSafeIdentifier] || [];
     const identifier = fromMongoSafeFieldName(mongoSafeIdentifier);
     
@@ -153,7 +189,10 @@ function processSchedulerFromUnified(subtypeData, targets) {
 function processAssetApiFromUnified(subtypeData, targets) {
   let count = 0;
   
-  for (const mongoSafeIdentifier of Object.keys(subtypeData || {})) {
+  // Sort identifiers alphabetically so the iteration order is deterministic
+  // across runs, independent of how the unified-collection JSON was written.
+  const identifierKeys = Object.keys(subtypeData || {}).sort();
+  for (const mongoSafeIdentifier of identifierKeys) {
     const classNames = subtypeData[mongoSafeIdentifier] || [];
     const identifier = fromMongoSafeFieldName(mongoSafeIdentifier);
     
@@ -178,7 +217,10 @@ function processAssetApiFromUnified(subtypeData, targets) {
 function processEventListenerFromUnified(subtypeData, targets) {
   let count = 0;
   
-  for (const mongoSafeIdentifier of Object.keys(subtypeData || {})) {
+  // Sort identifiers alphabetically so the iteration order is deterministic
+  // across runs, independent of how the unified-collection JSON was written.
+  const identifierKeys = Object.keys(subtypeData || {}).sort();
+  for (const mongoSafeIdentifier of identifierKeys) {
     const classNames = subtypeData[mongoSafeIdentifier] || [];
     const identifier = fromMongoSafeFieldName(mongoSafeIdentifier);
     
@@ -203,7 +245,10 @@ function processEventListenerFromUnified(subtypeData, targets) {
 function processResourceChangeListenerFromUnified(subtypeData, targets) {
   let count = 0;
   
-  for (const mongoSafeIdentifier of Object.keys(subtypeData || {})) {
+  // Sort identifiers alphabetically so the iteration order is deterministic
+  // across runs, independent of how the unified-collection JSON was written.
+  const identifierKeys = Object.keys(subtypeData || {}).sort();
+  for (const mongoSafeIdentifier of identifierKeys) {
     const classNames = subtypeData[mongoSafeIdentifier] || [];
     const identifier = fromMongoSafeFieldName(mongoSafeIdentifier);
     
@@ -228,7 +273,10 @@ function processResourceChangeListenerFromUnified(subtypeData, targets) {
 function processEventHandlerFromUnified(subtypeData, targets) {
   let count = 0;
   
-  for (const mongoSafeIdentifier of Object.keys(subtypeData || {})) {
+  // Sort identifiers alphabetically so the iteration order is deterministic
+  // across runs, independent of how the unified-collection JSON was written.
+  const identifierKeys = Object.keys(subtypeData || {}).sort();
+  for (const mongoSafeIdentifier of identifierKeys) {
     const classNames = subtypeData[mongoSafeIdentifier] || [];
     const identifier = fromMongoSafeFieldName(mongoSafeIdentifier);
     
@@ -248,9 +296,21 @@ function processEventHandlerFromUnified(subtypeData, targets) {
 }
 
 /**
- * Fetch findings from unified collection (mimics cam-bpa-fetcher behavior)
+ * Fetch findings from unified collection (mimics cam-bpa-fetcher behavior).
+ *
+ * The full ordered list for the requested `pattern` is assembled, then
+ * sliced into a batch via {@link paginate}. The returned object contains
+ * `targets` (the batch) and `paging` (batch metadata for resuming).
+ *
+ * Ordering contract: for a given unified-collection.json file and a given
+ * `pattern`, successive calls with incrementing `offset` return contiguous,
+ * non-overlapping batches covering the full list.
+ *
+ * @param {string} pattern
+ * @param {string} collectionsDir
+ * @param {{offset?: number, limit?: number|null|'all'}} [paging]
  */
-function fetchUnifiedBpaFindings(pattern = "all", collectionsDir = './unified-collections') {
+function fetchUnifiedBpaFindings(pattern = "all", collectionsDir = './unified-collections', paging = {}) {
   const result = new BpaResult();
   
   // Check if unified collection exists
@@ -293,8 +353,10 @@ function fetchUnifiedBpaFindings(pattern = "all", collectionsDir = './unified-co
     return result;
   }
   
-  const patternsToFetch = pattern === "all" 
-    ? availablePatterns
+  // Sort patterns alphabetically so "all" returns findings in a deterministic
+  // order independent of how availablePatterns was produced.
+  const patternsToFetch = pattern === "all"
+    ? [...availablePatterns].sort()
     : availablePatterns.filter(p => p === pattern);
   
   if (patternsToFetch.length === 0) {
@@ -356,10 +418,15 @@ function fetchUnifiedBpaFindings(pattern = "all", collectionsDir = './unified-co
     ];
     return result;
   }
-  
+
+  const { targets, paging: p } = paginate(result.targets, paging);
+  result.targets = targets;
+  result.paging = p;
   result.success = true;
-  console.log(`[Unified Collection Reader] Successfully loaded ${result.targets.length} findings from unified collection`);
-  
+  console.log(
+    `[Unified Collection Reader] Batch ${p.returned}/${p.total} ` +
+    `(offset ${p.offset}, hasMore=${p.hasMore})`
+  );
   return result;
 }
 
@@ -391,16 +458,26 @@ function getUnifiedCollectionSummary(collectionsDir = './unified-collections') {
 
 /**
  * CLI interface for testing
+ *
+ * Usage: node unified-collection-reader.js <pattern> [collectionsDir] [offset] [limit]
+ *   offset defaults to 0
+ *   limit  defaults to 5 (use 'all' to disable batching)
  */
 function main() {
   const args = process.argv.slice(2);
   const pattern = args[0] || 'all';
   const collectionsDir = args[1] || './unified-collections';
-  
+  const offset = args[2] !== undefined ? Number(args[2]) : 0;
+  const limit = args[3] !== undefined
+    ? (args[3] === 'all' ? null : Number(args[3]))
+    : DEFAULT_BATCH_SIZE;
+
   console.log('Unified Collection Reader');
   console.log('========================');
   console.log(`Pattern: ${pattern}`);
   console.log(`Collections Directory: ${collectionsDir}`);
+  console.log(`Offset: ${offset}`);
+  console.log(`Limit:  ${limit === null ? 'all' : limit}`);
   console.log('');
   
   // Check if unified collection exists
@@ -427,11 +504,11 @@ function main() {
   console.log('');
   
   // Fetch findings
-  const result = fetchUnifiedBpaFindings(pattern, collectionsDir);
-  
+  const result = fetchUnifiedBpaFindings(pattern, collectionsDir, { offset, limit });
+
   if (result.success) {
-    console.log('✅ Successfully loaded findings:');
-    console.log(`📊 Total targets: ${result.targets.length}`);
+    const p = result.paging;
+    console.log(`✅ Batch ${p.returned}/${p.total} (offset ${p.offset}, next ${p.nextOffset ?? 'none'}, hasMore=${p.hasMore})`);
     console.log('');
     
     // Group by pattern
@@ -475,6 +552,8 @@ module.exports = {
   fetchUnifiedBpaFindings,
   getUnifiedCollectionSummary,
   readUnifiedCollection,
+  paginate,
+  DEFAULT_BATCH_SIZE,
   BpaTarget,
   BpaResult
 };


### PR DESCRIPTION
Made-with: Cursor
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change adds batched retrieval and processing of BPA findings (default 5 per batch) across cached unified collections, BPA CSV ingestion, and CAM/MCP.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Large BPA reports and unconstrained MCP responses are hard for agents to handle in one step: they increase token use, obscure progress, and make it harder for users to steer work. Fixed-size batches with explicit paging keep behavior predictable for CSV, cache, and MCP, and match how the migration skill expects agents to report after each batch and resume with offset: paging.nextOffset.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Automated: node --test plugins/aem/cloud-service/skills/migration/scripts/bpa-findings-helper.test.js — all tests passing (pagination, CSV batches, collection continuity, MCP scenarios).
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
