### PR TITLE
stardust: extract integrity & capture-fidelity hardening from 2026-04-29 → 2026-05-04 dogfood

### DIFF
--- a/plugins/stardust/skills/direct/SKILL.md
+++ b/plugins/stardust/skills/direct/SKILL.md
@@ -51,7 +51,18 @@ downstream sub-commands.
 4. Read `stardust/direction.md` if present. If a prior direction
    exists and `--re-direct` was not passed, ask whether the user wants
    to refine the existing direction or replace it.
-5. **Classify the captured brand signal.** Read
+5. **Validate provenance on every in-scope page** (prep mode only).
+   When `--prep` is active, call
+   `validateProvenance(page)` per
+   `skills/stardust/reference/state-machine.md` § Provenance
+   validation on every `extracted` page in `state.json` before
+   typing or module detection. Abort with the helper's error
+   when any page lacks live-render evidence. Surface
+   `Provenance OK on N pages` in the prep summary. Discovery-
+   mode `direct` does not validate (it operates on a 5-page
+   sample for which extract's own write-time refusal is
+   sufficient).
+6. **Classify the captured brand signal.** Read
    `_brand-extraction.json` and stamp one of:
    - `signal-strong` — palette has ≥ 3 distinct colors (after
      near-duplicate clustering and excluding pure black/white if they
@@ -143,7 +154,7 @@ brand-faithful) catches ambiguous phrases, and the riskier mode
 (rebrand / full divergence-seed) requires the user to name it.
 
 1. **Site migration / refresh — DEFAULT.** When the captured brand
-   signal stamped in § Setup step 5 is `signal-strong`, Mode A is
+   signal stamped in § Setup step 6 is `signal-strong`, Mode A is
    active by default. The user's phrase moves *expressive*,
    *distinctiveness*, *tone*, and *density* axes inside Mode A — but
    palette and type are pinned to the captured surface, and the
@@ -852,7 +863,7 @@ Next: $stardust prototype  (defaults to home page)
 - **(b) Insufficient brand signal for N variants.** When the
   captured brand surface has fewer than 3 distinct moves to
   amplify (e.g., monochrome palette, single type face, no
-  distinctive motifs, or `signal-thin` per § Setup step 5), refuse
+  distinctive motifs, or `signal-thin` per § Setup step 6), refuse
   to render N ≥ 3 variants under Mode A. Surface honestly:
   *"the captured surface has 2 distinct traits to amplify; producing
   3 variants would force one to invent moves not present in the

--- a/plugins/stardust/skills/extract/SKILL.md
+++ b/plugins/stardust/skills/extract/SKILL.md
@@ -148,8 +148,14 @@ Capture per page (full schema in `reference/current-state-schema.md`):
 
 - Page metadata (title, meta description, OG tags, theme-color)
 - Semantic structure: heading outline, landmark roles, sections
-- Content: visible text per section, CTA labels and href targets,
-  link inventory (internal vs external)
+- Content: visible text per section (full innerText, **no
+  truncation** per `reference/playwright-recipe.md` § Capture
+  list 7), structured paragraphs (`body[]`), lists, FAQ Q/A
+  pairs, and review/testimonial quotes per
+  § Capture list 7-bis. Without these structured fields,
+  every body region under a heading falls back to placeholder
+  signature at migrate time.
+- CTA labels and href targets, link inventory (internal vs external)
 - Per-section computed style summary: dominant colors, font families
   in use, spacing rhythm, border-radius, shadows
 - Media inventory: img/srcset with original URLs and intrinsic
@@ -160,6 +166,23 @@ Capture per page (full schema in `reference/current-state-schema.md`):
 Save to `stardust/current/pages/<slug>.json` with `_provenance` as the
 first key. Save referenced media to `stardust/current/assets/media/`
 preserving basename plus a short content hash.
+
+**Live-render evidence (synthesis is forbidden).** Refuse to mark
+a page `extracted` in `state.json` unless its `_provenance`
+contains `renderedBy: "playwright"`, an ISO-8601 `fetchedAt`, a
+positive integer `waitMs`, a `waitMode` from the recipe, and a
+final `httpStatus` in the 2xx/3xx range. These five fields are
+the contract enforced by `reference/current-state-schema.md`
+§ Live-render evidence and read back by every downstream phase
+via `validateProvenance()` per
+`skills/stardust/reference/state-machine.md` § Provenance
+validation. Synthesizing a page record from
+`_brand-extraction.json` plus URL patterns plus captured photos
+— the 2026-04-30 lovesac shortcut — is the failure mode this
+guard exists to prevent. When the agent (or a delegated sub-
+agent) cannot satisfy the contract for a page, treat the page
+as a Phase 2 failure: record under `_crawl-log.json#crawl.failures[]`
+with `errorClass: "ProvenanceMissing"` and continue.
 
 Mark the page `extracted` in `state.json` immediately after each
 successful page write. If a page fails, record the error in
@@ -290,8 +313,16 @@ After all Phase 2-5 writes succeed:
      _brand-extraction.json
      _crawl-log.json
 
+   Per-page evidence:
+     slug         live  waitMode               waitMs   status
+     /            yes   medium                 2380     200
+     /about       yes   medium                 2110     200
+     /pricing     yes   medium                 1940     200
+     /products    yes   medium                 2640     200
+     /contact     yes   domcontentloaded(fb)   8000     200
+
    Wait summary: 4 resolved at medium (avg 2.4s), 1 fallback (timed out at 8s)
-     → /donate/ may be under-captured; consider --refresh
+     → /contact may be under-captured; consider --refresh
 
    Open stardust/current/brand-review.html to verify the extraction
    before running $stardust direct.
@@ -305,9 +336,21 @@ After all Phase 2-5 writes succeed:
    Next: $stardust direct  (resolve a redesign direction)
    ```
 
+   The **per-page evidence table** is mandatory. The `live` column
+   is `yes` when `_provenance.renderedBy === "playwright"` AND
+   `waitMs > 0`, else `no`. A `no` row means the page record was
+   not produced by a live Playwright render — this should never
+   happen given the write-time guard, but the visible column is
+   the defense-in-depth signal that catches the failure mode
+   when it does (the 2026-04-30 lovesac synthesis bug went four
+   phases deep before being caught because no report column
+   surfaced the missing provenance). A maintainer scanning the
+   summary should see `yes` on every row.
+
    Compute the wait summary by grouping each page's `_provenance.waitMode`
    and averaging `waitMs`. List slugs whose `waitMode` ends in
-   `(fallback)` as candidates for `--refresh`.
+   `(fallback)` (rendered as `(fb)` in the table for width) as
+   candidates for `--refresh`.
 
 ## Outputs
 
@@ -355,6 +398,20 @@ report; do not engineer around it.
   `domcontentloaded` and capture what is rendered. Record the
   fallback in the per-page `_provenance.waitMode` and surface in the
   wait-summary line of the final report.
+- **Synthesis attempt (forbidden).** When the agent (or a delegated
+  sub-agent) cannot run a real Playwright render for a page —
+  whether due to time pressure, token budget, or a tool/network
+  failure — the only correct outcome is to record the page as a
+  Phase 2 failure (`errorClass: "ProvenanceMissing"` in
+  `_crawl-log.json#crawl.failures[]`) and continue. **Synthesizing
+  a page record from `_brand-extraction.json` plus URL patterns
+  plus captured photos at "semantically matching" template
+  positions is forbidden.** This was the 2026-04-30 lovesac.com
+  failure — 20 of 25 pages synthesized this way and the cascade
+  ran four phases on the synthesized data before the gap was
+  caught by a meta-question. The synthesis shortcut produces
+  output indistinguishable from a successful run and propagates
+  fabricated content through every downstream phase.
 
 ## Prep mode (--prep)
 
@@ -373,6 +430,34 @@ inventory — the small discovery cap (5 pages) is insufficient. The
 cap-respecting selection logic from `reference/ia-extraction.md`
 § Page selection still applies for ordering and junk-filtering;
 it just doesn't truncate.
