### PR TITLE
feat(da-auth): add da-auth skill and surface DA auth in CDD workflow

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/building-blocks/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/building-blocks/SKILL.md
@@ -17,7 +17,7 @@ If you are not already following the CDD process, STOP and invoke the **content-
 ## Related Skills
 
 - **content-driven-development**: MUST be invoked before using this skill to ensure content and content models are ready
-- **da-auth**: Obtain a valid Adobe IMS token if test content needs to be pushed to a DA-backed CMS before implementation can begin
+- **da-auth**: Obtain a valid Adobe IMS token if test content needs to be pushed to DA before implementation can begin
 - **block-collection-and-party**: Use to find similar blocks for patterns
 - **testing-blocks**: Automatically invoked during Step 5 for comprehensive testing
 

--- a/plugins/aem/edge-delivery-services/skills/building-blocks/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/building-blocks/SKILL.md
@@ -3,7 +3,7 @@ name: building-blocks
 description: Guide for implementing code changes in AEM Edge Delivery Services. Handles block development (new or modified), core functionality changes (scripts.js, styles, delayed.js, etc.), or both. Use this skill for all implementation work guided by the content-driven-development workflow.
 license: Apache-2.0
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Building Blocks
@@ -17,6 +17,7 @@ If you are not already following the CDD process, STOP and invoke the **content-
 ## Related Skills
 
 - **content-driven-development**: MUST be invoked before using this skill to ensure content and content models are ready
+- **da-auth**: Obtain a valid Adobe IMS token if test content needs to be pushed to a DA-backed CMS before implementation can begin
 - **block-collection-and-party**: Use to find similar blocks for patterns
 - **testing-blocks**: Automatically invoked during Step 5 for comprehensive testing
 

--- a/plugins/aem/edge-delivery-services/skills/content-driven-development/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/content-driven-development/SKILL.md
@@ -3,7 +3,7 @@ name: content-driven-development
 description: Apply a Content Driven Development process to AEM Edge Delivery Services development. Use for ALL code changes - new blocks, block modifications, CSS styling, bug fixes, core functionality (scripts.js, styles, etc.), or any JavaScript/CSS work that needs validation.
 license: Apache-2.0
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Content Driven Development (CDD)
@@ -168,7 +168,7 @@ Expected: `200`
 
 **Goal:** End this step with accessible test content URL(s) covering all test scenarios
 
-**Choose the best ath based on your situation:**
+**Choose the best path based on your situation:**
 
 ---
 
@@ -198,6 +198,8 @@ Expected: `200`
 3. Wait for user to provide URL(s)
 4. Validate: `curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/path`
 5. Expected: `200` status
+
+> **DA-backed sites:** If the site uses DA as its CMS and you need to push HTML content programmatically (rather than asking the user to author it), invoke the **da-auth** skill first to obtain a valid `DA_TOKEN`, then use the DA Admin API (`POST https://admin.da.live/source/{org}/{repo}/{path}`) to push the content and trigger a preview.
 
 **Approach 2: Local HTML (Temporary)**
 1. Create HTML file in `drafts/tmp/{block-name}.plain.html`
@@ -348,7 +350,7 @@ npm test
    ```bash
    git commit -m "feat(block-name): add new block"
    ```
-   Include revelevant details in commit message and agent attribution in footer (agent adds `Co-authored-by: cursor <noreply@cursor.com>`)
+   Include relevant details in commit message and agent attribution in footer (agent adds `Co-authored-by: cursor <noreply@cursor.com>`)
 
 4. **Push to feature branch:**
    ```bash
@@ -427,6 +429,7 @@ This PR is currently a **draft** pending creation of CMS test content.
 
 - **analyze-and-plan**: Invoked in Step 2 for requirements analysis and acceptance criteria
 - **content-modeling**: Invoked in Step 3 for designing content models
+- **da-auth**: Obtain a valid Adobe IMS token before pushing content to DA or triggering DA previews programmatically — invoke at the start of Step 4 on DA-backed sites
 - **find-test-content**: Invoked in Step 4, Option C for finding existing content
 - **building-blocks**: Invoked in Step 5 for implementation
 - **testing-blocks**: Invoked by building-blocks for browser testing

--- a/plugins/aem/edge-delivery-services/skills/content-driven-development/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/content-driven-development/SKILL.md
@@ -199,7 +199,7 @@ Expected: `200`
 4. Validate: `curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/path`
 5. Expected: `200` status
 
-> **DA-backed sites:** If the site uses DA as its CMS and you need to push HTML content programmatically (rather than asking the user to author it), invoke the **da-auth** skill first to obtain a valid `DA_TOKEN`, then use the DA Admin API (`POST https://admin.da.live/source/{org}/{repo}/{path}`) to push the content and trigger a preview.
+> **Using DA:** If you need to push HTML content programmatically to DA (rather than asking the user to author it), invoke the **da-auth** skill first to obtain a valid `DA_TOKEN`, then use the DA Admin API (`POST https://admin.da.live/source/{org}/{repo}/{path}`) to push the content and trigger a preview.
 
 **Approach 2: Local HTML (Temporary)**
 1. Create HTML file in `drafts/tmp/{block-name}.plain.html`
