### PR TITLE
feat: add workflow-purge skill and fix launcher eventType bitmask

### DIFF
--- a/skills/aem/6.5-lts/skills/aem-workflow/workflow-development/references/workflow-foundation/65-lts-guardrails.md
+++ b/skills/aem/6.5-lts/skills/aem-workflow/workflow-development/references/workflow-foundation/65-lts-guardrails.md
@@ -72,4 +72,4 @@ To disable an OOTB launcher, create a node with the same name under `/conf/globa
 
 Configure via **Adobe Granite Workflow Purge Configuration** OSGi factory.
 
-Manual trigger: `curl -u admin:admin -X POST http://localhost:4502/libs/granite/operations/content/maintenance/granite_weekly/granite_workflowpurgetask.run.html`
+Manual trigger: `curl -u <user>:<password> -X POST http://localhost:4502/libs/granite/operations/content/maintenance/granite_weekly/granite_workflowpurgetask.run.html` (replace credentials with your own — never use default `admin` credentials)

--- a/skills/aem/6.5-lts/skills/aem-workflow/workflow-development/references/workflow-foundation/quick-start-guide.md
+++ b/skills/aem/6.5-lts/skills/aem-workflow/workflow-development/references/workflow-foundation/quick-start-guide.md
@@ -39,21 +39,23 @@ Before starting:
 
 ## Verify Deployment
 
+> **Note:** Replace `<user>:<password>` with your actual credentials. Never use default `admin` credentials in production or shared environments.
+
 ```bash
 # Check bundle is active
-curl -u admin:admin http://localhost:4502/system/console/bundles/com.example.my-bundle.json
+curl -u <user>:<password> http://localhost:4502/system/console/bundles/com.example.my-bundle.json
 
 # Check process.label registered (visible in model editor step picker)
 # Navigate to: Tools → Workflow → Models → Create → add Process step → configure
 
 # Check model synced to /var
-curl -u admin:admin "http://localhost:4502/var/workflow/models/my-workflow.json"
+curl -u <user>:<password> "http://localhost:4502/var/workflow/models/my-workflow.json"
 ```
 
 ## Start a Test Workflow via API
 
 ```bash
-curl -u admin:admin -X POST \
+curl -u <user>:<password> -X POST \
   "http://localhost:4502/api/workflow/instances" \
   -d "model=/var/workflow/models/my-workflow" \
   -d "payloadType=JCR_PATH" \

--- a/skills/aem/6.5-lts/skills/aem-workflow/workflow-launchers/SKILL.md
+++ b/skills/aem/6.5-lts/skills/aem-workflow/workflow-launchers/SKILL.md
@@ -131,7 +131,7 @@ Condition format: `property=<name>,value=<value>,type=<JCR_TYPE>` (type is optio
 - Check `/conf/global/settings/workflow/launcher/config/` and `/apps/settings/workflow/launcher/config/` in CRXDE Lite
 - Felix Web Console → OSGi → `WorkflowLauncherListener` service
 - Check `/var/workflow/launcher/` for active event registrations
-- Run `curl -u admin:admin http://localhost:4502/etc/workflow/launcher.json` to list all
+- Run `curl -u <user>:<password> http://localhost:4502/conf/global/settings/workflow/launcher/config.json` to list all (replace credentials with your own — never use default `admin` credentials)
 
 ## References in This Skill
 

--- a/skills/aem/6.5-lts/skills/aem-workflow/workflow-launchers/references/workflow-foundation/65-lts-guardrails.md
+++ b/skills/aem/6.5-lts/skills/aem-workflow/workflow-launchers/references/workflow-foundation/65-lts-guardrails.md
@@ -72,4 +72,4 @@ To disable an OOTB launcher, create a node with the same name under `/conf/globa
 
 Configure via **Adobe Granite Workflow Purge Configuration** OSGi factory.
 
-Manual trigger: `curl -u admin:admin -X POST http://localhost:4502/libs/granite/operations/content/maintenance/granite_weekly/granite_workflowpurgetask.run.html`
+Manual trigger: `curl -u <user>:<password> -X POST http://localhost:4502/libs/granite/operations/content/maintenance/granite_weekly/granite_workflowpurgetask.run.html` (replace credentials with your own — never use default `admin` credentials)

--- a/skills/aem/6.5-lts/skills/aem-workflow/workflow-launchers/references/workflow-foundation/quick-start-guide.md
+++ b/skills/aem/6.5-lts/skills/aem-workflow/workflow-launchers/references/workflow-foundation/quick-start-guide.md
@@ -39,21 +39,23 @@ Before starting:
 
 ## Verify Deployment
 
+> **Note:** Replace `<user>:<password>` with your actual credentials. Never use default `admin` credentials in production or shared environments.
+
 ```bash
 # Check bundle is active
-curl -u admin:admin http://localhost:4502/system/console/bundles/com.example.my-bundle.json
+curl -u <user>:<password> http://localhost:4502/system/console/bundles/com.example.my-bundle.json
 
 # Check process.label registered (visible in model editor step picker)
 # Navigate to: Tools → Workflow → Models → Create → add Process step → configure
 
 # Check model synced to /var
-curl -u admin:admin "http://localhost:4502/var/workflow/models/my-workflow.json"
+curl -u <user>:<password> "http://localhost:4502/var/workflow/models/my-workflow.json"
 ```
 
 ## Start a Test Workflow via API
 
 ```bash
-curl -u admin:admin -X POST \
+curl -u <user>:<password> -X POST \
   "http://localhost:4502/api/workflow/instances" \
   -d "model=/var/workflow/models/my-workflow" \
   -d "payloadType=JCR_PATH" \

--- a/skills/aem/6.5-lts/skills/aem-workflow/workflow-model-design/references/workflow-foundation/65-lts-guardrails.md
+++ b/skills/aem/6.5-lts/skills/aem-workflow/workflow-model-design/references/workflow-foundation/65-lts-guardrails.md
@@ -72,4 +72,4 @@ To disable an OOTB launcher, create a node with the same name under `/conf/globa
 
 Configure via **Adobe Granite Workflow Purge Configuration** OSGi factory.
 
-Manual trigger: `curl -u admin:admin -X POST http://localhost:4502/libs/granite/operations/content/maintenance/granite_weekly/granite_workflowpurgetask.run.html`
+Manual trigger: `curl -u <user>:<password> -X POST http://localhost:4502/libs/granite/operations/content/maintenance/granite_weekly/granite_workflowpurgetask.run.html` (replace credentials with your own — never use default `admin` credentials)

--- a/skills/aem/6.5-lts/skills/aem-workflow/workflow-model-design/references/workflow-foundation/quick-start-guide.md
+++ b/skills/aem/6.5-lts/skills/aem-workflow/workflow-model-design/references/workflow-foundation/quick-start-guide.md
@@ -39,21 +39,23 @@ Before starting:
 
 ## Verify Deployment
 
+> **Note:** Replace `<user>:<password>` with your actual credentials. Never use default `admin` credentials in production or shared environments.
+
 ```bash
 # Check bundle is active
-curl -u admin:admin http://localhost:4502/system/console/bundles/com.example.my-bundle.json
+curl -u <user>:<password> http://localhost:4502/system/console/bundles/com.example.my-bundle.json
 
 # Check process.label registered (visible in model editor step picker)
 # Navigate to: Tools → Workflow → Models → Create → add Process step → configure
 
 # Check model synced to /var
-curl -u admin:admin "http://localhost:4502/var/workflow/models/my-workflow.json"
+curl -u <user>:<password> "http://localhost:4502/var/workflow/models/my-workflow.json"
 ```
 
 ## Start a Test Workflow via API
 
 ```bash
-curl -u admin:admin -X POST \
+curl -u <user>:<password> -X POST \
   "http://localhost:4502/api/workflow/instances" \
   -d "model=/var/workflow/models/my-workflow" \
   -d "payloadType=JCR_PATH" \

--- a/skills/aem/6.5-lts/skills/aem-workflow/workflow-orchestrator/references/workflow-foundation/65-lts-guardrails.md
+++ b/skills/aem/6.5-lts/skills/aem-workflow/workflow-orchestrator/references/workflow-foundation/65-lts-guardrails.md
@@ -72,4 +72,4 @@ To disable an OOTB launcher, create a node with the same name under `/conf/globa
 
 Configure via **Adobe Granite Workflow Purge Configuration** OSGi factory.
 
-Manual trigger: `curl -u admin:admin -X POST http://localhost:4502/libs/granite/operations/content/maintenance/granite_weekly/granite_workflowpurgetask.run.html`
+Manual trigger: `curl -u <user>:<password> -X POST http://localhost:4502/libs/granite/operations/content/maintenance/granite_weekly/granite_workflowpurgetask.run.html` (replace credentials with your own — never use default `admin` credentials)