+
+#### Sub-agent prompt requirements (when delegating)
+
+When `--prep` is heavy enough that the agent delegates extraction
+to a sub-agent (a presales-shaped pattern when the inventory is
+large), the sub-agent prompt **must**:
+
+1. **Forbid synthesis by name.** The literal sentence
+   *"do not synthesize a page record from `_brand-extraction.json`
+   + URL patterns + captured photos; every page must be a live
+   Playwright render"* must appear in the prompt. The earlier
+   wording *"must actually invoke Playwright per page"* was
+   satisfiable in spirit by synthesis-with-photo-reuse and
+   produced the lovesac failure. Naming the shortcut explicitly
+   closes that loophole.
+2. **Require a per-page evidence table in the return.** Columns:
+   `slug | waitMode | waitMs | fetchedAt | httpStatus`. The
+   parent agent reads this table on completion and aborts if
+   any row is missing or shows `waitMs: 0`.
+3. **Require the wait-summary line in the return**, formatted
+   identically to Phase 6's wait summary, so the parent can
+   surface it in the user-facing report without reformatting.
+
+These three are mandatory; missing any of them in the sub-agent
+prompt is itself a recipe violation. The cascade-level guard in
+`prepare-migration` validates the resulting per-page JSONs via
+`validateProvenance()` regardless — but a well-formed sub-agent
+return makes the failure cheaper to diagnose.
 
 ### 2. Page typing
 
@@ -440,6 +525,7 @@ extract --prep complete
 =======================
 
 Inventory:    127 pages crawled (5 prior, 122 new)
+Provenance:   127/127 live (every page has Playwright evidence)
 Page types:   landing 1 · article 84 · listing 6 · program 12 · form 3 · static 18 · unique 3
               (LLM-inferred; refine in direct --prep)
 
@@ -453,6 +539,14 @@ Typed slots:  filled per page-type (see current/pages/<slug>.json § slots)
 
 Next: $stardust direct --prep  (confirm types, name modules)
 ```
+
+The `Provenance: <live>/<total> live` line is mandatory in
+prep-mode output. When the ratio is anything other than
+`<total>/<total>` the prep run has failed the synthesis guard;
+list the affected slugs as a sub-bullet and treat the prep run
+as incomplete (the cascade-level guard in
+`prepare-migration` SKILL.md surfaces the same check between
+phases).
 
 Default mode (no `--prep`) is unchanged. The flag is intended for
 the `prepare-migration` orchestrator, though direct invocation is

--- a/plugins/stardust/skills/extract/SKILL.md
+++ b/plugins/stardust/skills/extract/SKILL.md
@@ -184,7 +184,19 @@ Capture per page (full schema in `reference/current-state-schema.md`):
 - Per-section computed style summary: dominant colors, font families
   in use, spacing rhythm, border-radius, shadows
 - Media inventory: img/srcset with original URLs and intrinsic
-  dimensions, inline SVG count, video/iframe presence
+  dimensions, inline SVG count, video/iframe presence,
+  `cssBackgrounds[]` (including pseudo-element `::before`/
+  `::after` walks per § Capture list 11) so `background-image`
+  heroes and motifs do not silently disappear from extract.
+- Font files captured via network-intercept (per § Capture list
+  16): every `woff2`/`woff`/`ttf`/`otf` response saved under
+  `assets/fonts/` and recorded in `_brand-extraction.json#type.files[]`
+  with licensing flag.
+- Icon-font detection (per § Capture list 17): when the page
+  uses `[class^="icon-"]` with non-default `::before`
+  font-family + codepoint, capture the family, save the file,
+  and record the `iconClass → codepoint` table in
+  `_brand-extraction.json#iconFont`.
 - Interactive elements: forms (with field types), buttons, modals
   detected by ARIA roles
 
@@ -242,6 +254,15 @@ extracted pages** to avoid the home-page bias documented in
 - **Voice samples** — first paragraph of body copy, the hero headline,
   3 representative CTA labels, a representative link list. Used by
   `direct` later but extracted now so the network round-trip is over.
+- **Hero image** — elevate the home page's primary visual
+  asset to `voice.heroImage` (per `reference/brand-surface.md`
+  § heroImage resolution). Without this elevation, downstream
+  prototype reasons over a 16-image list and frequently picks
+  the `og:image` instead of the live hero.
+- **Icon font** — when detected per `reference/playwright-recipe.md`
+  § Capture list 17, populate `_brand-extraction.json#iconFont`
+  with family, file path, and the `iconClass → codepoint`
+  table so prototypes can render the brand's actual icons.
 - **System components** — cross-page repeated DOM blocks (site
   header, site footer, cross-promo strips, persistent CTAs,
   breadcrumbs). Detected by heading-sequence + CTA-label fingerprint
@@ -516,6 +537,49 @@ After Phase 3 (brand-surface extraction), scan extracted pages for
 pages with similar shape (same sequence of elements, same
 `data-section` / `data-purpose`, similar text shape) is surfaced
 as a module candidate.
+
+#### Signal-source priority
+
+Detection consumes per-page captured fields in this priority
+order. Each higher signal is **weighted more heavily** in the
+match-score; lower signals are tie-breakers and corroboration,
+not primary evidence. The priority exists because higher-up
+fields are explicitly extracted and structured (no parsing
+ambiguity), while the bottom of the list (`landmarks[].innerText`
+substring search) is fragile against capture variations and was
+the source of the 2026-04-29 sliccy.com under-detection (0
+hits for `pre-footer-shell`, 1 of 2 hits for `install-tile` —
+both modules genuinely present on every page, both invisible
+because the substrings being searched lived past the truncation
+boundary that has since been removed).
+
+1. **`pages/<slug>.json#headings[]`** — cross-page repeats of
+   the same heading text in the same level. Highest signal:
+   structured, explicit, captured in full regardless of body
+   length.
+2. **`pages/<slug>.json#ctas[]` labels** — cross-page repeats
+   of the same CTA label appearing on similar surfaces.
+3. **`pages/<slug>.json#media.cssBackgrounds[]` URLs** — same
+   asset URL on multiple pages is a strong system-component
+   signal (already specced as a system-component candidate in
+   `reference/brand-surface.md` § Cross-page CSS-background
+   reuse; module detection consumes the same signal at finer
+   granularity).
+4. **`pages/<slug>.json#forms[]` actions** — cross-page repeats
+   of the same form `action` URL. Newsletter / contact / search
+   forms are the typical hits.
+5. **`pages/<slug>.json#components.componentsByLandmark`** when
+   present (per future `current-state-schema.md` extension):
+   per-landmark counts of cards / grids / etc.
+6. **Substring search in `landmarks[].innerText`** — lowest
+   signal. Use only as corroboration once a candidate has
+   already passed the higher-signal checks; never as the
+   primary detector.
+
+A candidate that fires on signals 1 + 2 above the threshold is
+high-confidence; a candidate that fires only on 6 should be
+treated as speculative and surfaced as such for the user to
+confirm in `direct --prep`.
 
 Candidate output is a draft entry under
 `DESIGN.json.extensions.modules[]`:

--- a/plugins/stardust/skills/extract/SKILL.md
+++ b/plugins/stardust/skills/extract/SKILL.md
@@ -39,6 +39,15 @@ critique, and it does not modify the live site. It writes only under
   Default `medium`. See `reference/playwright-recipe.md` § Wait modes.
 - `--no-junk-filter` — optional. Disable the default junk-page filter
   in discovery (see `reference/ia-extraction.md` § Filtering).
+- `--no-consent-dismiss` — optional. Skip the pre-flight consent /
+  cookie banner dismissal (see `reference/playwright-recipe.md`
+  § Pre-flight: consent dismissal). Use when the redesign scope
+  explicitly includes the consent surface, or when the
+  dismissal's side-effects (script activation that wouldn't
+  otherwise run) need to be avoided. Default behaviour is to
+  dismiss; the contract preserves screenshots, voice
+  aggregation, and per-section style from being polluted by
+  the banner.
 - `--prep` — optional. Run in **migrate-prep mode**: lift the cap,
   type each page, detect module candidates, capture typed content
   slots, emit the prep summary. See § Prep mode below. Typically
