### PR TITLE
 fix(aem-workflow): correct workflow-model-design XML format and step resourceTypes (AEMaaCS)   

### DIFF
--- a/plugins/aem/cloud-service/skills/aem-workflow/workflow-model-design/SKILL.md
+++ b/plugins/aem/cloud-service/skills/aem-workflow/workflow-model-design/SKILL.md
@@ -6,12 +6,24 @@ license: Apache-2.0
 
 # Workflow Model Design (Cloud Service)
 
-Design workflow models for AEM Cloud Service: step structure, transitions, OR/AND splits, variables, and model XML deployment.
+Design workflow models for AEM as a Cloud Service: step structure, transitions, OR/AND splits, variables, and model XML deployment.
+
+## Audience
+
+Developers (and the IDE LLM acting on their behalf) authoring AEM workflow models for AEM as a Cloud Service — designing the step graph, splits, joins, transitions, and the model XML that ships through the Cloud Manager pipeline.
 
 ## Variant Scope
 
-- This skill is AEM Cloud Service only.
-- Models are stored at `/conf/global/settings/workflow/models/`. Do not write to `/libs` or `/etc`.
+- AEM as a Cloud Service only.
+- Models are stored at `/conf/global/settings/workflow/models/`. Do not write to `/libs` or `/etc` — `/libs` is immutable and `/etc/workflow/models/` is the legacy 6.5 path, deprecated on AEMaaCS.
+- Deploy via Cloud Manager pipeline; design-time → runtime sync is required after deploy (Tools → Workflow → Models → Sync).
+- **Not for AEM 6.5 LTS.** If the target is 6.5 LTS, stop and use the 6.5-lts variant of this skill — `/etc/workflow/models/` legacy auto-deploy and `mvn install -PautoInstallPackage` deploys documented there do not apply on AEMaaCS.
+
+## Dependencies
+
+- `workflow-foundation` references (architecture, API, JCR paths, Cloud Service guardrails) — load alongside.
+- `workflow-development` — every PROCESS step in the model needs a `WorkflowProcess` (or `process.label`) registered as an OSGi service. Model XML and Java code are co-authored.
+- `workflow-launchers` — when a launcher routes content into the model, see launcher-side guardrails.
 
 ## Workflow
 
@@ -21,9 +33,33 @@ Model Design Progress
 - [ ] 2) Map out steps: PROCESS (auto), PARTICIPANT (human), OR_SPLIT (decision), AND_SPLIT (parallel)
 - [ ] 3) Decide payload type: single JCR_PATH page/asset, or multi-page via workflow package
 - [ ] 4) Identify workflow variables needed for inter-step data passing
-- [ ] 5) Design model XML: nodes + transitions + metaData with correct step properties
+- [ ] 5) Design model XML: flow/parsys layer with correct nt:unstructured step components and sling:resourceType per step
 - [ ] 6) Add filter.xml entry with mode="merge" for the model path
-- [ ] 7) Verify model synced to /var/workflow/models/ after deployment
+- [ ] 7) Deploy via Cloud Manager pipeline
+- [ ] 8) Open the model in Tools → Workflow → Models → Edit → Sync; verify the model appears in /var/workflow/models/ and all steps render on the editor canvas
+- [ ] 9) Start a test workflow instance; confirm it runs to completion
+```
+
+## Output Contract
+
+**Generate only these files for a `/conf`-based model:**
+
+| File | Node type | Purpose |
+|---|---|---|
+| `jcr_root/conf/.../models/<id>/.content.xml` | `cq:Page` | Model root page |
+| `jcr_root/conf/.../models/<id>/jcr:content/.content.xml` | `cq:PageContent` | Title, template, resourceType |
+| `jcr_root/conf/.../models/<id>/jcr:content/flow/.content.xml` | `nt:unstructured` + parsys | Step nodes |
+
+**Never generate — hard stops:**
+
+- ❌ **Any file under `jcr_root/var/`** — AEM Sync writes `/var/workflow/models/` automatically after you click Sync in the editor. Never ship `/var` content in a content package.
+- ❌ **A `model/` directory inside `jcr:content/` at the `/conf` path** — a `cq:WorkflowModel` node with `<nodes>` and `<transitions>` is the runtime format. It must never appear under `/conf`. The Workflow Model Editor cannot open a model that contains it.
+- ❌ **`<filter root="/var/workflow/models/..."/>` in filter.xml** — `/var` is never a package filter target. The only filter entry needed is the `/conf` path.
+- ❌ **Any path under `/etc/workflow/models/`** — deprecated and unsupported on AEM as a Cloud Service.
+
+**filter.xml — correct entry:**
+```xml
+<filter root="/conf/global/settings/workflow/models/my-workflow" mode="merge"/>
 ```
 
 ## Node Types Quick Reference
@@ -35,17 +71,29 @@ Model Design Progress
 | `PROCESS` | Auto-executed Java step | `PROCESS` = FQCN or process.label |
 | `PARTICIPANT` | Human task (static assignee) | `PARTICIPANT` = principal name |
 | `DYNAMIC_PARTICIPANT` | Human task (runtime assignee) | `DYNAMIC_PARTICIPANT` = chooser.label |
-| `OR_SPLIT` | One branch selected by rule | Transition `rule` = ECMA/Groovy |
+| `OR_SPLIT` | One branch selected by rule | Transition `rule` = ECMAScript (Rhino) |
 | `AND_SPLIT` | All branches execute in parallel | — |
 | `AND_JOIN` | Wait for all parallel branches | — |
 | `EXTERNAL_PROCESS` | Poll an external system | `EXTERNAL_PROCESS` = FQCN |
 
+## Default Path Rule
+
+**Unless the user explicitly names a specific AEM site, always generate models at `/conf/global/settings/workflow/models/<id>`.** Do not infer a site-scoped path (e.g., `/conf/wknd/…`) from conversational context such as "for the WKND site" or "install on the WKND instance." Workflow models are not site-scoped by default — they are global resources. Only use `/conf/<site>/settings/workflow/models/<id>` when the user explicitly states that the model should be scoped to a specific site.
+
 ## Cloud Service Deployment
 
-1. Place model XML at: `/conf/global/settings/workflow/models/<name>/jcr:content/model/`
+1. Place model XML at: `conf/global/settings/workflow/models/<name>/.content.xml` (the `flow/parsys` design-time format — not `jcr:content/model/`)
 2. Add to `ui.content` package with `filter.xml` entry `mode="merge"`
-3. After Cloud Manager pipeline install: open Workflow Model Editor → **Sync** (or use `deployModel()`)
-4. Engine reads from `/var/workflow/models/<name>` — verify sync succeeded
+3. Deploy via Cloud Manager pipeline
+4. Open **Tools → Workflow → Models** → select model → **Edit** → **Sync**
+5. Verify the model appears in `/var/workflow/models/<name>` via CRX/DE and all steps render on the canvas
+
+**Design-time vs runtime paths**: `/conf/global/settings/workflow/models/` stores the editor's
+`flow/parsys` format — this is what you author and deploy. Steps are `nt:unstructured` nodes with
+`sling:resourceType`; no `cq:WorkflowNode` or `cq:WorkflowTransition` nodes appear here.
+`/var/workflow/models/` holds the runtime copy generated by Sync — it uses `cq:WorkflowModel`,
+`cq:WorkflowNode`, and `cq:WorkflowTransition`. Never write `cq:WorkflowModel` nodes to the `/conf`
+path, and never hand-author `/var` content — AEM manages the runtime layer entirely via Sync.
 
 ## References
 

--- a/plugins/aem/cloud-service/skills/aem-workflow/workflow-model-design/references/workflow-model-design/model-design-patterns.md
+++ b/plugins/aem/cloud-service/skills/aem-workflow/workflow-model-design/references/workflow-model-design/model-design-patterns.md
@@ -21,7 +21,7 @@ START → [PARTICIPANT: Review] → [OR_SPLIT] ──approve──→ [PROCESS: 
                                            └──reject───→ [PROCESS: Notify]   → END
 ```
 
