### PR TITLE
stardust: fix dependencies schema

### DIFF
--- a/plugins/stardust/.claude-plugin/plugin.json
+++ b/plugins/stardust/.claude-plugin/plugin.json
@@ -9,6 +9,6 @@
   "license": "Apache-2.0",
   "keywords": ["design", "redesign", "frontend", "skills", "impeccable"],
   "dependencies": [
-    { "name": "impeccable", "marketplace": "impeccable" }
+    "impeccable@impeccable"
   ]
 }


### PR DESCRIPTION
## Summary
- Fix `plugin.json` `dependencies` field: use `\"impeccable@impeccable\"` string form instead of the `{ name, marketplace }` object, which fails manifest validation (`dependencies.0: Invalid input`).
- Includes the prior commits on this branch bumping stardust to 0.4.0 and correcting the cross-marketplace dep reference.

## Test plan
- [ ] Reinstall stardust from the adobe-skills marketplace — verify no "invalid manifest" error
- [ ] `/plugin uninstall stardust@adobe-skills` succeeds without temp_local extraction failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)