### PR TITLE
feat: add AEM RDE skill to aem-cloud-service plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,13 +174,13 @@ The aem-replication skill contains four specialist sub-skills:
 - 12+ troubleshooting scenarios with step-by-step resolution
 - 3,575 lines of comprehensive documentation
 
-### AEM as a Cloud Service — Rapid Development Environment (RDE)
+### AEM as a Cloud Service — Rapid Development Environment (RDE) *(beta)*
 
-The `aem-rde` skill provides expert assistance for the Adobe I/O CLI plugin `@adobe/aio-cli-plugin-aem-rde` — used to deploy, inspect, log-tail, snapshot, and troubleshoot AEM Rapid Development Environments via `aio aem rde …` commands.
+The `aem-rde` skill provides expert assistance for the Adobe I/O CLI plugin `@adobe/aio-cli-plugin-aem-rde` — used to deploy, inspect, log-tail, snapshot, and troubleshoot AEM Rapid Development Environments via `aio aem rde …` commands. The skill activates only on explicit RDE references; generic AEMaaCS deployment requests are deferred to Cloud Manager skills.
 
 | Skill | Description |
 |-------|-------------|
-| `aem-rde` | Translate goals into the right `aio aem rde` commands (deploy, status, history, logs, inspect, snapshot, setup); diagnose RDE problems; guide setup, experimental feature flags, and CI/build-environment usage |
+| `aem-rde` *(beta)* | Translate goals into the right `aio aem rde` commands (deploy, status, history, logs, inspect, snapshot, setup); diagnose RDE problems; guide setup, experimental feature flags, and CI/build-environment usage |
 
 See `plugins/aem/cloud-service/skills/aem-rde/` for the skill and its reference files (commands, configuration, deployment types, troubleshooting, workflows).
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,16 @@ The aem-replication skill contains four specialist sub-skills:
 - 12+ troubleshooting scenarios with step-by-step resolution
 - 3,575 lines of comprehensive documentation
 
+### AEM as a Cloud Service — Rapid Development Environment (RDE)
+
+The `aem-rde` skill provides expert assistance for the Adobe I/O CLI plugin `@adobe/aio-cli-plugin-aem-rde` — used to deploy, inspect, log-tail, snapshot, and troubleshoot AEM Rapid Development Environments via `aio aem rde …` commands.
+
+| Skill | Description |
+|-------|-------------|
+| `aem-rde` | Translate goals into the right `aio aem rde` commands (deploy, status, history, logs, inspect, snapshot, setup); diagnose RDE problems; guide setup, experimental feature flags, and CI/build-environment usage |
+
+See `plugins/aem/cloud-service/skills/aem-rde/` for the skill and its reference files (commands, configuration, deployment types, troubleshooting, workflows).
+
 ### AEM as a Cloud Service — Best Practices & Migration
 
 Under `plugins/aem/cloud-service/skills/`, **`best-practices/`** is the **general-purpose** Cloud Service skill: pattern modules, Java baseline references (SCR→OSGi DS, resolver/logging, and related refs), and day-to-day Cloud Service alignment. Use it **without** loading **migration** for greenfield or maintainability work. **`migration/`** (BPA/CAM orchestration) is **scoped to legacy AEM → AEM as a Cloud Service** (not Edge Delivery or 6.5 LTS); it **delegates** concrete refactors to **`best-practices`** (`references/`). **Installing the AEM as a Cloud Service plugin** (`aem-cloud-service`, or the `plugins/aem/cloud-service` path with `npx skills` / `gh upskill`) **includes both**; the agent should load the appropriate `SKILL.md` for the task. Use **`gh upskill` / `npx skills` with `--skill`** when you need a specific bundled skill (see **Installation** above).

--- a/plugins/aem/cloud-service/.claude-plugin/plugin.json
+++ b/plugins/aem/cloud-service/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "aem-cloud-service",
-  "description": "All AEM as a Cloud Service skills: component development, Workflow model design, development, triggering, launchers, debugging, and triaging, plus Dispatcher config authoring, advisory, incident response, performance tuning, and security hardening.",
+  "description": "All AEM as a Cloud Service skills: component development, Workflow model design, development, triggering, launchers, debugging, and triaging, Dispatcher config authoring, advisory, incident response, performance tuning, and security hardening, plus Rapid Development Environment (RDE) deployment, log inspection, snapshots, and troubleshooting via `aio aem rde`.",
   "version": "1.0.0",
   "author": {
     "name": "Adobe"
   },
   "repository": "https://github.com/adobe/skills",
   "license": "Apache-2.0",
-  "keywords": ["aem", "aemaacs", "cloud-service", "dispatcher", "component", "workflow", "adobe"]
+  "keywords": ["aem", "aemaacs", "cloud-service", "dispatcher", "component", "workflow", "rde", "rapid-development-environment", "aio-cli", "adobe"]
 }

--- a/plugins/aem/cloud-service/skills/aem-rde/SKILL.md
+++ b/plugins/aem/cloud-service/skills/aem-rde/SKILL.md
@@ -1,12 +1,20 @@
 ---
 name: aem-rde
-description: "Expert assistance for the Adobe I/O CLI plugin `@adobe/aio-cli-plugin-aem-rde` — used to deploy, inspect, log-tail, snapshot, and troubleshoot AEM Rapid Development Environments via `aio aem rde …` commands. Use this skill whenever the user mentions AEM RDE, Rapid Development Environment, `aio aem rde`, `aio aem:rde`, deploying OSGi bundles or content packages to a cloud sandbox, dispatcher-config / frontend / env-config deployments, RDE snapshots, RDE logs/inspect, Cloud Manager program/environment configuration for an RDE, or anything that smells like working against an AEMaaCS RDE — even when they don't say 'RDE' explicitly (e.g. 'how do I push my bundle to the dev sandbox', 'tail the publish log on my AEM cloud env', 'reset my dev environment'). Also use it when looking at the `aio-cli-plugin-aem-rde` source or writing scripts/CI that wrap these commands."
+description: "[BETA] Expert assistance for the Adobe I/O CLI plugin `@adobe/aio-cli-plugin-aem-rde` — the `aio aem rde` / `aio aem:rde` command tree used to deploy, inspect, log-tail, snapshot, and troubleshoot AEM Rapid Development Environments (RDEs). Activate ONLY when the user explicitly references RDE concepts: 'AEM RDE', 'Rapid Development Environment', `aio aem rde`, `aio aem:rde`, `aem-rde`, RDE snapshots, RDE deploy/install, `rde install`, `rde inspect`, `rde status`, `rde history`, `rde reset`, the `@adobe/aio-cli-plugin-aem-rde` package, or Cloud Manager program/environment configuration that is specifically for an RDE environment. Do NOT activate on generic AEMaaCS phrases like 'deploy to AEM Cloud', 'push my bundle', 'tail the publish log', 'cloud sandbox', or unqualified 'dispatcher-config / frontend / env-config deployments' — those belong to Cloud Manager pipelines, not RDE. This skill is in beta. Verify all outputs before applying them to production projects."
+metadata:
+  status: beta
 license: Apache-2.0
 ---
+
+> **Beta Skill**: This skill is in beta and under active development.
+> Results should be reviewed carefully before use in production.
+> Report issues at https://github.com/adobe/skills/issues
 
 # AEM RDE Plugin (`aio aem rde`) Expert
 
 You help users work with the **Adobe I/O CLI plugin for AEM Rapid Development Environments** (`@adobe/aio-cli-plugin-aem-rde`). RDEs are short-lived AEMaaCS environments meant for fast iteration: they accept incremental deployments of bundles, configs, content, dispatcher, frontend, and env-config artifacts without going through Cloud Manager pipelines.
+
+**Activation discipline**: Only act on this skill when the user has explicitly referenced an RDE concept (RDE, Rapid Development Environment, `aio aem rde`, `@adobe/aio-cli-plugin-aem-rde`, RDE snapshots, etc.). Generic AEMaaCS deployment requests ("push my bundle to staging", "tail the publish log", "deploy to dispatcher") belong to Cloud Manager pipelines, **not** RDE — defer those to other AEMaaCS skills or ask the user to confirm they mean RDE before proceeding.
 
 Your job is to:
 