-OR_SPLIT transition rules (ECMA):
+OR_SPLIT transition rules (ECMAScript / Rhino — wrap Java string returns with `String(...)` and use strict equality `===` for safety):
 ```javascript
 // Approve transition
 function check() {
@@ -66,7 +66,7 @@ meta.put("retryCount", count + 1);
 // If validation succeeds, put "retryDone=true"
 ```
 
-Goto Step ECMA rule:
+Goto Step ECMAScript (Rhino) rule:
 ```javascript
 function check() {
     var count = workflowData.getMetaDataMap().get("retryCount", 0);
@@ -94,8 +94,13 @@ String completedBy = meta.get("lastTaskCompletedBy", "unknown");
 
 ## Pattern 6: Workflow Variables for Inter-Step Data
 
-Declare at model level:
+Variables are declared in the runtime model at `/var/workflow/models/<id>/` after Sync, via the
+Workflow Model Editor's variable configuration panel. They are not part of the design-time `flow`
+layer at `/conf`. The `cq:VariableTemplate` JCR structure below is what AEM stores in the runtime
+model — do not hand-author it in a content package:
+
 ```xml
+<!-- Runtime /var model only — managed by AEM after Sync -->
 <variables jcr:primaryType="nt:unstructured">
   <reviewDecision jcr:primaryType="cq:VariableTemplate"
       varName="reviewDecision" varType="java.lang.String"/>

--- a/plugins/aem/cloud-service/skills/aem-workflow/workflow-model-design/references/workflow-model-design/model-xml-reference.md
+++ b/plugins/aem/cloud-service/skills/aem-workflow/workflow-model-design/references/workflow-model-design/model-xml-reference.md
@@ -1,120 +1,200 @@
 # Model XML Reference — AEM Workflow (Cloud Service)
 
-## Full Model Structure
+## Design-time vs Runtime
+
+AEM as a Cloud Service separates workflow model storage into two layers at distinct paths. Never mix them.
+
+| Layer | Path | Format | Managed by |
+|---|---|---|---|
+| Design-time | `/conf/global/settings/workflow/models/<id>/` | `cq:Page` → `jcr:content` → `flow` (parsys components) | Content package + editor |
+| Runtime | `/var/workflow/models/<id>/` | `cq:WorkflowModel` → `nodes` + `transitions` | AEM Sync (automatic) |
+
+A content package delivers the **design-time** layer only. After Cloud Manager pipeline installation, an operator opens the model in the Workflow Model Editor and clicks **Sync** to generate the runtime layer at `/var`. Sync also adds the implicit START and END nodes and derives transitions from the step sequence and step component configuration.
+
+## Full Model Structure (canonical `/conf` form)
+
+A `/conf`-based workflow model is a `cq:Page` whose `jcr:content` carries a `flow` node of type `nt:unstructured` with `sling:resourceType="foundation/components/parsys"`. Each workflow step is a direct named child of `flow`, also `nt:unstructured`, with a `sling:resourceType` that identifies the step type. The `cq:template` and `sling:resourceType` values on `jcr:content` are required — wrong values produce a model that opens incorrectly in the Workflow Model Editor or fails to Sync.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root
+    xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
     xmlns:cq="http://www.day.com/jcr/cq/1.0"
     xmlns:jcr="http://www.jcp.org/jcr/1.0"
     xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="cq:WorkflowModel"
