### PR TITLE
Feat/skill workflow model design 65 lts

### DIFF
--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-model-design/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-model-design/SKILL.md
@@ -8,10 +8,32 @@ license: Apache-2.0
 
 Design workflow models for AEM 6.5 LTS: step structure, transitions, OR/AND splits, variables, and model XML deployment via Package Manager.
 
+## Audience
+
+Developers and workflow designers building or modifying AEM 6.5 LTS workflow models — via the Workflow Model Editor or by hand-authoring model XML and shipping it as a content package.
+
 ## Variant Scope
 
 - This skill is AEM 6.5 LTS only.
 - Models can be stored at `/conf/global/settings/workflow/models/` (preferred) or `/etc/workflow/models/` (legacy — auto-deployed without Sync).
+- **Not for AEM as a Cloud Service.** If the target instance is AEMaaCS, stop and use the cloud-service variant of this skill — `/etc/workflow/models/` is deprecated, the Sync flow differs, and several patterns documented here will produce models that fail to deploy.
+
+## Dependencies
+
+Models reference deployed `WorkflowProcess` and `ParticipantStepChooser` services by `process.label` / `chooser.label` or fully-qualified class name. **Build and deploy the Java step first; reference it from the model second.** A model that references a label whose service is not yet registered fails at runtime with `Process not found` — Sync will succeed and the model will appear in the editor, but instances will fail on first execution. See [workflow-development](../workflow-development/SKILL.md) for step implementation.
+
+## Prerequisites
+
+- AEM 6.5 LTS author instance reachable (local, dev, or sandbox).
+- Maven project with `ui.content` module — or the ability to author in the Workflow Model Editor and export as a content package.
+- Required `WorkflowProcess` / `ParticipantStepChooser` services already implemented and deployed (see Dependencies above).
+- `filter.xml` covering the model path you intend to install, with `mode="merge"`.
+
+## Required Permissions
+
+- `workflow-editors` (or equivalent write access to `/conf/global/settings/workflow/models/`) — create or modify models in the Workflow Model Editor or via content package.
+- `workflow-administrators` (or equivalent) — start test workflow instances and terminate stuck test instances during iteration.
+- Read access to `/conf/global/settings/workflow/models/` and `/var/workflow/models/` for verification.
 
 ## Workflow
 
@@ -19,12 +41,35 @@ Design workflow models for AEM 6.5 LTS: step structure, transitions, OR/AND spli
 Model Design Progress
 - [ ] 1) Clarify the workflow purpose: what triggers it, what steps are needed, who approves
 - [ ] 2) Map out steps: PROCESS (auto), PARTICIPANT (human), OR_SPLIT (decision), AND_SPLIT (parallel)
-- [ ] 3) Decide payload type: single JCR_PATH or multi-page cq:WorkflowContentPackage
+- [ ] 3) Decide payload type: single JCR_PATH or multi-page workflow package (a `cq:Page` collection, detected at runtime via `adaptTo(ResourceCollection.class)`)
 - [ ] 4) Identify workflow variables needed for inter-step data passing
-- [ ] 5) Design model XML: nodes + transitions + metaData with correct step properties
-- [ ] 6) Choose storage: /conf (requires Sync) vs /etc (auto-deployed)
+- [ ] 5) Design model XML: flow/parsys layer with correct nt:unstructured step components and sling:resourceType per step
+- [ ] 6) Choose storage: `/conf/global/settings/workflow/models/<id>` (default; requires Sync) unless the user explicitly names a site — then `/conf/<site>/settings/workflow/models/<id>`; or `/etc/workflow/models/<id>` (legacy, auto-deployed)
 - [ ] 7) Add filter.xml entry with mode="merge"
