### PR TITLE
stardust: close open clusters + declare cross-marketplace impeccable dep

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,6 +7,7 @@
     "description": "Official Adobe Skills for AI Agents",
     "version": "1.0.0"
   },
+  "allowCrossMarketplaceDependenciesOn": ["pbakaus/impeccable"],
   "plugins": [
     {
       "name": "adobe-for-creativity",

--- a/plugins/stardust/.claude-plugin/plugin.json
+++ b/plugins/stardust/.claude-plugin/plugin.json
@@ -7,5 +7,8 @@
   },
   "repository": "https://github.com/adobe/skills",
   "license": "Apache-2.0",
-  "keywords": ["design", "redesign", "frontend", "skills", "impeccable"]
+  "keywords": ["design", "redesign", "frontend", "skills", "impeccable"],
+  "dependencies": [
+    { "name": "impeccable", "marketplace": "pbakaus/impeccable" }
+  ]
 }

--- a/plugins/stardust/skills/direct/SKILL.md
+++ b/plugins/stardust/skills/direct/SKILL.md
@@ -37,6 +37,16 @@ downstream sub-commands.
   reservations and brand-level metadata defaults, re-evaluate
   direction against the wider crawl. See § Prep mode below.
   Typically invoked via the `prepare-migration` orchestrator.
+- `--add-variant <name>` — optional. Add a new variant against
+  the existing direction without re-running intent reasoning or
+  mode detection. Writes `DESIGN-<name>.{md,json}` at the
+  project root and appends a per-variant section to
+  `stardust/direction.md`. The previous direction stays
+  authoritative; existing prototypes are **not** stale-flagged.
+  Used when variants are spec'd incrementally — typical
+  workflow: render variant A, review, then ask for B and C as
+  "the alternatives we discussed earlier." See § Add-variant
+  mode below for the per-field inheritance rules.
 
 ## Setup
 