-    jcr:title="My Workflow Title"
-    description="What this workflow does">
-
-  <!-- Optional: workflow variables -->
-  <variables jcr:primaryType="nt:unstructured">
-    <approvalStatus
-        jcr:primaryType="cq:VariableTemplate"
-        varName="approvalStatus"
-        varType="java.lang.String"/>
-    <reviewerList
-        jcr:primaryType="cq:VariableTemplate"
-        varName="reviewerList"
-        varType="java.util.ArrayList"/>
-  </variables>
-
-  <!-- Step nodes -->
-  <nodes jcr:primaryType="nt:unstructured">
-    <node0 jcr:primaryType="cq:WorkflowNode" title="Start" type="START">
-      <metaData jcr:primaryType="nt:unstructured"/>
-    </node0>
-
-    <node1
-        jcr:primaryType="cq:WorkflowNode"
-        title="My Step"
-        type="PROCESS"
-        description="Optional description">
-      <metaData
+    jcr:primaryType="cq:Page">
+  <jcr:content
+      cq:template="/libs/cq/workflow/templates/model"
+      cq:designPath="/libs/settings/wcm/designs/default"
+      jcr:primaryType="cq:PageContent"
+      jcr:title="My Workflow"
+      sling:resourceType="cq/workflow/components/pages/model">
+    <flow
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="foundation/components/parsys">
+      <!--
+        Add step components here as direct children of flow.
+        Use descriptive node names (not node0/node1).
+        Step type is expressed by sling:resourceType, not a type= property.
+        Transitions are NOT declared here — Sync derives them from step order
+        and step component configuration.
+      -->
+      <mystep
           jcr:primaryType="nt:unstructured"