--- a/skills/aem/6.5-lts/skills/aem-workflow/workflow-orchestrator/references/workflow-foundation/quick-start-guide.md
+++ b/skills/aem/6.5-lts/skills/aem-workflow/workflow-orchestrator/references/workflow-foundation/quick-start-guide.md
@@ -39,21 +39,23 @@ Before starting:
 
 ## Verify Deployment
 
+> **Note:** Replace `<user>:<password>` with your actual credentials. Never use default `admin` credentials in production or shared environments.
+
 ```bash
 # Check bundle is active
-curl -u admin:admin http://localhost:4502/system/console/bundles/com.example.my-bundle.json
+curl -u <user>:<password> http://localhost:4502/system/console/bundles/com.example.my-bundle.json
 
 # Check process.label registered (visible in model editor step picker)
 # Navigate to: Tools → Workflow → Models → Create → add Process step → configure
 
 # Check model synced to /var
-curl -u admin:admin "http://localhost:4502/var/workflow/models/my-workflow.json"
+curl -u <user>:<password> "http://localhost:4502/var/workflow/models/my-workflow.json"
 ```
 
 ## Start a Test Workflow via API
 
 ```bash
-curl -u admin:admin -X POST \
+curl -u <user>:<password> -X POST \
   "http://localhost:4502/api/workflow/instances" \
   -d "model=/var/workflow/models/my-workflow" \
   -d "payloadType=JCR_PATH" \

--- a/skills/aem/6.5-lts/skills/aem-workflow/workflow-triggering/SKILL.md
+++ b/skills/aem/6.5-lts/skills/aem-workflow/workflow-triggering/SKILL.md
@@ -69,9 +69,11 @@ For `/etc/workflow/models/` legacy models, the ID is `/etc/workflow/models/my-wo
 
 ## 4. HTTP Workflow API
 
+> **Note:** Replace `<user>:<password>` with your actual credentials. Never use default `admin` credentials in production or shared environments.
+
 ```bash
 # Start
-curl -u admin:admin -X POST \
+curl -u <user>:<password> -X POST \
   "http://localhost:4502/api/workflow/instances" \
   -d "model=/var/workflow/models/my-workflow" \
   -d "payloadType=JCR_PATH" \
@@ -79,11 +81,11 @@ curl -u admin:admin -X POST \
   -d "workflowTitle=My Test Run"
 
 # List running instances
-curl -u admin:admin \
+curl -u <user>:<password> \
   "http://localhost:4502/api/workflow/instances?state=RUNNING"
 
 # Terminate an instance
-curl -u admin:admin -X DELETE \
+curl -u <user>:<password> -X DELETE \
   "http://localhost:4502/api/workflow/instances/<instanceId>"
 ```
 

--- a/skills/aem/6.5-lts/skills/aem-workflow/workflow-triggering/references/workflow-foundation/65-lts-guardrails.md
+++ b/skills/aem/6.5-lts/skills/aem-workflow/workflow-triggering/references/workflow-foundation/65-lts-guardrails.md
@@ -72,4 +72,4 @@ To disable an OOTB launcher, create a node with the same name under `/conf/globa
 
 Configure via **Adobe Granite Workflow Purge Configuration** OSGi factory.
 
-Manual trigger: `curl -u admin:admin -X POST http://localhost:4502/libs/granite/operations/content/maintenance/granite_weekly/granite_workflowpurgetask.run.html`
+Manual trigger: `curl -u <user>:<password> -X POST http://localhost:4502/libs/granite/operations/content/maintenance/granite_weekly/granite_workflowpurgetask.run.html` (replace credentials with your own — never use default `admin` credentials)

--- a/skills/aem/6.5-lts/skills/aem-workflow/workflow-triggering/references/workflow-foundation/quick-start-guide.md
+++ b/skills/aem/6.5-lts/skills/aem-workflow/workflow-triggering/references/workflow-foundation/quick-start-guide.md
@@ -39,21 +39,23 @@ Before starting:
 
 ## Verify Deployment
 
+> **Note:** Replace `<user>:<password>` with your actual credentials. Never use default `admin` credentials in production or shared environments.
+
 ```bash
 # Check bundle is active
-curl -u admin:admin http://localhost:4502/system/console/bundles/com.example.my-bundle.json
+curl -u <user>:<password> http://localhost:4502/system/console/bundles/com.example.my-bundle.json
 
 # Check process.label registered (visible in model editor step picker)
 # Navigate to: Tools → Workflow → Models → Create → add Process step → configure
 
 # Check model synced to /var
-curl -u admin:admin "http://localhost:4502/var/workflow/models/my-workflow.json"
+curl -u <user>:<password> "http://localhost:4502/var/workflow/models/my-workflow.json"
 ```
 
 ## Start a Test Workflow via API
 
 ```bash
-curl -u admin:admin -X POST \
+curl -u <user>:<password> -X POST \
   "http://localhost:4502/api/workflow/instances" \
   -d "model=/var/workflow/models/my-workflow" \
   -d "payloadType=JCR_PATH" \

--- a/skills/aem/6.5-lts/skills/aem-workflow/workflow-triggering/references/workflow-triggering/triggering-mechanisms.md
+++ b/skills/aem/6.5-lts/skills/aem-workflow/workflow-triggering/references/workflow-triggering/triggering-mechanisms.md
@@ -71,9 +71,11 @@ wfs.startWorkflow(model, data);
 
 **When to use:** CI/CD pipelines, external systems, shell scripts, integration tests.
 
+> **Note:** Replace `<user>:<password>` with your actual credentials. Never use default `admin` credentials in production or shared environments.
+
 ```bash
 # Start a workflow instance
-curl -u admin:admin -X POST \
+curl -u <user>:<password> -X POST \
   "http://localhost:4502/api/workflow/instances" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "model=/var/workflow/models/my-workflow" \
@@ -82,11 +84,11 @@ curl -u admin:admin -X POST \
   -d "workflowTitle=CI Triggered Review"
 
 # Get instance details
-curl -u admin:admin \
+curl -u <user>:<password> \
   "http://localhost:4502/api/workflow/instances/<instanceId>.json"
 
 # Terminate a workflow
-curl -u admin:admin -X DELETE \
+curl -u <user>:<password> -X DELETE \
   "http://localhost:4502/api/workflow/instances/<instanceId>"
 ```
 

--- a/skills/aem/cloud-service/skills/aem-workflow/README.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/README.md
@@ -31,6 +31,7 @@ This package contains workflow skills for **AEM as a Cloud Service** — coverin
 | `workflow-launchers/` | Development | `cq:WorkflowLauncher` nodes: event types, glob patterns, conditions |
 | `workflow-debugging/` | Production Support | Symptom → runbook, decision trees, thread pool analysis, remediation |
 | `workflow-triaging/` | Production Support | Symptom classification, log patterns, Splunk queries, data gathering |
+| `workflow-purge/` | Production Support | Purge Scheduler config, retention policies, bloat recovery, RUNNING/SUSPENDED cleanup |
 
 ## How To Start
 

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-debugging/reference.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-debugging/reference.md
@@ -31,7 +31,7 @@ Quick pointers used by the workflow-debugging skill. For full runbooks and proce
 | Developer Console | AEM Cloud Service → Developer Console | Thread dumps, OSGi bundles, config |
 | Cloud Manager Logs | Cloud Manager → Environments → Logs | error.log, access.log download/streaming |
 | Workflow Console | /libs/cq/workflow/admin/console/content/instances.html | Instance status, work items, history |
-| Sling Job Console | /system/console/slingjobs | Queue depth, failed jobs, active jobs |
+| Sling Job Console | /system/console/slingjobs | Queue depth, failed jobs, active jobs (**local SDK only** — not accessible on Cloud Service; use Developer Console) |
 | Inbox | /aem/inbox | Retry failed work items, complete tasks |
 
 ---

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-development/references/workflow-foundation/architecture-overview.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-development/references/workflow-foundation/architecture-overview.md
@@ -54,4 +54,4 @@ Workflow jobs run on the **Sling Job Queue** named `com/adobe/granite/workflow/j
 - OSGi config: `org.apache.sling.event.impl.jobs.queues.QueueConfigurationImpl`
 - Queue name: `com\/adobe\/granite\/workflow\/job\/.*`
 
-Monitor queue depth at: **Tools → Workflow → Instances** or `/system/console/slingevent`.
+Monitor queue depth at: **Tools → Workflow → Instances**. On the local SDK, you can also check `/system/console/slingevent` (not accessible on Cloud Service environments — use Developer Console instead).

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-development/references/workflow-foundation/quick-start-guide.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-development/references/workflow-foundation/quick-start-guide.md
@@ -38,21 +38,25 @@ Before starting:
 
 ## Verify Deployment
 