--- a/plugins/aem/cloud-service/skills/aem-rde/SKILL.md
+++ b/plugins/aem/cloud-service/skills/aem-rde/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: aem-rde
 description: "Expert assistance for the Adobe I/O CLI plugin `@adobe/aio-cli-plugin-aem-rde` — used to deploy, inspect, log-tail, snapshot, and troubleshoot AEM Rapid Development Environments via `aio aem rde …` commands. Use this skill whenever the user mentions AEM RDE, Rapid Development Environment, `aio aem rde`, `aio aem:rde`, deploying OSGi bundles or content packages to a cloud sandbox, dispatcher-config / frontend / env-config deployments, RDE snapshots, RDE logs/inspect, Cloud Manager program/environment configuration for an RDE, or anything that smells like working against an AEMaaCS RDE — even when they don't say 'RDE' explicitly (e.g. 'how do I push my bundle to the dev sandbox', 'tail the publish log on my AEM cloud env', 'reset my dev environment'). Also use it when looking at the `aio-cli-plugin-aem-rde` source or writing scripts/CI that wrap these commands."
-user-invocable: false
 license: Apache-2.0
 ---
 

--- a/plugins/aem/cloud-service/skills/aem-rde/SKILL.md
+++ b/plugins/aem/cloud-service/skills/aem-rde/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: aem-rde
+description: "Expert assistance for the Adobe I/O CLI plugin `@adobe/aio-cli-plugin-aem-rde` — used to deploy, inspect, log-tail, snapshot, and troubleshoot AEM Rapid Development Environments via `aio aem rde …` commands. Use this skill whenever the user mentions AEM RDE, Rapid Development Environment, `aio aem rde`, `aio aem:rde`, deploying OSGi bundles or content packages to a cloud sandbox, dispatcher-config / frontend / env-config deployments, RDE snapshots, RDE logs/inspect, Cloud Manager program/environment configuration for an RDE, or anything that smells like working against an AEMaaCS RDE — even when they don't say 'RDE' explicitly (e.g. 'how do I push my bundle to the dev sandbox', 'tail the publish log on my AEM cloud env', 'reset my dev environment'). Also use it when looking at the `aio-cli-plugin-aem-rde` source or writing scripts/CI that wrap these commands."
+user-invocable: false
+license: Apache-2.0
+---
+
+# AEM RDE Plugin (`aio aem rde`) Expert
+
+You help users work with the **Adobe I/O CLI plugin for AEM Rapid Development Environments** (`@adobe/aio-cli-plugin-aem-rde`). RDEs are short-lived AEMaaCS environments meant for fast iteration: they accept incremental deployments of bundles, configs, content, dispatcher, frontend, and env-config artifacts without going through Cloud Manager pipelines.
+
+Your job is to:
+
+1. Translate user goals into the right `aio aem rde` command(s) — including the right deployment **type**, **target** (author/publish), and any post-deploy step.
+2. Diagnose RDE problems by combining `status`, `history <id>`, `logs`, and `inspect` output.
+3. Guide setup/configuration (org/program/env), local vs. global config, experimental feature flags, and CI/build-environment usage.
+4. Walk users through snapshot create/restore/delete/undelete flows when they need to rebase or back up env state.
+
+Trust the user about what they want; don't run destructive commands (`reset`, `snapshot delete --all`, force-deletes) without confirming.
+
+## Plugin essentials
+
+- **Package**: `@adobe/aio-cli-plugin-aem-rde` (oclif plugin for `aio` / Adobe I/O CLI 10.3+ or 11+)
+- **Install**: `aio plugins:install @adobe/aio-cli-plugin-aem-rde`
+- **Update**: `aio plugins:update`
+- **Repo**: `https://github.com/adobe/aio-cli-plugin-aem-rde`
+- **Topics**:
+  - `aem:rde` — stable commands
+  - `aem:rde:inspect` — experimental, opt-in
+  - `aem:rde:snapshot` — experimental, opt-in
+- Both notations work and are equivalent: `aio aem rde …` and `aio aem:rde:…`.
+
+## Configuration model — get this right first
+
+Every RDE command needs three IDs from Cloud Manager:
+
+| Config key                       | Meaning            |
+|----------------------------------|--------------------|
+| `cloudmanager_orgid`             | IMS organization   |
+| `cloudmanager_programid`         | Cloud Manager program |
+| `cloudmanager_environmentid`     | RDE environment id |
+
+Two ways to set them:
+
+- **Interactive** (recommended for humans): `aio login` then `aio aem rde setup`. Walks the user through org → program → env pickers, optionally stores config locally in a `.aio` file in the current working directory.
+- **Scripted / CI** (build envs): `aio config:set cloudmanager_orgid <id>` etc. Strongly prefer the `-l` / `--local` flag so each project pins its own RDE; otherwise the global config bleeds across repos.
+
+`aio aem rde setup --show` prints the currently active config. `aio aem rde setup --enable-notifications` / `--disable-notifications` toggles desktop notifications for long-running tasks.
+
+When working with multiple RDEs, **always recommend local config** — see `references/configuration.md` for the storage hierarchy and a concrete multi-env recipe.
+
+## Experimental features — opt-in required
+
+`inspect` and `snapshot` topics are gated behind a config flag. Until enabled, the commands exist but won't run:
+
+```bash
+# enable inspect locally for this project
+aio config set -l -j aem-rde.experimental-features '["aem:rde:inspect"]'
+
+# enable both inspect and snapshot
+aio config set -l -j aem-rde.experimental-features '["aem:rde:inspect","aem:rde:snapshot"]'
+```
+
+Snapshot also requires the customer to be enrolled in the relevant EAP — the API answers `451 NON_EAP` otherwise.
+
+## Command surface (cheat sheet)
+
+Stable:
+
+| Command                              | One-liner                                                       |
+|--------------------------------------|-----------------------------------------------------------------|
+| `aio aem rde setup`                  | Interactive org/program/env picker                              |
+| `aio aem rde status`                 | Show env state + deployed artifacts (bundles/configs grouped by author/publish) |
+| `aio aem rde install <location>`     | Deploy a bundle/config/content/dispatcher/frontend/env-config artifact (URL or path) |
+| `aio aem rde delete <id>`            | Remove a bundle (BSN[-version]) or OSGi config (PID)            |
+| `aio aem rde history [id]`           | List recent updates; with `id`, drill into one update's logs    |
+| `aio aem rde logs`                   | Tail AEM logs with logger-level filters and highlight           |
+| `aio aem rde restart`                | Restart author + publish                                        |
+| `aio aem rde reset`                  | Reset env to base; long-running, can keep mutable content       |
+
+Experimental — `aem:rde:inspect:*`:
+
+| Command                                              | Purpose                                              |
+|------------------------------------------------------|------------------------------------------------------|
+| `aio aem rde inspect inventory [id]`                 | List or fetch an inventory (status info) entry       |
+| `aio aem rde inspect osgi-bundles [id]`              | List or fetch a single OSGi bundle                   |
+| `aio aem rde inspect osgi-components [name]`         | List or fetch an OSGi component                      |
+| `aio aem rde inspect osgi-configurations [pid]`      | List or fetch an OSGi configuration                  |
+| `aio aem rde inspect osgi-services [id]`             | List or fetch an OSGi service                        |
+| `aio aem rde inspect request-logs [id]`              | List request log entries / drill into one            |
+| `aio aem rde inspect request-logs enable`            | Turn on request logging (per-target)                 |
+| `aio aem rde inspect request-logs disable`           | Turn off request logging                             |
+
+Experimental — `aem:rde:snapshot:*`:
+
+| Command                                              | Purpose                                                       |
+|------------------------------------------------------|---------------------------------------------------------------|
+| `aio aem rde snapshot`                               | List snapshots (table sorted by Last Used)                    |
+| `aio aem rde snapshot create <name> [-d <desc>]`     | Create a content+deployment snapshot (locks RDE for 2–5 min)  |
+| `aio aem rde snapshot restore <name> [--only-mutable-content]` | Restore a snapshot; full restore restarts the RDE       |
+| `aio aem rde snapshot delete <name> [-f] [--all]`    | Mark a snapshot for deletion (7-day retention) or wipe it now |
+| `aio aem rde snapshot undelete <name>`               | Cancel a pending deletion                                     |
+
+Full args/flags for each command live in `references/commands.md`.
+
+## Common cross-cutting flags
+
+- `-s, --target <author|publish>` — restrict to one instance. `install`/`delete` deploy to **both** by default; `inspect`/`logs` default to `author`.
+- `--organizationId / --programId / --environmentId` — one-shot override of stored config (handy for ad-hoc scripts).
+- `-q, --quiet` — no log output, no prompts. Pair with `--json` for machine consumption.
+- `--json` — JSON result (not supported by `setup`, `logs`, `inspect:request-logs:enable/disable` — they declare `enableJsonFlag: false`).
+- `--no-color` — suitable for CI capture.
+
+## Deployment types — the install command's hardest decision
+
+`aio aem rde install <location>` accepts a local path **or** a public URL. The `--type` flag picks one of:
+
+```
+osgi-bundle | osgi-config | content-package | content-file | content-xml |
+dispatcher-config | frontend | env-config
+```
+
+If `--type` is omitted, the plugin guesses from the file extension and (for zips on disk) by peeking inside:
+
+| Input                                    | Guessed type           |
+|------------------------------------------|------------------------|
+| `*.jar`                                  | `osgi-bundle`          |
+| `*.json`                                 | `osgi-config`          |
+| zip containing `jcr_root/`               | `content-package`      |
+| zip containing `conf.dispatcher.d/`      | `dispatcher-config`    |
+| zip with `dist/` + `package.json`        | `frontend`             |
+| zip with any `*.yaml` entry              | `env-config`           |
+| `*.xml` with `--path`                    | `content-xml`          |
+| other file with `--path`                 | `content-file`         |
+
+For directories, only `frontend`, `dispatcher-config`, and `env-config` work — the plugin builds the zip on the fly. Other types fail with a clear message.
+
+For `content-file`/`content-xml`, `--path` is the JCR repository path. If the source path lives under `…/jcr_root/…`, the plugin will guess the path; otherwise pass it explicitly.
+
+`-r, --restart` issues a follow-up `restart`. Avoid this by default — RDEs accept hot deployment for almost everything; only use it when an OSGi or config change truly needs a full bounce.
+
+`-f, --force` is for unsticking the env when a previous upload was abandoned. Use sparingly.
+
+When the user describes an artifact, infer the type and target before suggesting a command — see `references/deployment-types.md` for type-by-type guidance and pitfalls.
+
+## Logs command — useful patterns
+
+`aio aem rde logs` opens a continuous tail until Ctrl-C. It creates an AEM log configuration on the server, polls it every 500 ms, and prints colorized output. Keep these in mind:
+
+- Pass per-level loggers as repeated flags: `-i org.foo -i org.bar -d com.adobe.aem`. Levels are `-t/--trace`, `-d/--debug`, `-i/--info`, `-w/--warn`, `-e/--error`.
+- If no logger is provided, the plugin defaults to `-i ""` (everything at INFO+).
+- `-H "<substring>"` highlights matching lines in white (repeatable).
+- `-f "<logback-pattern>"` overrides the format; default includes timestamp, level, thread, logger, message.
+- `--choose` — interactive picker over existing log configs (handy when another team member already enabled one).
+- `-s/--target` defaults to `author`; pass `publish` to tail the publish leg.
+- AEM allows only a small number of concurrent log configs per env; on `405` the plugin offers to remove an existing one.
+
+For triage workflows that combine `logs` with `status`/`history`, see `references/workflows.md`.
+
+## When something fails
+
+The plugin uses these exit codes (handy for CI):
+
+| Code | Meaning |
+|------|---------|
+| 1    | Generic / uncaught error |
+| 2    | Configuration error |
+| 3    | Validation error in flags or arguments |
+| 4    | Deployment error |
+| 5    | Internal error — retry may help |
+| 40   | Deployment-not-fully-performed (sometimes acceptable mid-pipeline) |
+
+Diagnostic playbook (in order):
+
+1. `aio aem rde setup --show` — confirm pointing at the right env.
+2. `aio aem rde status` — is the env even `Ready`? What's actually deployed?
+3. `aio aem rde history` — see the most recent update; grab the id of the failing one.
+4. `aio aem rde history <id>` — full per-instance log of that update.
+5. `aio aem rde logs -e "" -w ""` — tail errors+warnings for new symptoms.
+6. `aio aem rde inspect …` (if enabled) — read OSGi state to confirm bundles/components/configs are wired correctly.
+
+`references/troubleshooting.md` has detailed error → likely-cause → fix mappings, including the snapshot-specific error codes (`SNAPSHOT_NOT_FOUND`, `SNAPSHOT_LIMIT`, `INVALID_STATE`, `SNAPSHOT_CREATION_STUCK`, etc.) and the `NON_EAP` / `DIFFERENT_ENV_TYPE` configuration errors.
+
+## How to use this skill
+
+When the user asks something:
+
+- **"How do I deploy X?"** — Identify the artifact, pick the right `--type`, decide author/publish, suggest `install`. Point out `--restart` only if needed. Reference `deployment-types.md` only if the type choice is non-obvious.
+- **"My deploy failed."** — Walk the diagnostic playbook above. Look for the update id in the user's output and ask for `history <id>` if you don't have it.
+- **"I want to switch programs/envs."** — Suggest `aio aem rde setup` (or `aio logout` + `setup` if they're switching IMS orgs). Recommend `-l` storage if they juggle multiple RDEs.
+- **"I want a snapshot."** — Confirm the customer has the snapshot EAP enabled, then guide create/restore. Always describe expected duration (create ~3–8 min, restore ~7–15 min) so they don't kill the process.
+- **"Show me what's deployed."** — `aio aem rde status` first; `inspect osgi-bundles`/`osgi-components`/`osgi-configurations` for OSGi-level detail.
+- **"How do I script this in CI?"** — Recommend `aio config:set -l` for the three IDs, `--quiet --json` for commands, and warn against `setup` (it's interactive).
+
+If a question requires deep detail on a single command, read the matching reference file rather than guessing — descriptions, flags, and error codes drift between releases.
+
+## Reference files
+
+Read on demand:
+
+- `references/commands.md` — Per-command full args/flags/examples for all stable + experimental commands.
+- `references/configuration.md` — Config storage hierarchy, multi-RDE patterns, the `.aio` file, experimental-feature flags, notifications.
+- `references/deployment-types.md` — Detailed guidance on each `--type`, source-path conventions, `--path` handling for `content-file` / `content-xml`, type guessing rules, gotchas.
+- `references/workflows.md` — End-to-end recipes: first-time setup, deploy-and-verify, log triage, reset vs. restart vs. snapshot-restore, switching environments, CI usage.
+- `references/troubleshooting.md` — Error code → meaning → fix; snapshot/non-EAP errors; common deployment failures and recovery.

--- a/plugins/aem/cloud-service/skills/aem-rde/references/commands.md
+++ b/plugins/aem/cloud-service/skills/aem-rde/references/commands.md
@@ -1,0 +1,247 @@
+# `aio aem rde` — Per-command reference
+
+All commands inherit `--organizationId`, `--programId`, `--environmentId`, `--quiet`, and (where applicable) `--json` unless noted. Both `aio aem rde <cmd>` and `aio aem:rde:<cmd>` notations work.
+
+## Stable commands
+
+### `aio aem rde setup`
+
+Interactive setup for the three Cloud Manager IDs (org / program / environment). `enableJsonFlag: false` — does not produce JSON output. Always picks `rde`-typed environments only (filters others out). Asks if you want to store config locally (`.aio` file in current dir) or globally.
+
+| Flag | Description |
+|------|-------------|
+| `-s, --show` | Print current config and exit (no prompts). |
+| `-e, --enable-notifications` | Turn on desktop notifications for long tasks (snapshot, reset). Stored in global aio config. |
+| `-d, --disable-notifications` | Turn them off. |
+
+Internals:
+- Lists IMS organizations via `Ims.fromToken`. Single org auto-selected.
+- Lists programs and environments via Cloud Manager SDK; uses `inquirer-autocomplete-prompt` so the user can type to filter.
+- Persists `cloudmanager_orgid`, `cloudmanager_programid`, `cloudmanager_environmentid`, plus name fields `cloudmanager_programname` / `cloudmanager_environmentname`.
+
+### `aio aem rde status`
+
+Shows env state + a grouped listing of deployed artifacts.
+
+| Flag | Description |
+|------|-------------|
+| `--wait` | Block until env reports `Ready`, polling every 10s. Notifies on completion if notifications are enabled. |
+
+Output sections (each printed for both author and publish):
+- Bundles — `<bundleSymbolicName>-<bundleVersion>`
+- Configurations — `<configPid>`
+- (others depending on what's deployed)
+
+Throws `UNEXPECTED_API_ERROR` if status payload includes an error.
+
+### `aio aem rde install <location>`
+
+The deployment workhorse. Accepts a local path or a public URL (http/https) — automatically distinguishes:
+- Bare paths and `file://…` are treated as local files.
+- `http(s)://…` does a HEAD request to follow redirects and learn content-length.
+
+Argument:
+
+| Arg | Required | Description |
+|-----|----------|-------------|
+| `location` | yes | URL or filesystem path to the artifact (or directory for `frontend`/`dispatcher-config`/`env-config`). |
+
+Flags:
+
+| Flag | Description |
+|------|-------------|
+| `-t, --type` | One of `osgi-bundle`, `osgi-config`, `content-package`, `content-file`, `content-xml`, `dispatcher-config`, `frontend`, `env-config`. Auto-guessed if omitted. |
+| `-p, --path` | JCR repository path. Required for `content-file` and `content-xml` (auto-guessed if source path is under `…/jcr_root/…`). |
+| `-s, --target` | `author` or `publish`. Defaults to **both** when omitted (delivery to one, then the other). |
+| `-f, --force` | Force install — used when env is stuck on a previous upload. |
+| `-r, --restart` | Run `aio aem rde restart` after a successful deploy. Adds 2-5 minutes; rarely needed. |
+| `-q, --quiet` | Suppress progress bar / spinner output. |
+
+Type guessing rules (when `--type` omitted):
+
+| Source | Guessed |
+|--------|---------|
+| `*.jar` | `osgi-bundle` |
+| `*.json` | `osgi-config` |
+| Local zip with `jcr_root/` entry | `content-package` |
+| Local zip with `conf.dispatcher.d/` entry | `dispatcher-config` |
+| Local zip with `dist/` and `package.json` | `frontend` |
+| Local zip with any `*.yaml` | `env-config` |
+| Remote zip | one of `[content-package, dispatcher-config, frontend]` (will fail if ambiguous — pass `--type`) |
+| `*.xml` with `--path` | `content-xml` |
+| Other extension with `--path` | `content-file` |
+
+Directory inputs only work for `frontend`, `dispatcher-config`, and `env-config` — the plugin builds the zip via `frontendInputBuild` / `dispatcherInputBuild` / `configInputBuild`. A directory + any other type is rejected.
+
+After upload the plugin tracks the deployment via `loadUpdateHistory`, polling per-instance progress and writing them into the JSON result's `items` array. On failure throws `INTERNAL_INSTALL_ERROR` (exit 4 territory).
+
+### `aio aem rde delete <id>`
+
+Removes one or more bundles/configs by id.
+
+| Arg | Required | Description |
+|-----|----------|-------------|
+| `id` | yes | Bundle Symbolic Name (`com.example.foo`), BSN-version (`com.example.foo-1.0.0`), or OSGi config PID. |
+
+| Flag | Description |
+|------|-------------|
+| `-t, --type` | Restrict to `osgi-bundle` or `osgi-config`. Both checked if omitted. |
+| `-s, --target` | Restrict to one instance (default: both). |
+| `-f, --force` | Force the deletion. |
+| `-q, --quiet` | Quiet mode. |
+
+Behaviour: lists current artifacts via `loadAllArtifacts`, filters by id, deletes each match, then writes the per-update history into result. If no artifact matches, throws `DELETE_NOT_FOUND` with helpful context (which type, which target).
+
+### `aio aem rde history [id]`
+
+Without an id: lists all updates done to the env (status + summary).
+
+With an id: pulls the full per-instance install/delete progress for that update — same data shown live during `install`/`delete`. Validates the id is a non-negative integer (`INVALID_UPDATE_ID` otherwise).
+
+### `aio aem rde logs`
+
+Continuous log tail. Creates an AEM log configuration on the server, polls every 500 ms, prints colorized log lines until SIGINT. `enableJsonFlag: false`.
+
+| Flag | Description |
+|------|-------------|
+| `-f, --format` | Logback format string. Default: `%d{dd.MM.yyyy HH:mm:ss.SSS} *%level* [%thread] %logger %msg%n` |
+| `-t, --trace <logger>` | Add logger at TRACE level. Repeatable. |
+| `-d, --debug <logger>` | Add logger at DEBUG level. Repeatable. |
+| `-i, --info <logger>` | Add logger at INFO level. Repeatable. Default `-i ""` if no level flags given. |
+| `-w, --warn <logger>` | Add logger at WARN level. Repeatable. |
+| `-e, --error <logger>` | Add logger at ERROR level. Repeatable. |
+| `--color / --no-color` | Colorize output by level (TRACE gray, DEBUG cyan, INFO green, WARN yellow, ERROR red). |
+| `--choose` | Interactive picker over existing log configurations. |
+| `-H, --highlight <substr>` | Print matching lines in white. Repeatable. |
+| `-s, --target` | `author` (default) or `publish`. |
+
+Behavior notes:
+- AEM permits a small number of concurrent log configs per env; on `405` the plugin prompts to remove an existing one.
+- A small per-line delay (≈ `500ms / linecount`) makes the tail feel fluid.
+- SIGINT/SIGTERM both stop and clean up the server-side log config.
+- 404 means the configuration was removed remotely (e.g. by another user creating a new one) — the plugin stops gracefully.
+
+### `aio aem rde restart`
+
+Restarts both author and publish. No flags beyond the common ones. Triggers a "restarted" desktop notification if enabled.
+
+### `aio aem rde reset`
+
+Long-running env reset.
+
+| Flag | Description |
+|------|-------------|
+| `--keep-mutable-content` | Reset code/config but preserve content. |
+| `-f, --force` | Don't reuse a cached base repo — slower but recovers from broken state. |
+| `--wait / --no-wait` | Default `--wait`. Without it, the API call returns once the reset is queued. |
+
+Reset is destructive: it wipes all deployed artifacts. Always confirm with the user before running.
+
+## Experimental commands — `aem:rde:inspect:*`
+
+Enable with:
+```bash
+aio config set -l -j aem-rde.experimental-features '["aem:rde:inspect"]'
+```
+
+All inspect subcommands accept `--target` (defaults to `author`) and `--include` for a substring filter on the listing.
+
+### `aio aem rde inspect inventory [id]`
+
+Lists framework inventory items (table with `format` and `id` columns). With an id, fetches one item.
+
+### `aio aem rde inspect osgi-bundles [id]`
+
+OSGi bundle listing on the chosen target. With an id (BSN), prints the full bundle details.
+
+### `aio aem rde inspect osgi-components [name]`
+
+OSGi DS components.
+
+### `aio aem rde inspect osgi-configurations [pid]`
+
+OSGi configurations as managed by Configuration Admin.
+
+### `aio aem rde inspect osgi-services [id]`
+
+Registered OSGi services (numeric service id).
+
+### `aio aem rde inspect request-logs [id]`
+
+Lists request log entries on the chosen target. With an id, fetches one entry. Request logging must be enabled first.
+
+### `aio aem rde inspect request-logs enable`
+
+Turns on request logging (`enableJsonFlag: false`). Pass logger config like the `logs` command (`-i`, `-d`, etc.) and an optional `-f` format.
+
+### `aio aem rde inspect request-logs disable`
+
+Turns it off. `enableJsonFlag: false`.
+
+## Experimental commands — `aem:rde:snapshot:*`
+
+Enable with:
+```bash
+aio config set -l -j aem-rde.experimental-features '["aem:rde:snapshot"]'
+```
+
+Snapshot APIs additionally require the customer to be enrolled in the snapshot EAP — the API returns `451` (`NON_EAP`) otherwise.
+
+### `aio aem rde snapshot`
+
+List snapshots in a table sorted by `Last Used` (descending by default). Columns: name, description, usage, size, state, created, lastUsed.
+
+| Flag | Description |
+|------|-------------|
+| `-s, --sort` | Sort key; prefix `-` for reverse. Default `-Last Used`. |
+
+### `aio aem rde snapshot create <name> [-d <description>]`
+
+Locks the RDE while a content+deployment snapshot is taken, then unlocks.
+
+| Arg | Description |
+|-----|-------------|
+| `name` | Required. Must be unique within the env. |
+
+| Flag | Description |
+|------|-------------|
+| `-d, --description` | Free-text description shown in `snapshot` listing. |
+
+Phases (with progress spinners):
+1. **Requesting** — submit job (<1m).
+2. **Waiting for backend** — backend picks up the action.
+3. **Locking & creating** — RDE is locked, snapshot taken (2-5m).
+4. **Unlocking** — RDE returns to `Ready` (1-2m).
+
+If the progress percentage doesn't advance for 15 minutes the plugin throws `SNAPSHOT_CREATION_STUCK`. Other failures: `ALREADY_EXISTS` (409), `INVALID_STATE` (503), `SNAPSHOT_LIMIT` (507).
+
+### `aio aem rde snapshot restore <name>`
+
+Replaces RDE state with the snapshot. Restarts the env after restore.
+
+| Arg | Description |
+|-----|-------------|
+| `name` | Required. |
+
+| Flag | Description |
+|------|-------------|
+| `--only-mutable-content` | Only restore mutable content (no deployment rollback). Faster, no restart. |
+
+Phases: requesting → backend pickup → restoring (2-5m) → restart (5-10m). Errors include `SNAPSHOT_NOT_FOUND` (404 with that detail), `SNAPSHOT_DELETED` (404 with deleted detail), `INVALID_STATE` (406), `DEPLOYMENT_IN_PROGRESS` (503).
+
+### `aio aem rde snapshot delete <name>`
+
+Marks a snapshot for deletion (7-day retention by default). With `--all`, deletes every snapshot in the env (concurrently). With `-f, --force`, wipes immediately rather than soft-deleting.
+
+| Arg | Description |
+|-----|-------------|
+| `name` | Required unless `--all` is set. |
+
+| Flag | Description |
+|------|-------------|
+| `-a, --all` | Mark every snapshot for deletion. |
+| `-f, --force` | Force-delete (no retention period). Snapshot must already be in `removed` state — otherwise throws `SNAPSHOT_WRONG_STATE`. |
+
+### `aio aem rde snapshot undelete <name>`
+
+Cancels a pending deletion. Errors: `SNAPSHOT_NOT_FOUND` (404 with that detail), `SNAPSHOT_LIMIT` (507) if undeleting would push you past the snapshot quota.

--- a/plugins/aem/cloud-service/skills/aem-rde/references/configuration.md
+++ b/plugins/aem/cloud-service/skills/aem-rde/references/configuration.md
@@ -1,0 +1,147 @@
+# Configuration & multi-environment patterns
+
+## The three Cloud Manager IDs
+
+Every RDE command reads three keys from `aio` config:
+
+| Key | What it identifies |
+|-----|--------------------|
+| `cloudmanager_orgid` | IMS organization (`<id>@AdobeOrg`) |
+| `cloudmanager_programid` | Cloud Manager program |
+| `cloudmanager_environmentid` | The actual RDE environment within the program |
+
+Two helper keys are also written by `setup` and used in human-readable output:
+
+| Key | Purpose |
+|-----|---------|
+| `cloudmanager_programname` | Program display name |
+| `cloudmanager_environmentname` | Environment display name |
+
+Plus one notification toggle:
+
+| Key | Purpose |
+|-----|---------|
+| `rde_enableNotifications` | When `true`, long-running tasks emit desktop notifications. |
+
+## Storage hierarchy
+
+`aio-lib-core-config` (used by all `aio config:*` commands) reads in priority order:
+
+1. **Environment variables** — `AIO_<KEY>` overrides everything (e.g. `AIO_CLOUDMANAGER_ORGID`). Useful for one-off CI overrides.
+2. **Local file** — `.aio` in the current working directory or any ancestor. **Strongly recommended** when you have more than one RDE.
+3. **Global file** — `~/.config/aio/config.json` (or platform equivalent). Used when there's no local config.
+
+Use `-l, --local` with `aio config:set` / `aio config:delete` to write to the local `.aio` file. Without that flag the command writes globally.
+
+```bash
+# Pin this repo to a specific RDE
+aio config:set -l cloudmanager_orgid 1234@AdobeOrg
+aio config:set -l cloudmanager_programid 12345
+aio config:set -l cloudmanager_environmentid 67890
+```
+
+`aio aem rde setup` always asks "Do you want to store the information you enter in this setup procedure locally?" — answering yes writes to `.aio`.
+
+## Working with multiple RDEs
+
+The clean pattern is **one `.aio` file per project**:
+
+```
+~/Dev/
+├── customer-a/
+│   ├── .aio          # pins to customer A's RDE
+│   └── …
+└── customer-b/
+    ├── .aio          # pins to customer B's RDE
+    └── …
+```
+
+When running RDE commands, `cd` into the right project — config resolution starts from your CWD, walking upward.
+
+If you actually want one RDE for everything, use the global config (no `-l`). The setup wizard guards against confusion: when the last RDE command was more than 24h ago, it asks "Do you want to continue running the command on `cm-pXXXX-eYYYY`?" before proceeding.
+
+## Switching IMS organizations
+
+The token cached by `aio login` is org-bound. To move between orgs:
+
+```bash
+aio logout
+aio login
+aio aem rde setup
+```
+
+There's no shortcut — `setup` only enumerates organizations the current token is valid for.
+
+## Experimental feature flags
+
+`inspect` and `snapshot` topics ship in the plugin but stay hidden until enabled via `aem-rde.experimental-features`. The init hook (`src/lib/hooks/experimental-features-init-hook.js`) reads this list and registers/unregisters those topics at oclif boot time.
+
+Enable per-project:
+
+```bash
+# inspect only
+aio config set -l -j aem-rde.experimental-features '["aem:rde:inspect"]'
+
+# both inspect and snapshot
+aio config set -l -j aem-rde.experimental-features '["aem:rde:inspect","aem:rde:snapshot"]'
+```
+
+Note `-j` for JSON parsing of the array.
+
+To disable: overwrite with `'[]'` or delete the key (`aio config:delete aem-rde.experimental-features`).
+
+## Notifications
+
+Desktop notifications via `node-notifier` fire for slow operations (snapshot create/restore, env reset, status `--wait`). Toggle with:
+
+```bash
+aio aem rde setup --enable-notifications
+aio aem rde setup --disable-notifications
+```
+
+These write to global aio config, not local — they're a per-user preference.
+
+## Inspect the active config
+
+`aio aem rde setup --show` prints something like:
+
+```
+Current configuration: cm-p12345-e67890: My Program - dev-rde-01 (organization: 1234@AdobeOrg)
+```
+
+`aio config:get cloudmanager_orgid` (etc.) reads individual keys; `aio config:list` dumps everything resolved (local merged over global).
+
+## CI / build environments
+
+For non-interactive use (build pipelines, GitHub Actions, etc.):
+
+1. Authenticate via JWT or OAuth Server-to-Server credentials, **not** the interactive `aio login`. Configure an IMS context with a service-account credential and set `AIO_RUNTIME_AUTH` / `aio config set ims.contexts.<name>.…` accordingly.
+2. Set the three Cloud Manager IDs:
+   ```bash
+   aio config:set -l cloudmanager_orgid "$ORG_ID"
+   aio config:set -l cloudmanager_programid "$PROGRAM_ID"
+   aio config:set -l cloudmanager_environmentid "$ENV_ID"
+   ```
+3. Always pass `--quiet --json` to RDE commands so output is parseable and prompts are skipped.
+4. Avoid `setup` (it's interactive) and `logs` / inspect's `request-logs:enable` / `request-logs:disable` (they intentionally don't support `--json`).
+5. Honour the exit codes: `1`/`5` retryable, `2`/`3` config/validation (don't retry), `4`/`40` deployment (depends on the step).
+
+## Where the config actually lives
+
+If something looks "stuck" on the wrong env, check:
+
+```bash
+# Which file is currently winning?
+aio config:list
+
+# Local file, if any:
+cat .aio          # Project-pinned
+cat ~/.config/aio/config.json   # Global (path varies by OS)
+
+# Drop a stale local config:
+aio config:delete -l cloudmanager_orgid
+aio config:delete -l cloudmanager_programid
+aio config:delete -l cloudmanager_environmentid
+```
+
+The `.aio` file is JSON-ish (YAML-compatible). Editing it by hand is fine for emergencies.

--- a/plugins/aem/cloud-service/skills/aem-rde/references/configuration.md
+++ b/plugins/aem/cloud-service/skills/aem-rde/references/configuration.md
@@ -44,6 +44,8 @@ aio config:set -l cloudmanager_environmentid 67890
 
 ## Working with multiple RDEs
 
+> **Single-user constraint:** Per Adobe's official AEM documentation, ideally only one developer should use a given RDE at a time. Concurrent deployments from multiple developers race against each other and produce confusing state. For team workflows, give each developer their own RDE rather than sharing.
+
 The clean pattern is **one `.aio` file per project**:
 
 ```

--- a/plugins/aem/cloud-service/skills/aem-rde/references/deployment-types.md
+++ b/plugins/aem/cloud-service/skills/aem-rde/references/deployment-types.md
@@ -1,0 +1,145 @@
+# Deployment types — what `aio aem rde install` can ship
+
+`aio aem rde install` accepts a single artifact, of one of eight types, deployed to one or both AEM instances. This file catalogues each type, when to use it, and the gotchas.
+
+The full list (also available in `aio aem rde install --help`):
+
+```
+osgi-bundle | osgi-config | content-package | content-file | content-xml |
+dispatcher-config | frontend | env-config
+```
+
+When `--type` is omitted, the plugin guesses. See the table in `commands.md` for guess rules. The rest of this file goes deeper on each type.
+
+## `osgi-bundle`
+
+A standard OSGi `.jar`.
+
+- Source: `**/target/*.jar` from a Maven OSGi-bundle module.
+- Target: usually both author and publish (default). For instance-specific bundles, use `--target author` or `--target publish`.
+- Identification: bundle symbolic name (BSN). `aio aem rde delete <bsn>` removes it.
+- After install, use `aio aem rde inspect osgi-bundles` (if enabled) to confirm `Active` state.
+
+Pitfalls:
+- A bundle that fails to resolve sticks around as `Installed`/`Resolved`. Check the failed update via `history <id>` and look at the bundle in `inspect osgi-bundles`.
+- Restart only if the bundle has special activation needs (`@Activate` work that is fragile to refresh, native libs, etc.). Day-to-day bundle iteration is hot-reloadable.
+
+## `osgi-config`
+
+JSON-formatted OSGi configuration consumed via Configuration Admin. Filename **becomes** the config PID — there's no separate `--path` flag.
+
+- Source: `*.json` matching the OSGi config naming convention (e.g. `com.example.MyService.json` or `com.example.MyFactory~instance.json`).
+- Target: same as bundle.
+- Identification: PID = filename without `.json`. `aio aem rde delete <pid>` removes it.
+
+Pitfalls:
+- Filename matters. The plugin sends the filename as the config PID; renaming the file rewrites a different config.
+- Use `aio aem rde inspect osgi-configurations` to verify.
+
+## `content-package`
+
+A "regular" AEM content package zip with `jcr_root/` and `META-INF/vault/`.
+
+- Source: `*.zip` produced by `content-package-maven-plugin` / FileVault.
+- Detection: zip with a `jcr_root/` entry.
+- Target: typically both, but `--target author` lets you push author-only packages.
+- Larger packages: the upload is chunked and the progress bar shows KB transferred.
+
+Pitfalls:
+- Workflow-bearing packages may need a follow-up `--restart` if they replace OSGi bundles bundled inside the package.
+- For very large packages prefer creating a snapshot first so you can `restore` if it breaks state.
+- Known regression (SKYOPS-140701, affects RDEs with the buggy base image): install reports `deploy completed` but JCR content never lands. Symptom is silent — bundles in the same deploy still apply, only the content-package extraction is a no-op. Verify by hitting `/content/<site>.json` (404) or by looking for `LoginException … RDEProviderRepositoryAccess.handleContentPackages` in `aio aem rde logs -e ""`. See `troubleshooting.md` → "Content-package install reports success but JCR content never appears" for the workaround OSGi config.
+
+## `content-file`
+
+A single binary content file deployed under a specific JCR path. **Requires `--path`**.
+
+- Source: any non-zip / non-xml file (image, PDF, etc.).
+- `--path`: the full JCR path the file should land at, e.g. `/content/dam/example/foo.png`.
+- Auto-guess: if the source path is under `…/jcr_root/…`, the plugin derives `--path` from the substring after `jcr_root/`.
+
+Pitfalls:
+- Without `--path` and without a `jcr_root/` ancestor, the install throws `MISSING_CONTENT_PATH`.
+- Targets are still author/publish — if you only need it on author, pass `--target author`.
+
+## `content-xml`
+
+A single FileVault XML descriptor (`*.xml`, often `.content.xml`). Same `--path` semantics as `content-file`.
+
+- For a `.content.xml`, the auto-guessed path strips the `.content.xml` suffix (the file describes its parent node).
+- For other XML files, the path strips just `.xml`.
+
+Pitfalls:
+- Hand-crafted XML with non-canonical structure may be rejected by JCR — validate with FileVault first.
+- Best for surgical edits; for bigger changes, a content-package is more honest.
+
+## `dispatcher-config`
+
+Apache HTTPD + Dispatcher configuration tree. Shipped as a directory or zip; the directory form is built into a zip on the fly via `dispatcherInputBuild`.
+
+- Source: a directory containing `conf.dispatcher.d/`, or a zip with the same.
+- Detection (zip): zip has `conf.dispatcher.d/`.
+- Target: only `publish` makes sense for a dispatcher config — but `install` defaults to "both". The dispatcher tier handles it correctly; ignore the author "deploy" message unless something looks off.
+
+Pitfalls:
+- Dispatcher validation may surface errors that block the env. Run the [Adobe Dispatcher Validator](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/implementing/content-delivery/disp-overview) locally before deploying.
+- After dispatcher changes, `aio aem rde inspect request-logs` (if enabled) is a good way to verify rules are matching as expected.
+
+## `frontend`
+
+A frontend bundle for AEM's client-side asset pipeline.
+
+- Source: directory with `package.json` and a built `dist/` folder, or a zip with the same.
+- Detection (zip): zip contains both `dist/` and `package.json`.
+- Build step: `frontendInputBuild` zips the directory before upload.
+- Target: usually both.
+
+Pitfalls:
+- Don't include `node_modules` — `frontendInputBuild` zips the whole tree it's given. Build first, then point `install` at the build output's parent.
+- For SPAs/CSM the same artifact works; just respect the AEM frontend conventions.
+
+## `env-config`
+
+Cloud Manager environment-level config (variables, secrets references, log forwarding, etc.) packaged as YAML.
+
+- Source: directory containing one or more `*.yaml`, or a zip with `*.yaml` entries.
+- Detection (zip): any entry ending in `.yaml`.
+- Build step: `configInputBuild` zips the directory before upload.
+
+Pitfalls:
+- Order of reload is async — give the env a few seconds before re-reading the affected setting.
+- env-config is the only way to manage variables on RDEs without going through Cloud Manager UI; respect existing values to avoid stomping on teammates' settings.
+
+## Targeting (`--target`)
+
+| Type | Sensible default | Notes |
+|------|------------------|-------|
+| `osgi-bundle` | both | Bundle target depends on the code. |
+| `osgi-config` | both | Same. |
+| `content-package` | both, or `author` | Mostly author, but query indexes may need both. |
+| `content-file` | both, or `author` | Author for editorial content. |
+| `content-xml` | as above | |
+| `dispatcher-config` | both (plugin handles it) | Logically publish-only. |
+| `frontend` | both | |
+| `env-config` | both | Targeting flag is accepted but env-config is global to the env. |
+
+## Type-guessing failures
+
+The plugin throws `INVALID_GUESS_TYPE` when it can't narrow the choice to one. Fix by passing `--type` explicitly. Common cases:
+
+- A remote zip URL — the plugin can't peek inside before download. Pass `--type`.
+- Unknown extension — pass `--type` *and* `--path` if it's content-file/content-xml.
+- A `.zip` that fits multiple shapes (e.g. a content package that also has a stray `dist/` folder) — pass `--type`.
+
+## Source-path handling
+
+For URLs:
+- HEAD request to compute size and follow redirects (`computeStats`).
+- Effective URL is used for the upload; original URL is used for type guessing if the redirect dropped the extension.
+
+For local files:
+- `file://` prefix is stripped automatically.
+- `realpathSync` resolves symlinks.
+
+For directories:
+- Allowed only for `frontend`, `dispatcher-config`, `env-config`. The plugin packages them inline. Other types throw a clear error.

--- a/plugins/aem/cloud-service/skills/aem-rde/references/troubleshooting.md
+++ b/plugins/aem/cloud-service/skills/aem-rde/references/troubleshooting.md
@@ -1,0 +1,177 @@
+# Troubleshooting reference
+
+Map of error → likely cause → fix, plus exit-code semantics.
+
+## Exit codes
+
+The plugin sets these via the oclif error system:
+
+| Code | Meaning | What to do |
+|------|---------|-----------|
+| 1 | Generic / uncaught | Look at stderr; usually wraps a deeper error. |
+| 2 | Configuration | Org / program / env not set, IMS context missing. Run `aio aem rde setup --show`. |
+| 3 | Validation | Bad flag / argument. Re-read the relevant `--help`. |
+| 4 | Deployment | Install/delete failed server-side. Check `history <id>`. |
+| 5 | Internal (retryable) | Transient — retry once or twice before digging deeper. |
+| 40 | Deployment-not-fully-performed | Sometimes acceptable mid-pipeline (some steps OK, later step deferred). Inspect history. |
+
+In CI, distinguish 5 (retry) from 4 (don't retry the same artifact, fix the build).
+
+## Configuration errors
+
+### "Missing org/program/environment"
+
+Symptom: `MISSING_ORG_ID`, `MISSING_PROGRAM_ID`, `MISSING_ENVIRONMENT_ID`.
+Cause: `cloudmanager_*` config keys not set, or you're in a directory whose `.aio` is empty.
+Fix: `aio aem rde setup` (or set the keys with `aio config:set -l`).
+
+### "No IMS context found. Please run `aio login` first."
+
+Cause: token expired or never created.
+Fix: `aio login` (browser flow) or, in CI, configure a service-account context.
+
+### "The last RDE command ran more than 24h ago, do you want to continue running the command on cm-pXXXX-eYYYY?"
+
+This is an interactive guard, not an error. It prevents accidental deploys against a stale config. Answer yes if the env is correct; otherwise rerun `setup`.
+
+## Snapshot-specific errors
+
+| Error code | HTTP | Meaning | Fix |
+|------------|------|---------|-----|
+| `NON_EAP` | 451 | Snapshot EAP not enabled for this customer | Contact account team / Adobe TAM. |
+| `DIFFERENT_ENV_TYPE` | 400 | Target is not an RDE | Re-run `setup`, pick an actual RDE. |
+| `PROGRAM_OR_ENVIRONMENT_NOT_FOUND` | 404 | Program/env IDs are wrong | `setup --show`, verify with Cloud Manager UI. |
+| `SNAPSHOT_NOT_FOUND` | 404 | Snapshot name doesn't exist | `aio aem rde snapshot` to list names. Watch for typos / case. |
+| `SNAPSHOT_DELETED` | 404 | Snapshot is in deleted state | `undelete` first, or pick a different snapshot. |
+| `ALREADY_EXISTS` | 409 | Name collision | Pick a different name; snapshot names must be unique within env. |
+| `INVALID_STATE` | 503 / 406 | Env busy or snapshot is mid-operation | Wait, check `status`. |
+| `SNAPSHOT_LIMIT` | 507 | Quota reached | Delete an old snapshot first. |
+| `SNAPSHOT_CREATION_FAILED` | (progress = -2) | Backend failed during create | Check logs around the time; re-run create. |
+| `SNAPSHOT_CREATION_STUCK` | (no progress 15m) | Backend stalled | If stuck >1h, contact support; otherwise let it finish on its own and check `snapshot` listing later. |
+| `SNAPSHOT_RESTORE_FAILED` | (progress = -2) | Backend failed during restore | Check `history`; consider `reset --force`. |
+| `SNAPSHOT_WRONG_STATE` | 403 | Tried `delete --force` on a not-yet-removed snapshot | First soft-delete (`snapshot delete <name>`), then `--force` once it's in `removed`. |
+| `DEPLOYMENT_IN_PROGRESS` | 503 | Another deploy is running | Wait, check `aio aem rde status` and `history`. |
+
+## Install / delete errors
+
+### `INVALID_GUESS_TYPE`
+
+The plugin couldn't narrow `--type` to a single option. Usually a remote zip URL or an unusual file. Fix: pass `--type` explicitly. See `deployment-types.md` for the guess table.
+
+### `MISSING_CONTENT_PATH`
+
+For `content-file` / `content-xml`, no `--path` flag and the source isn't under `…/jcr_root/…`. Fix: pass `--path /path/in/jcr`.
+
+### `UNSUPPORTED_PROTOCOL`
+
+The location URL has a protocol other than `http`, `https`, or `file`. Fix: use one of the supported schemes.
+
+### `DELETE_NOT_FOUND`
+
+`aio aem rde delete <id>` matched nothing. The error message includes the type and target it searched. Fix: confirm BSN / PID via `aio aem rde status` or `aio aem rde inspect osgi-bundles` / `osgi-configurations`. BSN is case-sensitive.
+
+### `INTERNAL_INSTALL_ERROR`
+
+Generic wrapper around an upload/deploy failure. Use `aio aem rde history` to find the update id, then `history <id>` to see per-instance progress and which step failed.
+
+### Content-package install reports success but JCR content never appears
+
+Symptom: `aio aem rde install <ui.content.zip>` (or any container/all package) returns `deploy completed for content-package …`, `aio aem rde history` shows the update as completed with `No logs available`, but the targeted JCR paths (e.g. `/content/<site>`, `/conf/<site>`, `/apps/<site>`) all return 404 on author. OSGi bundles in the same deploy *do* land — only content-package extraction is a silent no-op.
+
+Cause: a regression in the AEM RDE base image — `com.adobe.granite.rde.provider.runtime` is not in the platform's `LoginAdminAllowList`, so `RDEProviderRepositoryAccess.handleContentPackages` aborts when it tries to open an admin session. The HTTP install API still returns success because the file uploaded fine; the failure happens in the async post-upload importer. Tracked as **SKYOPS-140701** (broken since CQ/quickstart PR #42307 — the property names in `src/main/features/docker/base/rde-runtime.json` were left as the legacy `whitelist.*` after the PID rename to `LoginAdminAllowList.fragment`).
+
+Confirm via `aio aem rde logs -e ""`:
+
+```
+*ERROR* com.adobe.granite.repository.impl.SlingRepositoryImpl Bundle
+com.adobe.granite.rde.provider.runtime is NOT allow listed to use
+SlingRepository.loginAdministrative
+javax.jcr.LoginException
+  at RDEProviderRepositoryAccess.handleContentPackages
+```
+
+Workaround until the platform fix ships — deploy this OSGi config once per affected RDE:
+
+`org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment~rdeprovider.cfg.json`
+```json
+{
+  "whitelist.name": "rde-provider-runtime",
+  "whitelist.bundles": ["com.adobe.granite.rde.provider.runtime"]
+}
+```
+
+```
+aio aem rde install --type osgi-config \
+  org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment~rdeprovider.cfg.json
+```
+
+Notes:
+- Filename is the factory PID — the `.fragment` (with a leading dot) form is what the platform actually consults. The `LoginAdminWhitelistFragment` (camelCase, no dot) form is registered but inert; don't use it.
+- After this lands, redeploy any content-packages that "succeeded" earlier — those previous deploys really were no-ops, the JCR is still empty.
+- Once SKYOPS-140701 is fixed in the base image and your RDE is re-provisioned (`aio aem rde reset` or naturally over time), this fragment becomes redundant. It's safe to leave in place — it's additive to the platform allow-list.
+- Symptoms similar but not the same: a content-package whose filter targets restricted paths (e.g. `/libs`) gets entries skipped — that's expected, not the SKYOPS-140701 bug. Distinguish by the `LoginException` in the logs.
+
+## Bundle-specific gotchas
+
+A bundle that uploaded fine but isn't doing anything is usually one of:
+
+1. **Resolved but not Active** — missing capabilities. `aio aem rde inspect osgi-bundles <bsn>` and read the wires/missing imports. Likely cause: a transitive dep wasn't included.
+2. **Active but components Unsatisfied** — DS reference can't bind. `aio aem rde inspect osgi-components` looks for `unsatisfiedReferences` entries.
+3. **Active, components Satisfied, but Configuration is wrong** — `aio aem rde inspect osgi-configurations` to see what Configuration Admin actually has.
+
+## Logs command issues
+
+### "405 — too many active log configurations"
+
+AEM caps concurrent log configs per env. The plugin offers to remove an existing one. Accept, then retry. To pick one without removing it, use `--choose`.
+
+### Log output stops mid-tail
+
+The server-side log config got removed (someone else's `logs` command, or env restart). The plugin prints "Log configuration not found any longer …" and exits. Just rerun.
+
+### Colors not rendering
+
+Either you piped the output (in which case pass `--no-color` for clean text) or your terminal doesn't support 256-color escape codes. The default colors are: TRACE gray, DEBUG cyan, INFO green, WARN yellow, ERROR red.
+
+## Reset / restart issues
+
+### Reset hangs
+
+`reset` takes 10-20 minutes. Don't kill it. Use `aio aem rde status --wait` in a separate shell to watch progress.
+
+### Reset fails
+
+Try `reset --force` to bypass the cached base repository. If that also fails, the env may need support intervention — file a ticket with the program and env IDs.
+
+### Restart doesn't bring the bundle back
+
+If the bundle was the one causing the env to be unhealthy, the restart preserves it. Try `delete <bsn>` first, then `restart`, then redeploy.
+
+## "Did I get logged out?" checklist
+
+If commands suddenly throw auth errors:
+
+```bash
+aio config:list ims                         # show contexts
+aio context:current 2>/dev/null || echo "no current ctx"
+aio auth:login                              # re-auth
+aio aem rde setup --show                    # confirm
+```
+
+For service-account / JWT contexts in CI, re-run the credential setup that initially populated `ims.contexts.<name>`.
+
+## When you don't know which command will help
+
+Run these in order — each is fast and cheap:
+
+```bash
+aio aem rde setup --show       # are we even pointed at the right RDE?
+aio aem rde status             # is the env Ready and what's deployed?
+aio aem rde history            # what just happened?
+```
+
+Then:
+
+- For "what's wrong inside AEM": `inspect osgi-bundles`, `inspect osgi-components`, `inspect osgi-configurations`.
+- For runtime symptoms: `logs` with `-e "" -w ""`.
+- For "I made it worse": `snapshot restore <name>` if you took one beforehand, else `reset --keep-mutable-content`.

--- a/plugins/aem/cloud-service/skills/aem-rde/references/workflows.md
+++ b/plugins/aem/cloud-service/skills/aem-rde/references/workflows.md
@@ -1,0 +1,238 @@
+# Common workflows
+
+End-to-end recipes for the things people actually do with `aio aem rde`.
+
+## First-time setup on a new machine
+
+```bash
+# 1. Install the AIO CLI
+npm install -g @adobe/aio-cli
+
+# 2. Add the RDE plugin
+aio plugins:install @adobe/aio-cli-plugin-aem-rde
+
+# 3. Authenticate
+aio login
+
+# 4. Pick org / program / RDE
+aio aem rde setup
+# When asked "Do you want to store … locally?" answer Yes if you'll
+# work with multiple RDEs from different directories.
+
+# 5. Verify
+aio aem rde setup --show
+aio aem rde status
+```
+
+If `setup` doesn't list your program, the IMS user lacks Cloud Manager Developer/Deployment-Manager role for it, or there are no RDE-typed environments in that program.
+
+## Pin a project to its own RDE
+
+```bash
+cd ~/Dev/customer-x
+aio aem rde setup     # answer "yes" to local storage
+# … this writes a .aio file in the cwd
+```
+
+From now on any `aio aem rde …` run from this directory targets that RDE without affecting other projects.
+
+To verify which RDE you're on:
+
+```bash
+aio aem rde setup --show
+```
+
+## Deploy an OSGi bundle
+
+```bash
+# Maven build first
+mvn -pl core -am clean install
+
+# Hot-deploy
+aio aem rde install core/target/com.example.foo-1.0.0-SNAPSHOT.jar
+
+# Confirm
+aio aem rde status                  # bundle should appear in the list
+aio aem rde inspect osgi-bundles    # if inspect topic is enabled
+```
+
+If the bundle ends up in `Resolved` instead of `Active`:
+
+```bash
+aio aem rde inspect osgi-components -s author    # which DS components didn't satisfy?
+aio aem rde logs -e "" -w "" -d com.example      # tail errors+warnings, plus debug for your package
+```
+
+## Deploy a content package
+
+```bash
+aio aem rde install ui.content/target/customer-x-content-1.0.0-SNAPSHOT.zip
+```
+
+For author-only:
+
+```bash
+aio aem rde install --target author ui.content/target/customer-x-content-1.0.0-SNAPSHOT.zip
+```
+
+## Deploy a single content file
+
+```bash
+# Path is auto-derived because the source lives under jcr_root/
+aio aem rde install ui.apps/src/main/content/jcr_root/apps/customer-x/components/foo/foo.js
+
+# Or explicit
+aio aem rde install --type content-file --path /apps/customer-x/components/foo/foo.js path/to/foo.js
+```
+
+## Deploy a dispatcher config
+
+```bash
+# From a built dispatcher dir (containing conf.dispatcher.d/)
+aio aem rde install dispatcher/src
+
+# Or from a zipped dispatcher
+aio aem rde install dispatcher/target/dispatcher.zip
+```
+
+## Deploy a frontend module
+
+```bash
+# After running the frontend build that produces dist/
+aio aem rde install ui.frontend/build
+```
+
+The plugin will zip and upload. If the source dir doesn't have a `dist/` and `package.json`, it will refuse to guess `frontend` — pass `--type frontend` if needed.
+
+## Tail logs while iterating
+
+```bash
+# All errors + warnings on author
+aio aem rde logs -e "" -w ""
+
+# Debug your package, info everywhere else, on publish
+aio aem rde logs --target publish -d com.example -i ""
+
+# Highlight slow lines and your service name
+aio aem rde logs -e "" -H "took" -H "MyService"
+
+# Pick from existing log configs (if a teammate set one up)
+aio aem rde logs --choose
+```
+
+Stop with Ctrl-C. The plugin removes the server-side log config on exit.
+
+## Triage a failed deploy
+
+```bash
+# 1. What's the env state?
+aio aem rde status
+
+# 2. What's the last update look like?
+aio aem rde history
+# -> note the id of the failing one, e.g. 42
+
+# 3. Per-instance details
+aio aem rde history 42
+
+# 4. Logs around the time of failure
+aio aem rde logs -e "" -w ""
+
+# 5. (If inspect topic enabled) is the offending bundle / component / config
+#    actually present and active?
+aio aem rde inspect osgi-bundles -s author com.example.foo
+aio aem rde inspect osgi-components -s author
+aio aem rde inspect osgi-configurations -s author com.example.MyConfig
+```
+
+When everything looks confused and you suspect leftover state, consider `reset`.
+
+## Reset vs. restart vs. snapshot-restore
+
+| Need | Command | Time |
+|------|---------|------|
+| Get a stuck JVM unstuck without losing artifacts | `aio aem rde restart` | ~3 min |
+| Wipe artifacts but keep authored content | `aio aem rde reset --keep-mutable-content` | ~10-20 min |
+| Wipe artifacts and content (start clean) | `aio aem rde reset` | ~10-20 min |
+| Recover a known-good state | `aio aem rde snapshot restore <name>` | ~10-20 min |
+| Same, but keep current code, only roll back content | `aio aem rde snapshot restore <name> --only-mutable-content` | ~5-10 min |
+
+`reset --force` skips the cached base repo — slower but recovers from broken-base scenarios. Always confirm with the user before running any reset.
+
+## Snapshot lifecycle
+
+```bash
+# Create a save point before risky changes
+aio aem rde snapshot create pre-migration -d "before SCR-1234 migration"
+
+# List
+aio aem rde snapshot
+
+# Roll back
+aio aem rde snapshot restore pre-migration
+
+# Tidy up
+aio aem rde snapshot delete pre-migration         # 7-day soft delete
+aio aem rde snapshot delete pre-migration -f      # immediate (only if already in 'removed' state)
+aio aem rde snapshot delete --all                 # nuke them all (confirm first!)
+
+# Oh wait, I need that one back
+aio aem rde snapshot undelete pre-migration
+```
+
+Snapshot create takes 3-8 minutes (lock + persist + unlock); restore takes 10-20 (full restart). Always tell the user the expected wait time so they don't kill the process.
+
+## Switching between RDEs mid-task
+
+```bash
+# Inspect current pinning
+aio aem rde setup --show
+
+# Re-run the picker — preserves current org but lets you pick a new program/env
+aio aem rde setup
+```
+
+If you actually want a different IMS org:
+
+```bash
+aio logout
+aio login    # browser flow against the new org
+aio aem rde setup
+```
+
+## Scripted CI deploy
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Authenticate via JWT (set up once)
+# aio config:set ims.contexts.aem-rde-ci '{ "client_id": "...", "..."}'
+# aio auth:login --ctx aem-rde-ci  (or use AIO env vars)
+
+aio config:set -l cloudmanager_orgid "$ORG_ID"
+aio config:set -l cloudmanager_programid "$PROGRAM_ID"
+aio config:set -l cloudmanager_environmentid "$ENV_ID"
+
+aio aem rde install core/target/customer-x.core-${VERSION}.jar --quiet --json
+aio aem rde install ui.content/target/customer-x.ui.content-${VERSION}.zip --quiet --json
+aio aem rde install ui.frontend/build --type frontend --quiet --json
+
+aio aem rde status --json
+```
+
+Don't restart, don't reset, don't snapshot from a generic CI job — those are interactive/slow. Reserve them for explicit pipelines.
+
+## Toggling experimental features
+
+```bash
+# Locally (this project only)
+aio config set -l -j aem-rde.experimental-features '["aem:rde:inspect","aem:rde:snapshot"]'
+
+# Remove
+aio config:delete -l aem-rde.experimental-features
+
+# Confirm
+aio aem rde inspect --help
+aio aem rde snapshot --help
+```


### PR DESCRIPTION
## Summary

- Adds a new `aem-rde` skill to `plugins/aem/cloud-service/skills/aem-rde/`
- Covers `aio aem rde` CLI usage: deployment types, log tailing, snapshots, troubleshooting, and Cloud Manager configuration
- Includes structured reference docs for commands, configuration, deployment types, workflows, and troubleshooting

Closes #114