-- [ ] 8) Deploy via mvn install or Package Manager; verify sync to /var/workflow/models/
+- [ ] 8) Deploy via mvn install or Package Manager
+- [ ] 9) Open the model in Tools → Workflow → Models → Edit → Sync; verify the model appears in /var/workflow/models/ and all steps render on the editor canvas
+- [ ] 10) Start a test workflow instance; confirm it runs to completion
+```
+
+## Output Contract
+
+**Generate only these files for a `/conf`-based model:**
+
+| File | Node type | Purpose |
+|---|---|---|
+| `jcr_root/conf/.../models/<id>/.content.xml` | `cq:Page` | Model root page |
+| `jcr_root/conf/.../models/<id>/jcr:content/.content.xml` | `cq:PageContent` | Title, template, resourceType |
+| `jcr_root/conf/.../models/<id>/jcr:content/flow/.content.xml` | `nt:unstructured` + parsys | Step nodes |
+
+**Never generate — hard stops:**
+
+- ❌ **Any file under `jcr_root/var/`** — AEM Sync writes `/var/workflow/models/` automatically after you click Sync in the editor. Never ship `/var` content in a content package.
+- ❌ **A `model/` directory inside `jcr:content/` at the `/conf` path** — a `cq:WorkflowModel` node with `<nodes>` and `<transitions>` is the runtime format. It must never appear under `/conf`. The Workflow Model Editor cannot open a model that contains it.
+- ❌ **`<filter root="/var/workflow/models/..."/>` in filter.xml** — `/var` is never a package filter target. The only filter entry needed is the design-time `/conf` (or `/etc`) path.
+
+**filter.xml — correct entry:**
+```xml
+<filter root="/conf/global/settings/workflow/models/my-workflow" mode="merge"/>
 ```
 
 ## Node Types Quick Reference
@@ -36,9 +81,13 @@ Model Design Progress
 | `PROCESS` | Auto-executed Java step | `PROCESS` = FQCN or process.label |
 | `PARTICIPANT` | Human task (static assignee) | `PARTICIPANT` = principal name |
 | `DYNAMIC_PARTICIPANT` | Human task (runtime assignee) | `DYNAMIC_PARTICIPANT` = chooser.label |
-| `OR_SPLIT` | One branch selected by rule | Transition `rule` = ECMA/Groovy |
+| `OR_SPLIT` | One branch selected by rule | Transition `rule` = ECMAScript (Rhino) |
 | `AND_SPLIT` | All branches execute in parallel | — |
 | `AND_JOIN` | Wait for all parallel branches | — |
+
+## Default Path Rule
+
+**Unless the user explicitly names a specific AEM site, always generate models at `/conf/global/settings/workflow/models/<id>`.** Do not infer a site-scoped path (e.g., `/conf/wknd/…`) from conversational context such as "for the WKND site" or "install on the WKND instance." Workflow models are not site-scoped by default — they are global resources. Only use `/conf/<site>/settings/workflow/models/<id>` when the user explicitly states that the model should be scoped to a specific site.
 
 ## 6.5 LTS: /conf vs /etc
 
@@ -46,6 +95,14 @@ Model Design Progress
 |---|---|---|
 | `/conf/global/settings/workflow/models/` | Yes — via UI or `deployModel()` | New models, forward-compatible |
 | `/etc/workflow/models/` | No — auto-deployed | Legacy models, simple setups |
+
+**Design-time vs runtime paths**: `/conf/global/settings/workflow/models/` stores the editor's
+`flow/parsys` format — this is what you author and deploy in a content package. Steps are
+`nt:unstructured` nodes with `sling:resourceType`; no `cq:WorkflowNode` or `cq:WorkflowTransition`
+nodes appear here. `/var/workflow/models/` holds the runtime copy generated by Sync — it uses
+`cq:WorkflowModel`, `cq:WorkflowNode`, and `cq:WorkflowTransition`. Never write `cq:WorkflowModel`
+nodes to the `/conf` path, and never hand-author `/var` content — AEM manages the runtime layer
+entirely via Sync.
 
 ## Deployment
 
@@ -57,11 +114,21 @@ mvn clean install -P autoInstallPackage
 http://localhost:4502/crx/packmgr
 ```
 
+## Architecture Considerations
+
+These choices are made at design time and are hard to retrofit. Apply them before locking the model shape:
+
+- **Transient vs persistent.** Set `transient="true"` on the model for high-volume, short-lived workflows (e.g., asset metadata extraction, replication side-effects). Transient instances create no JCR node under `/var/workflow/instances` until a retry or external-process step forces persistence — the difference between a healthy repository and unbounded growth.
+- **Participant timeouts.** A `PARTICIPANT` step with no timeout can stall a workflow indefinitely and consume a job slot for the duration. For any human task that may not be acted on promptly, configure `TIMEOUT` and a `TIMEOUT_HANDLER` route on the step's metaData.
+- **Goto retry caps.** Always enforce a hard cap on retry counters used by `Goto Step` rules (e.g., `count < 3`). An uncapped Goto loop will pin a worker thread and accumulate failed instances until the workflow is terminated by hand.
+- **Purge is a design-time concern.** Estimate instance volume before go-live. Configure the **Adobe Granite Workflow Purge Configuration** factory in the same content package as the model so purge ships with the workflow, not as an after-the-fact follow-up. Set `scheduledpurge.purgePackagePayload=true` if the workflow uses workflow packages.
+- **Model versioning.** In-flight instances stay bound to the model version they started with; new instances pick up the new version. When changing a deployed model, plan a brief drain window for old-version instances before declaring the change complete.
+
 ## References
 
 - [step-types-catalog.md](./references/workflow-model-design/step-types-catalog.md) — complete step type reference with XML snippets
 - [model-xml-reference.md](./references/workflow-model-design/model-xml-reference.md) — full model XML structure and property reference
 - [model-design-patterns.md](./references/workflow-model-design/model-design-patterns.md) — common design patterns: linear, decision, parallel, loop-back
-- [architecture-overview.md](./references/workflow-foundation/architecture-overview.md)
-- [jcr-paths-reference.md](./references/workflow-foundation/jcr-paths-reference.md)
-- [65-lts-guardrails.md](./references/workflow-foundation/65-lts-guardrails.md)
+- [architecture-overview.md](../workflow-orchestrator/references/workflow-foundation/architecture-overview.md) — canonical foundation copy
+- [jcr-paths-reference.md](../workflow-orchestrator/references/workflow-foundation/jcr-paths-reference.md) — canonical foundation copy
+- [65-lts-guardrails.md](../workflow-orchestrator/references/workflow-foundation/65-lts-guardrails.md) — canonical foundation copy