+> **Note:** The examples below use local AEM SDK credentials. Replace `<user>:<password>` with your actual credentials. Never use default `admin` credentials in production or shared environments.
+
 ```bash
-# Check OSGi bundle active
-curl -u admin:admin http://localhost:4502/system/console/bundles/<bundle-name>.json
+# Check OSGi bundle active (local SDK only — /system/console is not accessible on Cloud Service environments)
+curl -u <user>:<password> http://localhost:4502/system/console/bundles/<bundle-name>.json
 
 # Verify process.label registered
-curl -u admin:admin "http://localhost:4502/libs/cq/workflow/admin/console/content/models.json"
+curl -u <user>:<password> "http://localhost:4502/libs/cq/workflow/admin/console/content/models.json"
 
 # Check model synced to /var
-curl -u admin:admin "http://localhost:4502/var/workflow/models/my-workflow.json"
+curl -u <user>:<password> "http://localhost:4502/var/workflow/models/my-workflow.json"
 ```
+
+On Cloud Service environments, verify bundle status via **AEM Developer Console** instead of `/system/console`.
 
 ## Start a Test Workflow via API
 
 ```bash
-curl -u admin:admin -X POST \
+curl -u <user>:<password> -X POST \
   "http://localhost:4502/api/workflow/instances" \
   -d "model=/var/workflow/models/my-workflow" \
   -d "payloadType=JCR_PATH" \

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-launchers/SKILL.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-launchers/SKILL.md
@@ -33,14 +33,14 @@ Workflow Instance created at /var/workflow/instances/
 
 | Property | Type | Description |
 |---|---|---|
-| `eventType` | Long | `1` = NODE_ADDED, `2` = NODE_MODIFIED, `4` = NODE_REMOVED, `8` = PROPERTY_ADDED, `16` = PROPERTY_CHANGED, `32` = PROPERTY_REMOVED |
+| `eventType` | Long | Bitmask of JCR event types — see [Event Type Bitmask](#event-type-bitmask) below |
 | `glob` | String | Glob pattern matched against the event node path (e.g., `/content/dam(/.*)?`) |
 | `nodetype` | String | JCR node type the event node must be (e.g., `dam:AssetContent`) |
 | `conditions` | String[] | Additional JCR property conditions on the event node |
 | `workflow` | String | Runtime path of the workflow model `/var/workflow/models/<id>` |
 | `enabled` | Boolean | Whether the launcher is active |
 | `description` | String | Human-readable description |
-| `excludeList` | String[] | Workflow model IDs to exclude |
+| `excludeList` | String[] | Runtime model paths (`/var/workflow/models/...`) whose active instances suppress this launcher — primary loop-prevention mechanism |
 | `runModes` | String[] | Restrict to specific run modes (e.g., `author`) |
 
 ## Deploying a Custom Launcher on Cloud Service
@@ -95,6 +95,29 @@ To disable or modify an OOTB launcher (e.g., `dam_update_asset_create`):
 | `dam_xmp_writeback` | NODE_MODIFIED on rendition | DAM Writeback |
 | `update_page_version_*` | Node events on cq:Page jcr:content | Page Version Create |
 
+## Event Type Bitmask
+
+`eventType` is a bitmask combining one or more of the following values:
+
+| Value | Name | Meaning |
+|-------|------|---------|
+| `1` | `NODE_ADDED` | A node was created (e.g., asset uploaded, page created) |
+| `2` | `NODE_MODIFIED` | A node's properties or child nodes changed |
+| `4` | `NODE_REMOVED` | A node was deleted |
+| `8` | `PROPERTY_ADDED` | A property was added to a node |
+| `16` | `PROPERTY_CHANGED` | A property value was changed |
+| `32` | `PROPERTY_REMOVED` | A property was removed from a node |
+
+Common combined values:
+
+| `eventType` value | Listens for |
+|---|---|
+| `1` | Creation only |
+| `2` | Modification only |
+| `3` | Creation **or** modification (1+2) |
+| `7` | Creation, modification, **or** deletion (1+2+4) |
+| `18` | Property added **or** property changed (8+16) — fine-grained metadata watch |
+
 ## Event Type Combinations
 
 To listen for both ADD and MODIFY, combine event types:
@@ -121,6 +144,48 @@ runModes="[publish]"  <!-- only fires on Publish -->
 ```
 
 Omit `runModes` to fire on all run modes.
+
+## Launcher Loop Prevention
+
+A **launcher loop** occurs when a workflow step writes back to a JCR path that matches the same launcher's `glob`, causing the launcher to fire again — repeatedly, until the queue floods.
+
+**Scenario:** A process step updates `jcr:content/metadata` on a DAM asset. A launcher on `/content/dam(/.*)?` with `eventType=2` (NODE_MODIFIED) re-triggers the same workflow, which updates metadata again, ad infinitum.
+
+### Prevention Strategy 1: `excludeList` (recommended)
+
+Add the workflow model's runtime path to `excludeList`. When an instance of that model is already running against the same payload, the launcher will not enqueue a new instance.
+
+```xml
+excludeList="[/var/workflow/models/my-workflow]"
+```
+
+This is the safest approach: the launcher still fires for new content, but suppresses re-entry while the workflow is in-flight.
+
+### Prevention Strategy 2: Narrow the `glob`
+
+Make the glob pattern specific enough that the paths written by the workflow don't match:
+
+```xml
+<!-- Fires on original rendition upload only, not on metadata writes -->
+glob="/content/dam(/.*)?/jcr:content/renditions/original"
+nodetype="nt:file"
+eventType="{Long}1"
+```
+
+### Prevention Strategy 3: `conditions` filter
+
+Add a property condition that is only true on the initial trigger path, not on paths written by the workflow:
+
+```xml
+conditions="[property=dam:assetState,value=processing,type=STRING]"
+```
+
+### Detecting a Loop
+
+Signs of a launcher loop in Cloud Manager logs:
+- `WorkflowLauncherListener` enqueue messages for the same payload repeating rapidly
+- Sling Job queue depth for the workflow topic growing without bound
+- `numberOfQueuedJobs` metric continuously increasing
 
 ## Debugging Launchers
 

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-launchers/SKILL.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-launchers/SKILL.md
@@ -192,7 +192,7 @@ Signs of a launcher loop in Cloud Manager logs:
 - **Tools → Workflow → Launchers** UI — lists all active launchers, you can enable/disable interactively
 - Check `/conf/global/settings/workflow/launcher/config/` in CRXDE Lite for your deployed configs
 - Check OSGi console → `WorkflowLauncherListener` service properties
-- After deployment, verify via: `curl -u admin:admin http://localhost:4502/etc/workflow/launcher.json`
+- After deployment, verify via: `curl -u <user>:<password> http://localhost:4502/conf/global/settings/workflow/launcher/config.json` (local SDK only; replace credentials with your own — never use default `admin` credentials)
 
 ## References in This Skill
 

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-launchers/references/workflow-foundation/architecture-overview.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-launchers/references/workflow-foundation/architecture-overview.md
@@ -54,4 +54,4 @@ Workflow jobs run on the **Sling Job Queue** named `com/adobe/granite/workflow/j
 - OSGi config: `org.apache.sling.event.impl.jobs.queues.QueueConfigurationImpl`
 - Queue name: `com\/adobe\/granite\/workflow\/job\/.*`
 
-Monitor queue depth at: **Tools → Workflow → Instances** or `/system/console/slingevent`.
+Monitor queue depth at: **Tools → Workflow → Instances**. On the local SDK, you can also check `/system/console/slingevent` (not accessible on Cloud Service environments — use Developer Console instead).

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-launchers/references/workflow-foundation/quick-start-guide.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-launchers/references/workflow-foundation/quick-start-guide.md
@@ -38,21 +38,25 @@ Before starting:
 
 ## Verify Deployment
 
+> **Note:** The examples below use local AEM SDK credentials. Replace `<user>:<password>` with your actual credentials. Never use default `admin` credentials in production or shared environments.
+
 ```bash
-# Check OSGi bundle active
-curl -u admin:admin http://localhost:4502/system/console/bundles/<bundle-name>.json
+# Check OSGi bundle active (local SDK only — /system/console is not accessible on Cloud Service environments)
+curl -u <user>:<password> http://localhost:4502/system/console/bundles/<bundle-name>.json
 
 # Verify process.label registered
-curl -u admin:admin "http://localhost:4502/libs/cq/workflow/admin/console/content/models.json"
+curl -u <user>:<password> "http://localhost:4502/libs/cq/workflow/admin/console/content/models.json"
 
 # Check model synced to /var
-curl -u admin:admin "http://localhost:4502/var/workflow/models/my-workflow.json"
+curl -u <user>:<password> "http://localhost:4502/var/workflow/models/my-workflow.json"
 ```
+
+On Cloud Service environments, verify bundle status via **AEM Developer Console** instead of `/system/console`.
 
 ## Start a Test Workflow via API
 
 ```bash