@@ -429,7 +429,7 @@ This PR is currently a **draft** pending creation of CMS test content.
 
 - **analyze-and-plan**: Invoked in Step 2 for requirements analysis and acceptance criteria
 - **content-modeling**: Invoked in Step 3 for designing content models
-- **da-auth**: Obtain a valid Adobe IMS token before pushing content to DA or triggering DA previews programmatically — invoke at the start of Step 4 on DA-backed sites
+- **da-auth**: Obtain a valid Adobe IMS token before pushing content to DA or triggering DA previews programmatically — invoke at the start of Step 4 when using DA
 - **find-test-content**: Invoked in Step 4, Option C for finding existing content
 - **building-blocks**: Invoked in Step 5 for implementation
 - **testing-blocks**: Invoked by building-blocks for browser testing

--- a/plugins/aem/edge-delivery-services/skills/da-auth/.releaserc.json
+++ b/plugins/aem/edge-delivery-services/skills/da-auth/.releaserc.json
@@ -1,0 +1,1 @@
+{"extends": "../../../../../release.config.cjs"}

--- a/plugins/aem/edge-delivery-services/skills/da-auth/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/da-auth/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: da-auth
+description: Obtains a valid Adobe IMS access token for the DA (Document Authoring) API. Use this skill as a prerequisite step whenever another skill needs to call admin.da.live — for example, before pushing HTML content, listing documents, or triggering a DA preview. Do NOT use this skill if you already have a valid DA_TOKEN in scope from a previous step in the same session.
+license: Apache-2.0
+metadata:
+  version: "1.0.0"
+---
+
+# DA Authentication
+
+Gets a valid Adobe IMS access token and stores it in `DA_TOKEN` for use in subsequent `admin.da.live` API calls.
+
+## When to Use This Skill
+
+Use this skill whenever you need to call the DA Admin API (`admin.da.live`) and do not already have a valid token in scope. Common cases:
+- Pushing or updating page content in DA
+- Listing documents in a DA repository
+- Triggering a DA content preview
+
+Do NOT use this skill when:
+- You already obtained a `DA_TOKEN` earlier in the same session and it has not expired (tokens are valid for ~1 hour with a 60-second buffer)
+- The **create-site** skill is already handling authentication as part of its own flow
+- A DA MCP server is active in the session — use its authentication tool directly instead
+
+## Prerequisites
+
+- Node.js 18+ installed
+- A browser accessible from the machine (for the OAuth flow)
+- Network access to `ims-na1.adobelogin.com`
+
+## Related Skills
+
+- **create-site** — includes its own DA auth step for new site onboarding; do not invoke da-auth separately within that flow
+- **content-driven-development** — use da-auth before pushing authored content to DA
+- **building-blocks** — use da-auth if test content needs to be pushed to DA for block development
+
+---
+
+## Step 1: Check for a Cached Token
+
+Before triggering a browser login, check whether a valid token is already cached.
+
+```bash
+DA_TOKEN=$(node -e "
+  const fs = require('fs');
+  const p = process.env.HOME + '/.aem/da-token.json';
+  try {
+    const t = JSON.parse(fs.readFileSync(p, 'utf8'));
+    if (t.expires_at > Date.now() + 60000) process.stdout.write(t.access_token);
+  } catch {}
+")
+```
+
+If `DA_TOKEN` is non-empty, skip to **Step 3**.
+
+## Step 2: Obtain a Token *(login required)*
+
+Choose the option that fits the environment:
+
+**Option A (preferred) — `da-auth-helper` CLI:**
+
+The `da-auth-helper` tool handles the full IMS OAuth 2.0 implicit flow, caches the token at `~/.aem/da-token.json`, and prints the token to stdout.
+
+```bash
+# Run directly without a global install
+DA_TOKEN=$(npx github:adobe-rnd/da-auth-helper token)
+```
+
+If `npx` is unavailable or slow, install globally first:
+
+```bash
+npm install -g github:adobe-rnd/da-auth-helper
+DA_TOKEN=$(da-auth-helper token)
+```
+
+This opens a browser window. Instruct the user:
+
+> Please complete the Adobe IMS login in the browser window that just opened. The token will be captured automatically once you log in.
+
+Success: `DA_TOKEN` is a non-empty JWT string starting with `eyJ`.
+
+**Option B — DA MCP server:**
+
+If a DA MCP server is configured in the session, use its authentication tool to start the OAuth flow and retrieve the token from the response.
+
+**Option C — Manual paste *(last resort)*:**
+
+> I need an Adobe IMS access token to push content to DA. You can copy one from your browser:
+> 1. Open [da.live](https://da.live) and log in
+> 2. Open DevTools → Network tab → find any request to `admin.da.live`
+> 3. Copy the `Authorization: Bearer <token>` value (without the `Bearer ` prefix)
+> 4. Paste it here
+
+## Step 3: Verify the Token Works
+
+Confirm the token is accepted by the DA API before proceeding:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer {{DA_TOKEN}}" \
+  "https://admin.da.live/list/{{ORG}}/{{REPO}}"
+```
+
+Success: HTTP `200`. The token is valid — `DA_TOKEN` is ready for use by the calling skill.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `DA_TOKEN` is empty after Step 1 | No cached token or token expired | Proceed to Step 2 |
+| Browser window does not open | `npx` / `da-auth-helper` blocked or headless environment | Use Option B (MCP) or Option C (manual paste) |
+| `npx github:adobe-rnd/da-auth-helper` fails | Network restrictions on GitHub package registry | Use Option B (DA MCP server) or Option C (manual token paste) |
+| Step 3 returns `401` | Token expired between steps | Re-run Step 2 to refresh |
+| Step 3 returns `403` | Authenticated user lacks access to `{{ORG}}/{{REPO}}` | Ask the user to verify their DA permissions for that org/repo |
+
+## Reference
+
+- DA Auth Helper: https://github.com/adobe-rnd/da-auth-helper
+- DA Admin API: https://opensource.adobe.com/da-admin/
+- Token cache location: `~/.aem/da-token.json`

--- a/plugins/aem/edge-delivery-services/skills/da-auth/package.json
+++ b/plugins/aem/edge-delivery-services/skills/da-auth/package.json
@@ -1,0 +1,1 @@
+{"name": "da-auth", "version": "0.0.0-semantically-released", "private": true}


### PR DESCRIPTION
## Summary

- Adds a new `da-auth` sub-skill for obtaining a valid Adobe IMS token before making DA Admin API calls
- Updates `content-driven-development` (Step 4 DA callout + Related Skills)
- Updates `building-blocks` (Related Skills)

## Motivation

During a real AEM EDS project session, an agent had to be manually guided through DA authentication every time it needed to push content or trigger a preview. The `da-auth-helper` tool and DA Admin API were only referenced in `create-site` (new-site onboarding), leaving agents in any other context — content updates, block development, test content creation — with no guidance.

## What the `da-auth` skill does

1. **Step 1** — Check token cache at `~/.aem/da-token.json` (skip login if still valid)
2. **Step 2** — Three fallback options: `da-auth-helper` CLI (preferred), DA MCP server, manual paste
3. **Step 3** — Verify the token works against `admin.da.live` before returning

The `description` frontmatter tells the agent not to re-invoke if a token is already in scope, preventing unnecessary re-auth mid-session.

## Changes

```
plugins/aem/edge-delivery-services/skills/
├── da-auth/                          ← NEW
│   ├── SKILL.md
│   ├── package.json
│   └── .releaserc.json
├── content-driven-development/
│   └── SKILL.md                      ← Step 4 DA callout + da-auth in Related Skills
└── building-blocks/
    └── SKILL.md                      ← da-auth in Related Skills
```

## What was NOT changed

- `create-site` — already handles DA auth well as its own Step 4; no change needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)