@@ -61,6 +70,22 @@ Additional checks for this sub-command:
    `site.originUrl` and the new `<url>` is a different origin, stop and
    ask before clobbering. Stardust does not silently mix two sites in
    one project.
+3. **Browser context.** Open a fresh `BrowserContext` for the run.
+   Run the **consent dismissal pre-flight** per
+   `reference/playwright-recipe.md` § Pre-flight: consent
+   dismissal *unless* `--no-consent-dismiss` is set. Cookies
+   persist across the per-page loop within the same context, so
+   one dismissal covers the whole crawl. Record the resolved
+   method in `_crawl-log.json#consent.method`.
+4. **Bot-management probe.** When the first navigation in the run
+   returns `ERR_HTTP2_PROTOCOL_ERROR` or `ERR_QUIC_PROTOCOL_ERROR`,
+   or hangs through the entire hard-cap on what should be a fast
+   origin, **do not retry headless**. Switch to
+   `headless: false, channel: 'chrome'` per
+   `reference/playwright-recipe.md` § Bot-management fallback and
+   record the switch in `_crawl-log.json#discovery.fetchTechnique`
+   so re-runs start in headed mode without rediscovering the
+   issue.
 
 ## Procedure
 
@@ -392,6 +417,20 @@ report; do not engineer around it.
   redirects to a login screen, capture that one page, mark the rest as
   unreachable, and ask the user how to proceed (provide cookies via
   Playwright config, change the entry URL, or scope to public pages).
+- **Bot-management block (Akamai / Cloudflare / F5 / Imperva).**
+  When the first navigation returns `ERR_HTTP2_PROTOCOL_ERROR`,
+  `ERR_QUIC_PROTOCOL_ERROR`, or hangs through the hard-cap on a
+  TLS/H2 fingerprint check, the issue is JA3/H2 fingerprinting on
+  bundled-chromium-default headless mode — not auth, not network.
+  Switch to `headless: false, channel: 'chrome'` per
+  `reference/playwright-recipe.md` § Bot-management fallback. Do
+  **not** retry headless: it will fail identically. The headed
+  fallback works against most enterprise / commerce origins;
+  `playwright-extra` + stealth plugin is a non-standard escape
+  hatch for the residual cases. The headed window pops visibly,
+  which is acceptable for interactive runs and unacceptable for
+  unattended pipelines — surface this to the user when first
+  triggered.
 - **JavaScript-only content.** Playwright already handles this. If
   the configured wait condition never fires within the mode's hard
   cap (`reference/playwright-recipe.md` § Wait modes), fall back to

--- a/plugins/stardust/skills/extract/reference/brand-surface.md
+++ b/plugins/stardust/skills/extract/reference/brand-surface.md
@@ -46,6 +46,7 @@ values, and carries a source citation.
   "motifs": { /* see § Motifs */ },
   "componentStyle": { /* see § Component style */ },
   "systemComponents": [ /* see § System components */ ],
+  "iconFont": null,                // null | { /* see § Icon font */ }
   "voice": { /* see § Voice */ },
   "voiceTable": { /* see § Voice table */ },
   "crossPromo": { /* see § Cross-promo */ },
@@ -206,9 +207,30 @@ Aggregation rules:
     "ratios": [1.25, 1.25, 1.20],
     "matchedScale": "major-third"  // null when kind == "ad-hoc"
   },
-  "loadStrategy": "swap"            // detected from font-display in @font-face rules
+  "loadStrategy": "swap",           // detected from font-display in @font-face rules
+  "files": [                        // captured font files (per playwright-recipe.md § Capture list 16)
+    {
+      "url": "https://example.com/fonts/sohne-buch.woff2",
+      "family": "Söhne",
+      "weight": 400,
+      "style": "normal",
+      "unicodeRange": "U+0000-00FF",
+      "localPath": "stardust/current/assets/fonts/sohne-buch.woff2",
+      "sourceCssRule": "@font-face { font-family: 'Söhne'; src: url('/fonts/sohne-buch.woff2') format('woff2'); ... }",
+      "licensingFlag": "private"     // null | "private" | "open"
+    }
+  ]
 }
 ```
+
+`files[]` is required when at least one captured page references
+a `@font-face` rule. Empty array when the site uses only
+system-stack fallbacks. `licensingFlag` defaults to `null`; set
+to `"private"` when the family name does not appear in the
+known-open-licence list (Google Fonts, Adobe Fonts free tier,
+fontsource.org); `"open"` when it does. The flag is heuristic —
+a `"private"` flag means *"verify before redeploying with
+prototype output"*, not *"this font is non-free."*
 
 Identify heading vs body by which family appears in the heading
 outline (`pages/<slug>.json` § Headings) most often. If only one
@@ -435,6 +457,37 @@ component detection requires ≥ 3 pages; crawl too small").
 DOM-fingerprint diff (the thorough version) is out of scope for v0.2 —
 file an issue if the heading-sequence version misses important blocks.
 
+## § Icon font
+
+When the site uses an icon font (per `playwright-recipe.md`
+§ Capture list 17), capture the family name, the saved file, and
+the `iconClass → codepoint` table so downstream `prototype` and
+`migrate` can render the brand's actual icons rather than emoji
+fallbacks.
+
+```json
+{
+  "family": "panynj-icons",
+  "localPath": "stardust/current/assets/fonts/panynj-icons.woff2",
+  "sourceCss": "@font-face { font-family: 'panynj-icons'; src: url('/fonts/panynj-icons.woff2') format('woff2'); ... }",
+  "glyphCount": 19,                // distinct icon classes captured (subset of the font's glyph table — only the ones the site actually uses)
+  "glyphs": [
+    { "class": "icon-search",       "codepoint": "\\E928", "name": "search" },
+    { "class": "icon-accessible",   "codepoint": "\\E852", "name": "accessible" },
+    { "class": "icon-arrow-right",  "codepoint": "\\E806", "name": "arrow-right" }
+  ]
+}
+```
+
+Set `iconFont: null` when no icon font is detected (the common
+case for SVG-icon and inline-graphic sites). When detected, every
+glyph the captured pages used appears in `glyphs[]`; glyphs the
+font defines but the site doesn't deploy are out of scope.
+
+`name` is a heuristic guess from the class suffix
+(`icon-search` → `"search"`); leave `null` when the suffix is
+opaque (`icon-i7`, `glyph-22`, etc.).
+
 ## § Voice
 
 Sampled copy from the home page. Used by `direct` to reason about
@@ -445,6 +498,14 @@ DESIGN.json.
 {
   "heroHeadline": "Build, ship, and own your work",
   "heroSubcopy": "...",
+  "heroImage": {
+    "url": "https://example.com/img/hero-2-engineers-tablet.avif",
+    "alt": "Two engineers reviewing a tablet at a standing desk",
+    "source": "css-background",       // "img" | "css-background" | "css-pseudo-background" | null
+    "domPath": "main > section.hero",
+    "localPath": "stardust/current/assets/media/hero-a3f9.avif",
+    "rect": { "x": 0, "y": 80, "width": 1440, "height": 720 }
+  },
   "primaryCTALabel": "Start free trial",
   "ctaSamples": ["Start free trial", "Talk to sales", "See pricing", "Read the docs"],
   "navItems": ["Product", "Pricing", "Customers", "Docs", "Sign in"],
@@ -456,6 +517,46 @@ DESIGN.json.
   }
 }
 ```