-          PROCESS="com.example.workflow.MyProcess"
-          PROCESS_AUTO_ADVANCE="{Boolean}true"
-          myArg="argValue"/>
-    </node1>
-
-    <node2 jcr:primaryType="cq:WorkflowNode" title="End" type="END">
-      <metaData jcr:primaryType="nt:unstructured"/>
-    </node2>
-  </nodes>
-
-  <!-- Transitions connect nodes -->
-  <transitions jcr:primaryType="nt:unstructured">
-    <t1 jcr:primaryType="cq:WorkflowTransition"
-        from="node0" to="node1" rule=""/>
-    <t2 jcr:primaryType="cq:WorkflowTransition"
-        from="node1" to="node2" rule=""/>
-  </transitions>
+          jcr:title="My Step"
+          jcr:description="What this step does"
+          sling:resourceType="cq/workflow/components/model/process">
+        <metaData
+            jcr:primaryType="nt:unstructured"
+            PROCESS="com.example.workflow.MyProcess"
+            PROCESS_AUTO_ADVANCE="true"/>
+      </mystep>
+    </flow>
+  </jcr:content>
 </jcr:root>
 ```
 
-## Property Reference
+See [step-types-catalog.md](./step-types-catalog.md) for the correct `sling:resourceType` and `metaData` structure for each step type.
 
-### cq:WorkflowModel Properties
+## Runtime Model Structure (what Sync generates at /var — never hand-author this)
 
-| Property | Type | Purpose |
-|---|---|---|
-| `jcr:primaryType` | String | Must be `cq:WorkflowModel` |
-| `jcr:title` | String | Display name in model picker |
-| `description` | String | Optional description |
+After Sync, AEM writes the runtime model at `/var/workflow/models/<id>/`. Its shape is a mirror of
+the `/conf` page wrapper but with `jcr:content` being a `cq:WorkflowModel` node instead of
+`cq:PageContent`, and steps replaced by `cq:WorkflowNode` entries with a `type` property:
 
-### cq:WorkflowNode Properties
+```
+/var/workflow/models/<id>/          ← cq:Page (AEM-managed, never ship in a package)
+└── jcr:content/                    ← cq:WorkflowModel  (jcr:content IS the model — no "model/" child)
+    ├── nodes/  (nt:unstructured)
+    │   ├── node0  cq:WorkflowNode  type=START
+    │   ├── node1  cq:WorkflowNode  type=PROCESS / PARTICIPANT / OR_SPLIT / …
+    │   └── node3  cq:WorkflowNode  type=END
+    ├── transitions/  (nt:unstructured)
+    │   └── t01  cq:WorkflowTransition  from=node0  to=node1
+    └── variables/  (nt:unstructured)
+```
 
-| Property | Type | Purpose |
-|---|---|---|
-| `jcr:primaryType` | String | Must be `cq:WorkflowNode` |
-| `title` | String | Display label in editor |
-| `type` | String | Node type constant (e.g. `PROCESS`, `PARTICIPANT`) |
-| `description` | String | Optional step description |
+Key facts:
+- `jcr:content` at `/var` **is** the `cq:WorkflowModel`. There is no separate `model/` child node.
+- Step nodes under `nodes/` use `cq:WorkflowNode` primary type and a `type` string property (`START`, `END`, `PROCESS`, `PARTICIPANT`, `OR_SPLIT`, `AND_SPLIT`, `AND_JOIN`).
+- Sequential names (`node0`, `node1`) are used by Sync — never use them in the design-time `flow` layer.
+- AEM derives this entire structure from the design-time `flow` layer when you click **Sync**.
 
-### cq:WorkflowNode metaData Properties
+## Forbidden Patterns — if you are about to generate any of these, STOP
 
-| Property | Type | Applies to | Purpose |
-|---|---|---|---|
-| `PROCESS` | String | PROCESS | FQCN or process.label of WorkflowProcess |
-| `PROCESS_AUTO_ADVANCE` | Boolean | PROCESS | true = auto advance, false = hold |
-| `PARTICIPANT` | String | PARTICIPANT | JCR principal name |
-| `DYNAMIC_PARTICIPANT` | String | DYNAMIC_PARTICIPANT | chooser.label value |
-| `DESCRIPTION` | String | PARTICIPANT | Instruction shown to user in inbox |
-| `allowInboxSharing` | Boolean | PARTICIPANT | Show to all group members |
-| `allowExplicitSharing` | Boolean | PARTICIPANT | Allow inbox sharing delegation |
-| `PROCESS_ARGS` | String | PROCESS | Legacy comma-separated args string |
-| `PERSIST_ANONYMOUS_WORKITEM` | Boolean | PROCESS | Persist transient work item |
+**Forbidden 1 — `model/` child inside `jcr:content` at `/conf`:**
 
-### cq:WorkflowTransition Properties
+```xml
+<!-- WRONG — never generate this -->
+<jcr:content jcr:primaryType="cq:PageContent" ...>
+  <flow .../>                            <!-- correct -->
+  <model jcr:primaryType="cq:WorkflowModel">   <!-- FORBIDDEN: no model/ child at /conf -->
+    <variables jcr:primaryType="nt:unstructured"/>
+    <nodes jcr:primaryType="nt:unstructured">
+      <node0 jcr:primaryType="cq:WorkflowNode" type="START"/>
+    </nodes>
+    <transitions jcr:primaryType="nt:unstructured"/>
+  </model>
+</jcr:content>
+```
 
-| Property | Type | Purpose |
-|---|---|---|
-| `jcr:primaryType` | String | Must be `cq:WorkflowTransition` |
-| `from` | String | Node ID of source |
-| `to` | String | Node ID of destination |
-| `rule` | String | ECMA/Groovy rule (empty = always true) |
+Why wrong: `jcr:content` at `/conf` is `cq:PageContent`. The `cq:WorkflowModel` format lives at `/var/workflow/models/<id>/jcr:content`, not as a child called `model/` inside the design-time page content. Sync creates it; you never write it.
 
-### cq:VariableTemplate Properties
+**Forbidden 2 — any file under `jcr_root/var/`:**
 
-| Property | Type | Purpose |
-|---|---|---|
-| `varName` | String | Variable name (used in MetaDataMap) |
-| `varType` | String | Java FQCN: `java.lang.String`, `java.lang.Long`, `java.lang.Boolean`, `java.util.Date`, `java.util.ArrayList`, `java.util.HashMap` |
+```xml
+<!-- WRONG — never ship /var content in a package -->
+<!-- var/workflow/models/my-workflow/.content.xml -->
+<jcr:root jcr:primaryType="cq:WorkflowModel" ...>
+  <nodes .../>
+  <transitions .../>
+</jcr:root>
+```
+
+Why wrong: AEM Sync owns `/var/workflow/models/` entirely. Shipping it in a package produces conflicts and stale runtime state on re-install.
+
+**Forbidden 3 — `cq:WorkflowNode` steps or `{Boolean}` properties in the `/conf` flow layer:**
+
+```xml
+<!-- WRONG — cq:WorkflowNode belongs only at /var -->
+<node1 jcr:primaryType="cq:WorkflowNode" type="PROCESS">
+  <metaData PROCESS_AUTO_ADVANCE="{Boolean}true"/>   <!-- also wrong: must be plain string -->
+</node1>
+```
+
+Why wrong: Steps in the design-time `flow` layer must be `nt:unstructured` with `sling:resourceType`. Property values like `PROCESS_AUTO_ADVANCE` are plain strings (`"true"`), not typed JCR booleans.
+
+- ❌ `cq:template="/libs/settings/workflow/templates/model"` — wrong. The correct value is `/libs/cq/workflow/templates/model`.
+- ❌ Sequential node names `node0`, `node1` in the `flow` layer — use descriptive slugs (`sendnotification`, `approvaldecision`). Sequential names are generated by Sync at `/var`.
+- ❌ Omitting the `<flow>` wrapper with `sling:resourceType="foundation/components/parsys"` — the Workflow Model Editor cannot display the canvas without it.
+- ❌ Writing to `/etc/workflow/models/` — this path is deprecated and unsupported on AEM as a Cloud Service. All custom models must be at `/conf/global/settings/workflow/models/`.
 
 ## File Location (Cloud Service)
 
+Only `/conf` is supported on AEMaaCS — `/etc/workflow/models/` is deprecated and must not be used.
+
 ```
 ui.content/src/main/content/jcr_root/