-curl -u admin:admin -X POST \
+curl -u <user>:<password> -X POST \
   "http://localhost:4502/api/workflow/instances" \
   -d "model=/var/workflow/models/my-workflow" \
   -d "payloadType=JCR_PATH" \

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-launchers/references/workflow-launchers/launcher-config-reference.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-launchers/references/workflow-launchers/launcher-config-reference.md
@@ -12,19 +12,23 @@ Bit-field combining one or more JCR event types:
 
 | Value | Constant | Meaning |
 |---|---|---|
-| `1` | `Event.NODE_ADDED` | A node was created |
-| `2` | `Event.NODE_MODIFIED` | Node properties or child nodes changed |
-| `4` | `Event.NODE_REMOVED` | A node was deleted |
-| `8` | `Event.PROPERTY_ADDED` | A property was added |
-| `16` | `Event.PROPERTY_CHANGED` | A property value changed |
-| `32` | `Event.PROPERTY_REMOVED` | A property was removed |
+| `1` | `EVENT_NODE_ADDED` | A node was created |
+| `2` | `EVENT_NODE_MODIFIED` | Node properties or child nodes changed |
+| `4` | `EVENT_NODE_REMOVED` | A node was deleted |
+| `8` | `EVENT_PROPERTY_ADDED` | A property was added |
+| `16` | `EVENT_PROPERTY_CHANGED` | A property value changed |
+| `32` | `EVENT_PROPERTY_REMOVED` | A property was removed |
 
-Combine with addition: `eventType="{Long}3"` listens for NODE_ADDED (1) + NODE_MODIFIED (2).
+Combine with addition:
 
-Most common values:
-- `1` — fire on creation only (upload)
-- `2` — fire on modification only (edit)
-- `3` — fire on both creation and modification
+| `eventType` value | Combination | Use case |
+|---|---|---|
+| `1` | NODE_ADDED | Fire on upload/creation only |
+| `2` | NODE_MODIFIED | Fire on edits only |
+| `3` | NODE_ADDED + NODE_MODIFIED | Fire on create or edit (most common for DAM workflows) |
+| `7` | NODE_ADDED + NODE_MODIFIED + NODE_REMOVED | Fire on any structural change |
+| `18` | PROPERTY_ADDED + PROPERTY_CHANGED | Watch metadata property changes |
+| `26` | NODE_MODIFIED + PROPERTY_ADDED + PROPERTY_CHANGED | Broad content-change listener |
 
 ### `glob` (String, required)
 
@@ -96,7 +100,16 @@ Free-text description visible in the Launchers UI.
 
 ### `excludeList` (String[], optional)
 
-List of workflow model IDs. If the content's `cq:lastReplicatedBy` or similar metadata indicates one of these models triggered the last change, the launcher will not re-fire.
+Array of workflow model **runtime paths** (`/var/workflow/models/...`). If an instance of one of these models is currently running against the same payload that triggered the event, the launcher will not enqueue a new workflow instance.
+
+This is the primary mechanism for **launcher loop prevention** — it suppresses re-entry while the specified workflow is already in-flight on that payload, while still allowing the launcher to fire for new, unprocessed content.
+
+Example — prevent a DAM workflow from re-triggering itself when it writes back metadata:
+```xml
+excludeList="[/var/workflow/models/dam/my-custom-processing]"
+```
+
+> Use the **runtime path** under `/var/workflow/models/`, not the design-time path under `/conf/global/settings/workflow/models/`.
 
 ### `runModes` (String[], optional)
 

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-model-design/references/workflow-foundation/architecture-overview.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-model-design/references/workflow-foundation/architecture-overview.md
@@ -54,4 +54,4 @@ Workflow jobs run on the **Sling Job Queue** named `com/adobe/granite/workflow/j
 - OSGi config: `org.apache.sling.event.impl.jobs.queues.QueueConfigurationImpl`
 - Queue name: `com\/adobe\/granite\/workflow\/job\/.*`
 
-Monitor queue depth at: **Tools → Workflow → Instances** or `/system/console/slingevent`.
+Monitor queue depth at: **Tools → Workflow → Instances**. On the local SDK, you can also check `/system/console/slingevent` (not accessible on Cloud Service environments — use Developer Console instead).

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-model-design/references/workflow-foundation/quick-start-guide.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-model-design/references/workflow-foundation/quick-start-guide.md
@@ -38,21 +38,25 @@ Before starting:
 
 ## Verify Deployment
 
+> **Note:** The examples below use local AEM SDK credentials. Replace `<user>:<password>` with your actual credentials. Never use default `admin` credentials in production or shared environments.
+
 ```bash
-# Check OSGi bundle active
-curl -u admin:admin http://localhost:4502/system/console/bundles/<bundle-name>.json
+# Check OSGi bundle active (local SDK only — /system/console is not accessible on Cloud Service environments)
+curl -u <user>:<password> http://localhost:4502/system/console/bundles/<bundle-name>.json
 
 # Verify process.label registered
-curl -u admin:admin "http://localhost:4502/libs/cq/workflow/admin/console/content/models.json"
+curl -u <user>:<password> "http://localhost:4502/libs/cq/workflow/admin/console/content/models.json"
 
 # Check model synced to /var
-curl -u admin:admin "http://localhost:4502/var/workflow/models/my-workflow.json"
+curl -u <user>:<password> "http://localhost:4502/var/workflow/models/my-workflow.json"
 ```
+
+On Cloud Service environments, verify bundle status via **AEM Developer Console** instead of `/system/console`.
 
 ## Start a Test Workflow via API
 
 ```bash
-curl -u admin:admin -X POST \
+curl -u <user>:<password> -X POST \
   "http://localhost:4502/api/workflow/instances" \
   -d "model=/var/workflow/models/my-workflow" \
   -d "payloadType=JCR_PATH" \

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-orchestrator/SKILL.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-orchestrator/SKILL.md
@@ -33,7 +33,8 @@ This is the **master entry point** for all AEM Workflow tasks on Cloud Service �
 | "Workflow is stuck", "Why isn't my workflow advancing?", "No work item", "Workflow failed", "Step shows error" | `workflow-debugging` |
 | "Task not in Inbox", "User can't see work item", "Permissions error on workflow" | `workflow-debugging` |
 | "Thread pool exhausted", "Auto-advancement not working", "Queue backlog", "Sling Jobs stuck" | `workflow-debugging` |
-| "Repository bloat", "Too many workflow instances", "Purge not working", "Stale workflows" | `workflow-debugging` |
+| "Repository bloat", "Too many workflow instances", "Stale workflows" | `workflow-debugging` |
+| "Configure purge", "Purge Scheduler", "How to purge workflow instances", "Delete old workflows", "Retention policy", "scheduledpurge", "Purge not working", "Instances accumulating" | `workflow-purge` |
 | "What workflow errors on host X?", "Workflow activity for the past N hours", "What should I collect?" | `workflow-triaging` |
 | "Classify this workflow ticket", "What Splunk query should I use?", "What logs do I need?" | `workflow-triaging` |
 | "Why did workflow X fail? Show me the error.", "Failure details for model Y" | `workflow-triaging` |
@@ -69,6 +70,7 @@ workflow-triggering/SKILL.md           ← for start/trigger tasks
 workflow-launchers/SKILL.md            ← for launcher config tasks
 workflow-debugging/SKILL.md            ← for production debugging tasks
 workflow-triaging/SKILL.md             ← for incident triage tasks
+workflow-purge/SKILL.md                ← for purge configuration and cleanup tasks
 ```
 
 ### Step 3: Load the sub-skill's topic references
@@ -108,6 +110,11 @@ workflow-debugging/reference.md
 **workflow-triaging:**
 ```
 workflow-triaging/SKILL.md
+```
+
+**workflow-purge:**
+```
+workflow-purge/SKILL.md
 ```
 
 ---

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-orchestrator/references/workflow-foundation/architecture-overview.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-orchestrator/references/workflow-foundation/architecture-overview.md
@@ -54,4 +54,4 @@ Workflow jobs run on the **Sling Job Queue** named `com/adobe/granite/workflow/j
 - OSGi config: `org.apache.sling.event.impl.jobs.queues.QueueConfigurationImpl`
 - Queue name: `com\/adobe\/granite\/workflow\/job\/.*`
 
-Monitor queue depth at: **Tools → Workflow → Instances** or `/system/console/slingevent`.
+Monitor queue depth at: **Tools → Workflow → Instances**. On the local SDK, you can also check `/system/console/slingevent` (not accessible on Cloud Service environments — use Developer Console instead).

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-orchestrator/references/workflow-foundation/quick-start-guide.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-orchestrator/references/workflow-foundation/quick-start-guide.md
@@ -38,21 +38,25 @@ Before starting:
 
 ## Verify Deployment
 
