### PR TITLE
feat: add bootstrap prerequisite check to all AEM skills with CI enforcement

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -93,3 +93,102 @@ jobs:
           fi
 
           echo "All SKILL.md files have a license field."
+
+  bootstrap-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: AEM skills must include the bootstrap prerequisite check
+        run: |
+          # Three required markers — heading, AGENTS.md reference, and ensure-agents-md reference.
+          # A valid section must contain ALL three, not just the heading.
+          heading="## AEM Project Bootstrap Check"
+          ref_agents="AGENTS.md"
+          ref_skill="ensure-agents-md"
+
+          missing=()
+          incomplete=()
+
+          for file in $(find plugins/aem/cloud-service/skills plugins/aem/6.5-lts/skills \
+                        -name SKILL.md ! -path '*/ensure-agents-md/*' | sort); do
+            has_heading=false
+            has_agents_ref=false
+            has_skill_ref=false
+
+            grep -qF "$heading" "$file" && has_heading=true
+            grep -qF "$ref_agents" "$file" && has_agents_ref=true
+            grep -qF "$ref_skill" "$file" && has_skill_ref=true
+
+            if [ "$has_heading" = false ]; then
+              missing+=("$file")
+            elif [ "$has_agents_ref" = false ] || [ "$has_skill_ref" = false ]; then
+              incomplete+=("$file (heading present but missing references: agents_md=$has_agents_ref, ensure_skill=$has_skill_ref)")
+            fi
+          done
+
+          all_bad=("${missing[@]}" "${incomplete[@]}")
+
+          # Write GitHub Step Summary
+          echo "## AEM Bootstrap Prerequisite Check" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "AEM skills (cloud-service, 6.5-lts) must include a complete \`## AEM Project Bootstrap Check\` section" >> "$GITHUB_STEP_SUMMARY"
+          echo "that references both \`AGENTS.md\` and \`ensure-agents-md\` so the agent checks for project" >> "$GITHUB_STEP_SUMMARY"
+          echo "bootstrap even when \`ensure-agents-md\` is not installed." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Skill | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|--------|" >> "$GITHUB_STEP_SUMMARY"
+
+          for file in $(find plugins/aem/cloud-service/skills plugins/aem/6.5-lts/skills \
+                        -name SKILL.md ! -path '*/ensure-agents-md/*' | sort); do
+            if printf '%s\n' "${missing[@]}" | grep -qx "$file"; then
+              echo "| $file | ❌ Missing section |" >> "$GITHUB_STEP_SUMMARY"
+            elif printf '%s\n' "${incomplete[@]}" | grep -q "^$file "; then
+              echo "| $file | ⚠️ Incomplete |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| $file | ✅ Pass |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
+          failed=false
+
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo ""
+            echo "::error::The following AEM SKILL.md files are missing the '## AEM Project Bootstrap Check' section entirely:"
+            for f in "${missing[@]}"; do
+              echo "  $f"
+            done
+            failed=true
+          fi
+
+          if [ ${#incomplete[@]} -gt 0 ]; then
+            echo ""
+            echo "::error::The following AEM SKILL.md files have the heading but are missing required references:"
+            for f in "${incomplete[@]}"; do
+              echo "  $f"
+            done
+            failed=true
+          fi
+
+          if [ "$failed" = true ]; then
+            echo ""
+            echo "Each AEM skill must have a complete bootstrap check section containing:"
+            echo "  1. The heading: ## AEM Project Bootstrap Check"
+            echo "  2. A reference to AGENTS.md (the file the agent should look for)"
+            echo "  3. A reference to ensure-agents-md (the skill to run if AGENTS.md is missing)"
+            echo ""
+            echo "Standard block to add after the first heading:"
+            echo ""
+            echo '  ## AEM Project Bootstrap Check'
+            echo '  '
+            echo '  > Before running this skill, check if `AGENTS.md` exists at the **workspace root**.'
+            echo '  >'
+            echo '  > | Status | Action |'
+            echo '  > |--------|--------|'
+            echo '  > | `AGENTS.md` **exists** | Continue with this skill. |'
+            echo '  > | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |'
+            echo '  > | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |'
+            exit 1
+          fi
+
+          echo "All AEM skills include a complete bootstrap prerequisite check."

--- a/plugins/aem/6.5-lts/skills/aem-replication/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-replication/SKILL.md
@@ -15,6 +15,16 @@ metadata:
 
 Route user requests to the appropriate specialist skill based on intent.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Intent Router
 
 | User Intent | Skill | Path |

--- a/plugins/aem/6.5-lts/skills/aem-replication/configure-replication-agent/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-replication/configure-replication-agent/SKILL.md
@@ -8,6 +8,16 @@ license: Apache-2.0
 
 This skill guides you through configuring replication agents in Adobe Experience Manager 6.5 LTS. Replication agents are the core mechanism for distributing content from Author to Publish environments, managing Dispatcher cache, and handling user-generated content flows.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## When to Use This Skill
 
 Use this skill when you need to:

--- a/plugins/aem/6.5-lts/skills/aem-replication/replicate-content/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-replication/replicate-content/SKILL.md
@@ -8,6 +8,16 @@ license: Apache-2.0
 
 This skill guides you through activating (publishing) and deactivating (unpublishing) content in Adobe Experience Manager 6.5 LTS. Replication moves content from the Author environment to one or more Publish instances, making it available to end users.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## When to Use This Skill
 
 Use this skill when you need to:

--- a/plugins/aem/6.5-lts/skills/aem-replication/replication-api/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-replication/replication-api/SKILL.md
@@ -8,6 +8,16 @@ license: Apache-2.0
 
 This skill provides comprehensive guidance on using the official Adobe Experience Manager 6.5 LTS Replication API for programmatic replication operations. The API enables custom code to activate, deactivate, and manage content distribution workflows.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## When to Use This Skill
 
 Use this skill when you need to:

--- a/plugins/aem/6.5-lts/skills/aem-replication/replication-orchestrator/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-replication/replication-orchestrator/SKILL.md
@@ -10,6 +10,16 @@ license: Apache-2.0
 
 Coordinates complex replication workflows that span multiple sub-skills (configure, replicate, troubleshoot).
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## When to Use This Skill
 
 Use the orchestrator for multi-step scenarios requiring coordination across sub-skills:

--- a/plugins/aem/6.5-lts/skills/aem-replication/troubleshoot-replication/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-replication/troubleshoot-replication/SKILL.md
@@ -8,6 +8,16 @@ license: Apache-2.0
 
 This skill provides systematic troubleshooting guidance for Adobe Experience Manager 6.5 LTS replication issues. Use this to diagnose and resolve problems with content distribution, agent configuration, and replication workflows.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## When to Use This Skill
 
 Use this skill when experiencing:

--- a/plugins/aem/6.5-lts/skills/aem-workflow/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/SKILL.md
@@ -16,6 +16,16 @@ metadata:
 
 Route user requests to the appropriate specialist skill based on intent.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Intent Router
 
 | User Intent | Skill | Path |

--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/SKILL.md
@@ -8,6 +8,16 @@ license: Apache-2.0
 
 Production-grade debugging for AEM Granite Workflow engine, launcher, Inbox, Sling Jobs, thread pools, and purge on **AEM 6.5 LTS** and **Adobe Managed Services (AMS)**.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - This skill is **6.5-lts-only** (includes AMS).

--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-development/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-development/SKILL.md
@@ -8,6 +8,16 @@ license: Apache-2.0
 
 Implement custom workflow components for AEM 6.5 LTS: `WorkflowProcess`, `ParticipantStepChooser`, OSGi registration, metadata handling, and error patterns.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - AEM 6.5 LTS only.

--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-launchers/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-launchers/SKILL.md
@@ -6,6 +6,16 @@ license: Apache-2.0
 
 # Workflow Launchers Skill — AEM 6.5 LTS
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Purpose
 
 This skill teaches you how to configure and deploy Workflow Launchers that automatically start workflows in response to JCR content changes on AEM 6.5 LTS.

--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-model-design/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-model-design/SKILL.md
@@ -8,6 +8,16 @@ license: Apache-2.0
 
 Design workflow models for AEM 6.5 LTS: step structure, transitions, OR/AND splits, variables, and model XML deployment via Package Manager.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - This skill is AEM 6.5 LTS only.

--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-orchestrator/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-orchestrator/SKILL.md
@@ -6,6 +6,16 @@ license: Apache-2.0
 
 # Workflow Orchestrator — AEM 6.5 LTS
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Purpose
 
 This is the **master entry point** for all AEM Workflow tasks on AEM 6.5 LTS — spanning both **development** (building workflows) and **production support** (debugging and triaging workflow issues). Read this skill first. It classifies the user's request and routes to the right sub-skill.

--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-triaging/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-triaging/SKILL.md
@@ -8,6 +8,16 @@ license: Apache-2.0
 
 Classify workflow issues, determine what logs and data to gather, and map to the correct runbook or log search. Optimized for **production support** on **AEM 6.5 LTS** and **Adobe Managed Services (AMS)**.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - This skill is **6.5-lts-only** (includes AMS).

--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-triggering/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-triggering/SKILL.md
@@ -8,6 +8,16 @@ license: Apache-2.0
 
 All mechanisms to start a workflow on AEM 6.5 LTS — from UI, programmatic API, HTTP API, Manage Publication, and replication-linked triggers.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - AEM 6.5 LTS only.

--- a/plugins/aem/6.5-lts/skills/dispatcher/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/dispatcher/SKILL.md
@@ -16,6 +16,16 @@ metadata:
 
 Route user requests to the appropriate specialist skill based on intent.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Intent Router
 
 | User Intent | Skill | Path |

--- a/plugins/aem/6.5-lts/skills/dispatcher/config-authoring/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/dispatcher/config-authoring/SKILL.md
@@ -12,6 +12,16 @@ metadata:
 
 Design minimal, deterministic changes for the Adobe Dispatcher Apache HTTP Server module and related HTTPD configuration in AEM 6.5/AMS, then verify with MCP evidence.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - This skill is AMS-only.

--- a/plugins/aem/6.5-lts/skills/dispatcher/incident-response/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/dispatcher/incident-response/SKILL.md
@@ -12,6 +12,16 @@ metadata:
 
 Investigate AMS runtime incidents involving the Adobe Dispatcher Apache HTTP Server module and related HTTPD configuration with an evidence-first workflow.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - This skill is AMS-only.

--- a/plugins/aem/6.5-lts/skills/dispatcher/performance-tuning/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/dispatcher/performance-tuning/SKILL.md
@@ -12,6 +12,16 @@ metadata:
 
 Improve cache efficiency, latency, and throughput for AMS deployments that use the Adobe Dispatcher Apache HTTP Server module and related HTTPD configuration.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - This skill is AMS-only.

--- a/plugins/aem/6.5-lts/skills/dispatcher/security-hardening/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/dispatcher/security-hardening/SKILL.md
@@ -12,6 +12,16 @@ metadata:
 
 Deliver evidence-backed security findings and remediations for AMS workflows that use the Adobe Dispatcher Apache HTTP Server module and related HTTPD configuration.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - This skill is AMS-only.

--- a/plugins/aem/6.5-lts/skills/dispatcher/technical-advisory/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/dispatcher/technical-advisory/SKILL.md
@@ -12,6 +12,16 @@ metadata:
 
 Provide deterministic guidance for AEM 6.5/AMS use cases involving the Adobe Dispatcher Apache HTTP Server module and related HTTPD configuration.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - This skill is AMS-only.

--- a/plugins/aem/6.5-lts/skills/dispatcher/workflow-orchestrator/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/dispatcher/workflow-orchestrator/SKILL.md
@@ -12,6 +12,16 @@ metadata:
 
 Use this skill when users need end-to-end Dispatcher support instead of a single specialist workflow.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Scope
 
 - Full lifecycle orchestration for AMS Dispatcher work:

--- a/plugins/aem/cloud-service/skills/aem-workflow/SKILL.md
+++ b/plugins/aem/cloud-service/skills/aem-workflow/SKILL.md
@@ -16,6 +16,16 @@ metadata:
 
 Route user requests to the appropriate specialist skill based on intent.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Intent Router
 
 | User Intent | Skill | Path |

--- a/plugins/aem/cloud-service/skills/aem-workflow/workflow-debugging/SKILL.md
+++ b/plugins/aem/cloud-service/skills/aem-workflow/workflow-debugging/SKILL.md
@@ -8,6 +8,16 @@ license: Apache-2.0
 
 Production-grade debugging for AEM Granite Workflow engine, launcher, Inbox, Sling Jobs, thread pools, and purge on **AEM as a Cloud Service**.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - This skill is **cloud-service-only**.

--- a/plugins/aem/cloud-service/skills/aem-workflow/workflow-development/SKILL.md
+++ b/plugins/aem/cloud-service/skills/aem-workflow/workflow-development/SKILL.md
@@ -8,6 +8,16 @@ license: Apache-2.0
 
 Implement custom workflow components for AEM Cloud Service: `WorkflowProcess`, `ParticipantStepChooser`, OSGi registration, metadata handling, and error patterns.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - AEM Cloud Service only.

--- a/plugins/aem/cloud-service/skills/aem-workflow/workflow-launchers/SKILL.md
+++ b/plugins/aem/cloud-service/skills/aem-workflow/workflow-launchers/SKILL.md
@@ -6,6 +6,16 @@ license: Apache-2.0
 
 # Workflow Launchers Skill — AEM as a Cloud Service
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Purpose
 
 This skill teaches you how to configure and deploy Workflow Launchers that automatically start workflows in response to JCR content changes on AEM as a Cloud Service.

--- a/plugins/aem/cloud-service/skills/aem-workflow/workflow-model-design/SKILL.md
+++ b/plugins/aem/cloud-service/skills/aem-workflow/workflow-model-design/SKILL.md
@@ -8,6 +8,16 @@ license: Apache-2.0
 
 Design workflow models for AEM Cloud Service: step structure, transitions, OR/AND splits, variables, and model XML deployment.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - This skill is AEM Cloud Service only.

--- a/plugins/aem/cloud-service/skills/aem-workflow/workflow-orchestrator/SKILL.md
+++ b/plugins/aem/cloud-service/skills/aem-workflow/workflow-orchestrator/SKILL.md
@@ -6,6 +6,16 @@ license: Apache-2.0
 
 # Workflow Orchestrator — AEM as a Cloud Service
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Purpose
 
 This is the **master entry point** for all AEM Workflow tasks on Cloud Service — spanning both **development** (building workflows) and **production support** (debugging and triaging workflow issues). Read this skill first. It classifies the user's request and routes to the right sub-skill.

--- a/plugins/aem/cloud-service/skills/aem-workflow/workflow-triaging/SKILL.md
+++ b/plugins/aem/cloud-service/skills/aem-workflow/workflow-triaging/SKILL.md
@@ -8,6 +8,16 @@ license: Apache-2.0
 
 Classify workflow issues, determine what logs and data to gather, and map to the correct runbook or log search. Optimized for **production support** on **AEM as a Cloud Service**.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - This skill is **cloud-service-only**.

--- a/plugins/aem/cloud-service/skills/aem-workflow/workflow-triggering/SKILL.md
+++ b/plugins/aem/cloud-service/skills/aem-workflow/workflow-triggering/SKILL.md
@@ -8,6 +8,16 @@ license: Apache-2.0
 
 All mechanisms to start a workflow on AEM Cloud Service — from UI, programmatic API, HTTP API, and Manage Publication.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - AEM Cloud Service only.

--- a/plugins/aem/cloud-service/skills/best-practices/SKILL.md
+++ b/plugins/aem/cloud-service/skills/best-practices/SKILL.md
@@ -12,6 +12,16 @@ This skill holds the **pattern transformation modules** (`references/*.md`). The
 
 **Quick pick:** Open the **Pattern Reference Modules** table below → jump to the matching `references/<file>.md` → read it fully before editing. For Java: Felix SCR, resolvers, or logging, use **Java / OSGi baseline** links first when those appear in the same change set.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## When to Use This Skill
 
 Use this skill when you need to:

--- a/plugins/aem/cloud-service/skills/content-distribution/SKILL.md
+++ b/plugins/aem/cloud-service/skills/content-distribution/SKILL.md
@@ -14,6 +14,16 @@ description: |
 
 Programmatic content publishing and distribution monitoring using official AEM Cloud Service APIs.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## When to Use This Skill
 
 Use this skill collection for:

--- a/plugins/aem/cloud-service/skills/content-distribution/replication/SKILL.md
+++ b/plugins/aem/cloud-service/skills/content-distribution/replication/SKILL.md
@@ -10,6 +10,16 @@ description: |
 
 Programmatic content publishing and unpublishing using the official AEM Replication API.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## When to Use This Skill
 
 Use the Replication API for programmatic content distribution:

--- a/plugins/aem/cloud-service/skills/content-distribution/sling-distribution/SKILL.md
+++ b/plugins/aem/cloud-service/skills/content-distribution/sling-distribution/SKILL.md
@@ -10,6 +10,16 @@ description: |
 
 Monitor and react to content distribution lifecycle events using the Sling Distribution API.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## When to Use This Skill
 
 Use Sling Distribution event handling for:

--- a/plugins/aem/cloud-service/skills/create-component/SKILL.md
+++ b/plugins/aem/cloud-service/skills/create-component/SKILL.md
@@ -21,6 +21,16 @@ metadata:
 
 Creates complete AEM components following Adobe best practices.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Configuration Gate Check — Do This First
 
 > This configuration check needs to happen first because without it, the skill will use incorrect project paths and package names, causing every generated file to be wrong.

--- a/plugins/aem/cloud-service/skills/dispatcher/SKILL.md
+++ b/plugins/aem/cloud-service/skills/dispatcher/SKILL.md
@@ -15,6 +15,16 @@ metadata:
 
 Route user requests to the appropriate specialist skill based on intent.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Intent Router
 
 | User Intent | Skill | Path |

--- a/plugins/aem/cloud-service/skills/dispatcher/config-authoring/SKILL.md
+++ b/plugins/aem/cloud-service/skills/dispatcher/config-authoring/SKILL.md
@@ -12,6 +12,16 @@ metadata:
 
 Design minimal, deterministic changes for the Adobe Dispatcher Apache HTTP Server module and related HTTPD configuration in AEMaaCS, then verify with MCP evidence.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - This skill is cloud-service-only.

--- a/plugins/aem/cloud-service/skills/dispatcher/incident-response/SKILL.md
+++ b/plugins/aem/cloud-service/skills/dispatcher/incident-response/SKILL.md
@@ -12,6 +12,16 @@ metadata:
 
 Investigate cloud runtime incidents involving the Adobe Dispatcher Apache HTTP Server module and related HTTPD configuration with an evidence-first workflow.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - This skill is cloud-service-only.

--- a/plugins/aem/cloud-service/skills/dispatcher/performance-tuning/SKILL.md
+++ b/plugins/aem/cloud-service/skills/dispatcher/performance-tuning/SKILL.md
@@ -12,6 +12,16 @@ metadata:
 
 Improve cache efficiency, latency, and throughput for cloud deployments that use the Adobe Dispatcher Apache HTTP Server module and related HTTPD configuration.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - This skill is cloud-service-only.

--- a/plugins/aem/cloud-service/skills/dispatcher/security-hardening/SKILL.md
+++ b/plugins/aem/cloud-service/skills/dispatcher/security-hardening/SKILL.md
@@ -12,6 +12,16 @@ metadata:
 
 Deliver evidence-backed security findings and remediations for cloud workflows that use the Adobe Dispatcher Apache HTTP Server module and related HTTPD configuration.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - This skill is cloud-service-only.

--- a/plugins/aem/cloud-service/skills/dispatcher/technical-advisory/SKILL.md
+++ b/plugins/aem/cloud-service/skills/dispatcher/technical-advisory/SKILL.md
@@ -12,6 +12,16 @@ metadata:
 
 Provide deterministic guidance for AEMaaCS use cases involving the Adobe Dispatcher Apache HTTP Server module and related HTTPD configuration.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Variant Scope
 
 - This skill is cloud-service-only.

--- a/plugins/aem/cloud-service/skills/dispatcher/workflow-orchestrator/SKILL.md
+++ b/plugins/aem/cloud-service/skills/dispatcher/workflow-orchestrator/SKILL.md
@@ -12,6 +12,16 @@ metadata:
 
 Use this skill when users need end-to-end Dispatcher support instead of a single specialist workflow.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Scope
 
 - Full lifecycle orchestration for cloud Dispatcher work:

--- a/plugins/aem/cloud-service/skills/migration/SKILL.md
+++ b/plugins/aem/cloud-service/skills/migration/SKILL.md
@@ -12,6 +12,16 @@ This skill is **orchestration**: BPA data, CAM/MCP, **one pattern per session**,
 
 **Setup:** Use the **`aem-cloud-service`** install (see repository root **README**) so both **migration** and **best-practices** paths are available. If you already have the monorepo open with resolvable `{best-practices}` paths, no separate install step is required.
 
+## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |
+
 ## Quick start (for the person driving the agent)
 
 **One pattern per chat/session** — if you ask to "fix everything," the skill will ask you to pick first (e.g. scheduler vs replication vs htlLint).

--- a/scripts/add-bootstrap-check.sh
+++ b/scripts/add-bootstrap-check.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# One-time script to add the AEM Project Bootstrap Check to all AEM skills
+# (cloud-service and 6.5-lts) that don't already have it.
+# Excludes ensure-agents-md itself.
+
+set -euo pipefail
+
+MARKER="## AEM Project Bootstrap Check"
+
+BOOTSTRAP_BLOCK='## AEM Project Bootstrap Check
+
+> Before running this skill, check if `AGENTS.md` exists at the **workspace root**.
+>
+> | Status | Action |
+> |--------|--------|
+> | `AGENTS.md` **exists** | Continue with this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` skill is available | Run `ensure-agents-md` first, then return to this skill. |
+> | `AGENTS.md` **missing** and `ensure-agents-md` is not installed | Tell the user: *"For optimal project guidance, install the `ensure-agents-md` skill to bootstrap AGENTS.md before using this skill."* Then continue. |'
+
+files=$(find plugins/aem/cloud-service/skills plugins/aem/6.5-lts/skills \
+  -name SKILL.md ! -path '*/ensure-agents-md/*' | sort)
+
+added=0
+skipped=0
+
+for file in $files; do
+  if grep -qF "$MARKER" "$file"; then
+    echo "SKIP (already has check): $file"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  # Find the line number of the end of frontmatter (second ---)
+  frontmatter_end=$(awk '/^---$/{n++; if(n==2){print NR; exit}}' "$file")
+  if [ -z "$frontmatter_end" ]; then
+    echo "WARN: No frontmatter found in $file, skipping"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  # Find the first # heading after frontmatter
+  heading_line=$(awk -v start="$frontmatter_end" 'NR > start && /^# /{print NR; exit}' "$file")
+  if [ -z "$heading_line" ]; then
+    echo "WARN: No heading found after frontmatter in $file, skipping"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  # Find the next non-empty line after the heading (the intro text or next section)
+  insert_after=$(awk -v start="$heading_line" '
+    NR > start && /^[^[:space:]]/ { print NR; exit }
+    NR > start && /^$/ { next }
+  ' "$file")
+
+  # If no content after heading, insert right after heading
+  if [ -z "$insert_after" ]; then
+    insert_after=$((heading_line + 1))
+  fi
+
+  # Find the line before the next ## section (or end of intro paragraph)
+  next_section=$(awk -v start="$heading_line" 'NR > start && /^## /{print NR; exit}' "$file")
+
+  if [ -n "$next_section" ]; then
+    # Insert before the first ## section
+    insert_before=$next_section
+  else
+    # No ## section found, insert after heading + 1 blank line
+    insert_before=$((heading_line + 2))
+  fi
+
+  # Build the new file: everything before insert point, bootstrap block, everything after
+  {
+    head -n $((insert_before - 1)) "$file"
+    echo "$BOOTSTRAP_BLOCK"
+    echo ""
+    tail -n +"$insert_before" "$file"
+  } > "${file}.tmp"
+
+  mv "${file}.tmp" "$file"
+  echo "ADDED: $file"
+  added=$((added + 1))
+done
+
+echo ""
+echo "Done. Added: $added, Skipped: $skipped"


### PR DESCRIPTION
## Summary

- **Problem**: The `ensure-agents-md` skill declares itself as a prerequisite that must run before other AEM skills (create-component, dispatcher, etc.), but the dependency is one-directional. If a customer installs only a single skill (e.g., `create-component`) without `ensure-agents-md`, the `AGENTS.md` bootstrap never triggers — there is nothing in `create-component` that references `ensure-agents-md`.

- **Fix**: Adds a self-contained **"AEM Project Bootstrap Check"** section to all 42 AEM skills under `cloud-service/` and `6.5-lts/` (excluding `ensure-agents-md` itself). The section instructs the agent to:
  1. Check if `AGENTS.md` exists at the workspace root
  2. Run `ensure-agents-md` first if it is available
  3. Advise the user to install `ensure-agents-md` if it is not available

- **CI enforcement**: Adds a new `bootstrap-check` job in `validate.yml` that **fails the build** if any AEM skill is missing this section or has an incomplete version (heading only, without `AGENTS.md` / `ensure-agents-md` references). This prevents the check from being accidentally omitted when new skills are added.

- **Helper script**: `scripts/add-bootstrap-check.sh` can bulk-add the section to new skills. It is idempotent (skips files that already have it).

## Changes

| Area | Files | What changed |
|------|-------|-------------|
| AEM skills (cloud-service) | 21 SKILL.md files | Added `## AEM Project Bootstrap Check` section |
| AEM skills (6.5-lts) | 21 SKILL.md files | Added `## AEM Project Bootstrap Check` section |
| CI workflow | `.github/workflows/validate.yml` | New `bootstrap-check` job |
| Helper script | `scripts/add-bootstrap-check.sh` | Idempotent insertion script |

## Test plan

- [x] `npm run validate` — all 75 skills pass `skills-ref validate`
- [x] `license-field` check — all skills pass
- [x] `bootstrap-check` — all 42 AEM skills pass (heading + `AGENTS.md` ref + `ensure-agents-md` ref)
- [x] Negative test: fake skill with no section → detected as "Missing section"
- [x] Negative test: fake skill with heading only (no references) → detected as "Incomplete"
- [x] Idempotency: running `add-bootstrap-check.sh` again skips all 42 files


Made with [Cursor](https://cursor.com)