-└── conf/global/settings/workflow/models/
-    └── my-workflow/
-        └── jcr:content/
-            └── model/
-                └── .content.xml   ← cq:WorkflowModel root
+└── conf/global/settings/workflow/models/my-workflow/.content.xml
 ```
 
-> Use `.content.xml` (Sling Docview format) for content packages, as shown above.
+After Cloud Manager pipeline installation: open **Tools → Workflow → Models**, select the model, click **Edit**, then click **Sync**. Verify the model appears in `/var/workflow/models/` via CRX/DE and all steps render on the editor canvas before starting a test instance.
+
+## Property Reference
+
+### Step metaData Properties
+
+These properties go inside the `<metaData jcr:primaryType="nt:unstructured"/>` child of each step node in the `flow` layer. The property names are the same regardless of whether you are looking at the design-time `flow` format or the runtime model.
+
+| Property | Applies to | Purpose |
+|---|---|---|
+| `PROCESS` | PROCESS | FQCN or process.label of the registered OSGi service |
+| `PROCESS_AUTO_ADVANCE` | PROCESS | String `"true"` = auto-advance; `"false"` = hold for external completion |
+| `PARTICIPANT` | PARTICIPANT | JCR principal name (user ID or group ID) |
+| `DYNAMIC_PARTICIPANT` | DYNAMIC_PARTICIPANT | chooser.label value or ECMAScript path |
+| `DESCRIPTION` | PARTICIPANT | Instruction text shown in the Inbox |
+| `allowInboxSharing` | PARTICIPANT | Show work item to all members of the assigned group |
+| `allowExplicitSharing` | PARTICIPANT | Allow explicit inbox sharing |
+| `PERSIST_ANONYMOUS_WORKITEM` | PROCESS | Persist transient work item across step boundaries |
+
+### Workflow Variables
+
+Variables are declared in the runtime model at `/var` after Sync, either via the Workflow Model Editor's variable configuration panel or by adding `cq:VariableTemplate` nodes to the synced model. They are not declared in the design-time `flow` layer.
+
+### cq:VariableTemplate Properties (runtime `/var` model only)
+
+| varType value | Java type |
+|---|---|
+| `java.lang.String` | String |
+| `java.lang.Long` | Long |
+| `java.lang.Boolean` | Boolean |
+| `java.util.Date` | Date |
+| `java.util.ArrayList` | ArrayList |
+| `java.util.HashMap` | HashMap |
+
+## OOTB Process Steps (Cloud Service)
+
+| process.label | FQCN | Purpose |
+|---|---|---|
+| `Create Version` | `com.day.cq.wcm.workflow.process.CreateVersionProcess` | JCR version |
+| `Set Variable Step` | `com.adobe.granite.workflow.core.process.SetVariableProcess` | Set workflow variable |
+| `Goto Step` | `com.adobe.granite.workflow.core.process.GotoProcess` | Loop-back redirect |
+| `Lock Payload Process` | `com.adobe.granite.workflow.core.process.LockProcess` | JCR lock |
+| `Unlock Payload Process` | `com.adobe.granite.workflow.core.process.UnlockProcess` | Remove JCR lock |
+| `Task Manager Step` | `com.adobe.granite.taskmanagement.impl.workflow.TaskWorkflowProcess` | Create Inbox task |
+
+> `Activate Page` / `Deactivate Page` are 6.5 LTS only — use replication APIs or Sling distribution on AEMaaCS.
+
+### SetVariableProcess Argument Modes
+
+`Set Variable Step` supports seven assignment modes via step metaData. Configure on the step node's `<metaData>`. Use this OOTB step instead of writing a custom `WorkflowProcess` for simple value assignment.
+
+| Mode | Source |
+|---|---|
+| `LITERAL` | A literal string value (e.g., `"APPROVED"`) |
+| `RELATIVE_TO_PAYLOAD` | JCR property relative to the payload (e.g., `jcr:title`) |
+| `ABSOLUTE_PATH` | Full JCR path to a property |
+| `EXPRESSION` | ECMAScript expression evaluated against `workflowData` |
+| `VARIABLE` | Another workflow variable's value |
+| `JSON_DOT_NOTATION` | JSON path like `data.response.status` (over a JSON-typed variable) |
+| `XPATH` | XPath over an XML-typed variable |

--- a/plugins/aem/cloud-service/skills/aem-workflow/workflow-model-design/references/workflow-model-design/step-types-catalog.md
+++ b/plugins/aem/cloud-service/skills/aem-workflow/workflow-model-design/references/workflow-model-design/step-types-catalog.md
@@ -1,66 +1,83 @@
-# Step Types Catalog — AEM Workflow
+# Step Types Catalog — AEM Workflow (Cloud Service)
 
-## START Node
+This catalog documents the design-time format for workflow steps in the `flow/parsys` layer at
+`/conf/global/settings/workflow/models/<id>/jcr:content/flow/`. Steps are `nt:unstructured` nodes
+whose type is expressed by `sling:resourceType`, not a `type=` property or `cq:WorkflowNode`
+primary type.
+
+After Cloud Manager pipeline installation, click **Sync** in the Workflow Model Editor to generate
+the runtime model at `/var/workflow/models/`. Sync adds START/END nodes and derives transitions from
+the step sequence and step component configuration.
+
+## sling:resourceType Reference
+
+| Step type | sling:resourceType |
+|---|---|
+| Initiator Participant Chooser | `cq/workflow/components/workflow/initiatorparticipantchooser` |
+| PROCESS | `cq/workflow/components/model/process` |
+| PARTICIPANT | `cq/workflow/components/model/participant` |
+| DYNAMIC_PARTICIPANT | `cq/workflow/components/model/dynamic_participant` |
+| OR_SPLIT | `cq/workflow/components/model/or` |
+| AND_SPLIT | `cq/workflow/components/model/AND_split` |
+| AND_JOIN | `cq/workflow/components/model/AND_join` |
+| EXTERNAL_PROCESS | `cq/workflow/components/model/external_process` |
+| END | `cq/workflow/components/model/end` |
+
+## Initiator Participant Chooser (AEM default first step)
+
+AEM's Workflow Model Editor pre-inserts this as "Step 1" when a new model is created. It is a
+Dynamic Participant step backed by `/libs/workflow/scripts/initiator-participant-chooser.ecma`,
+which resolves to the user who triggered the workflow. Include it when the workflow needs to assign
+a task back to the initiator. Not required in every model.
 
 ```xml