--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-model-design/references/workflow-model-design/model-design-patterns.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-model-design/references/workflow-model-design/model-design-patterns.md
@@ -21,11 +21,11 @@ START → [PARTICIPANT: Review] → [OR_SPLIT] ──approve──→ [PROCESS: 
                                            └──reject───→ [PROCESS: Notify]   → END
 ```
 
-OR_SPLIT transition rules (ECMA):
+OR_SPLIT transition rules (ECMAScript / Rhino). Wrap Java string returns with `String(...)` and use strict equality (`===`) — Rhino's `==` between a Java String and a JS literal works through coercion but is fragile and inconsistent with the sibling skill's style.
 ```javascript
 // Approve transition
 function check() {
-    return workflowData.getMetaDataMap().get("reviewDecision", "") == "APPROVE";
+    return 'APPROVE' === String(workflowData.getMetaDataMap().get('reviewDecision', ''));
 }
 // Reject transition (catch-all)
 function check() { return true; }
@@ -34,7 +34,12 @@ function check() { return true; }
 The PARTICIPANT step must store the decision in metadata before completing:
 ```java
 item.getWorkflowData().getMetaDataMap().put("reviewDecision", "APPROVE");
-session.complete(item, routes.get(0));
+List<Route> routes = session.getRoutes(item, false);
+Route approveRoute = routes.stream()
+    .filter(r -> "Approve".equalsIgnoreCase(r.getName()))
+    .findFirst()
+    .orElse(routes.get(0));
+session.complete(item, approveRoute);
 ```
 
 ---
@@ -60,17 +65,23 @@ START → [PROCESS: Validate] → [PROCESS: Goto?] ──true (retry)──→ [
 Goto Step evaluates a rule. If retryCount < 3, redirects to Validate node; otherwise falls through.
 
 ```java
-// In Validate step: increment counter
-int count = meta.get("retryCount", 0);
-meta.put("retryCount", count + 1);
+// In Validate step: increment counter. Use Long consistently — MetaDataMap
+// is type-strict, and mixing Integer/Long across steps throws ClassCastException.
+Long count = meta.get("retryCount", 0L);
+meta.put("retryCount", count + 1L);
 // If validation succeeds, put "retryDone=true"
 ```
 
-Goto Step ECMA rule:
+Goto Step ECMAScript (Rhino) rule:
 ```javascript
 function check() {
-    var count = workflowData.getMetaDataMap().get("retryCount", 0);
-    return count < 3 && workflowData.getMetaDataMap().get("retryDone", false) == false;
+    // MetaDataMap is type-strict. When Java stored Long, calling
+    // get(key, 0) from Rhino casts against the default's class (Double in
+    // Rhino) and can throw ClassCastException. Read raw, then longValue()
+    // for a clean numeric compare that survives both step types.
+    var raw = workflowData.getMetaDataMap().get('retryCount');
+    var count = raw != null ? raw.longValue() : 0;
+    return count < 3 && !workflowData.getMetaDataMap().get('retryDone', false);
 }
 ```
 
@@ -84,6 +95,29 @@ START → [PROCESS: TaskWorkflowProcess (SUSPEND)] → [PROCESS: Post-Approval] 
 
 `TaskWorkflowProcess` creates an Inbox Task, stores `taskId` in metadata, and **suspends** the workflow (`PROCESS_AUTO_ADVANCE=false`). When the user completes the task, `TaskEventListener` advances the workflow automatically.
 
+Configure the step as a PROCESS node referencing the OOTB `Task Manager Step` (design-time `flow` layer format):
+```xml
+<approvecontent
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Approve Content"
+    sling:resourceType="cq/workflow/components/model/process">
+  <metaData
+      jcr:primaryType="nt:unstructured"
+      PROCESS="Task Manager Step"
+      PROCESS_AUTO_ADVANCE="false"
+      taskTitle="Approve content for publication"
+      taskDescription="Review the page and approve or reject."
+      taskInstructions="Click Approve to publish, Reject to send back to author."
+      taskOwner="content-reviewers"
+      taskPriority="medium"/>
+</approvecontent>
+```
+
+- `PROCESS="Task Manager Step"` — OOTB label (FQCN: `com.adobe.granite.taskmanagement.impl.workflow.TaskWorkflowProcess`).
+- `PROCESS_AUTO_ADVANCE="false"` (plain string, not `{Boolean}false`) is required — the engine must hold here while the human acts.
+- `taskOwner` is a JCR principal name (user ID or group ID).
+- After the user completes the task, `TaskEventListener` writes `lastTaskAction` and `lastTaskCompletedBy` to instance metadata; route by `lastTaskAction` in a downstream OR_SPLIT.
+
 Post-approval step reads the task result:
 ```java
 String action = meta.get("lastTaskAction", "UNKNOWN");  // e.g. "APPROVE"
@@ -94,8 +128,13 @@ String completedBy = meta.get("lastTaskCompletedBy", "unknown");
 
 ## Pattern 6: Workflow Variables for Inter-Step Data
 
-Declare at model level:
+Variables are declared in the runtime model at `/var/workflow/models/<id>/` after Sync, via the
+Workflow Model Editor's variable configuration panel. They are not part of the design-time `flow`
+layer at `/conf`. The `cq:VariableTemplate` JCR structure below is what AEM stores in the runtime
+model — do not hand-author it in a content package:
+
 ```xml
+<!-- Runtime /var model only — managed by AEM after Sync -->
 <variables jcr:primaryType="nt:unstructured">
   <reviewDecision jcr:primaryType="cq:VariableTemplate"
       varName="reviewDecision" varType="java.lang.String"/>

--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-model-design/references/workflow-model-design/model-xml-reference.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-model-design/references/workflow-model-design/model-xml-reference.md
@@ -1,81 +1,172 @@
 # Model XML Reference — AEM Workflow (6.5 LTS)
 
-## Full Model Structure
+## Design-time vs Runtime
+
+AEM 6.5 LTS separates workflow model storage into two layers at distinct paths. Never mix them.
+
+| Layer | Path | Format | Managed by |
+|---|---|---|---|
+| Design-time | `/conf/global/settings/workflow/models/<id>/` | `cq:Page` → `jcr:content` → `flow` (parsys components) | Content package + editor |
+| Runtime | `/var/workflow/models/<id>/` | `cq:WorkflowModel` → `nodes` + `transitions` | AEM Sync (automatic) |
+
+A content package delivers the **design-time** layer only. After installation, an operator opens the model in the Workflow Model Editor and clicks **Sync** to generate the runtime layer at `/var`. Sync also adds the implicit START and END nodes and derives transitions from the step sequence and step component configuration.
+
+## Full Model Structure (canonical `/conf` form)
+
+A `/conf`-based workflow model is a `cq:Page` whose `jcr:content` carries a `flow` node of type `nt:unstructured` with `sling:resourceType="foundation/components/parsys"`. Each workflow step is a direct named child of `flow`, also `nt:unstructured`, with a `sling:resourceType` that identifies the step type. The `cq:template` and `sling:resourceType` values on `jcr:content` are required — wrong values produce a model that opens incorrectly in the Workflow Model Editor or fails to Sync.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root
+    xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
     xmlns:cq="http://www.day.com/jcr/cq/1.0"
     xmlns:jcr="http://www.jcp.org/jcr/1.0"
     xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="cq:WorkflowModel"
-    jcr:title="My Workflow Title"
-    description="What this workflow does">
-
-  <variables jcr:primaryType="nt:unstructured">
-    <approvalStatus
-        jcr:primaryType="cq:VariableTemplate"
-        varName="approvalStatus"
-        varType="java.lang.String"/>
-  </variables>
-
-  <nodes jcr:primaryType="nt:unstructured">
-    <node0 jcr:primaryType="cq:WorkflowNode" title="Start" type="START">
-      <metaData jcr:primaryType="nt:unstructured"/>
-    </node0>
-
-    <node1
-        jcr:primaryType="cq:WorkflowNode"
-        title="My Step"
-        type="PROCESS">
-      <metaData
+    jcr:primaryType="cq:Page">
+  <jcr:content
+      cq:template="/libs/cq/workflow/templates/model"
+      cq:designPath="/libs/settings/wcm/designs/default"
+      jcr:primaryType="cq:PageContent"
+      jcr:title="My Workflow"
+      sling:resourceType="cq/workflow/components/pages/model">
+    <flow
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="foundation/components/parsys">
+      <!--
+        Add step components here as direct children of flow.
+        Use descriptive node names (not node0/node1).
+        Step type is expressed by sling:resourceType, not a type= property.
+        Transitions are NOT declared here — Sync derives them from step order
+        and step component configuration.
+      -->
+      <mystep
           jcr:primaryType="nt:unstructured"
-          PROCESS="com.example.workflow.MyProcess"
-          PROCESS_AUTO_ADVANCE="{Boolean}true"
-          myArg="argValue"/>
-    </node1>
-
-    <node2 jcr:primaryType="cq:WorkflowNode" title="End" type="END">
-      <metaData jcr:primaryType="nt:unstructured"/>
-    </node2>
-  </nodes>
-
-  <transitions jcr:primaryType="nt:unstructured">
-    <t1 jcr:primaryType="cq:WorkflowTransition" from="node0" to="node1" rule=""/>
-    <t2 jcr:primaryType="cq:WorkflowTransition" from="node1" to="node2" rule=""/>
-  </transitions>
+          jcr:title="My Step"
+          jcr:description="What this step does"
+          sling:resourceType="cq/workflow/components/model/process">
+        <metaData
+            jcr:primaryType="nt:unstructured"
+            PROCESS="com.example.workflow.MyProcess"
+            PROCESS_AUTO_ADVANCE="true"/>
+      </mystep>
+    </flow>
+  </jcr:content>
 </jcr:root>
 ```
 
+See [step-types-catalog.md](./step-types-catalog.md) for the correct `sling:resourceType` and `metaData` structure for each step type.
+
+## Runtime Model Structure (what Sync generates at /var — never hand-author this)
+
+After Sync, AEM writes the runtime model at `/var/workflow/models/<id>/`. Its shape is a mirror of
+the `/conf` page wrapper but with `jcr:content` being a `cq:WorkflowModel` node instead of
+`cq:PageContent`, and steps replaced by `cq:WorkflowNode` entries with a `type` property:
+
+```
+/var/workflow/models/<id>/          ← cq:Page (AEM-managed, never ship in a package)
+└── jcr:content/                    ← cq:WorkflowModel  (jcr:content IS the model — no "model/" child)
+    ├── nodes/  (nt:unstructured)
+    │   ├── node0  cq:WorkflowNode  type=START
+    │   ├── node1  cq:WorkflowNode  type=PROCESS / PARTICIPANT / OR_SPLIT / …
+    │   └── node3  cq:WorkflowNode  type=END
+    ├── transitions/  (nt:unstructured)
+    │   └── t01  cq:WorkflowTransition  from=node0  to=node1
+    └── variables/  (nt:unstructured)
+```
+
+Key facts:
+- `jcr:content` at `/var` **is** the `cq:WorkflowModel`. There is no separate `model/` child node.
+- Step nodes under `nodes/` use `cq:WorkflowNode` primary type and a `type` string property (`START`, `END`, `PROCESS`, `PARTICIPANT`, `OR_SPLIT`, `AND_SPLIT`, `AND_JOIN`).
+- Sequential names (`node0`, `node1`) are used by Sync — never use them in the design-time `flow` layer.
+- AEM derives this entire structure from the design-time `flow` layer when you click **Sync**.
+
+## Forbidden Patterns — if you are about to generate any of these, STOP
+
+**Forbidden 1 — `model/` child inside `jcr:content` at `/conf`:**
+
+```xml
+<!-- WRONG — never generate this -->
+<jcr:content jcr:primaryType="cq:PageContent" ...>
+  <flow .../>                            <!-- correct -->
+  <model jcr:primaryType="cq:WorkflowModel">   <!-- FORBIDDEN: no model/ child at /conf -->
+    <variables jcr:primaryType="nt:unstructured"/>
+    <nodes jcr:primaryType="nt:unstructured">
+      <node0 jcr:primaryType="cq:WorkflowNode" type="START"/>
+    </nodes>
+    <transitions jcr:primaryType="nt:unstructured"/>
+  </model>
+</jcr:content>
+```
+
+Why wrong: `jcr:content` at `/conf` is `cq:PageContent`. The `cq:WorkflowModel` format lives at `/var/workflow/models/<id>/jcr:content`, not as a child called `model/` inside the design-time page content. Sync creates it; you never write it.
+
+**Forbidden 2 — any file under `jcr_root/var/`:**
+
+```xml
+<!-- WRONG — never ship /var content in a package -->
+<!-- var/workflow/models/my-workflow/.content.xml -->
+<jcr:root jcr:primaryType="cq:WorkflowModel" ...>
+  <nodes .../>
+  <transitions .../>
+</jcr:root>
+```
+
+Why wrong: AEM Sync owns `/var/workflow/models/` entirely. Shipping it in a package produces conflicts and stale runtime state on re-install.
+
+**Forbidden 3 — `cq:WorkflowNode` steps or `{Boolean}` properties in the `/conf` flow layer:**
+
+```xml
+<!-- WRONG — cq:WorkflowNode belongs only at /var -->
+<node1 jcr:primaryType="cq:WorkflowNode" type="PROCESS">
+  <metaData PROCESS_AUTO_ADVANCE="{Boolean}true"/>   <!-- also wrong: must be plain string -->
+</node1>
+```
+
+Why wrong: Steps in the design-time `flow` layer must be `nt:unstructured` with `sling:resourceType`. Property values like `PROCESS_AUTO_ADVANCE` are plain strings (`"true"`), not typed JCR booleans.
+
+- ❌ `cq:template="/libs/settings/workflow/templates/model"` — wrong. Confirmed from live AEM: `/libs/cq/workflow/templates/model`.
+- ❌ Sequential node names `node0`, `node1` in the `flow` layer — use descriptive slugs (`sendnotification`, `approvaldecision`). Sequential names are generated by Sync at `/var`.
+- ❌ Omitting the `<flow>` wrapper with `sling:resourceType="foundation/components/parsys"` — the Workflow Model Editor cannot display the canvas without it.
+
 ## File Locations (6.5 LTS)
+
+The XML above is a single file representing the entire `cq:Page` subtree:
 
 ```
 ui.content/src/main/content/jcr_root/
 
 Option A — /conf (recommended, requires Sync):
-└── conf/global/settings/workflow/models/my-workflow/jcr:content/model/.content.xml
+└── conf/global/settings/workflow/models/my-workflow/.content.xml
 
 Option B — /etc (legacy, auto-deployed):
-└── etc/workflow/models/my-workflow/jcr:content/model/.content.xml
+└── etc/workflow/models/my-workflow/.content.xml
 ```
+
+For `/conf` models: after `mvn clean install -P autoInstallPackage`, open **Tools → Workflow → Models**, select the model, click **Edit**, then click **Sync**. Verify the model appears in `/var/workflow/models/` via CRX/DE and all steps render on the editor canvas before starting a test instance.
 
 ## Property Reference
 
-### cq:WorkflowNode metaData Properties
+### Step metaData Properties
+
+These properties go inside the `<metaData jcr:primaryType="nt:unstructured"/>` child of each step node in the `flow` layer. The property names are the same regardless of whether you are looking at the design-time `flow` format or the runtime model.
 
 | Property | Applies to | Purpose |
 |---|---|---|
-| `PROCESS` | PROCESS | FQCN or process.label |
-| `PROCESS_AUTO_ADVANCE` | PROCESS | Boolean: auto advance or hold |
-| `PARTICIPANT` | PARTICIPANT | JCR principal name |
-| `DYNAMIC_PARTICIPANT` | DYNAMIC_PARTICIPANT | chooser.label value |
-| `DESCRIPTION` | PARTICIPANT | Instruction in inbox |
-| `allowInboxSharing` | PARTICIPANT | Show to all group members |
+| `PROCESS` | PROCESS | FQCN or process.label of the registered OSGi service |
+| `PROCESS_AUTO_ADVANCE` | PROCESS | String `"true"` = auto-advance; `"false"` = hold for external completion |
+| `PARTICIPANT` | PARTICIPANT | JCR principal name (user ID or group ID) |
+| `DYNAMIC_PARTICIPANT` | DYNAMIC_PARTICIPANT | chooser.label value or ECMAScript path |
+| `DESCRIPTION` | PARTICIPANT | Instruction text shown in the Inbox |
+| `allowInboxSharing` | PARTICIPANT | Show work item to all members of the assigned group |
 | `allowExplicitSharing` | PARTICIPANT | Allow explicit inbox sharing |
 
-### cq:VariableTemplate Properties
+### Workflow Variables
 
-| Property | Java Type |
+Variables are declared in the runtime model at `/var` after Sync, either via the Workflow Model Editor's variable configuration panel or by adding `cq:VariableTemplate` nodes to the synced model. They are not declared in the design-time `flow` layer.
+
+### cq:VariableTemplate Properties (runtime `/var` model only)
+
+| varType value | Java type |
 |---|---|
 | `java.lang.String` | String |
 | `java.lang.Long` | Long |
@@ -96,3 +187,17 @@ Option B — /etc (legacy, auto-deployed):
 | `Lock Payload Process` | `com.adobe.granite.workflow.core.process.LockProcess` | JCR lock |
 | `Unlock Payload Process` | `com.adobe.granite.workflow.core.process.UnlockProcess` | Remove JCR lock |
 | `Task Manager Step` | `com.adobe.granite.taskmanagement.impl.workflow.TaskWorkflowProcess` | Create Inbox task |
+
+### SetVariableProcess Argument Modes
+
+`Set Variable Step` supports seven assignment modes via step metaData. Configure on the step node's `<metaData>`. Use this OOTB step instead of writing a custom `WorkflowProcess` for simple value assignment.
+
+| Mode | Source |
+|---|---|
+| `LITERAL` | A literal string value (e.g., `"APPROVED"`) |
+| `RELATIVE_TO_PAYLOAD` | JCR property relative to the payload (e.g., `jcr:title`) |
+| `ABSOLUTE_PATH` | Full JCR path to a property |
+| `EXPRESSION` | ECMAScript expression evaluated against `workflowData` |
+| `VARIABLE` | Another workflow variable's value |
+| `JSON_DOT_NOTATION` | JSON path like `data.response.status` (over a JSON-typed variable) |
+| `XPATH` | XPath over an XML-typed variable |

--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-model-design/references/workflow-model-design/step-types-catalog.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-model-design/references/workflow-model-design/step-types-catalog.md
@@ -1,66 +1,82 @@
-# Step Types Catalog — AEM Workflow
+# Step Types Catalog — AEM Workflow (6.5 LTS)
 
-## START Node
+This catalog documents the design-time format for workflow steps in the `flow/parsys` layer at
+`/conf/global/settings/workflow/models/<id>/jcr:content/flow/`. Steps are `nt:unstructured` nodes
+whose type is expressed by `sling:resourceType`, not a `type=` property or `cq:WorkflowNode`
+primary type.
+
+After installing a model package, click **Sync** in the Workflow Model Editor to generate the
+runtime model at `/var/workflow/models/`. Sync adds START/END nodes and derives transitions from
+the step sequence and step component configuration.
+
+## sling:resourceType Reference
+
+| Step type | sling:resourceType |
+|---|---|
+| Initiator Participant Chooser | `cq/workflow/components/workflow/initiatorparticipantchooser` |
+| PROCESS | `cq/workflow/components/model/process` |
+| PARTICIPANT | `cq/workflow/components/model/participant` |
+| DYNAMIC_PARTICIPANT | `cq/workflow/components/model/dynamic_participant` |
+| OR_SPLIT | `cq/workflow/components/model/or` |
+| AND_SPLIT | `cq/workflow/components/model/AND_split` |
+| AND_JOIN | `cq/workflow/components/model/AND_join` |
+| END | `cq/workflow/components/model/end` |
+
+## Initiator Participant Chooser (AEM default first step)
+
+AEM's Workflow Model Editor pre-inserts this as "Step 1" when a new model is created. It is a
+Dynamic Participant step backed by `/libs/workflow/scripts/initiator-participant-chooser.ecma`,
+which resolves to the user who triggered the workflow. Include it when the workflow needs to assign
+a task back to the initiator. Not required in every model.
 
 ```xml
-<node0
-    jcr:primaryType="cq:WorkflowNode"
-    title="Start"
-    type="START">
-  <metaData jcr:primaryType="nt:unstructured"/>
-</node0>
+<initiatorparticipant
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Step 1"
+    jcr:description="Description of step 1"
+    sling:resourceType="cq/workflow/components/workflow/initiatorparticipantchooser">
+  <metaData
+      jcr:primaryType="nt:unstructured"
+      DYNAMIC_PARTICIPANT="/libs/workflow/scripts/initiator-participant-chooser.ecma"
+      PROCESS_AUTO_ADVANCE="true"/>
+</initiatorparticipant>
 ```
-
-One START node per model. All transitions originate from here.
-
-## END Node
-
-```xml
-<node_end
-    jcr:primaryType="cq:WorkflowNode"
-    title="End"
-    type="END">
-  <metaData jcr:primaryType="nt:unstructured"/>
-</node_end>
-```
-
-Terminal node. Multiple branches can converge to END.
 
 ## PROCESS Node (Auto-executed Java Step)
 
 ```xml
-<node1
-    jcr:primaryType="cq:WorkflowNode"
-    title="Send Notification"
-    type="PROCESS"
-    description="Sends an email to the assignee">
+<sendnotification
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Send Notification"
+    jcr:description="Sends an email to the assignee"
+    sling:resourceType="cq/workflow/components/model/process">
   <metaData
       jcr:primaryType="nt:unstructured"
       PROCESS="com.example.workflow.SendNotificationProcess"
-      PROCESS_AUTO_ADVANCE="{Boolean}true"
+      PROCESS_AUTO_ADVANCE="true"
       recipient="workflow-administrators"
       subject="Content ready for review"/>
-</node1>
+</sendnotification>
 ```
 
 - `PROCESS`: fully-qualified class name or `process.label` value of the registered OSGi service
-- `PROCESS_AUTO_ADVANCE`: `true` = auto-advance after execute(); `false` = step holds (TaskWorkflowProcess pattern)
+- `PROCESS_AUTO_ADVANCE`: `"true"` = auto-advance after execute(); `"false"` = step holds
 - Additional metaData keys = step arguments accessible via `MetaDataMap args` in `execute()`
 
 ## PARTICIPANT Node (Static Human Task)
 
 ```xml
-<node2
-    jcr:primaryType="cq:WorkflowNode"
-    title="Content Review"
-    type="PARTICIPANT">
+<contentreview
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Content Review"
+    sling:resourceType="cq/workflow/components/model/participant">
   <metaData
       jcr:primaryType="nt:unstructured"
       PARTICIPANT="content-reviewers"
       DESCRIPTION="Please review the content and approve or reject"
-      allowInboxSharing="{Boolean}true"
-      allowExplicitSharing="{Boolean}true"/>
-</node2>
+      allowInboxSharing="true"
+      allowExplicitSharing="true"/>
+</contentreview>
 ```
 
 - `PARTICIPANT`: JCR principal name (user ID or group ID)
@@ -70,84 +86,131 @@ Terminal node. Multiple branches can converge to END.
 ## DYNAMIC_PARTICIPANT Node (Runtime-Resolved Human Task)
 
 ```xml
-<node3
-    jcr:primaryType="cq:WorkflowNode"
-    title="Manager Approval"
-    type="DYNAMIC_PARTICIPANT">
+<managerapproval
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Manager Approval"
+    sling:resourceType="cq/workflow/components/model/dynamic_participant">
   <metaData
       jcr:primaryType="nt:unstructured"
       DYNAMIC_PARTICIPANT="Department Manager Chooser"
       fallbackGroup="workflow-administrators"/>
-</node3>
+</managerapproval>
 ```
 
-- `DYNAMIC_PARTICIPANT`: must match the `chooser.label` property of a registered `ParticipantStepChooser` OSGi service
+- `DYNAMIC_PARTICIPANT`: must match the `chooser.label` property of a registered
+  `ParticipantStepChooser` OSGi service
 - Additional metaData keys = args passed to `getParticipant()`
 
 ## OR_SPLIT Node (Decision Branch)
 
 ```xml
-<node_split
-    jcr:primaryType="cq:WorkflowNode"
-    title="Approval Decision"
-    type="OR_SPLIT">
+<approvaldecision
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Approval Decision"
+    sling:resourceType="cq/workflow/components/model/or">
   <metaData jcr:primaryType="nt:unstructured"/>
-</node_split>
-
-<!-- Transitions with rules — first matching transition wins -->
-<t_approve
-    jcr:primaryType="cq:WorkflowTransition"
-    from="node_split"
-    to="node_activate"
-    rule="function check(){
-        return workflowData.getMetaDataMap().get('decision','')=='APPROVE';
-    }"/>
-<t_reject
-    jcr:primaryType="cq:WorkflowTransition"
-    from="node_split"
-    to="node_notify"
-    rule="function check(){ return true; }"/>
+</approvaldecision>
 ```
 
-Rules are ECMA (JavaScript). `workflowData` is the `WorkflowData` object. Use `get('key', defaultValue)` for safe reads.
+OR_SPLIT routing rules (ECMAScript / Rhino) are configured on the outgoing transitions in the
+runtime model. After Sync, open the model in the Workflow Model Editor and configure the route
+rules on each outgoing arrow from the OR_SPLIT node. Rules use `workflowData.getMetaDataMap()` to
+read step-set values:
+
+```javascript
+// Approve route
+function check() {
+    return 'APPROVE' === String(workflowData.getMetaDataMap().get('reviewDecision', ''));
+}
+// Catch-all / reject route
+function check() { return true; }
+```
 
 ## AND_SPLIT / AND_JOIN (Parallel Branches)
 
 ```xml
-<!-- AND_SPLIT fans out to all connected outgoing transitions -->
-<node_split
-    jcr:primaryType="cq:WorkflowNode"
-    title="Start Parallel Review"
-    type="AND_SPLIT">
+<!-- AND_SPLIT: fans out to all connected outgoing steps -->
+<startparallelreview
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Start Parallel Review"
+    sling:resourceType="cq/workflow/components/model/AND_split">
   <metaData jcr:primaryType="nt:unstructured"/>
-</node_split>
+</startparallelreview>
 
-<!-- AND_JOIN waits for all incoming branches to arrive -->
-<node_join
-    jcr:primaryType="cq:WorkflowNode"
-    title="Synchronize"
-    type="AND_JOIN">
+<!-- AND_JOIN: waits for all incoming branches before continuing -->
+<synchronize
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Synchronize"
+    sling:resourceType="cq/workflow/components/model/AND_join">
   <metaData jcr:primaryType="nt:unstructured"/>
-</node_join>
+</synchronize>
 ```
 
-All outgoing transitions from AND_SPLIT execute. Workflow pauses at AND_JOIN until all branches complete.
+All outgoing transitions from AND_SPLIT execute in parallel. Workflow pauses at AND_JOIN until all
+branches complete.
 
-## EXTERNAL_PROCESS Node (Polling Step)
+## END Node
 
 ```xml
-<node_ext
-    jcr:primaryType="cq:WorkflowNode"
-    title="Wait for DAM Processing"
-    type="EXTERNAL_PROCESS">
-  <metaData
-      jcr:primaryType="nt:unstructured"
-      EXTERNAL_PROCESS="com.example.workflow.DamProcessingExternalStep"
-      pollingInterval="{Long}30000"/>
-</node_ext>
+<workflowend
+    jcr:primaryType="nt:unstructured"
+    jcr:title="End"
+    sling:resourceType="cq/workflow/components/model/end">
+  <metaData jcr:primaryType="nt:unstructured"/>
+</workflowend>
 ```
 
-`WorkflowExternalProcess` SPI — the engine polls at `pollingInterval` ms until the process signals completion.
+Multiple branches can converge to the same END node. Sync also inserts a START node automatically
+— you do not need to declare it in the design-time `flow` layer.
+
+## Goto Step (OOTB Loop-back PROCESS Node)
+
+`Goto Step` is an OOTB PROCESS step that re-routes execution back to an earlier step when its
+rule returns true. Use it for **capped** retry loops; always enforce a hard cap.
+
+```xml
+<retryvalidate
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Retry Validate?"
+    sling:resourceType="cq/workflow/components/model/process">
+  <metaData
+      jcr:primaryType="nt:unstructured"
+      PROCESS="Goto Step"
+      PROCESS_AUTO_ADVANCE="true"
+      targetStep="validate"/>
+</retryvalidate>
+```
+
+- `PROCESS`: `"Goto Step"` (label) or `com.adobe.granite.workflow.core.process.GotoProcess` (FQCN)
+- `targetStep`: node name of the step in the `flow` layer to redirect to when the rule returns true
+- Goto rules are configured on the outgoing transition in the runtime model after Sync
+- Always cap the retry counter (`count < 3`). An uncapped Goto pins a worker thread and
+  accumulates failed instances
+
+## Task Manager Step (Inbox Task + Workflow Suspend)
+
+```xml
+<approvecontent
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Approve Content"
+    sling:resourceType="cq/workflow/components/model/process">
+  <metaData
+      jcr:primaryType="nt:unstructured"
+      PROCESS="Task Manager Step"
+      PROCESS_AUTO_ADVANCE="false"
+      taskTitle="Approve content for publication"
+      taskDescription="Review the page and approve or reject."
+      taskInstructions="Click Approve to publish, Reject to send back to author."
+      taskOwner="content-reviewers"
+      taskPriority="medium"/>
+</approvecontent>
+```
+
+- `PROCESS="Task Manager Step"` — OOTB label (FQCN: `com.adobe.granite.taskmanagement.impl.workflow.TaskWorkflowProcess`)
+- `PROCESS_AUTO_ADVANCE="false"` is required — the engine holds here while the human acts
+- `taskOwner` is a JCR principal name (user ID or group ID)
+- After task completion, `TaskEventListener` writes `lastTaskAction` and `lastTaskCompletedBy` to
+  instance metadata; route by `lastTaskAction` in a downstream OR_SPLIT
 
 ## OOTB Process Labels Reference
 

--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-model-design/references/workflow-model-design/step-types-catalog.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-model-design/references/workflow-model-design/step-types-catalog.md
@@ -18,9 +18,9 @@ the step sequence and step component configuration.
 | PARTICIPANT | `cq/workflow/components/model/participant` |
 | DYNAMIC_PARTICIPANT | `cq/workflow/components/model/dynamic_participant` |
 | OR_SPLIT | `cq/workflow/components/model/or` |
-| AND_SPLIT | `cq/workflow/components/model/AND_split` |
-| AND_JOIN | `cq/workflow/components/model/AND_join` |
-| END | `cq/workflow/components/model/end` |
+| AND_SPLIT | `cq/workflow/components/model/and` |
+
+START, END, and AND_JOIN have no design-time component on AEM 6.5 LTS. AEM Sync derives them automatically at `/var/workflow/models/<id>`. Never write `cq/workflow/components/model/start`, `cq/workflow/components/model/end`, or `cq/workflow/components/model/AND_join` as `sling:resourceType` — no such components exist under `/libs/cq/workflow/components/model/`, and the Workflow Model Editor will not render them.
 
 ## Initiator Participant Chooser (AEM default first step)
 
@@ -126,42 +126,27 @@ function check() {
 function check() { return true; }
 ```
 
-## AND_SPLIT / AND_JOIN (Parallel Branches)
+## AND_SPLIT (Parallel Branches)
+
+In the design-time `flow` layer, author only the AND_SPLIT step. AEM Sync derives the matching AND_JOIN node automatically at `/var/workflow/models/<id>` based on where the parallel branches converge in the editor.
 
 ```xml
 <!-- AND_SPLIT: fans out to all connected outgoing steps -->
 <startparallelreview
     jcr:primaryType="nt:unstructured"
     jcr:title="Start Parallel Review"
-    sling:resourceType="cq/workflow/components/model/AND_split">
+    sling:resourceType="cq/workflow/components/model/and">
   <metaData jcr:primaryType="nt:unstructured"/>
 </startparallelreview>
-
-<!-- AND_JOIN: waits for all incoming branches before continuing -->
-<synchronize
-    jcr:primaryType="nt:unstructured"
-    jcr:title="Synchronize"
-    sling:resourceType="cq/workflow/components/model/AND_join">
-  <metaData jcr:primaryType="nt:unstructured"/>
-</synchronize>
 ```
 
-All outgoing transitions from AND_SPLIT execute in parallel. Workflow pauses at AND_JOIN until all
-branches complete.
+All outgoing transitions from AND_SPLIT execute in parallel. Workflow pauses at the Sync-generated AND_JOIN until all branches complete. There is no design-time component for AND_JOIN — never write `sling:resourceType="cq/workflow/components/model/AND_join"`; the editor will not render it.
 
-## END Node
+## START and END (Sync-Derived)
 
-```xml
-<workflowend
-    jcr:primaryType="nt:unstructured"
-    jcr:title="End"
-    sling:resourceType="cq/workflow/components/model/end">
-  <metaData jcr:primaryType="nt:unstructured"/>
-</workflowend>
-```
+AEM Sync adds both START and END nodes automatically to the runtime model at `/var/workflow/models/<id>`. Do not author them in the design-time `flow` layer. The design-time flow simply ends after the last step component; Sync inserts the END node and connects it. The START node is similarly auto-generated as the entry point.
 
-Multiple branches can converge to the same END node. Sync also inserts a START node automatically
-— you do not need to declare it in the design-time `flow` layer.
+There is no `cq/workflow/components/model/end` or `cq/workflow/components/model/start` component under `/libs/cq/workflow/components/model/` on AEM 6.5 LTS — never write these as `sling:resourceType` values.
 
 ## Goto Step (OOTB Loop-back PROCESS Node)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the AEM 6.5 LTS `workflow-model-design` skill to generate valid workflow model XML aligned with verified OOTB workflow components.

Corrects invalid `jcr:content/flow/<step>` structures and unsupported `sling:resourceType` values that previously produced models incompatible with Workflow Model Editor and Sync processing.

## Motivation and Context

A customer reported that the workflow-model-design skill documents an incorrect workflow model XML structure for AEM 6.5 LTS.
The previous guidance instructed developers to author workflow models at:/conf/global/settings/workflow/models/<id>

However, these represent the runtime format generated under /var during Sync, not the design-time format used by the Workflow Model Editor.
This PR aligns the skill with the actual AEM 6.5 LTS workflow model structure and verified OOTB workflow components, ensuring generated models:
1. open correctly in Workflow Model Editor,
2.synchronize successfully,execute end-to-end as expected.

## How Has This Been Tested?

Verified against an AEM 6.5 LTS instance and different sources for correctness
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