+
+### `heroImage` resolution
+
+The hero photo is the home page's most load-bearing visual asset.
+Without this field elevated, downstream `prototype` has to re-derive
+"which captured image is the hero" from a noisy 16-image list every
+render — and frequently picks the `og:image` (a curated thumbnail
+optimised for social cards) instead of the actual visible hero. The
+2026-05-04 ups.com home shipped the wrong hero on three variants
+this way before the user noticed.
+
+Resolve from the home page's captured media (both
+`pages/home.json#media.images[]` and `media.cssBackgrounds[]` —
+the second covers `background-image` and `::before` /
+`::after` pseudo-element heroes per `playwright-recipe.md`
+§ Capture list 11):
+
+1. Filter to candidates with `rect.top < 800 px` (within the
+   first viewport).
+2. Filter to candidates with `rect.width × rect.height` ≥
+   100 000 px² (excludes header logos, tiny chips, decorative
+   columns).
+3. Filter to candidates with `rect.aspectRatio` in `[0.3, 3.0]`
+   — excludes thin banners and tall vertical strips.
+4. Pick the candidate with the **largest visible area**. Tie-
+   breaker: `<img>` over `cssBackgrounds[]` over
+   `cssBackgrounds[]` with pseudo selector (slight preference
+   for explicit DOM imagery, which downstream consumers can
+   manipulate more reliably).
+
+Set `source` to `"img"`, `"css-background"`, or
+`"css-pseudo-background"` based on which capture produced the
+winner. When no candidate survives the filters, set `heroImage:
+null` and surface in `_provenance.notes` (most non-marketing
+pages — search, 404, login — legitimately have no hero).
+
+Downstream `prototype` reads `heroImage.url` /
+`heroImage.localPath` directly when composing the hero slot
+under Mode A's image-reuse contract (per
+`skills/direct/SKILL.md` § Mode A).
 
 The `tone.guess` is a heuristic — never present it as ground truth in
 the user report. `direct` will use it as one of several signals, not

--- a/plugins/stardust/skills/extract/reference/current-state-schema.md
+++ b/plugins/stardust/skills/extract/reference/current-state-schema.md
@@ -19,8 +19,10 @@ The file is JSON because every consumer is non-human. It carries a
     "readArtifacts": ["https://example.com/about"],
     "synthesizedInputs": [],
     "stardustVersion": "0.2.0",
+    "renderedBy": "playwright",      // REQUIRED. "playwright" only — synthesis is forbidden (see § Live-render evidence)
+    "fetchedAt": "2026-04-25T13:41:58Z",  // ISO 8601 timestamp of the live fetch (distinct from writtenAt)
     "waitMode": "networkidle",       // configured mode: fast | medium | spec | networkidle | domcontentloaded(fallback)
-    "waitMs": 3820,                  // actual wait time, including grace and scroll pass
+    "waitMs": 3820,                  // actual wait time, including grace and scroll pass — must be > 0
     "httpStatus": 200,               // final response status after redirects
     "contentType": "text/html"       // final response content-type (without charset)
   },
@@ -99,7 +101,7 @@ full DOM tree, just enough to map IA.
   "role": "main",
   "id": null,
   "classes": [],