-<node0
-    jcr:primaryType="cq:WorkflowNode"
-    title="Start"
-    type="START">
-  <metaData jcr:primaryType="nt:unstructured"/>
-</node0>
+<initiatorparticipant
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Step 1"
+    jcr:description="Description of step 1"
+    sling:resourceType="cq/workflow/components/workflow/initiatorparticipantchooser">
+  <metaData
+      jcr:primaryType="nt:unstructured"
+      DYNAMIC_PARTICIPANT="/libs/workflow/scripts/initiator-participant-chooser.ecma"
+      PROCESS_AUTO_ADVANCE="true"/>
+</initiatorparticipant>
 ```
-
-One START node per model. All transitions originate from here.
-
-## END Node
-
-```xml
-<node_end
-    jcr:primaryType="cq:WorkflowNode"
-    title="End"
-    type="END">
-  <metaData jcr:primaryType="nt:unstructured"/>
-</node_end>
-```
-
-Terminal node. Multiple branches can converge to END.
 
 ## PROCESS Node (Auto-executed Java Step)
 
 ```xml
-<node1
-    jcr:primaryType="cq:WorkflowNode"
-    title="Send Notification"
-    type="PROCESS"
-    description="Sends an email to the assignee">
+<sendnotification
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Send Notification"
+    jcr:description="Sends an email to the assignee"
+    sling:resourceType="cq/workflow/components/model/process">
   <metaData
       jcr:primaryType="nt:unstructured"
       PROCESS="com.example.workflow.SendNotificationProcess"
-      PROCESS_AUTO_ADVANCE="{Boolean}true"
+      PROCESS_AUTO_ADVANCE="true"
       recipient="workflow-administrators"
       subject="Content ready for review"/>
-</node1>
+</sendnotification>
 ```
 
 - `PROCESS`: fully-qualified class name or `process.label` value of the registered OSGi service
-- `PROCESS_AUTO_ADVANCE`: `true` = auto-advance after execute(); `false` = step holds (TaskWorkflowProcess pattern)
+- `PROCESS_AUTO_ADVANCE`: `"true"` = auto-advance after execute(); `"false"` = step holds
 - Additional metaData keys = step arguments accessible via `MetaDataMap args` in `execute()`
 
 ## PARTICIPANT Node (Static Human Task)
 
 ```xml
-<node2
-    jcr:primaryType="cq:WorkflowNode"
-    title="Content Review"
-    type="PARTICIPANT">
+<contentreview
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Content Review"
+    sling:resourceType="cq/workflow/components/model/participant">
   <metaData
       jcr:primaryType="nt:unstructured"
       PARTICIPANT="content-reviewers"
       DESCRIPTION="Please review the content and approve or reject"
-      allowInboxSharing="{Boolean}true"
-      allowExplicitSharing="{Boolean}true"/>
-</node2>
+      allowInboxSharing="true"
+      allowExplicitSharing="true"/>
+</contentreview>
 ```
 
 - `PARTICIPANT`: JCR principal name (user ID or group ID)
@@ -70,94 +87,157 @@ Terminal node. Multiple branches can converge to END.
 ## DYNAMIC_PARTICIPANT Node (Runtime-Resolved Human Task)
 
 ```xml
-<node3
-    jcr:primaryType="cq:WorkflowNode"
-    title="Manager Approval"
-    type="DYNAMIC_PARTICIPANT">
+<managerapproval
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Manager Approval"
+    sling:resourceType="cq/workflow/components/model/dynamic_participant">
   <metaData
       jcr:primaryType="nt:unstructured"
       DYNAMIC_PARTICIPANT="Department Manager Chooser"
       fallbackGroup="workflow-administrators"/>
-</node3>
+</managerapproval>
 ```
 
-- `DYNAMIC_PARTICIPANT`: must match the `chooser.label` property of a registered `ParticipantStepChooser` OSGi service
+- `DYNAMIC_PARTICIPANT`: must match the `chooser.label` property of a registered
+  `ParticipantStepChooser` OSGi service
 - Additional metaData keys = args passed to `getParticipant()`
 
 ## OR_SPLIT Node (Decision Branch)
 
 ```xml
-<node_split
-    jcr:primaryType="cq:WorkflowNode"
-    title="Approval Decision"
-    type="OR_SPLIT">
+<approvaldecision
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Approval Decision"
+    sling:resourceType="cq/workflow/components/model/or">
   <metaData jcr:primaryType="nt:unstructured"/>
-</node_split>
-
-<!-- Transitions with rules — first matching transition wins -->
-<t_approve
-    jcr:primaryType="cq:WorkflowTransition"
-    from="node_split"
-    to="node_activate"
-    rule="function check(){
-        return workflowData.getMetaDataMap().get('decision','')=='APPROVE';
-    }"/>
-<t_reject
-    jcr:primaryType="cq:WorkflowTransition"
-    from="node_split"
-    to="node_notify"
-    rule="function check(){ return true; }"/>
+</approvaldecision>
 ```
 
-Rules are ECMA (JavaScript). `workflowData` is the `WorkflowData` object. Use `get('key', defaultValue)` for safe reads.
+OR_SPLIT routing rules (ECMAScript / Rhino) are configured on the outgoing transitions in the
+runtime model. After Sync, open the model in the Workflow Model Editor and configure the route
+rules on each outgoing arrow from the OR_SPLIT node. Rules use `workflowData.getMetaDataMap()` to
+read step-set values. Use `String(...)` and strict equality (`===`) to avoid Rhino coercion issues:
+
+```javascript
+// Approve route
+function check() {
+    return 'APPROVE' === String(workflowData.getMetaDataMap().get('reviewDecision', ''));
+}
+// Catch-all / reject route
+function check() { return true; }
+```
 
 ## AND_SPLIT / AND_JOIN (Parallel Branches)
 
 ```xml
-<!-- AND_SPLIT fans out to all connected outgoing transitions -->
-<node_split
-    jcr:primaryType="cq:WorkflowNode"
-    title="Start Parallel Review"
-    type="AND_SPLIT">
+<!-- AND_SPLIT: fans out to all connected outgoing steps -->
+<startparallelreview
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Start Parallel Review"
+    sling:resourceType="cq/workflow/components/model/AND_split">
   <metaData jcr:primaryType="nt:unstructured"/>