@@ -1019,6 +1029,157 @@ Next: $stardust prototype --prep  (fill template gaps, write canon)
 ```
 
 Default mode is unchanged.
+
+## Add-variant mode (--add-variant)
+
+When the user has already approved (or rendered) variant A and
+asks for B / C / etc. as alternatives, `--re-direct` is too
+heavy: it replaces the active direction, re-runs Phase 1
+reasoning, and stale-flags every approved or migrated page
+against the prior direction. The user is **not** changing
+direction — they are extending it with additional variant
+expressions of the same direction. `--add-variant <name>` is the
+incremental-extension flow.
+
+The flow surfaced on the 2026-05-04 ups.com session: variant A
+shipped, the user later asked for B and C as the directional
+alternatives that had been surfaced in the initial menu but not
+committed to. Without an additive flag, the agent had to author
+B and C as page-shape briefs + proposed HTML only (skipping
+`DESIGN-B.{md,json}` / `DESIGN-C.{md,json}`), embedding their
+system-level deviations inline in per-variant CSS. Migrate then
+had no machine-readable source to re-derive B / C from.
+
+### Procedure
+
+When `--add-variant <name>` is passed:
+
+1. **Setup** runs as normal (impeccable dep check, state read,
+   brand-extraction read, brand-signal classification).
+   Validation step 5 (provenance) is **skipped** — add-variant
+   does not consume per-page extracted JSON; it consumes the
+   already-resolved direction. The brand-signal stamp stays
+   useful for the inheritance rules below.
+2. **Skip Phase 1 (Reasoning).** The user's intent is *"add
+   another variant against the existing direction,"* not "resolve
+   a fresh direction." If the existing `direction.md` Active
+   section is missing, refuse — there is no direction to extend.
+3. **Skip Phase 2 (Mode detection + divergence).** Mode is
+   inherited from the existing direction (typically Mode A
+   given the brand-faithful default). The seed, font deck,
+   palette, and ground family are all inherited as-is.
+4. **Run Phase 2.5 (Improvements list)** **only if** the
+   existing direction is Mode A and a variant-A improvements
+   list does not yet exist for the slug being prototyped later.
+   The improvements list is shared across all Mode A variants
+   per `direct/SKILL.md` § Phase 2.5; if it already exists, the
+   add-variant pass reads it as input and does not regenerate.
+5. **Run Phase 2.6 (Multi-variant fork)** only enough to
+   resolve the **new variant's** role per the variant role
+   contract (faithful + improvements / one captured trait
+   amplified / different captured trait amplified). Surface the
+   role choice to the user before proceeding. Do not re-run the
+   role contract for variants that already exist — their roles
+   are stamped in `direction.md`.
+6. **Run Phase 4 against the new variant only.** Derive the
+   variant's system-level deviations (font-weight changes,
+   surface-color additions, motif amplifications, etc.) and
+   write:
+   - `DESIGN-<name>.md` — Stitch frontmatter + 6 canonical
+     sections, **inheriting** every token that doesn't change
+     for this variant.
+   - `DESIGN-<name>.json` — sidecar with extensions
+     (`divergence`, `componentStyle`, `voice`, `iaPriorities`).
+   When variant A has been written as the unsuffixed
+   `DESIGN.{md,json}` (single-variant flow), upgrade A's files
+   to the suffixed form (`DESIGN-A.{md,json}`) and **leave the
+   unsuffixed files in place as backward-compatible aliases
+   pointing at A** — `migrate` and `prototype` continue to
+   resolve the unsuffixed form to A.
+7. **Append a section to `direction.md`** under the existing
+   Active section, titled `## Variant <name>`, recording: the
+   variant's role (faithful / amplified-trait), the captured
+   trait being amplified (when applicable), the system-level
+   deviations from variant A, the IA-priority audit (must
+   match A's audit — variants cannot opt out of preservation
+   under Mode A), and a one-line thesis.
+8. **Skip Phase 5 update of state.json's `direction.*` block**.
+   The active direction has not changed; the direction file's
+   resolvedAt / phrase / directionFile fields stay untouched.
+   Pages already in `prototyped` / `approved` / `migrated`
+   states are **not** stale-flagged — adding a variant is
+   additive, not a re-direction. State.json gains a
+   `direction.variants[].<name>` entry (per
+   `state-machine.md`'s multi-variant additions) recording the
+   new variant's id and DESIGN files.
+
+### Per-field inheritance rules
+
+When writing `DESIGN-<name>.{md,json}`, fields fall into three
+categories:
+
+| inherit-as-is | inherit-then-extend | variant-local |
+|---|---|---|
+| `colors` (palette) — Mode A pin | `componentStyle` — base treatment from A; variant adds variant-local component overrides keyed by `data-variant="<name>"` | `narrative.northStar` — per-variant thesis |
+| `typography` family / scale — Mode A pin | `extensions.divergence.brand_faithful_inversions[]` — A's list is the floor; variant may add inversions that follow from its amplified trait | `narrative.overview`, `narrative.keyCharacteristics` — written against the variant's role |
+| `rounded`, `spacing` — site-wide tokens | `extensions.iaPriorities[]` — same audit as A; cannot opt out under Mode A | `voice.examples.do/dont` — variant may amplify a captured voice register A didn't lean on |
+| `extensions.colorMeta`, `typographyMeta`, `breakpoints` | `narrative.rules[]` — A's house standards inherit; variant adds its own | `extensions.divergence.seed.anchors[]` — variant may add a captured trait as the anchor for its amplified-trait role |
+| `extensions.systemComponentRoles` (abstract roles) | | The variant-id stamp in `_provenance` |
+
+Variants **cannot**:
+
+- Introduce a font outside the captured surface (Mode A pin).
+- Introduce a color outside the captured palette (Mode A pin).
+- Shift the register from PRODUCT.md (per-brand strategy is
+  variant-invariant under Mode A).
+- Skip the IA-priority audit (variants are visual expressions,
+  not strategic re-shapings).
+
+When the user's add-variant request would violate one of the
+forbidden rules, refuse with the same § Failure modes (c) hard
+rule conflict pattern: name the conflict, propose targeted
+alternatives (rebrand mode via `--rebrand`, or a Mode A
+expression that fits within the pins).
+
+### Add-variant summary
+
+```
+direct --add-variant B complete
+==============================
+
+Variant role:         one captured trait amplified — editorial confidence
+Captured trait:       caption-band typography + named-driver portraits
+Inheritance:          palette, typography, rounded, spacing inherited from A
+Variant-local:        narrative.northStar, voice DOs (eyebrow voice expanded),
+                      componentStyle.heroOverlay (variant override)
+IA-priority audit:    matches A — commercial-conversion + crisis-affordance preserved
+
+Wrote:
+  DESIGN-B.md, DESIGN-B.json (alongside DESIGN-A.{md,json})
+  stardust/direction.md  (appended ## Variant B section)
+
+State:
+  pages unchanged (no stale flags — add-variant is additive)
+  direction.variants[]:  A + B
+
+Next: $stardust prototype <slug> --variant B
+```
+
+### Failure modes specific to add-variant
+
+- **No active direction.** Refuse — there is nothing to extend.
+  Recommend `$stardust direct` first.
+- **Variant `<name>` already exists.** Refuse — pass `--re-direct`
+  and re-resolve the variant explicitly if a refresh is wanted,
+  or pick a different name (variants are case-sensitive; B and b
+  are distinct entries but discouraged for clarity).
+- **Mode A constraint violation.** Per § Per-field inheritance
+  rules above; surface the conflict and propose targeted
+  alternatives.
+- **Existing direction is rebrand mode.** Add-variant is allowed,
+  but the inheritance rules relax — rebrand permits a different
+  PRODUCT.md per variant. Surface the relaxed contract to the
+  user before writing.
 
 ## References
 

--- a/plugins/stardust/skills/migrate/SKILL.md
+++ b/plugins/stardust/skills/migrate/SKILL.md
@@ -43,6 +43,14 @@ sidecars.
   Default logs the deviation and continues. Useful for projects
   where canon discipline matters more than per-template
   flexibility.
+- `--skip-adapt-audit` — skip the mobile-adapt audit at
+  per-page render time. Default refuses pages whose proposed /
+  approved file has no `<meta viewport>`, zero `@media (max-width:
+  ...)` rules, or no mobile-targeted breakpoint at ≤ 640px (per
+  `skills/prototype/SKILL.md` § Mobile-adapt audit). Use this
+  flag for an explicit desktop-only demo deploy; the failure
+  is real and the override is recorded in the per-page
+  `_meta.json#audit.adapt`.
 
 ## Setup
 
@@ -73,6 +81,26 @@ sidecars.
    that misrepresents the source site, the exact failure mode
    that motivated the validator. Surface `Provenance OK on N
    pages` in the migrate-plan output before Phase 1.
+8. **Mobile-adapt audit on every Path A / Path A′ source.** For
+   every page whose render branch consumes a proposed or
+   archetype HTML file (Path A, Path A′ per
+   `reference/template-and-module-rendering.md` § Render path
+   selection), run the audit per `skills/prototype/SKILL.md`
+   § Mobile-adapt audit:
+
+   - `<meta name="viewport" content="width=device-width, ...">`
+     present, width not pinned to a fixed pixel value.
+   - At least one `@media (max-width: ...)` rule.
+   - At least one mobile-targeted breakpoint at ≤ 640px.
+
+   Refuse pages that fail unless `--skip-adapt-audit` was passed.
+   Record the audit result per page in the migrate report and
+   in the post-render `_meta.json#audit.adapt` sidecar. Path B
+   (unique-renders) skips the audit because adapt hasn't run
+   on those pages — a Path B page that needs mobile coverage
+   gets it via `$impeccable adapt` invoked separately by the
+   user. Surface this distinction in the report so it's not
+   read as a silent skip.
 
 ## Procedure
 

--- a/plugins/stardust/skills/prototype/SKILL.md
+++ b/plugins/stardust/skills/prototype/SKILL.md
@@ -28,11 +28,26 @@ is delegated to `$impeccable craft` and `$impeccable live`.
 - `--no-iterate` — write the initial proposed render and the viewer,
   open the viewer in the browser, but **do not** invoke
   `$impeccable live`. The user iterates manually later.
-- `--no-critique` — skip the automatic post-render critique pass
-  (Phase 2.5). Default behaviour runs critique and gates
-  `prototyped` status on P0/P1 findings; this flag opts out of the
-  gate for fast iteration cycles where the user is running
-  critique manually between iterations.
+- `--no-critique` — skip the automatic post-render critique +
+  audit pass (Phase 2.5). Default behaviour runs both
+  `impeccable critique` and `impeccable audit` and gates
+  `prototyped` status on P0/P1 findings from either; this flag
+  opts out of the gate for fast iteration cycles where the user
+  is running critique / audit manually between iterations. The
+  flag's name predates the audit addition; the scope now covers
+  both validators.
+- `--skip-adapt-audit` — skip Phase 5.5 (Adapt for mobile) on
+  approval. Default behaviour runs `$impeccable adapt` against
+  the approved variant and gates downstream `migrate` and
+  `--publish-sample` on the mobile-adapt audit (per
+  `reference/before-after-shell.md` § Mobile-adapt audit). Use
+  this flag for explicit desktop-only demo runs; the proposed
+  file's `_provenance.adapt[]` records `adapt: skipped (user)`
+  so downstream consumers see the override.
+- `--adapt-variant <id>` — extend the adapt pass to a non-primary
+  variant. Default Phase 5.5 only adapts the variant the user
+  approves (or the variant flagged `isPrimary: true`); pass this
+  flag to adapt B / C / etc. on demand.
 - `--publish-sample <slug>` — submit the named slug to the
   stardust showcase. Triggers the publish-sample sub-flow
   documented in `reference/publish-sample.md`: eligibility checks,
@@ -258,73 +273,126 @@ After craft returns, validate the output:
 If validation fails, do not write the file. Surface the failure to
 the user with the specific rule violated and a suggested fix.
 
-### Phase 2.5 — Validate via critique
+### Phase 2.5 — Validate via critique + audit
 
-Before composing the viewer, run an automatic critique pass against
-the rendered proposed file. Critique catches AI-slop reflexes and
-brand-misalignment that craft's hard-rules audit doesn't cover —
-visual hierarchy regressions, cognitive-load issues, color/contrast
-gaps, anti-pattern reflexes, register/voice drift. The pass is a
-**contract**, not a courtesy: previously the agent ran critique
-only when the user asked, and the user has to remember to ask.
+Before composing the viewer, run **two parallel validators**
+against the rendered proposed file: `critique` and `audit`. They
+are explicitly designed as a complementary pair — critique
+covers *design* (AI-slop reflexes, hierarchy, brand fit,
+cognitive load); audit covers *technical correctness*
+(accessibility / performance / theming / responsive /
+anti-patterns). Running only critique misses every quantifiable
+WCAG / perf / responsive failure; running only audit misses
+brand-misalignment and design slop. The pass is a **contract**,
+not a courtesy.
+
+The 2026-05-04 nvidia.com home prototype critique returned
+1 P0 + 2 P1 + 3 P2; the audit on the same artifact returned
+**six additional findings** (no skip-link, theme carousels
+without keyboard arrow nav, hero ~3.5MB without responsive
+`<picture>`, layout-property animation, JS-gated reveal with
+no `<noscript>` fallback, `scroll-behavior: smooth` not
+respecting `prefers-reduced-motion`). None were design issues,
+none would have been caught by critique alone. Without an
+audit gate the page would have been marked `prototyped` with
+quantifiable WCAG failures.
 
 Procedure:
 
-1. **Run the deterministic detector first.** Invoke
-   `impeccable:impeccable` via the Skill tool with sub-command
-   `critique`:
+1. **Run both validators in parallel.** Invoke `impeccable:impeccable`
+   twice in the same Skill-tool batch:
 
    ```
-   Skill {
-     skill: "impeccable:impeccable",
-     args: "critique stardust/prototypes/<slug>-proposed.html --json"
-   }
+   Skill { skill: "impeccable:impeccable",
+           args: "critique stardust/prototypes/<slug>-proposed.html --json" }
+
+   Skill { skill: "impeccable:impeccable",
+           args: "audit stardust/prototypes/<slug>-proposed.html --json" }
    ```
 
-   Critique returns a JSON findings list — each finding has
+   Each returns a JSON findings list — each finding has
    `priority` (P0 / P1 / P2 / P3), `category` (hierarchy /
-   contrast / motion / etc.), and a one-line description.
-   Capture verbatim into `_provenance.critique[]` on the proposed
-   file (append; never overwrite previous runs' entries).
+   contrast / motion / a11y / perf / responsive / etc.), and a
+   one-line description. Capture critique findings into
+   `_provenance.critique[]` and audit findings into
+   `_provenance.audit[]` on the proposed file (append; never
+   overwrite previous runs' entries).
 
-2. **Surface findings in the user-facing report** alongside the
-   prototype-rendered confirmation. Group by priority. List the
-   first 5 P0/P1 verbatim; collapse P2/P3 to a count with a
-   "expand to see all" pointer.
+2. **Brand-faithful inversion auto-dismiss.** Both validators
+   ship known false positives on Mode A renders — Arial fallback
+   reads as "overused-font," eyebrow uppercase reads as
+   "all-caps body," pure white / pure black flagged when the
+   brand's captured palette includes them. Before surfacing
+   findings to the user, diff each finding against
+   `DESIGN.json#extensions.divergence.brand_faithful_inversions[]`
+   and `DESIGN.md#narrative.rules` (e.g. permitted uppercase
+   contexts). Drop findings whose category and target match an
+   approved inversion; keep the original list in
+   `_provenance.<critique|audit>[]` with a
+   `dismissedAsBrandFaithful: true` flag for audit-trail
+   purposes. The user-facing report shows only the real hits.
 
-3. **Gate `prototyped` status on P0/P1 findings.** If the detector
-   returned ≥1 P0 or ≥1 P1 finding, do **not** mark the page
-   `prototyped` in `state.json` yet. The proposed file is on disk;
-   the viewer can render it; but the page stays in `directed`
-   until either:
+3. **Surface findings in the user-facing report**, grouped by
+   priority across both validators with the source attributed
+   (`critique:` / `audit:`). List the first 5 P0/P1 verbatim;
+   collapse P2/P3 to per-source counts with an "expand to see
+   all" pointer. Format:
+
+   ```
+   Critique + audit on home-proposed.html
+
+   P0 (1)
+     audit:    skip-link missing — header has no <a href="#main"> as first focusable
+   P1 (4)
+     critique: hierarchy regression — H2 visually heavier than H1 in section #features
+     audit:    hero <img> 3.5MB; no responsive <picture> set despite captured srcset
+     audit:    transition: width animates layout properties (jank)
+     audit:    .hero scroll-behavior: smooth not gated by prefers-reduced-motion
+   P2 (3 critique, 1 audit) — expand to see
+   P3 (0)
+   ```
+
+4. **Gate `prototyped` status on P0/P1 findings from EITHER
+   validator.** If the merged-and-deduped findings list (after
+   the brand-faithful auto-dismiss) contains any P0 or P1, do
+   **not** mark the page `prototyped` in `state.json` yet. The
+   proposed file is on disk; the viewer can render it; but the
+   page stays in `directed` until either:
    - The agent fixes the issue (run a chat-driven impeccable
      command per Phase 4 iteration paths, then re-run Phase 2.5).
    - The user explicitly acknowledges (e.g. "ship as-is" /
      "accept the P1 findings"). Acknowledgement is recorded in
-     `_provenance.critique[]` with the verbatim user phrase.
+     `_provenance.critique[]` AND `_provenance.audit[]` with the
+     verbatim user phrase, so re-runs see the existing
+     acknowledgement and don't re-prompt.
 
    P2/P3 findings do not block `prototyped`. They surface as
    advisory.
 
-4. **Optionally spawn an LLM design-review subagent** for an
+5. **Optionally spawn an LLM design-review subagent** for an
    independent take when the user wants more than the
    deterministic detector. Trigger only when the user explicitly
    asks ("give me a deeper critique", "second opinion") or when
-   the deterministic pass returns ≥3 findings (signal that the
-   render has multiple issues worth a closer look). Default off
-   to keep the loop fast.
+   the deterministic pass returns ≥3 P0/P1 findings (signal that
+   the render has multiple issues worth a closer look). Default
+   off to keep the loop fast.
 
-5. **`--no-critique` opt-out.** When the user passes
-   `--no-critique` to `$stardust prototype`, skip the entire
-   pass. Useful for fast iteration cycles where the user is
-   already running critique manually between iterations. Without
-   the flag, the pass is mandatory.
+6. **`--no-critique` opt-out.** When the user passes
+   `--no-critique` to `$stardust prototype`, skip **both**
+   validators. The flag's name is preserved for backward
+   compatibility (it predates the audit addition); document the
+   broader scope in the help text. Useful for fast iteration
+   cycles where the user is already running critique / audit
+   manually between iterations. Without the flag, both
+   validators are mandatory.
 
 Failure handling: when impeccable is unavailable (per Delegation
 mechanic § When impeccable is not available), record
-`_provenance.critique[]` with one entry of class `unavailable`
-and continue. Prototype proceeds to mark the page `prototyped` —
-the user will need to run critique manually before approving.
+`_provenance.critique[]` and `_provenance.audit[]` each with one
+entry of class `unavailable` and continue. Prototype proceeds to
+mark the page `prototyped` — the user will need to run both
+validators manually before approving. Surface the gap loudly in
+the report so the user doesn't forget.
 
 ### Phase 3 — Compose the viewer
 
@@ -344,15 +412,18 @@ relative path to `<slug>-proposed.html`.
    (`open` macOS, `xdg-open` Linux, `start ""` Windows). Skip in
    pipeline-automation mode.
 2. Mark the page `prototyped` in `state.json` — **gated on the
-   Phase 2.5 critique result**. If critique returned ≥1 P0 or P1
-   finding and the user has not acknowledged, the page stays
-   `directed` (not `prototyped`); surface the critique findings in
-   the report and recommend either fixing the issue or
-   acknowledging explicitly. The transition itself does not require
-   *approval* (a separate later step) — but it does require the
-   critique gate to clear, since shipping a `prototyped` flag on
-   work that fails P0/P1 critique misleads downstream consumers
-   (migrate, the dashboard) about the prototype's quality.
+   Phase 2.5 critique + audit result**. If either validator
+   returned ≥1 P0 or P1 finding (after the brand-faithful
+   inversion auto-dismiss) and the user has not acknowledged,
+   the page stays `directed` (not `prototyped`); surface the
+   findings in the report grouped by source (`critique:` /
+   `audit:`) and recommend either fixing the issue or
+   acknowledging explicitly. The transition itself does not
+   require *approval* (a separate later step) — but it does
+   require the gate to clear, since shipping a `prototyped` flag
+   on work that fails P0/P1 critique or audit misleads
+   downstream consumers (migrate, the dashboard) about the
+   prototype's quality.
 3. If `--no-iterate` was passed, stop here and report the prototype
    path.
 4. Otherwise, invoke `$impeccable live` against
@@ -430,17 +501,103 @@ On approval:
 2. Mark the page `approved` in `state.json`. Append a
    `{ status: "approved", at: <ts> }` history entry.
 3. Clear any `stale` flag on the page.
-4. Print:
+4. **Run Phase 5.5 — Adapt for mobile** (below) on the variant
+   the user is signing off on. Approval does not complete until
+   the adapt pass lands; the viewer's "Approve" button surfaces
+   this as one extra step rather than a separate user gesture.
+5. Print:
    ```
    home: approved
      proposed: stardust/prototypes/home-proposed.html
      viewer:   stardust/prototypes/home.html
+     mobile:   adapted (4 @media rules at 640/768/1024/1280)
 
    Next: $stardust migrate home  (write final redesigned static HTML)
    ```
 
 If multiple pages are in flight, approval is per-page; the user can
 approve some and continue iterating on others.
+
+### Phase 5.5 — Adapt for mobile
+
+Every variant the user approves goes through `$impeccable adapt`
+before it leaves the prototype phase. The cascade ships
+desktop-only HTML otherwise — viewports are tuned to ~1440×900
+through render and iteration, and nothing earlier in the
+pipeline produces responsive coverage. The 2026-05-03 lovesac.com
+showcase publish surfaced this: stakeholders eyeballing variants
+on a phone got the unadjusted desktop layout (bracket motif
+crowding, overflowing trust band, hamburger absent, hero
+unstacked) — and the question *"did you run impeccable adapt?"*
+was the only thing that caught the gap, after publish.
+
+Trigger: any variant the user approves OR any variant explicitly
+flagged `isPrimary: true` in `meta.json#variants[]` for a
+multi-variant render. The user can extend coverage to other
+variants on demand (`$stardust prototype <slug> --adapt-variant <id>`).
+
+Procedure:
+
+1. Invoke impeccable adapt against the approved file:
+
+   ```
+   Skill {
+     skill: "impeccable:impeccable",
+     args: "adapt stardust/prototypes/<slug>-proposed.html"
+   }
+   ```
+
+   Pass the captured viewport breakpoints from
+   `DESIGN.json#extensions.breakpoints` if present; otherwise
+   adapt picks defaults (640 / 768 / 1024 / 1280 are the
+   stardust spec defaults — anything above 640 used as a "mobile
+   breakpoint" is a smell per § Mobile-adapt audit below).
+
+2. Validate the adapted file against the same contracts Phase 2
+   ran (`:root` token block, data attributes, anti-toolbox audit
+   clean, impeccable hard rules, content sourcing). The adapt
+   pass is an iteration over the existing render; it must not
+   reintroduce contract violations.
+
+3. Append an entry to the proposed file's `_provenance.adapt[]`
+   recording: ISO timestamp, the breakpoint list applied, the
+   number of `@media` rules added, and any layout decisions the
+   adapt pass surfaced (carousel → stack, sidebar → drawer,
+   hamburger → menu, etc.).
+
+4. Update the report (Phase 5 step 5) with the `mobile:` line.
+
+#### Mobile-adapt audit
+
+Phase 5.5 also runs a hard audit, separate from the adapt pass
+itself, that the resulting file would survive a publish or
+migrate. The same audit re-runs at `migrate` and `--publish-sample`
+so an adapted-but-broken render can't slip through (per
+`skills/migrate/SKILL.md` § Setup, `skills/prototype/reference/
+publish-sample.md` § Phase 1).
+
+Refuse the file when **any** of:
+
+- `<meta name="viewport" content="width=device-width, ...">` is
+  missing or width is set to a fixed pixel value.
+- The file declares zero `@media (max-width: ...)` rules at all
+  (desktop-only).
+- The file declares mobile-targeted breakpoints **above 640px**
+  — `@media (max-width: 1024px)` as the *narrowest* breakpoint
+  is the recognisable shape of "didn't actually adapt for
+  phones." Adapt should produce at least one rule at ≤ 640px.
+
+Pass `--skip-adapt-audit` to the prototype invocation when the
+user explicitly wants a desktop-only render (a presales demo
+cycle that won't ship to phones, an internal review). The flag
+records `adapt: skipped (user)` in the proposed file's
+`_provenance.adapt[]` so downstream consumers can see the
+override.
+
+When the audit refuses, the page does **not** demote from
+`approved` (the approval already landed); but the report carries
+the failure prominently and migrate / publish-sample will refuse
+to consume the file until it passes.
 
 ### Stale handling
 

--- a/plugins/stardust/skills/prototype/reference/publish-sample.md
+++ b/plugins/stardust/skills/prototype/reference/publish-sample.md
@@ -1,9 +1,12 @@
 # Publish a sample to the showcase
 
 The procedure for `$stardust prototype --publish-sample <slug>`.
-Stages a new sample folder in the stardust source repo, opens a
+Stages a new sample folder in the stardust showcase repo, opens a
 PR, and lands the sample in the showcase published at
-`https://{owner}.github.io/stardust-2/`.
+`https://{owner}.github.io/stardust-site/`. Per-sample deep links
+go through `samples/brand.html?slug={showcase-slug}#{variantId}`
+— the showcase is a single-page viewer that reads the slug from
+the query string and the variant from the URL hash.
 
 The flow assumes:
 
@@ -15,8 +18,8 @@ The flow assumes:
   a block).
 - The user has the GitHub CLI (`gh`) installed and authenticated.
   `gh auth status` exits zero.
-- The stardust source repo is reachable (default upstream:
-  `paolomoz/stardust-2`; configurable via `--upstream <owner/repo>`).
+- The stardust showcase repo is reachable (default upstream:
+  `paolomoz/stardust-site`; configurable via `--upstream <owner/repo>`).
 
 The user does **not** need write access to the upstream repo —
 `gh pr create` will fork on the user's behalf if needed.
@@ -30,7 +33,7 @@ The user does **not** need write access to the upstream repo —
   `stardust/prototypes/<slug>-proposed.html` (single-variant) or
   `stardust/prototypes/<slug>-proposed-A.html` (multi-variant).
 - `--upstream <owner/repo>` — optional. Override the upstream repo
-  the PR targets. Default `paolomoz/stardust-2`.
+  the PR targets. Default `paolomoz/stardust-site`.
 - `--variants <list>` — optional. Comma-separated variant ids to
   include (e.g. `A,B,C`). Default: every variant on disk for the
   slug.
@@ -120,21 +123,25 @@ combine into a single "not eligible" message.
    visual sample vs. end-users browsing a deployed site),
    different stakes (design demonstration vs. production claim),
    different gate. Don't conflate them.
-5. **No outstanding P0/P1 critique findings.** Read each proposed
-   file's `_provenance.critique[]`.
+5. **No outstanding P0/P1 critique or audit findings.** Read
+   each proposed file's `_provenance.critique[]` AND
+   `_provenance.audit[]`.
 
-   - If the field exists and contains any P0 or P1 finding without
-     a recorded user acknowledgement: refuse. The user runs Phase
-     2.5 (Validate via critique) and either fixes or acknowledges
-     before publishing.
-   - If the field is **absent entirely**: that means critique was
-     not run on this file (typical for prototypes from before P-3
-     landed in the spec). This is **not** a publish blocker — the
-     spec treats absence as "no findings." But the PR body
-     records `critique: not run` so the reviewer knows to run it
-     before merging, and the publish flow surfaces a one-line
-     warning to the user: "critique not run on N variant(s);
-     reviewer will see this in the PR."
+   - If either field exists and contains any P0 or P1 finding
+     without a recorded user acknowledgement (after the
+     brand-faithful inversion auto-dismiss per
+     `prototype/SKILL.md` § Phase 2.5): refuse. The user runs
+     Phase 2.5 (Validate via critique + audit) and either fixes
+     or acknowledges before publishing.
+   - If either field is **absent entirely**: that means the
+     corresponding validator was not run (typical for prototypes
+     from before the spec landed). This is **not** a publish
+     blocker — the spec treats absence as "no findings." But
+     the PR body records `critique: not run` and/or
+     `audit: not run` so the reviewer knows to run them before
+     merging, and the publish flow surfaces a one-line warning:
+     "critique not run on N variant(s); audit not run on M
+     variant(s); reviewer will see this in the PR."
 6. **Anti-toolbox audit clean.** Read
    `DESIGN.json#extensions.divergence.anti_toolbox_hits[]`. Every
    hit must have a brand-specific justification (per
@@ -144,6 +151,26 @@ combine into a single "not eligible" message.
    `_brand-extraction.json`, and `current/PRODUCT.md` exist in the
    project — these are the inputs the publish flow reads to
    author `meta.json`.
+8. **Mobile-adapt audit on every variant being published.** For
+   every variant in scope (the primary, plus any variants named
+   in `--variants <list>`), run the audit per
+   `skills/prototype/SKILL.md` § Mobile-adapt audit:
+
+   - `<meta name="viewport" content="width=device-width, ...">`
+     present, width not pinned to a fixed pixel value.
+   - At least one `@media (max-width: ...)` rule.
+   - At least one mobile-targeted breakpoint at ≤ 640px.
+
+   Refuse to publish variants that fail unless
+   `--skip-adapt-audit` was passed. Record the audit result per
+   variant in the PR body's submitter checklist (a new line:
+   *"adapt: passed for A, B"* or *"adapt: skipped (user) for C"*)
+   so the maintainer reviewing the PR can see at a glance which
+   variants the showcase visitor will actually see render
+   correctly on a phone. The 2026-05-03 lovesac.com showcase
+   ran without this gate and shipped variant B to mobile
+   visitors with the bracket motif crowding, an overflowing
+   trust band, and a missing hamburger.
 
 ### Phase 1.5 — Backup originals (mandatory before any transform)
 
@@ -302,17 +329,27 @@ Sample published as PR.
   source:        https://aurora-coffee.example.com/
   variants:      A (primary)
 
-  PR:            https://github.com/paolomoz/stardust-2/pull/42
+  PR:            https://github.com/paolomoz/stardust-site/pull/42
 
 The sample lands in the showcase at
-https://paolomoz.github.io/stardust-2/ once the PR merges and the
-showcase-pages workflow redeploys (~1 minute after merge).
+https://paolomoz.github.io/stardust-site/samples/brand.html?slug=aurora-coffee#A
+once the PR merges and the showcase-pages workflow redeploys
+(~1 minute after merge).
 
 The PR carries an opinionated body summarising the run. Review it
 before requesting merge — the auto-generated tagline and category
 are best-guess; refine them in the PR before the maintainer
 reviews.
 ```
+
+The deep-link URL points the reviewer (and any later visitor)
+straight at the variant the publish flow flagged as primary —
+the `meta.json#variants[]` entry whose `isPrimary: true`. For
+single-variant samples this is always `#A`. For multi-variant
+samples, render the hash to match the primary variant id; the
+showcase's `samples/brand.html` reads the slug from
+`URLSearchParams(location.search)` and the variant from the
+hash, so the URL must carry both.
 
 ---
 
@@ -364,10 +401,13 @@ The publish flow already verified these — reviewer can spot-check.
       above]` otherwise. Placeholders are allowed in the showcase
       per the visual-demonstration policy; the listing makes them
       visible to reviewers without opening files.}
-- [{x|⚠}] No outstanding P0/P1 critique findings. {Render `[x]`
-      when critique[] is present with no P0/P1; render `[⚠]
-      critique: not run` when critique[] is absent on any variant
-      — the reviewer should run `$impeccable critique` before
+- [{x|⚠}] No outstanding P0/P1 critique or audit findings.
+      {Render `[x]` when critique[] AND audit[] are present with
+      no P0/P1 on either (after brand-faithful auto-dismiss);
+      render `[⚠] critique: not run on <ids>` and/or `audit: not
+      run on <ids>` for any variant where the corresponding
+      field is absent — the reviewer should run both
+      `$impeccable critique` and `$impeccable audit` before
       merging.}
 - [x] All anti-toolbox hits carry brand-specific justifications.
 - [x] Every `meta.json#direction.seed.pickedBy` accurately records