-  "innerText": "...",
+  "innerText": "...",                  // FULL innerText, no truncation
   "children": [
     {
       "tag": "section",
@@ -109,15 +111,44 @@ full DOM tree, just enough to map IA.
       "purpose": "hero",          // heuristic: "hero" | "feature-list" | "social-proof" | "cta-band" | "footer-nav" | "form" | "rich-text" | "unknown"
       "headlineRef": 0,            // index into headings[] if any
       "innerTextSummary": "first 240 chars",
-      "wordCount": 87
+      "wordCount": 87,
+      "body": [                    // structured paragraphs, in DOM order
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+        "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+      ],
+      "lists": [
+        { "ordered": false, "items": ["Item one", "Item two", "Item three"] }
+      ],
+      "qa": [                      // populated when an accordion is detected
+        { "q": "How do I cancel?",  "a": "From settings → billing → cancel." }
+      ],
+      "quotes": [                  // populated when testimonials / blockquotes detected
+        { "text": "Best tool we ship.", "attribution": "Jane Doe, Acme",
+          "rating": 5 }
+      ]
     }
   ]
 }
 ```
 
+`innerText` is captured in **full** — no length cap. The
+`innerTextSummary` field stays as a 240-char preview for cheap
+display in reports; consumers that need the full body read
+`innerText` directly or use the structured fields below.
+
 `purpose` is a **heuristic guess**, not ground truth. Helps `direct`
 and `prototype` reason about IA without re-parsing. When unsure, emit
 `"unknown"` — never invent.
+
+`body[]`, `lists[]`, `qa[]`, `quotes[]` are required; emit `[]` when
+the section has none of that shape (a hero card with one heading and
+one CTA legitimately has no paragraphs / lists / accordion / quotes).
+Capture rules in `playwright-recipe.md` § Capture list (7-bis). These
+fields are what migrate consumes to render real body copy under
+each section heading; without them every body region falls back to
+the placeholder-with-signature treatment (per `prototype/reference/
+before-after-shell.md` § Content sourcing hierarchy) even when the
+source page had real prose to reuse.
 
 ## § CTAs
 
@@ -378,3 +409,44 @@ The schema version is implicit in
 `_provenance.stardustVersion`. If the schema evolves, downstream
 consumers branch on the version. Backward-compatible additions do not
 require a version bump.
+
+## Live-render evidence (synthesis is forbidden)
+
+Every per-page JSON file is the result of a Playwright (or
+Playwright MCP) live render against the source URL. Synthesizing
+a page record from `_brand-extraction.json` + URL patterns +
+captured photo IDs is **forbidden**, even when the synthesized
+shape would be plausible. The 2026-04-30 lovesac.com cascade ran
+"successfully" for four phases on a 25-page inventory where 20
+pages had been synthesized this way; the failure was invisible
+until a meta-question exposed the missing live-render evidence.
+
+The forbidden shortcut is signed for in `_provenance`:
+
+| field | required value | enforced where |
+|---|---|---|
+| `renderedBy` | `"playwright"` | `extract` write-time + `validateProvenance()` at every downstream phase |
+| `waitMs` | integer `> 0` | same |
+| `fetchedAt` | ISO 8601 timestamp string | same |
+| `httpStatus` | integer (the *final* response status after redirects) | same |
+| `waitMode` | one of `fast` / `medium` / `spec` / `networkidle` / `domcontentloaded` / a `<mode>(fallback)` form | same |
+
+`extract` (and `extract --prep`) **must refuse to mark a page
+`extracted` in `state.json`** without these five fields populated
+from a real Playwright render. Sub-agents delegated to perform
+extraction must return a per-page evidence table (slug / waitMode
+/ waitMs / fetchedAt) and explicitly forbid synthesis in their
+prompt — *"must actually invoke Playwright per page"* alone is
+not sufficient; spec-level prompts must list the synthesis
+shortcut by name and forbid it.
+
+Downstream phases (`direct --prep`, `prototype`, `migrate`,
+`prepare-migration` orchestrator) call
+`validateProvenance(page)` per
+`skills/stardust/reference/state-machine.md` § Provenance
+validation **on entry, before any work**, and abort with a clear
+error if any page in scope has missing or fabricated provenance.
+The double-guard (write-time refusal at extract + read-time
+validation at every consumer) is intentional defense-in-depth:
+single-layer guards have already missed at least one synthesis
+failure mode in production.

--- a/plugins/stardust/skills/extract/reference/playwright-recipe.md
+++ b/plugins/stardust/skills/extract/reference/playwright-recipe.md
@@ -86,7 +86,43 @@ For each page, capture:
    letter-spacing, color.
 6. **Landmark structure** — every `header`, `nav`, `main`, `aside`,
    `footer`, plus elements with `role="banner|navigation|main|complementary|contentinfo|region"`. For each: tag, role, id, class, child element count.
-7. **Visible text per landmark** — innerText, normalised whitespace.
+7. **Visible text per landmark** — innerText in full, normalised
+   whitespace. **No truncation.** Reference scripts must not slice
+   `innerText` to a fixed length (an early v0.2 reference did
+   `.slice(0, 4000)`, which silently discarded most of the body on
+   long-form pages — privacy / policy / docs templates routinely run
+   to 6,000+ words). Storing the full innerText across a 25-page crawl
+   adds ~250 KB to the per-page JSON corpus, well below any reasonable
+   threshold; whatever cost is involved, the alternative is silent
+   data loss that compounds into module-detection misses and missing
+   body copy at migrate time. See § Capture list (7-bis) below for
+   the structured-content fields that supplement innerText.
+
+7-bis. **Section body, lists, Q&A, quotes (structured)** — innerText
+   alone gives one big blob per landmark; downstream phases need the
+   structure preserved. For each heading-bounded block within a
+   landmark, additionally capture:
+   - `body[]` — `textContent` of every direct-descendant `<p>` /
+     `<blockquote>` not inside a nested heading, in DOM order. Strip
+     leading/trailing whitespace, preserve internal breaks.
+   - `lists[]` — for every `<ul>` / `<ol>` not nested inside a
+     captured paragraph, an entry `{ ordered: bool, items: [string] }`
+     where each item is `textContent` of one `<li>`.
+   - `qa[]` — when an accordion (`<details>` or
+     ARIA-driven disclosure) is detected within the section, capture
+     each entry as `{ q: <trigger text>, a: <disclosed textContent> }`.
+   - `quotes[]` — when a review-card / testimonial / pullquote
+     pattern is detected (a `<blockquote>` or `[class*="testimonial"
+     i]` containing prose plus an optional attribution / rating),
+     capture each as `{ text, attribution?, rating? }` (rating
+     numeric when available, e.g. from `aria-label="5 out of 5"`).
+
+   These attach to the section entry in `landmarks[].children[]`
+   (per `current-state-schema.md` § Landmarks). They are required
+   for migrate to render production-quality body copy from captured
+   data — without them, every body region under a heading falls back
+   to placeholder-with-signature even when the source page had real
+   prose to reuse.
 8. **CTA inventory** — every `button`, `[role="button"]`, and `<a>`
    that visually presents as a button (background-color != transparent,
    `border-radius > 2px`, padding > 4 px). Capture: label, href if any,
@@ -238,4 +274,8 @@ A failure on one page must not abort the crawl. Record the error
 under `failures[]` and continue with the next page. The skill's final
 state report counts successes vs failures, and surfaces the failure
 classes (`HTTPError`, `ContentTypeError`, `EmptyPageError`,
-`TimeoutError`) so the user can diagnose at a glance.
+`TimeoutError`, `ProvenanceMissing`) so the user can diagnose at a
+glance. `ProvenanceMissing` covers the synthesis-guard refusal in
+`extract/SKILL.md` § Phase 2 — a page record could not be marked
+`extracted` because the Playwright evidence contract was not
+satisfiable for that slug.

--- a/plugins/stardust/skills/extract/reference/playwright-recipe.md
+++ b/plugins/stardust/skills/extract/reference/playwright-recipe.md
@@ -327,6 +327,26 @@ For each page, capture:
     applied via `background-image` (parallax sections, full-bleed
     sections) are silently invisible to extract — `STARDUST-FEEDBACK.md
     F-018 / X-1`.
+
+    **Pseudo-element walk.** `document.querySelectorAll('*')` does
+    not reach `::before` / `::after` generated content, so a hero
+    photo set on a pseudo (a common WordPress / page-builder
+    pattern) silently drops out of capture. For every element
+    surviving the visible-size filter, additionally check both
+    `getComputedStyle(el, '::before').backgroundImage` and
+    `getComputedStyle(el, '::after').backgroundImage`. When the
+    pseudo carries a non-`none` value with one or more `url(...)`
+    references, emit a separate `cssBackgrounds[]` entry with
+    `domPath = "<host-path>::before"` (or `::after`), the host
+    element's rect (the pseudo doesn't have its own rect at this
+    granularity), and the pseudo's `backgroundSize` /
+    `backgroundPosition` / `backgroundRepeat`. The 2026-05-04
+    ups.com home dropped its hero this way: zero `cssBackgrounds[]`
+    hits for the home, prototype defaulted to the `og:image`
+    instead of the actual visible hero. Performance: the pseudo
+    walk runs only on elements that already passed the rect-size
+    filter, so the cost on a typical 4000-element page is in the
+    low-millisecond range, not seconds.
 12. **Form inventory** — for every `<form>`: action, method, list of
     fields with type and name; whether it's wired to an obvious
     third-party (Stripe, Calendly, Typeform, Mailchimp).
@@ -342,6 +362,69 @@ For each page, capture:
     no design tokens. An empty list across all extracted pages is the
     signal "no tokens defined."
 
+16. **Font files (network-intercept).** Subscribe to
+    `context.on('response', ...)` for the duration of the run.
+    Save every response whose URL matches `\.(woff2?|ttf|otf|eot)$`
+    or whose `Content-Type` starts with `font/` to
+    `stardust/current/assets/fonts/<basename>`. De-dupe by URL
+    across pages — the same font fetched on three pages saves
+    once. Record per font in `_brand-extraction.json#type.files[]`:
+    `{ url, family, weight, style, unicodeRange, localPath,
+    sourceCssRule }`. Resolve `family` / `weight` / `style` by
+    finding the `@font-face` block in any captured stylesheet that
+    references the same URL — the rule's font descriptors are the
+    authoritative metadata.
+
+    Without this capture every prototype falls back to a `system-ui`
+    / `Helvetica Neue` stack and the Mode A "brand-faithful" claim
+    weakens visibly on any site whose typography is the most
+    distinctive thing about it (private cuts on commercial brands,
+    Google-Font-but-licenced-elsewhere combinations on agency
+    sites, etc.). The 2026-05-03 jfkairport.com run had two
+    private cuts (Sharp Grotesk Semibold, Helvetica Now for PANYNJ)
+    visible in network responses and absent from every captured
+    artifact until added by a one-off script.
+
+    Captured fonts are sometimes private brand assets. Flag any
+    font whose family name does not match a known open-license
+    list (Google Fonts, Adobe Fonts free tier, fontsource.org
+    catalogue) in `_brand-extraction.json#type.files[].licensingFlag`
+    so the user can verify usage rights before deploying. Internal
+    prototype review is generally fine — the files are already
+    publicly served by the source site.
+
+17. **Icon font detection.** Many production sites ship an icon
+    font (a single woff2 carrying tens to hundreds of glyphs)
+    rather than inline SVG. Without a detector for this, prototypes
+    on icon-font sites render with emoji stand-ins (♿, 🔍, →, f,
+    𝕏) that read as visibly amateur in a brand-faithful Mode A
+    output. Detection:
+
+    - Query every element matching
+      `[class^="icon-"], [class*=" icon-"], i.icon, [data-icon]`.
+    - For each matched element, read the computed `::before`
+      `font-family` and `content` properties. When `font-family`
+      is non-default (i.e. not in `system-ui, sans-serif, Arial`,
+      etc.) and `content` is a quoted Unicode codepoint (not
+      `none`, `""`, or visible text), the element uses an icon
+      font.
+    - Build the icon-class → codepoint table from the unique
+      `(class, content)` pairs.
+    - Resolve the icon font's URL via the `@font-face` rule for
+      that family and save the file via the network-intercept
+      from § 16.
+
+    Record in `_brand-extraction.json#iconFont`:
+    `{ family, localPath, sourceCss, glyphs: [{ class, codepoint, name? }] }`.
+    Optional `name` is a heuristic guess from the class suffix
+    (`icon-search` → `"search"`, `icon-arrow-right` → `"arrow-right"`).
+
+    When `inlineSvgCount < 5` on a page but `[class*="icon-" i]`
+    elements with non-default `::before` font-family are present,
+    surface in the brand-review HTML: *"icon font detected
+    (`<family>`, N distinct classes used) — see
+    `_brand-extraction.json#iconFont` for the mapping."*
+
 ## Logo locator chain
 
 For the brand-surface pass (Phase 3 of `extract`), find the logo in
@@ -351,9 +434,33 @@ this exact priority order. Stop at the first hit.
    or `nav` that is not an icon (heuristic: width or viewBox-derived
    width ≥ 60 px and contains `<text>` or has `aria-label` matching
    the brand name).