-</node_split>
+</startparallelreview>
 
-<!-- AND_JOIN waits for all incoming branches to arrive -->
-<node_join
-    jcr:primaryType="cq:WorkflowNode"
-    title="Synchronize"
-    type="AND_JOIN">
+<!-- AND_JOIN: waits for all incoming branches before continuing -->
+<synchronize
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Synchronize"
+    sling:resourceType="cq/workflow/components/model/AND_join">
   <metaData jcr:primaryType="nt:unstructured"/>
-</node_join>
+</synchronize>
 ```
 
-All outgoing transitions from AND_SPLIT execute. Workflow pauses at AND_JOIN until all branches complete.
+All outgoing transitions from AND_SPLIT execute in parallel. Workflow pauses at AND_JOIN until all
+branches complete.
 
 ## EXTERNAL_PROCESS Node (Polling Step)
 
 ```xml
-<node_ext
-    jcr:primaryType="cq:WorkflowNode"
-    title="Wait for DAM Processing"
-    type="EXTERNAL_PROCESS">
+<waitfordamprocessing
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Wait for DAM Processing"
+    sling:resourceType="cq/workflow/components/model/external_process">
   <metaData
       jcr:primaryType="nt:unstructured"
       EXTERNAL_PROCESS="com.example.workflow.DamProcessingExternalStep"
-      pollingInterval="{Long}30000"/>
-</node_ext>
+      pollingInterval="30000"/>
+</waitfordamprocessing>
 ```
 
-`WorkflowExternalProcess` SPI — the engine polls at `pollingInterval` ms until the process signals completion.
+`WorkflowExternalProcess` SPI — the engine polls at `pollingInterval` ms until the process signals
+completion. `pollingInterval` is stored as a plain string in the design-time `flow` layer.
 
-## OOTB Process Labels Reference
+## END Node
+
+```xml
+<workflowend
+    jcr:primaryType="nt:unstructured"
+    jcr:title="End"
+    sling:resourceType="cq/workflow/components/model/end">
+  <metaData jcr:primaryType="nt:unstructured"/>
+</workflowend>
+```
+
+Multiple branches can converge to the same END node. Sync also inserts a START node automatically
+— you do not need to declare it in the design-time `flow` layer.
+
+## Goto Step (OOTB Loop-back PROCESS Node)
+
+`Goto Step` is an OOTB PROCESS step that re-routes execution back to an earlier step when its
+rule returns true. Always enforce a hard cap on the retry counter.
+
+```xml
+<retryvalidate
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Retry Validate?"
+    sling:resourceType="cq/workflow/components/model/process">
+  <metaData
+      jcr:primaryType="nt:unstructured"
+      PROCESS="Goto Step"
+      PROCESS_AUTO_ADVANCE="true"
+      targetStep="validate"/>
+</retryvalidate>
+```
+
+- `PROCESS`: `"Goto Step"` (label) or `com.adobe.granite.workflow.core.process.GotoProcess` (FQCN)
+- `targetStep`: node name of the step in the `flow` layer to redirect to
+- Goto rules are configured on the outgoing transition in the runtime model after Sync
+- Always cap the retry counter (`count < 3`). An uncapped Goto pins a worker thread
+
+## Task Manager Step (Inbox Task + Workflow Suspend)
+
+```xml
+<approvecontent
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Approve Content"
+    sling:resourceType="cq/workflow/components/model/process">
+  <metaData
+      jcr:primaryType="nt:unstructured"
+      PROCESS="Task Manager Step"
+      PROCESS_AUTO_ADVANCE="false"
+      taskTitle="Approve content for publication"
+      taskDescription="Review the page and approve or reject."
+      taskInstructions="Click Approve to publish, Reject to send back to author."
+      taskOwner="content-reviewers"
+      taskPriority="medium"/>
+</approvecontent>
+```
+
+- `PROCESS="Task Manager Step"` — OOTB label (FQCN: `com.adobe.granite.taskmanagement.impl.workflow.TaskWorkflowProcess`)
+- `PROCESS_AUTO_ADVANCE="false"` is required — the engine holds here while the human acts
+- `taskOwner` is a JCR principal name (user ID or group ID)
+- After task completion, `TaskEventListener` writes `lastTaskAction` and `lastTaskCompletedBy` to
+  instance metadata; route by `lastTaskAction` in a downstream OR_SPLIT
+
+## OOTB Process Labels Reference (Cloud Service)
 
 | process.label | Purpose |
 |---|---|
-| `Activate Page` | Replicates page to publish (6.5 LTS only) |
-| `Deactivate Page` | Deactivates page from publish |
 | `Create Version` | Creates a JCR version of the payload |
 | `Set Variable Step` | Assigns workflow variable from literal/expression/JCR |
 | `Goto Step` | Loop-back redirect if rule evaluates true |
 | `Lock Payload Process` | JCR-locks the payload node |
 | `Unlock Payload Process` | Removes JCR lock from payload |
 | `Task Manager Step` | Creates Inbox task and suspends workflow |
+
+> `Activate Page` / `Deactivate Page` are 6.5 LTS only and must not be used on AEMaaCS.

--- a/plugins/aem/cloud-service/skills/aem-workflow/workflow-model-design/references/workflow-model-design/step-types-catalog.md
+++ b/plugins/aem/cloud-service/skills/aem-workflow/workflow-model-design/references/workflow-model-design/step-types-catalog.md
@@ -18,10 +18,10 @@ the step sequence and step component configuration.
 | PARTICIPANT | `cq/workflow/components/model/participant` |
 | DYNAMIC_PARTICIPANT | `cq/workflow/components/model/dynamic_participant` |
 | OR_SPLIT | `cq/workflow/components/model/or` |
-| AND_SPLIT | `cq/workflow/components/model/AND_split` |
-| AND_JOIN | `cq/workflow/components/model/AND_join` |
+| AND_SPLIT | `cq/workflow/components/model/and` |
 | EXTERNAL_PROCESS | `cq/workflow/components/model/external_process` |
-| END | `cq/workflow/components/model/end` |
+
+START, END, and AND_JOIN have no design-time component on AEM Cloud Service. AEM Sync derives them automatically at `/var/workflow/models/<id>`. Never write `cq/workflow/components/model/start`, `cq/workflow/components/model/end`, or `cq/workflow/components/model/AND_join` as `sling:resourceType` — no such components exist under `/libs/cq/workflow/components/model/`, and the Workflow Model Editor will not render them.
 
 ## Initiator Participant Chooser (AEM default first step)
 
@@ -127,28 +127,21 @@ function check() {
 function check() { return true; }
 ```
 
