### PR TITLE
stardust: fix cross-marketplace dep reference (0.4.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     "description": "Official Adobe Skills for AI Agents",
     "version": "1.0.0"
   },
-  "allowCrossMarketplaceDependenciesOn": ["pbakaus/impeccable"],
+  "allowCrossMarketplaceDependenciesOn": ["impeccable"],
   "plugins": [
     {
       "name": "adobe-for-creativity",
@@ -32,7 +32,7 @@
       "name": "stardust",
       "source": "./plugins/stardust",
       "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "category": "design",
       "keywords": [
         "design",

--- a/plugins/stardust/.claude-plugin/plugin.json
+++ b/plugins/stardust/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stardust",
   "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "Adobe"
   },
@@ -9,6 +9,6 @@
   "license": "Apache-2.0",
   "keywords": ["design", "redesign", "frontend", "skills", "impeccable"],
   "dependencies": [
-    { "name": "impeccable", "marketplace": "pbakaus/impeccable" }
+    { "name": "impeccable", "marketplace": "impeccable" }
   ]
 }


### PR DESCRIPTION
## Summary
- Fixes the stardust plugin manifest, which Claude Code flagged as invalid on install at 0.4.0.
- Root cause: both the plugin's `dependencies[].marketplace` and the marketplace's `allowCrossMarketplaceDependenciesOn` were set to the GitHub repo path `pbakaus/impeccable`. Per the [Claude Code plugin-dependencies docs](https://code.claude.com/docs/en/plugin-dependencies.md), those fields must reference the marketplace's `name` (which is `impeccable`).
- Bumps version `0.4.0` → `0.4.1` in both `plugins/stardust/.claude-plugin/plugin.json` and the marketplace entry.

## Test plan
- [ ] Reinstall stardust at 0.4.1 — no "invalid manifest file" error in `/plugin` or `/doctor`.
- [ ] Confirm impeccable dependency resolves automatically (marketplace `impeccable` already added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)