-2. **`<img>` with logo-ish identifier** — `img` whose `src`, `alt`,
-   `class`, or `id` contains `logo`, `brand`, or the brand name slug
-   (case-insensitive). Inside `header`, `[role="banner"]`, or `nav`.
+2. **`<img>` with logo-ish identifier** — `<img>` whose `src`, `alt`,
+   `class`, or `id` contains `logo`, `brand`, or the brand name
+   slug (case-insensitive), inside `header`, `[role="banner"]`, or
+   `nav`. **Additionally**, all of the following must hold,
+   otherwise fall through to step 3:
+   - rendered `height ≥ 32 px` AND rendered `width ≥ 40 px` —
+     filters tiny promotional icons that happen to share the
+     brand-name substring (e.g. `ups-package-ontime-box-fast.avif`
+     in a UPS utility bar at 24×24).
+   - `top ≤ 200 px` after the wait+scroll pass — filters images
+     that happen to be inside `<header>` markup but render far
+     below the visible header band.
+   - rendered aspect ratio in `[0.5, 3.0]` — covers square
+     wordmarks (1:1) through wide signature wordmarks (3:1)
+     while excluding tall column glyphs and wide spacer SVGs.
+
+   When multiple candidates qualify, **rank by aspect-ratio
+   proximity to a 1.5 ideal** (most logos cluster between 1.0 and
+   2.5; 1.5 is the centre) and pick the closest. Tie-breaker:
+   highest rendered area.
+
+   The 32 px height threshold is conservative — most real logos
+   render at 40–80 px even in tight headers. Sites that intentionally
+   ship sub-32 px logos on desktop fall through to step 3
+   (`apple-touch-icon`), which is correct most of the time;
+   surface in `_brand-extraction.json#logo._provenance.notes`
+   when this happens so the user can verify.
 3. **`apple-touch-icon`** — `<link rel="apple-touch-icon">` href.
    Resolve relative to base URL.
 4. **`og:image`** — `<meta property="og:image">` content.

--- a/plugins/stardust/skills/extract/reference/playwright-recipe.md
+++ b/plugins/stardust/skills/extract/reference/playwright-recipe.md
@@ -23,6 +23,164 @@ javaScriptEnabled: true
 ignoreHTTPSErrors: true     (some staging hosts ship invalid certs)
 ```
 
+### Bot-management fallback (Akamai / Cloudflare / F5 / Imperva)
+
+Bundled-chromium-default headless mode (no `channel`,
+`headless: true`) emits a TLS/H2 fingerprint that Akamai and
+several other bot-management products reject outright — the
+first navigation returns `net::ERR_HTTP2_PROTOCOL_ERROR` or
+`net::ERR_QUIC_PROTOCOL_ERROR` immediately, before any JS runs.
+The bare Playwright `request` API hits the same fingerprint and
+fails identically; passing `--disable-http2` flips the failure
+mode to a 30-second `TimeoutError` (connection accepted, no
+content) but doesn't recover.
+
+The known-working fallback is **headed real Chrome**:
+
+```
+chromium.launch({ headless: false, channel: 'chrome' })
+```
+
+This pops a visible browser window during the run, which is
+acceptable for a local dogfood / interactive session and
+unacceptable for an unattended pipeline. The trade-off is the
+correct one for stardust's primary use case (presales redesign
+of an existing commercial site, agent-driven from a developer's
+machine) — the alternative is silently failing on most
+enterprise / large-retail / commerce origins.
+
+**Retry rule.** When the first navigation in a run returns any
+of `ERR_HTTP2_PROTOCOL_ERROR`, `ERR_QUIC_PROTOCOL_ERROR`, or
+hangs for the entire hard-cap on a connection that doesn't
+fingerprint cleanly: do **not** retry headless. Switch to
+`headless: false, channel: 'chrome'` immediately and record the
+switch in `_crawl-log.json#discovery.fetchTechnique` so re-runs
+start in headed mode without rediscovering the issue.
+
+**Sub-resource fetches.** Once a page context is open in headed
+Chrome, additional fetches (sitemap, logo file, ad-hoc inspection
+URLs) inherit the JA3 fingerprint when issued via
+`page.evaluate(async () => fetch('/...'))` — the in-page fetch
+goes through the same TLS context. The bare Playwright `request`
+API does **not** inherit the page context's fingerprint and
+will hit the same H2 protocol error even after cookies are
+established. Use the in-page evaluate pattern for any sub-resource
+fetch on a bot-managed origin.
+
+**Escape hatch (not standard).** The `playwright-extra` plugin
+plus `puppeteer-extra-plugin-stealth` works on some Akamai
+configurations but is non-standard and brittle across vendor
+config changes. Stardust does not depend on it; mention to the
+user as a path of last resort when even headed real Chrome is
+blocked.
+
+## Pre-flight: consent dismissal
+
+Most production-tier sites ship a consent / cookie banner
+(OneTrust, Cookiebot, Didomi, Osano, TCF v2-compliant custom
+implementations) that overlays the bottom 25–35% of the
+viewport. With default extract behavior the banner:
+
+- covers the hero in every screenshot — the most load-bearing
+  surface for downstream `direct` and `prototype` reasoning;
+- dominates `voiceTable.ctaFrequency` with cookie-modal buttons
+  (`Manage Settings`, `Reject All`, `Accept All` — appearing
+  once per page across an N-page crawl);
+- adds a phantom modal to every page's component count;
+- leaks the banner's own font stack into per-section style
+  aggregation.
+
+Pre-flight a **consent dismissal** before the per-page loop.
+One dismissal in a fresh `BrowserContext` typically persists
+the cookie state across every subsequent page in the same
+context, so the cost is one extra navigation per crawl.
+
+### Dismissal procedure
+
+API-first (most reliable across vendor config changes), then
+selector fallback. Stop at the first method that hides the
+banner. Probe in this order:
+
+```js
+async function dismissConsent(context, originUrl) {
+  const page = await context.newPage();
+  await page.goto(originUrl, { waitUntil: 'domcontentloaded' });
+
+  // 1. JS APIs — defensive (?., try/catch, short timeouts)
+  const apiTried = await page.evaluate(() => {
+    try { if (window.OneTrust?.RejectAll)        { window.OneTrust.RejectAll();    return 'api:OneTrust.RejectAll'; } } catch {}
+    try { if (window.Cookiebot?.dismiss)         { window.Cookiebot.dismiss();     return 'api:Cookiebot.dismiss'; } } catch {}
+    try { if (window.CookieConsent?.dismiss)     { window.CookieConsent.dismiss(); return 'api:CookieConsent.dismiss'; } } catch {}
+    try { if (window.Didomi?.notice?.hide)       { window.Didomi.notice.hide();    return 'api:Didomi.notice.hide'; } } catch {}
+    try { if (window.osano?.cm?.dismiss)         { window.osano.cm.dismiss();      return 'api:osano.cm.dismiss'; } } catch {}
+    return null;
+  });
+
+  // 2. Selector fallbacks — clicked in order; first that
+  //    dismisses the banner wins.
+  const selectorChain = [
+    '#onetrust-reject-all-handler',
+    '#onetrust-accept-btn-handler',
+    '#CybotCookiebotDialogBodyButtonDecline',
+    '#CybotCookiebotDialogBodyLevelButtonAccept',
+    '[data-testid="uc-deny-all-button"]',     // Usercentrics
+    '[aria-label*="reject" i]',
+    '[aria-label*="accept" i]'
+  ];
+
+  let methodUsed = apiTried;
+  if (!methodUsed) {
+    for (const sel of selectorChain) {
+      try {
+        await page.click(sel, { timeout: 3000 });
+        methodUsed = `selector:${sel}`;
+        break;
+      } catch {}
+    }
+  }
+
+  // 3. Wait for the most common banner containers to be hidden
+  //    or 8s elapse — whichever first.
+  for (const sel of ['#onetrust-banner-sdk', '#CybotCookiebotDialog',
+                     '[id*="didomi"]', '[id*="osano"]']) {
+    await page.waitForSelector(sel, { state: 'hidden', timeout: 8000 }).catch(() => {});
+  }
+
+  await page.close();
+  return methodUsed ?? 'none-detected';
+}
+```
+
+Record the chosen method in
+`_crawl-log.json#consent.method`. Values:
+`api:<vendor>.<call>`, `selector:<css>`, `none-detected` (no
+banner present — common on small / dev / non-EU sites),
+`failed` (banner detected but neither API nor selectors
+hid it — surface to the user as a per-site warning, the
+banner will remain visible in screenshots).
+
+### Opt-out
+
+`extract --no-consent-dismiss` skips the pre-flight entirely.
+Useful when the user wants to capture the banner deliberately
+(e.g. a redesign whose scope explicitly includes the consent
+surface) or when an unattended pipeline must avoid the
+side-effects below.
+
+### Side-effect caveat
+
+Calling `OneTrust.RejectAll()` (and equivalents) commits a
+"non-essential cookies declined" state, which on some sites
+**activates other scripts** that wouldn't have run otherwise —
+analytics, geo-IP detection, locale-cookie writes, A/B test
+slots, live-chat. The 2026-05-03 nvidia.com run observed an
+expanded localization leak after the dismissal step that
+wasn't present in the pre-dismissal run. The dismissal step
+is therefore not behavior-neutral: cleaner screenshots come
+with the possibility of script-activation deltas. When the
+extract returns content that visibly differs from the live
+site, run with `--no-consent-dismiss` to compare.
+
 ## Wait modes
 
 The wait strategy is configurable per `extract` invocation via