-## AND_SPLIT / AND_JOIN (Parallel Branches)
+## AND_SPLIT (Parallel Branches)
+
+In the design-time `flow` layer, author only the AND_SPLIT step. AEM Sync derives the matching AND_JOIN node automatically at `/var/workflow/models/<id>` based on where the parallel branches converge in the editor.
 
 ```xml
 <!-- AND_SPLIT: fans out to all connected outgoing steps -->
 <startparallelreview
     jcr:primaryType="nt:unstructured"
     jcr:title="Start Parallel Review"
-    sling:resourceType="cq/workflow/components/model/AND_split">
+    sling:resourceType="cq/workflow/components/model/and">
   <metaData jcr:primaryType="nt:unstructured"/>
 </startparallelreview>
-
-<!-- AND_JOIN: waits for all incoming branches before continuing -->
-<synchronize
-    jcr:primaryType="nt:unstructured"
-    jcr:title="Synchronize"
-    sling:resourceType="cq/workflow/components/model/AND_join">
-  <metaData jcr:primaryType="nt:unstructured"/>
-</synchronize>
 ```
 
-All outgoing transitions from AND_SPLIT execute in parallel. Workflow pauses at AND_JOIN until all
-branches complete.
+All outgoing transitions from AND_SPLIT execute in parallel. Workflow pauses at the Sync-generated AND_JOIN until all branches complete. There is no design-time component for AND_JOIN — never write `sling:resourceType="cq/workflow/components/model/AND_join"`; the editor will not render it.
 
 ## EXTERNAL_PROCESS Node (Polling Step)
 
@@ -167,19 +160,11 @@ branches complete.
 `WorkflowExternalProcess` SPI — the engine polls at `pollingInterval` ms until the process signals
 completion. `pollingInterval` is stored as a plain string in the design-time `flow` layer.
 
-## END Node
+## START and END (Sync-Derived)
 
-```xml
-<workflowend
-    jcr:primaryType="nt:unstructured"
-    jcr:title="End"
-    sling:resourceType="cq/workflow/components/model/end">
-  <metaData jcr:primaryType="nt:unstructured"/>
-</workflowend>
-```
+AEM Sync adds both START and END nodes automatically to the runtime model at `/var/workflow/models/<id>`. Do not author them in the design-time `flow` layer. The design-time flow simply ends after the last step component; Sync inserts the END node and connects it. The START node is similarly auto-generated as the entry point.
 
-Multiple branches can converge to the same END node. Sync also inserts a START node automatically
-— you do not need to declare it in the design-time `flow` layer.
+There is no `cq/workflow/components/model/end` or `cq/workflow/components/model/start` component under `/libs/cq/workflow/components/model/` on AEM Cloud Service — never write these as `sling:resourceType` values.
 
 ## Goto Step (OOTB Loop-back PROCESS Node)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Audits and fixes the AEM Cloud Service `workflow-model-design` skill against the customer-flagged concern about workflow model XML format (`jcr:content/flow/<step>`
  structure) and against verified-correct OOTB step components on AEM Cloud Service SDK.                                                                                  
                                                                                   
 This PR corrects the design-time XML format
   and fixes wrong `sling:resourceType` values that do not exist as components on AEM Cloud Service.
                                                                                                                                                                          
  This is the cloud-service mirror of the 6.5 LTS PR (`feat/skill-workflow-model-design-65-lts`) — same root-cause fixes, adapted for AEMaaCS (no `/etc/workflow/models/` 
  legacy, no Felix SCR, Cloud Manager deployment). 



## Motivation and Context

  The skill incorrectly taught developers to author models at `/conf/global/settings/workflow/models/<id>` using `cq:WorkflowModel` / `cq:WorkflowNode` /                 
  `cq:WorkflowTransition` — but that is the **runtime** format that AEM Sync auto-generates at `/var`. The **design-time** format the Workflow Model Editor reads and
  writes at `/conf` is `cq:Page` + `jcr:content/flow/<step-component>` with `nt:unstructured` step nodes identified by `sling:resourceType`.
                                                                                                                                                                                                          
                                                                                   
  Additionally, the step-types-catalog listed `sling:resourceType` values that do not exist as components on AEM Cloud Service: `cq/workflow/components/model/AND_split`, 
  `cq/workflow/components/model/AND_join`, `cq/workflow/components/model/end`. The actual OOTB component for AND_SPLIT is named `and` (lowercase); AND_JOIN and END have
  no design-time component because Sync derives them automatically at `/var`.  

## How Has This Been Tested?

Verified on AEM instance

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