+> **Note:** The examples below use local AEM SDK credentials. Replace `<user>:<password>` with your actual credentials. Never use default `admin` credentials in production or shared environments.
+
 ```bash
-# Check OSGi bundle active
-curl -u admin:admin http://localhost:4502/system/console/bundles/<bundle-name>.json
+# Check OSGi bundle active (local SDK only — /system/console is not accessible on Cloud Service environments)
+curl -u <user>:<password> http://localhost:4502/system/console/bundles/<bundle-name>.json
 
 # Verify process.label registered
-curl -u admin:admin "http://localhost:4502/libs/cq/workflow/admin/console/content/models.json"
+curl -u <user>:<password> "http://localhost:4502/libs/cq/workflow/admin/console/content/models.json"
 
 # Check model synced to /var
-curl -u admin:admin "http://localhost:4502/var/workflow/models/my-workflow.json"
+curl -u <user>:<password> "http://localhost:4502/var/workflow/models/my-workflow.json"
 ```
+
+On Cloud Service environments, verify bundle status via **AEM Developer Console** instead of `/system/console`.
 
 ## Start a Test Workflow via API
 
 ```bash
-curl -u admin:admin -X POST \
+curl -u <user>:<password> -X POST \
   "http://localhost:4502/api/workflow/instances" \
   -d "model=/var/workflow/models/my-workflow" \
   -d "payloadType=JCR_PATH" \

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-purge/SKILL.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-purge/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: workflow-purge
+description: Configure, run, and troubleshoot workflow instance purge on AEM as a Cloud Service. Use when the user reports repository bloat from workflow instances, needs to configure the Purge Scheduler, wants to understand retention policies, or is seeing purge failures in Cloud Manager logs.
+license: Apache-2.0
+---
+
+# Workflow Purge — AEM as a Cloud Service
+
+Operational guide for purging completed, failed, and stale workflow instances to prevent repository bloat on **AEM as a Cloud Service**.
+
+## Variant Scope
+
+- This skill is **cloud-service-only**.
+- No JMX `purgeCompleted` operation — use Purge Scheduler (OSGi config in Git) or Workflow Maintenance UI.
+- All config changes require code in Git deployed via Cloud Manager pipeline.
+
+---
+
+## When to Use This Skill
+
+- `/var/workflow/instances/` is growing without bound (repository bloat)
+- Purge Scheduler is configured but old instances still accumulate
+- Purge job is throwing errors in Cloud Manager logs
+- User asks how to clean up completed, failed, or stale workflow instances
+- Performance degradation suspected due to large volume of workflow instances
+- User needs to set a retention policy for workflow audit history
+
+---
+
+## Core Concept: What Gets Purged?
+
+The Granite Workflow Purge Scheduler removes workflow instances from `/var/workflow/instances/` based on age and status.
+
+| Status | Purged by default? | Notes |
+|--------|--------------------|-------|
+| `COMPLETED` | Yes | After `scheduledpurge.daysold` days |
+| `ABORTED` | Yes | After `scheduledpurge.daysold` days |
+| `FAILED` | Configurable | Requires `scheduledpurge.workflowStatus=FAILED` or `ALL` |
+| `RUNNING` | **Never** | Must be terminated first via Workflow Console or REST API |
+| `SUSPENDED` | **Never** | Must be resumed or terminated before purge can act |
+
+**What is NOT removed by purge:**
+- Any instance newer than `scheduledpurge.daysold`
+- RUNNING or SUSPENDED instances regardless of age
+- Workflow models or launcher configs — purge only touches `/var/workflow/instances/`
+
+---
+
+## Step 1: Configure the Purge Scheduler (OSGi)
+
+### OSGi factory PID
+
+```
+com.adobe.granite.workflow.purge.Scheduler
+```
+
+### Configuration Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `scheduledpurge.name` | String | (required) | Unique name for this purge job — used in log output |
+| `scheduledpurge.workflowStatus` | String | `COMPLETED` | Status to purge: `COMPLETED`, `ABORTED`, `FAILED`, or `ALL` |
+| `scheduledpurge.daysold` | Long | `30` | Minimum age in days; instances newer than this are retained |
+| `scheduledpurge.modelIds` | String[] | `[]` (all) | Restrict purge to specific model runtime paths; empty = all models |
+| `scheduledpurge.maxProcessed` | Long | `-1` (unlimited) | Max instances purged per run; use to batch large cleanups |
+| `scheduledpurge.scheduler.expression` | String | `0 0 1 * * ?` | Cron expression (default: 1 AM daily) |
+
+> **Note:** `scheduledpurge.includefailed` is a legacy alias; prefer `scheduledpurge.workflowStatus=FAILED` or `ALL` for clarity.
+
+### Example OSGi Config File
+
+Place in the Maven `ui.apps` module under `config.author` to restrict purge to the Author tier:
+
+```
+ui.apps/src/main/content/jcr_root/apps/my-project/config.author/
+    com.adobe.granite.workflow.purge.Scheduler-daily.xml
+```
+
+Content:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root
+    xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:OsgiConfig"
+    scheduledpurge.name="daily-completed"
+    scheduledpurge.workflowStatus="COMPLETED"
+    scheduledpurge.daysold="{Long}30"
+    scheduledpurge.modelIds="[]"
+    scheduledpurge.maxProcessed="{Long}-1"
+    scheduledpurge.scheduler.expression="0 0 1 * * ?"/>
+```
+
+> **Always deploy to `config.author`**: Workflow instances live on Author. Running purge on Publish is unnecessary and adds load.
+
+---
+
+## Step 2: Recommended Multi-Job Configuration
+
+Use separate Scheduler factory instances for different retention windows and statuses. Each instance needs a unique OSGi factory suffix (e.g., `-daily`, `-weekly-failed`).
+
+### Job 1 — Completed workflows (30-day retention)
+
+```xml
+scheduledpurge.name="purge-completed-30d"
+scheduledpurge.workflowStatus="COMPLETED"
+scheduledpurge.daysold="{Long}30"
+scheduledpurge.scheduler.expression="0 0 1 * * ?"
+```
+
+### Job 2 — Failed workflows (90-day retention for audit)
+
+```xml
+scheduledpurge.name="purge-failed-90d"
+scheduledpurge.workflowStatus="FAILED"
+scheduledpurge.daysold="{Long}90"
+scheduledpurge.scheduler.expression="0 30 1 * * ?"
+```
+
+### Job 3 — High-volume DAM workflows (7-day retention)
+
+```xml
+scheduledpurge.name="purge-dam-update-7d"
+scheduledpurge.workflowStatus="COMPLETED"
+scheduledpurge.daysold="{Long}7"
+scheduledpurge.modelIds="[/var/workflow/models/dam/update_asset]"
+scheduledpurge.scheduler.expression="0 0 2 * * ?"
+```
+
+---
+
+## Step 3: Workflow Maintenance UI (Ad-hoc Purge)
+
+For immediate, ad-hoc purge without deploying a new config:
+
+**Tools → Operations → Maintenance → Weekly Maintenance Window → Workflow Purge**
+
+This UI-based task uses the same Purge Scheduler mechanism. On Cloud Service, always back any retention settings here with an OSGi config in Git to ensure they persist across environment rebuilds.
+
+---
+
+## Step 4: Recovering from Severe Bloat
+
+If the scheduler was never configured and `/var/workflow/instances/` contains millions of nodes:
+
+1. **Deploy a short-retention config** with `scheduledpurge.daysold=7` and trigger it immediately via the Maintenance UI.
+2. **Batch the purge**: Set `scheduledpurge.maxProcessed=5000` to avoid long-running JCR transactions that cause lock contention.
+3. **Run multiple cycles** until the instance count is manageable. Each run processes at most `maxProcessed` instances.
+4. **Restore the target retention** (e.g., 30 days) once the backlog is cleared.
+
+> **Warning:** Purging millions of instances in a single transaction causes long GC pauses and JCR lock contention. Always batch via `maxProcessed` in high-volume environments.
+
+---
+
+## Step 5: Handling RUNNING and SUSPENDED Instances
+
+The purge scheduler never removes RUNNING or SUSPENDED instances. Investigate before terminating:
+
+| Situation | Action |
+|-----------|--------|
+| High count of RUNNING with no active work item (stale) | Terminate via Workflow Console or REST `DELETE /api/workflow/instances/{id}` |
+| Legitimate RUNNING instances | Do not terminate; resolve the blocking step first |
+| SUSPENDED instances | Resume or terminate via Workflow Console → **Suspend** tab |
+
+**Terminate a single instance via REST:**
+```
+DELETE /api/workflow/instances/{id}
+Authorization: Bearer <token>
+```
+
+**Bulk-terminate via Workflow Console:**
+Tools → Workflow → Instances → filter by status RUNNING → select → Terminate
+
+After termination, the next purge cycle will remove them once they exceed `scheduledpurge.daysold`.
+
+---
+
+## Step 6: Monitoring Purge Activity
+
+Download `error.log` or `workflow.log` from **Cloud Manager → Environments → Logs**.
+
+| Log Pattern | Meaning |
+|-------------|---------|
+| `Workflow purge '<name>': purged X instances` | Successful run; X instances removed |
+| `Workflow purge '<name>': 0 instances purged` | No instances matched the criteria — check `daysold` and `workflowStatus` |
+| `Workflow purge '<name>': repository exception` | Purge failed; check service user permissions on `/var/workflow/instances/` |
+| `com.adobe.granite.workflow.purge.Scheduler ... started` | Scheduler triggered |
+| `RejectedExecutionException` in Sling Jobs | Thread pool exhaustion; purge jobs queued but not executing |
+
+---
+
+## Step 7: Common Misconfiguration Patterns
+
+| Misconfiguration | Symptom | Fix |
+|-----------------|---------|-----|
+| No purge job configured | Repository grows indefinitely | Add at least one `com.adobe.granite.workflow.purge.Scheduler` config |
+| `scheduledpurge.daysold` too high (e.g., 365) | Old instances accumulate | Reduce to 30 days for completed, 90 for failed |
+| Purge deployed to all run modes | Unnecessary load on Publish | Move config to `config.author` |
+| Single purge run without `maxProcessed` | Long JCR transaction, lock contention in logs | Set `scheduledpurge.maxProcessed=5000` during backlog recovery |
+| Purging `RUNNING` instances expected | Instances still present after purge run | Terminate RUNNING instances first; purge does not touch them |
+| DAM Update Asset instances not purged | Model path mismatch in `modelIds` | Use runtime path `/var/workflow/models/dam/update_asset`, not design-time path |
+
+---
+
+## Cloud Service Constraints Summary
+
+| Operation | Cloud Service Approach |
+|-----------|-----------------------|
+| Schedule purge | `com.adobe.granite.workflow.purge.Scheduler` OSGi config in Git → Cloud Manager pipeline |
+| Run purge immediately | Tools → Operations → Maintenance → Workflow Purge |
+| Check purge history | Cloud Manager logs → `error.log` |
+| Terminate RUNNING instances | Workflow Console UI or `DELETE /api/workflow/instances/{id}` |
+| JMX `purgeCompleted` | **Not available** — use Purge Scheduler |
+| JMX `countInstances` | **Not available** — use Workflow Console or custom JCR query |
+
+---
+
+## References in This Skill
+
+| Reference | What It Covers |
+|-----------|---------------|
+| `references/workflow-foundation/architecture-overview.md` | Granite Workflow Engine and `/var/workflow/instances/` JCR storage |
+| `references/workflow-foundation/jcr-paths-reference.md` | Instance path structure and node types |
+| `references/workflow-foundation/cloud-service-guardrails.md` | Cloud Service deployment and config constraints, purge config note |

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-purge/references/workflow-foundation/README.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-purge/references/workflow-foundation/README.md
@@ -1,0 +1,15 @@
+# Workflow Foundation References — AEM Cloud Service
+
+This directory contains cross-cutting references shared by all AEM Workflow skills on AEM as a Cloud Service.
+
+It supports model design, Java development, triggering, launcher configuration, and purge work. It is not advisory-only content.
+
+## Files in This Directory
+
+| File | Purpose |
+|---|---|
+| `architecture-overview.md` | Granite engine, Sling Jobs, engine flow, JCR storage |
+| `jcr-paths-reference.md` | Authoritative path map for models, instances, launchers, packages |
+| `api-reference.md` | `WorkflowProcess`, `WorkflowSession`, `MetaDataMap`, `ParticipantStepChooser` contracts |
+| `cloud-service-guardrails.md` | Cloud Service-specific constraints: immutable `/libs`, service users, deployment, purge |
+| `quick-start-guide.md` | Entry path for new or broad requests |

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-purge/references/workflow-foundation/api-reference.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-purge/references/workflow-foundation/api-reference.md
@@ -1,0 +1,98 @@
+# Workflow API Reference — AEM Cloud Service
+
+## WorkflowProcess (SPI)
+
+```java
+// com.adobe.granite.workflow.exec.WorkflowProcess
+public interface WorkflowProcess {
+    void execute(WorkItem item, WorkflowSession session, MetaDataMap args)
+            throws WorkflowException;
+}
+```
+
+**Registration:** `@Component(service=WorkflowProcess.class, property={"process.label=My Label"})`
+
+The engine calls `execute()` on a Sling Job thread. Return normally to advance; throw `WorkflowException` to trigger retry.
+
+## ParticipantStepChooser (SPI)
+
+```java
+// com.adobe.granite.workflow.exec.ParticipantStepChooser
+public interface ParticipantStepChooser {
+    String SERVICE_PROPERTY_LABEL = "chooser.label";
+    String getParticipant(WorkItem workItem, WorkflowSession session,
+                          MetaDataMap args) throws WorkflowException;
+}
+```
+
+**Registration:** `@Component(service=ParticipantStepChooser.class, property={"chooser.label=My Chooser"})`
+
+Return value must be a valid JCR `rep:principalName` (user ID or group ID).
+
+## WorkflowSession (API)
+
+Obtain via `resourceResolver.adaptTo(WorkflowSession.class)`.
+
+| Method | Purpose |
+|---|---|
+| `startWorkflow(model, data)` | Start a new workflow instance |
+| `startWorkflow(model, data, metaData)` | Start with initial metadata |
+| `getModel(id)` | Get a deployed model by its `/var/workflow/models/<name>` path |
+| `getModels()` | List all deployed models |
+| `deployModel(model)` | Publish design-time model to runtime (`/var/workflow/models/`) |
+| `newWorkflowData(type, payload)` | Create a `WorkflowData` for `JCR_PATH` or `BLOB` |
+| `getWorkflows(filter)` | Query instances by state |
+| `getActiveWorkItems(filter)` | Get active work items for a user |
+| `complete(workItem, route)` | Advance a participant step |
+| `terminate(workflow)` | Abort a running workflow |
+| `suspend(workflow)` | Suspend a running workflow |
+| `resume(workflow)` | Resume a suspended workflow |
+
+## WorkflowData (Runtime data carrier)
+
+```java
+WorkflowData data = session.newWorkflowData("JCR_PATH", "/content/mypage");
+data.getMetaDataMap().put("initiatorNote", "sent from batch job");
+Workflow instance = session.startWorkflow(model, data);
+```
+
+**Payload types:**
+- `"JCR_PATH"` — a JCR repository path
+- `"BLOB"` — binary data
+
+## MetaDataMap
+
+`com.adobe.granite.workflow.metadata.MetaDataMap` — a typed property bag.
+
+```java
+// Read with default
+String status = map.get("approvalStatus", "PENDING");
+Long count = map.get("retryCount", Long.class);
+
+// Write
+map.put("approver", "john.doe");
+map.put("timestamp", new Date());
+```
+
+`SimpleMetaDataMap` is the standard implementation for testing.
+
+## WorkflowModel Graph
+
+| Interface | Method | Purpose |
+|---|---|---|
+| `WorkflowModel` | `getId()` | `/var/workflow/models/<name>` path |
+| `WorkflowModel` | `getNodes()` | All `WorkflowNode` objects |
+| `WorkflowModel` | `getTransitions()` | All `WorkflowTransition` objects |
+| `WorkflowNode` | `getType()` | `START`, `END`, `PROCESS`, `PARTICIPANT`, `DYNAMIC_PARTICIPANT`, `OR_SPLIT`, `AND_SPLIT`, `AND_JOIN`, `EXTERNAL_PROCESS` |
+| `WorkflowNode` | `getMetaData()` | `MetaDataMap` of step args (e.g. `PROCESS`, `PARTICIPANT`) |
+| `WorkflowTransition` | `getRule()` | ECMA/Groovy rule string (for OR splits) |
+
+## WorkItem
+
+| Method | Purpose |
+|---|---|
+| `getWorkflowData()` | Get `WorkflowData` (payload + instance metadata) |
+| `getMetaDataMap()` | Step-scoped metadata (not shared across steps) |
+| `getNode()` | The `WorkflowNode` this work item is at |
+| `getWorkflow()` | The `Workflow` instance |
+| `getId()` | Unique work item ID |

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-purge/references/workflow-foundation/architecture-overview.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-purge/references/workflow-foundation/architecture-overview.md
@@ -1,0 +1,57 @@
+# Granite Workflow Engine — Architecture Overview (AEM Cloud Service)
+
+## Engine Flow
+
+```
+User / Launcher / API
+        ↓
+WorkflowSession.startWorkflow(model, data)
+        ↓
+Sling Event Job created
+  topic: com/adobe/granite/workflow/job/**
+  (transient: com/adobe/granite/workflow/transient/job/**)
+        ↓
+JobHandler.process()   ← consumes job, drives step loop
+        ↓
+For PROCESS nodes:     WorkflowProcess.execute(item, session, args)
+For PARTICIPANT nodes: WorkItem persisted → Inbox / Task Management
+For EXTERNAL_PROCESS:  ExternalProcessPollingHandler (polling job)
+        ↓
+On normal return:      workflow advances to next node
+On WorkflowException:  retry (up to queue max), then FAILED + Inbox alert
+```
+
+## Key Design Points
+
+- **Consecutive PROCESS steps** run in a single thread loop — no job re-queue between them.
+- **Two JCR sessions** per job: one for workflow state (`/var/workflow/instances`), one for payload operations. Keeps payload changes isolated from engine state.
+- **Transient workflows** create no JCR node until a retry or external process forces persistence.
+- **InstanceLock** serializes concurrent access to the same workflow instance.
+
+## Workflow Instance States
+
+| State | Meaning |
+|---|---|
+| `RUNNING` | Active, steps executing |
+| `SUSPENDED` | Paused at a Participant or Task step awaiting human action |
+| `COMPLETED` | Terminal — all steps completed normally |
+| `ABORTED` | Terminated by admin or a process step |
+| `FAILED` | Exhausted retries; failure inbox item created |
+
+## OSGi Registration Requirements
+
+| SPI Interface | Required Property | Value |
+|---|---|---|
+| `WorkflowProcess` | `process.label` | Display label shown in model editor |
+| `ParticipantStepChooser` | `chooser.label` | Label shown in Dynamic Participant step config |
+| `WorkflowExternalProcess` | `process.label` | Same as WorkflowProcess |
+| `RuleEngine` | (standard OSGi) | Used for OR-split rule evaluation |
+
+## Thread Pool and Queues
+
+Workflow jobs run on the **Sling Job Queue** named `com/adobe/granite/workflow/job`. Thread pool size and queue capacity are configured via:
+
+- OSGi config: `org.apache.sling.event.impl.jobs.queues.QueueConfigurationImpl`
+- Queue name: `com\/adobe\/granite\/workflow\/job\/.*`
+
+Monitor queue depth at: **Tools → Workflow → Instances**. On the local SDK, you can also check `/system/console/slingevent` (not accessible on Cloud Service environments — use Developer Console instead).

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-purge/references/workflow-foundation/cloud-service-guardrails.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-purge/references/workflow-foundation/cloud-service-guardrails.md
@@ -1,0 +1,68 @@
+# Cloud Service Guardrails — AEM Workflow
+
+## Immutability Constraints
+
+| Path | Status | Action |
+|---|---|---|
+| `/libs/settings/workflow/models/` | **Immutable** | Create models under `/conf/global/settings/workflow/models/` |
+| `/libs/settings/workflow/launcher/config/` | **Immutable** | Create launchers under `/conf/global/settings/workflow/launcher/config/` |
+| `/libs/workflow/scripts/` | **Immutable** | Do not edit OOTB scripts |
+| `/etc/workflow/` | **Deprecated** | Avoid; use `/conf/global` |
+
+## Model Deployment
+
+1. Source model: `/conf/global/settings/workflow/models/<name>/jcr:content/model`
+2. Deploy to runtime: call `WorkflowSession.deployModel(model)` or use Workflow Model Editor → **Sync**
+3. Engine reads only from `/var/workflow/models/<name>`
+4. Deploy via Cloud Manager pipeline — models land as content package in `ui.content`
+
+**filter.xml (use `merge` mode):**
+```xml
+<filter root="/conf/global/settings/workflow/models/my-workflow" mode="merge"/>
+```
+
+## Service Users
+
+- Always use service users — never use admin credentials in production code
+- Map your bundle's sub-service to `workflow-process-service` or a custom user with minimal ACLs
+- Define mappings via `org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-*.xml` OSGi configs in `ui.apps`
+- Use repoinit (`sling.content.repoinit`) to create custom service users and set ACLs
+
+## OSGi Annotations
+
+On Cloud Service (AEM SDK targets OSGi 7):
+- Use `org.osgi.service.component.annotations.*` (DS R6/R7)
+- Avoid Felix SCR (`org.apache.felix.scr.annotations.*`) — deprecated
+- Use `@Designate(ocd=...)` + `@ObjectClassDefinition` for configuration schemas
+
+## Deployment via Cloud Manager
+
+- Workflow models and launcher configs go into the `ui.content` package
+- Bundle containing custom `WorkflowProcess` classes goes into `ui.apps`
+- Do not write workflow-related content to mutable repository paths from bundle activators in Cloud Service
+
+## Disabling OOTB Launchers
+
+Never modify `/libs`. Override with an `enabled=false` node at `/conf/global/settings/workflow/launcher/config/<same-name>`:
+
+```xml
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:WorkflowLauncher"
+    enabled="{Boolean}false"/>
+```
+
+## Globally Excluded Launcher Paths
+
+These paths never trigger launchers regardless of configuration:
+- `/var/audit`
+- `/var/eventing`
+- `/var/taskmanagement`
+- `/tmp`
+- `/var/workflow/instances`
+
+## Purge
+
+Configure purge via **Adobe Granite Workflow Purge Configuration** OSGi factory  
+(`com.adobe.granite.workflow.purge.Scheduler`) — do not manually delete from `/var/workflow/instances`.
+
+Run under: **Tools → Operations → Maintenance → Weekly Maintenance**.

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-purge/references/workflow-foundation/jcr-paths-reference.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-purge/references/workflow-foundation/jcr-paths-reference.md
@@ -1,0 +1,64 @@
+# JCR Paths Reference — AEM Workflow (Cloud Service)
+
+## Model Paths
+
+| Path | Purpose | Notes |
+|---|---|---|
+| `/conf/global/settings/workflow/models/<name>` | Design-time model root | Writable; source of truth for code |
+| `/conf/global/settings/workflow/models/<name>/jcr:content/model` | `cq:WorkflowModel` node | Contains `nodes/` and `transitions/` subtrees |
+| `/var/workflow/models/<name>` | Runtime (deployed) model | Engine reads from here; written by Sync / `deployModel()` |
+| `/libs/settings/workflow/models/` | OOTB models | **Immutable on Cloud Service** — do not write |
+
+## Launcher Config Paths
+
+| Path | Priority | Notes |
+|---|---|---|
+| `/libs/settings/workflow/launcher/config/` | Base (OOTB) | **Immutable** — never edit directly |
+| `/conf/global/settings/workflow/launcher/config/` | Override (customer) | Always write here |
+| `/etc/workflow/launcher/config/` | Legacy (backward compat) | Avoid on Cloud Service |
+
+Override chain (lowest to highest): `/etc` → `/libs` → `/conf/global`
+
+## Instance Paths
+
+| Path | Purpose |
+|---|---|
+| `/var/workflow/instances/` | All active and historical workflow instances |
+| `/var/workflow/instances/server0/<yyyy-MM-dd>/<id>` | Specific instance root |
+| `/var/workflow/instances/server0/<yyyy-MM-dd>/<id>/history` | Step history log |
+| `/var/workflow/instances/server0/<yyyy-MM-dd>/<id>/workItems/<step>` | Work item nodes |
+
+## Task Management Paths
+
+| Path | Purpose |
+|---|---|
+| `/var/taskmanagement/tasks/` | Inbox Task nodes |
+| `/var/taskmanagement/tasks/<bucket>/<taskId>` | Single task node |
+
+## Other Workflow Paths
+
+| Path | Purpose |
+|---|---|
+| `/var/workflow/packages/` | Workflow packages (multi-page payloads) |
+| `/etc/workflow/packages/` | Legacy workflow packages |
+| `/libs/workflow/scripts/` | OOTB ECMAScript for workflow steps |
+| `/conf/global/settings/inbox/` | Inbox sharing preferences |
+
+## ACL Groups
+
+| Group | Access |
+|---|---|
+| `workflow-administrators` | Full workflow CRUD + admin operations |
+| `workflow-editors` | Create/modify models |
+| `workflow-users` | Start workflows, complete work items |
+
+## Service User Mapping (Cloud Service)
+
+The OOTB workflow service user is `workflow-process-service`. Map your bundle's sub-service:
+
+```xml
+<!-- org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-<pid>.xml -->
+<jcr:root
+    jcr:primaryType="sling:OsgiConfig"
+    user.mapping="[com.example.my-bundle:workflow=workflow-process-service]"/>
+```

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-purge/references/workflow-foundation/quick-start-guide.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-purge/references/workflow-foundation/quick-start-guide.md
@@ -1,0 +1,66 @@
+# Quick Start Guide — AEM Workflow Development (Cloud Service)
+
+## Determine What You Need
+
+```
+User request
+    ├── "How do I create a workflow model?"
+    │       → workflow-model-design/SKILL.md
+    │
+    ├── "How do I write a custom process step / participant chooser?"
+    │       → workflow-development/SKILL.md
+    │
+    ├── "How do I start a workflow programmatically / via API?"
+    │       → workflow-triggering/SKILL.md
+    │
+    ├── "How do I auto-trigger a workflow when content changes?"
+    │       → workflow-launchers/SKILL.md
+    │
+    └── "I need end-to-end help designing + building + deploying a workflow"
+            → workflow-orchestrator/SKILL.md
+```
+
+## Minimum Viable Workflow (3 steps)
+
+1. **Create** a model XML at `/conf/global/settings/workflow/models/my-workflow/jcr:content/model`
+2. **Implement** a `WorkflowProcess` class registered with `process.label=My Step`
+3. **Deploy** via Cloud Manager pipeline (model in `ui.content`, bundle in `ui.apps`)
+
+## Prerequisite Checklist
+
+```
+Before starting:
+- [ ] AEM Cloud Service SDK installed locally
+- [ ] Maven project with ui.apps + ui.content modules
+- [ ] Service user configured (or use existing workflow-process-service)
+- [ ] Bundle deployed and process.label visible in Workflow Model Editor
+```
+
+## Verify Deployment
+
+> **Note:** The examples below use local AEM SDK credentials. Replace `<user>:<password>` with your actual credentials. Never use default `admin` credentials in production or shared environments.
+
+```bash
+# Check OSGi bundle active (local SDK only — /system/console is not accessible on Cloud Service environments)
+curl -u <user>:<password> http://localhost:4502/system/console/bundles/<bundle-name>.json
+
+# Verify process.label registered
+curl -u <user>:<password> "http://localhost:4502/libs/cq/workflow/admin/console/content/models.json"
+
+# Check model synced to /var
+curl -u <user>:<password> "http://localhost:4502/var/workflow/models/my-workflow.json"
+```
+
+On Cloud Service environments, verify bundle status via **AEM Developer Console** instead of `/system/console`.
+
+## Start a Test Workflow via API
+
+```bash
+curl -u <user>:<password> -X POST \
+  "http://localhost:4502/api/workflow/instances" \
+  -d "model=/var/workflow/models/my-workflow" \
+  -d "payloadType=JCR_PATH" \
+  -d "payload=/content/test-page"
+```
+
+Monitor at: **Tools → Workflow → Instances** → filter by model.

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-triggering/SKILL.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-triggering/SKILL.md
@@ -79,9 +79,11 @@ public class MyWorkflowService {
 
 ## 4. HTTP Workflow API
 
+> **Note:** The examples below use local AEM SDK URLs and placeholder credentials. Replace `<user>:<password>` with your actual credentials. Never use default `admin` credentials in production.
+
 ```bash
 # Start a workflow
-curl -u admin:admin -X POST \
+curl -u <user>:<password> -X POST \
   "http://localhost:4502/api/workflow/instances" \
   -d "model=/var/workflow/models/my-workflow" \
   -d "payloadType=JCR_PATH" \
@@ -91,11 +93,11 @@ curl -u admin:admin -X POST \
 # Response: 201 Created with Location header pointing to instance path
 
 # Get workflow instance details
-curl -u admin:admin \
+curl -u <user>:<password> \
   "http://localhost:4502/api/workflow/instances/<instanceId>.json"
 
 # List running instances
-curl -u admin:admin \
+curl -u <user>:<password> \
   "http://localhost:4502/api/workflow/instances?state=RUNNING&model=/var/workflow/models/my-workflow"
 ```
 

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-triggering/references/workflow-foundation/architecture-overview.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-triggering/references/workflow-foundation/architecture-overview.md
@@ -54,4 +54,4 @@ Workflow jobs run on the **Sling Job Queue** named `com/adobe/granite/workflow/j
 - OSGi config: `org.apache.sling.event.impl.jobs.queues.QueueConfigurationImpl`
 - Queue name: `com\/adobe\/granite\/workflow\/job\/.*`
 
-Monitor queue depth at: **Tools → Workflow → Instances** or `/system/console/slingevent`.
+Monitor queue depth at: **Tools → Workflow → Instances**. On the local SDK, you can also check `/system/console/slingevent` (not accessible on Cloud Service environments — use Developer Console instead).

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-triggering/references/workflow-foundation/quick-start-guide.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-triggering/references/workflow-foundation/quick-start-guide.md
@@ -38,21 +38,25 @@ Before starting:
 
 ## Verify Deployment
 
+> **Note:** The examples below use local AEM SDK credentials. Replace `<user>:<password>` with your actual credentials. Never use default `admin` credentials in production or shared environments.
+
 ```bash
-# Check OSGi bundle active
-curl -u admin:admin http://localhost:4502/system/console/bundles/<bundle-name>.json
+# Check OSGi bundle active (local SDK only — /system/console is not accessible on Cloud Service environments)
+curl -u <user>:<password> http://localhost:4502/system/console/bundles/<bundle-name>.json
 
 # Verify process.label registered
-curl -u admin:admin "http://localhost:4502/libs/cq/workflow/admin/console/content/models.json"
+curl -u <user>:<password> "http://localhost:4502/libs/cq/workflow/admin/console/content/models.json"
 
 # Check model synced to /var
-curl -u admin:admin "http://localhost:4502/var/workflow/models/my-workflow.json"
+curl -u <user>:<password> "http://localhost:4502/var/workflow/models/my-workflow.json"
 ```
+
+On Cloud Service environments, verify bundle status via **AEM Developer Console** instead of `/system/console`.
 
 ## Start a Test Workflow via API
 
 ```bash
-curl -u admin:admin -X POST \
+curl -u <user>:<password> -X POST \
   "http://localhost:4502/api/workflow/instances" \
   -d "model=/var/workflow/models/my-workflow" \
   -d "payloadType=JCR_PATH" \

--- a/skills/aem/cloud-service/skills/aem-workflow/workflow-triggering/references/workflow-triggering/triggering-mechanisms.md
+++ b/skills/aem/cloud-service/skills/aem-workflow/workflow-triggering/references/workflow-triggering/triggering-mechanisms.md
@@ -71,9 +71,11 @@ wfs.startWorkflow(model, data);
 
 **When to use:** CI/CD pipelines, external systems, shell scripts, integration tests.
 
+> **Note:** The examples below use local AEM SDK URLs and placeholder credentials. Replace `<user>:<password>` with your actual credentials. Never use default `admin` credentials in production.
+
 ```bash
 # Start a workflow instance
-curl -u admin:admin -X POST \
+curl -u <user>:<password> -X POST \
   "http://localhost:4502/api/workflow/instances" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "model=/var/workflow/models/my-workflow" \
@@ -83,25 +85,25 @@ curl -u admin:admin -X POST \
 # Response: 201 Created, Location: /api/workflow/instances/<id>
 
 # Get instance details
-curl -u admin:admin \
+curl -u <user>:<password> \
   "http://localhost:4502/api/workflow/instances/<instanceId>.json"
 
 # List running instances filtered by model
-curl -u admin:admin \
+curl -u <user>:<password> \
   "http://localhost:4502/api/workflow/instances?state=RUNNING&model=/var/workflow/models/my-workflow"
 
 # Suspend a running workflow
-curl -u admin:admin -X PUT \
+curl -u <user>:<password> -X PUT \
   "http://localhost:4502/api/workflow/instances/<instanceId>" \
   -d "state=SUSPENDED"
 
 # Resume a suspended workflow
-curl -u admin:admin -X PUT \
+curl -u <user>:<password> -X PUT \
   "http://localhost:4502/api/workflow/instances/<instanceId>" \
   -d "state=RUNNING"
 
 # Terminate a workflow
-curl -u admin:admin -X DELETE \
+curl -u <user>:<password> -X DELETE \
   "http://localhost:4502/api/workflow/instances/<instanceId>"
 ```
 


### PR DESCRIPTION
Add workflow-purge/SKILL.md covering Purge Scheduler OSGi config, retention policies, bloat recovery, RUNNING/SUSPENDED cleanup, and Cloud Manager log monitoring
Add workflow-purge to orchestrator routing table, skill map, and reference loading order
Expand launcher eventType table to full 6-value bitmask with combined-value lookup (3, 7, 18, 26)
Add Launcher Loop Prevention section with excludeList, glob, and conditions strategies
Fix excludeList description in launcher-config-reference.md to correctly document its loop-prevention role