--- a/plugins/stardust/skills/migrate/SKILL.md
+++ b/plugins/stardust/skills/migrate/SKILL.md
@@ -64,6 +64,15 @@ sidecars.
      `approved`, `stale: false` (or `--all` /
      `--refresh-stale` / explicit `<slug>`).
    - **skipped**: everything else, with reason captured.
+7. **Validate provenance on every in-scope page.** Call
+   `validateProvenance(page)` per
+   `skills/stardust/reference/state-machine.md` § Provenance
+   validation for every page in `inScope`. Abort with the
+   helper's error when any page lacks live-render evidence —
+   migrating a synthesized page record produces deployable HTML
+   that misrepresents the source site, the exact failure mode
+   that motivated the validator. Surface `Provenance OK on N
+   pages` in the migrate-plan output before Phase 1.
 
 ## Procedure
 

--- a/plugins/stardust/skills/prepare-migration/SKILL.md
+++ b/plugins/stardust/skills/prepare-migration/SKILL.md
@@ -98,6 +98,43 @@ User options:
   "exclude /search and /404 from inventory"). Re-surface summary;
   loop.
 
+#### Provenance guard (between Phase 1 and Phase 2)
+
+Before invoking `direct --prep`, validate every page in the
+inventory via `validateProvenance(page)` per
+`skills/stardust/reference/state-machine.md` § Provenance
+validation. Abort the cascade with the helper's error if any
+page lacks live-render evidence. This is the cascade-level
+defense against the failure mode where `extract --prep` (or its
+delegated sub-agent) silently synthesized one or more page
+records — extract's own write-time refusal is the primary guard,
+but the cascade adds a second check between phases so the
+synthesis bug recurring under a different rationale cannot
+quietly contaminate the rest of the run.
+
+The same guard runs implicitly inside Phase 2, 3, and 4 (each
+underlying skill's setup calls `validateProvenance()` per its
+own SKILL.md) — but surfacing it here as an explicit cascade
+step makes the abort happen *before* the user sees the Phase 2
+prep summary, which would otherwise look like a successful run.
+
+Surface in the cascade output:
+
+```
+Provenance OK on 127 pages.
+```
+
+When the check fails:
+
+```
+Provenance check failed on 20 of 127 pages — see error above.
+Cascade aborted between Phase 1 and Phase 2.
+   → Re-run extract for the affected slugs:
+       $stardust extract --refresh <slug-1>
+       $stardust extract --refresh <slug-2>
+       ...
+```
+
 ### Phase 2 — direct --prep
 
 Invoke:

--- a/plugins/stardust/skills/prototype/SKILL.md
+++ b/plugins/stardust/skills/prototype/SKILL.md
@@ -67,7 +67,17 @@ is delegated to `$impeccable craft` and `$impeccable live`.
    `$stardust direct` and stop.
 4. Verify `stardust/direction.md` has an active (not pending)
    direction. Pending directions block prototype.