@@ -392,10 +432,15 @@ The publish flow already verified these — reviewer can spot-check.
 
 ### Showcase URL after merge
 
-`https://{owner}.github.io/stardust-2/`
+`https://{owner}.github.io/stardust-site/samples/brand.html?slug={showcase-slug}#{primaryVariantId}`
 
 The `showcase-pages` workflow redeploys on merge to main; the
-sample is visible within ~1 minute.
+sample is visible within ~1 minute. The hash carries the primary
+variant's id (the `meta.json#variants[]` entry with
+`isPrimary: true`); single-variant samples always resolve to
+`#A`. The `samples/brand.html` viewer reads `slug` from the
+query string and the variant from the hash — both are required
+for the deep link to land on the right rendering.
 
 ---
 


### PR DESCRIPTION
## Summary

Two commits on this branch:

- **`feat(stardust)`: close open clusters** — four bundled stardust fixes from the 2026-05-05 review session (UPS F7+F9, NVIDIA F8, dogfood-feedback 2026-05-03-a / JFK F14):
  - `publish-sample` showcase URL fix — updated to the actual single-page-viewer route (`samples/brand.html?slug=<slug>#<variantId>`) and synced upstream default to `paolomoz/stardust-site`.
  - Mobile-adapt as a pipeline phase — new prototype Phase 5.5 runs `$impeccable adapt` against the approved variant on approval; mobile-adapt audit at prototype/migrate/publish-sample refuses files missing `<meta viewport>`, `@media (max-width: …)` rules, or a `<= 640px` breakpoint. `--skip-adapt-audit` escape hatch threads through all three.
  - Phase 2.5 renamed to "Validate via critique + audit" — runs both impeccable validators in parallel and gates `prototyped` on P0/P1 from either. Adds brand-faithful inversion auto-dismiss against `DESIGN.json#extensions.divergence.brand_faithful_inversions[]`.
  - `direct --add-variant <name>` — incremental variant addition without re-running Phase 1 or stale-flagging existing prototypes. Per-field inheritance rules table specifies pinned vs. extended vs. variant-local fields.

- **`chore(stardust)`: cross-marketplace dependency on impeccable** — whitelists `pbakaus/impeccable` in `marketplace.json` and declares it as a dependency in stardust's `plugin.json` so stardust can formally depend on the impeccable plugin hosted in a different marketplace.

## Test plan

- [ ] `direct --add-variant` produces a new variant without touching existing prototype state
- [ ] Mobile-adapt audit fires on a desktop-only HTML file at prototype, migrate, and publish-sample
- [ ] `--skip-adapt-audit` flag bypasses the audit at all three phases
- [ ] Phase 2.5 runs both critique and audit validators; P0/P1 from either blocks `prototyped` status
- [ ] `publish-sample` PR body links resolve to the single-page-viewer route
- [ ] Cross-marketplace dependency on `pbakaus/impeccable` resolves when installing stardust

🤖 Generated with [Claude Code](https://claude.com/claude-code)