-5. Read `stardust/current/DESIGN.md` (the descriptive snapshot of the
+5. **Validate provenance on every page in scope.** Call
+   `validateProvenance(page)` per
+   `skills/stardust/reference/state-machine.md` § Provenance
+   validation for every page that this run will render (the
+   single `<slug>` argument when present, otherwise every
+   non-stale `directed`/`prototyped`/`approved` page). Abort with
+   the helper's error when any page lacks live-render evidence
+   — re-running `prototype` against a synthesized page record
+   silently propagates the synthesis into the rendered prototype.
+   Surface `Provenance OK on N pages` once the check passes.
+6. Read `stardust/current/DESIGN.md` (the descriptive snapshot of the
    existing site, used by the viewer's CURRENT side fallback path).
 
 ## Delegation mechanic

--- a/plugins/stardust/skills/stardust/reference/state-machine.md
+++ b/plugins/stardust/skills/stardust/reference/state-machine.md
@@ -229,6 +229,74 @@ The recommended next step uses these heuristics, in order:
 
 ---
 
+## Provenance validation
+
+Every downstream phase that reads per-page extracted JSON must
+validate its `_provenance` block before doing any work. The check
+is read-time defense-in-depth against the failure mode where
+extract (or a sub-agent delegated to it) wrote a page record by
+synthesizing from existing artifacts instead of running a live
+Playwright render. Extract's own write-time refusal
+(`current-state-schema.md` § Live-render evidence) is the
+primary guard; the read-time validator catches mid-cascade
+corruption, manual edits, partial re-runs, and recurrences of
+the synthesis bug under different rationales.
+
+### `validateProvenance(page)` — contract
+
+Given a page entry and the path to its `current/pages/<slug>.json`,
+the helper succeeds when every condition below holds and aborts
+the calling phase otherwise:
+
+| condition | rule |
+|---|---|
+| file exists | `current/pages/<slug>.json` resolves to a regular file |
+| renderedBy | `_provenance.renderedBy === "playwright"` (string equality) |
+| fetchedAt | parses as ISO 8601, not in the future, not before the project's earliest extract |
+| waitMs | integer, strictly `> 0` |
+| waitMode | matches `^(fast|medium|spec|networkidle|domcontentloaded)(\(fallback\))?$` |
+| httpStatus | integer in `[200, 399]` (4xx/5xx pages should never have landed in `state.json` as `extracted` per `extract/reference/playwright-recipe.md` § Response validation; if one did, the validator surfaces it) |
+
+When any condition fails, the calling phase aborts immediately
+with a structured error naming the slug, the failed condition,
+and the artifact path. Hint at the recovery command:
+> Page `<slug>` lacks live-render evidence (`<failed condition>`).
+> Re-extract with `$stardust extract --refresh <slug>`, or
+> investigate the synthesis source if the page record was
+> hand-edited.
+
+### When each phase calls it
+
+| phase | scope of validation |
+|---|---|
+| `direct --prep` | every page in the inventory before typing / module detection |
+| `prototype` (any mode) | every page referenced by the variant being rendered |
+| `prototype --prep` | every page-type representative slated for the archetype pass |
+| `migrate` (any mode) | every page in the migrate target list |
+| `prepare-migration` orchestrator | every claimed-extracted page at the start of Phase 1, **before** invoking `direct --prep` |
+
+Discovery-mode `extract` does **not** call the validator on its
+own outputs (it just wrote them); but extract Phase 6 must
+include a **`live: yes/no` column** in its summary report so the
+user can eyeball provenance coverage before the next phase runs.
+A column of `live: yes` across every row is the visible signal
+that the validator will pass downstream. See
+`skills/extract/SKILL.md` § Phase 6 for the report format.
+
+### Surfacing validation in reports
+
+Each consumer phase prefixes its report with a one-liner:
+> `Provenance OK on N pages.`
+
+When validation fails, the failure replaces the report:
+> `Provenance check failed on M of N pages — see error above. Phase aborted.`
+
+The visible signal makes regression cheap to catch — a
+maintainer running the cascade twice should see `Provenance OK`
+twice; a quiet absence of that line is itself a smell.
+
+---
+
 ## Concurrency
 
 Stardust does not own a long-running process. Every sub-command reads


### PR DESCRIPTION
## Summary

Twelve spec / SKILL changes across three coherent bundles, all driven by the dogfood evidence in `notes/dogfood-feedback.md`, `dogfood-fan-out-findings-2026-04-29.md`, `dogfood-jfkairport-findings-2026-05-03.md`, `dogfood-nvidia-findings-2026-05-03.md`, and `dogfood-ups-findings-2026-05-04.md`. Scope is `extract` and the cascade that consumes its output (`direct --prep`, `prototype`, `migrate`, `prepare-migration`); `direct` / `prototype` / `migrate` design changes are intentionally deferred to a follow-up.

Three commits, mapped to the failure mode each bundle protects against.

## Bundle 1 — provenance integrity (`85d7496`)

Closes the silent-corruption class where `extract --prep` (or a delegated sub-agent) synthesizes page records from `_brand-extraction.json` + URL patterns + captured photos. The 2026-04-30 lovesac.com cascade ran four phases on 20 of 25 synthesized pages before being caught by a meta-question.

- **Synthesis guard at write-time.** Extract refuses to mark a page `extracted` without `_provenance.{renderedBy:"playwright", fetchedAt, waitMs>0, waitMode, httpStatus}`. New `ProvenanceMissing` error class. Sub-agent prompts must forbid synthesis by name and return a per-page evidence table.
- **`validateProvenance(page)` cascade-level helper.** Specced in `state-machine.md`; called at the setup of `direct --prep`, `prototype`, and `migrate`. `prepare-migration` runs it as an explicit guard between Phase 1 and Phase 2 — aborting before the user sees a Phase 2 prep summary that would otherwise look like a successful run.
- **`innerText` captured in full.** No truncation. The v0.2 reference's `.slice(0, 4000)` silently dropped most body content on long-form pages and broke module detection downstream.
- **Schema additions for `sections[].body`, `lists`, `qa`, `quotes`.** Gives migrate real body copy to render under each heading instead of falling back to placeholder-with-signature throughout.
- **Mandatory `live: yes/no` column** in extract Phase 6 report; `Provenance: N/N live` line in prep-mode summary. Visible signal that the contract is holding — its absence in 2026-04-30 is what let the synthesis bug travel four phases unnoticed.

## Bundle 2 — discovery / context reliability (`e4bbabb`)

Two unrelated context-setup gaps that silently produced bad captures.

- **Bot-management fallback** (UPS, ups.com/gb). Akamai rejects bundled-chromium-default headless on its TLS/H2 fingerprint with `ERR_HTTP2_PROTOCOL_ERROR`, before any JS runs. Recipe now specifies `headless: false, channel: 'chrome'` as the retry path; `extract` setup switches modes on the protocol error without retrying headless. Sub-resource fetches use `page.evaluate(async () => fetch(...))` to inherit the JA3 fingerprint.
- **Consent-banner pre-flight** (NVIDIA, nvidia.com). API-first dismissal (OneTrust / Cookiebot / Didomi / Osano / Usercentrics) with selector fallbacks; `--no-consent-dismiss` opt-out; `consent.method` recorded in `_crawl-log.json`. Side-effect caveat documented: dismissal can activate other gated scripts (analytics, geo-IP, A/B) and the result may differ from a no-dismiss capture.

## Bundle 3 — capture fidelity (`2bf1ce1`)

Five capture-fidelity gaps that produced thinner or wrong brand surfaces.

- **Logo locator rect + aspect filter** (UPS): step 2 of the locator chain now requires height ≥ 32, width ≥ 40, top ≤ 200, aspect in [0.5, 3.0]; ranks by proximity to a 1.5 ideal. Stops promotional icons that share the brand-name substring from being picked as the masthead logo.
- **CSS-background pseudo-element walk** (UPS): `::before` / `::after` generated content that `document.querySelectorAll('*')` misses. Performance-bounded by the prior visible-size filter.
- **`voice.heroImage` elevation** (UPS): single canonical hero per home, resolved by viewport-top + visible-area + aspect filters with explicit `<img>` > CSS-bg > pseudo tie-breakers. Ends downstream re-derivation from a 16-image list.
- **Font file capture via network-intercept** (JFK): every `woff2`/`woff`/`ttf`/`otf` saved to `assets/fonts/`, recorded in `_brand-extraction.json#type.files[]` with `@font-face` metadata + licensing flag. Closes the gap where Mode A prototypes silently fall back to `system-ui` on private-cut brands.
- **Icon-font detection** (JFK): query `[class^="icon-"]` + `::before` font-family + codepoint, build `iconClass → codepoint` table, save the font file. Closes the emoji-fallback render path on Chakra / Material / government sites.
- **Module-detection signal priority** (sliccy): explicit ranking — headings → CTAs → cssBackgrounds → forms → componentsByLandmark → innerText substring. Substring search drops to corroboration only; was the source of the 2026-04-29 under-detection.

## Out of scope (deferred to a follow-up)

These items came up in the same dogfood corpus and were excluded for this PR — most because the underlying failure was observed once and the spec change risks overfitting until a second site reproduces. Captured as the natural slice 2 of slice 2.

- Sitemap content-type validation + locale-prefix variants (UPS F2)
- Geo-IP locale-divergence detector + `T-locale-divergence` (NVIDIA F1)
- Signed-CDN URL handling + magic-byte extension (JFK F1)
- Brand-review tension catalog: `T-color-single-context` rename, `T-no-footer-landmark` / `T-no-main-landmark` / `T-hidden-h1`, `T-cta-vocab-large`, `T-geo-locator`, `T-mega-menu-bloat` + `componentsByLandmark` schema (NVIDIA F3-F7)
- Closed-list CTA filter for consent-UI labels in voice aggregation (NVIDIA F2 part 2)

## Files touched

- `skills/extract/SKILL.md` — Phase 2 capture summary, Phase 3 brand-surface, Phase 6 report, prep-mode synthesis prompt rules + summary, failure modes, inputs.
- `skills/extract/reference/playwright-recipe.md` — bot-management fallback, consent dismissal pre-flight, full-innerText rule, structured body/lists/qa/quotes capture, CSS-bg pseudo walk, logo locator rect+aspect filter, font network-intercept, icon-font detection, `ProvenanceMissing` failure class.
- `skills/extract/reference/current-state-schema.md` — `_provenance` additions (`renderedBy`, `fetchedAt`), structured section fields, Live-render evidence section.
- `skills/extract/reference/brand-surface.md` — `voice.heroImage`, `type.files[]`, `iconFont` section.
- `skills/stardust/reference/state-machine.md` — `validateProvenance()` helper contract, per-phase calling sites, surfacing rules.
- `skills/direct/SKILL.md` / `skills/prototype/SKILL.md` / `skills/migrate/SKILL.md` — provenance validator setup steps.
- `skills/prepare-migration/SKILL.md` — cascade-level provenance guard between Phase 1 and Phase 2.

## Test plan

These are spec changes consumed by the agent at runtime — there is no JS to compile or unit-test. Verification is per-site dogfood:

- [ ] Re-run `extract` against `ups.com/gb` — expect headed-Chrome fallback to engage, hero `cssBackgrounds[]` to capture the live hero, logo locator to pick the UPS shield not the promo icon.
- [ ] Re-run `extract` against `nvidia.com/en-us` — expect consent dismissal to fire (`consent.method: api:OneTrust.RejectAll`), screenshots clean, voice table free of cookie-modal CTAs.
- [ ] Re-run `extract` against `jfkairport.com` — expect woff2 files to land under `current/assets/fonts/`, icon-font detected (`iconFont.family: panynj-icons`).
- [ ] Re-run a long-form page extract (any policy / docs / annual-report page) — confirm `innerText` is captured in full and `sections[].body` populated.
- [ ] Attempt to manually edit a `pages/<slug>.json` to remove `_provenance.renderedBy` — confirm `direct --prep`, `prototype`, `migrate`, and `prepare-migration` all abort with the validator's structured error and recovery hint.
- [ ] Verify the per-page evidence table appears in the extract Phase 6 summary on a fresh run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)