### PR TITLE
stardust: mobile-nav collapse + drop before/after viewer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
       "name": "stardust",
       "source": "./plugins/stardust",
       "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "category": "design",
       "keywords": [
         "design",

--- a/plugins/stardust/.claude-plugin/plugin.json
+++ b/plugins/stardust/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stardust",
   "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "author": {
     "name": "Adobe"
   },

--- a/plugins/stardust/evals/README.md
+++ b/plugins/stardust/evals/README.md
@@ -31,7 +31,7 @@ v2 evals without modification.
 |------------------------------|---------------------------|-----------------------------------------------------------------------------------------------------|
 | `extract-multipage/`         | Phase 1 (`extract`)       | Multi-page crawl with cap + Playwright (not WebFetch) + correct file shapes + direct authoring of current PRODUCT.md / DESIGN.md. |
 | `direct-from-phrase/`        | Phase 2 (`direct`)        | Dimensional restatement + at most two questions + plan-before-execution + direct authoring of target spec + direction.md trace. |
-| `prototype-before-after/`    | Phase 3 (`prototype`)     | Two files per page (viewer + proposed) + `:root` block + data attributes + content preserved + delegates to `$impeccable craft`. |
+| `prototype-before-after/`    | Phase 3 (`prototype`)     | One proposed file per page + `:root` block + data attributes + content preserved + delegates to `$impeccable craft` + opens in browser. |
 | `migrate-incremental/`       | Phase 4 (`migrate`)       | Both render paths (A and B) + nested index.html output + content preservation + idempotent skip on re-run.                 |
 | `intent-reasoning-style/`    | Master skill principle    | "Open and reasoned" — vague phrases get clarified, never silently mapped to commands. Pending direction persisted.          |
 

--- a/plugins/stardust/evals/migrate-incremental/task.md
+++ b/plugins/stardust/evals/migrate-incremental/task.md
@@ -5,7 +5,7 @@
 A project where extract + direct + partial prototype have completed:
 
 - `stardust/state.json` lists 5 pages:
-  - `home`, `pricing` — `approved` (with proposed.html + viewer)
+  - `home`, `pricing` — `approved` (with proposed.html)
   - `about`, `features`, `contact` — `directed` (no prototype yet)
 - `stardust/current/` populated.
 - Project-root `PRODUCT.md`, `DESIGN.md`, `DESIGN.json` exist.

--- a/plugins/stardust/evals/prototype-before-after/criteria.json
+++ b/plugins/stardust/evals/prototype-before-after/criteria.json
@@ -3,17 +3,16 @@
   "total": 100,
   "criteria": [
     { "id": "activated",                 "weight": 5,  "description": "The stardust:prototype skill was invoked." },
-    { "id": "two_files_written",         "weight": 10, "description": "Both stardust/prototypes/home.html (viewer) AND stardust/prototypes/home-proposed.html (proposed redesign) are written. Two files, not one." },
-    { "id": "viewer_two_iframes",        "weight": 10, "description": "The viewer file has two iframes side-by-side. CURRENT side resolves via the chain (live URL > screenshot > landmarks-text fallback). PROPOSED side references home-proposed.html via a relative path." },
-    { "id": "viewer_action_buttons",     "weight": 5,  "description": "The viewer's header strip includes the four action buttons: swap sides, approve, stash, open in $impeccable live." },
+    { "id": "single_proposed_file",      "weight": 15, "description": "Exactly one file is written for the page: stardust/prototypes/home-proposed.html. No separate before/after viewer file (home.html) is composed — the viewer was dropped from the skill." },
     { "id": "root_token_block",          "weight": 15, "description": "home-proposed.html has the :root block as the first content of the first <style>. All required tokens present per token-contract.md (--heading-*, --body, --body-sm, --line-height-*, --color-bg, --color-fg, --color-accent, --spacing-*, --section-padding, --max-width, --radius)." },
     { "id": "data_attributes_on_sections","weight": 10, "description": "Every <section> in home-proposed.html has data-section, data-intent, data-layout. Optional attributes (data-items, data-media, data-interactive) used where applicable. Lowercase kebab-case slugs." },
-    { "id": "provenance_complete",       "weight": 10, "description": "home-proposed.html has a stardust:provenance block as the first child of <head> listing: writtenBy, writtenAt, page, pageUrl, againstDirection (with the active direction's resolvedAt), readArtifacts, divergenceVersion, fontDeck, paletteSource. Viewer has its own provenance with proposedFile reference." },
-    { "id": "self_contained",            "weight": 10, "description": "home-proposed.html is self-contained: no external CSS files, no external JS files, no analytics, no fonts loaded from CDN that aren't justified by the chosen font deck." },
+    { "id": "provenance_complete",       "weight": 10, "description": "home-proposed.html has a stardust:provenance block as the first child of <head> listing: writtenBy, writtenAt, page, pageUrl, againstDirection (with the active direction's resolvedAt), readArtifacts, divergenceVersion, fontDeck, paletteSource." },
+    { "id": "self_contained",            "weight": 10, "description": "home-proposed.html is self-contained: no external CSS files, no external JS files, no analytics, no fonts loaded from CDN that aren't justified by the chosen font deck. The only inline <script> allowed is the ≤10-line mobile-nav a11y shim when the stock hamburger pattern is applied." },
     { "id": "content_preserved",         "weight": 10, "description": "Content from current/pages/home.json is preserved: hero headline, body copy, CTA labels, navigation labels, link destinations. The redesign restyles, it does not rewrite." },
     { "id": "delegates_to_craft",        "weight": 5,  "description": "The agent invoked $impeccable craft (or its equivalent flow) to perform the creative rendering, rather than inventing the design from scratch in stardust." },
-    { "id": "browser_opened",            "weight": 3,  "description": "The viewer was opened in the default browser via open / xdg-open / start. Skipped only in pipeline-automation mode." },
-    { "id": "state_prototyped_not_approved", "weight": 4, "description": "state.json marks home as 'prototyped'. Approval is a separate explicit step the user takes; the agent did not auto-approve." },
+    { "id": "browser_opened",            "weight": 5,  "description": "home-proposed.html was opened in the default browser via open / xdg-open / start. Skipped only in pipeline-automation mode." },
+    { "id": "approval_chat_only",        "weight": 5,  "description": "Approval is documented as chat-only ('approve <slug>' or 'approve'). The agent does not reference a viewer button or postMessage mechanism." },
+    { "id": "state_prototyped_not_approved", "weight": 7, "description": "state.json marks home as 'prototyped' with prototypePath pointing at stardust/prototypes/home-proposed.html. Approval is a separate explicit step the user takes; the agent did not auto-approve." },
     { "id": "no_eds_references",         "weight": 3,  "description": "No mention of EDS, AEM, framework targets, or production CMS output in either file or in narration." }
   ]
 }

--- a/plugins/stardust/evals/prototype-before-after/task.md
+++ b/plugins/stardust/evals/prototype-before-after/task.md
@@ -1,4 +1,4 @@
-# Eval: prototype writes before/after viewer + proposed file
+# Eval: prototype writes the proposed file and opens it in the browser
 
 ## Setup
 
@@ -44,16 +44,12 @@ The `stardust:prototype` skill is invoked. It:
    - Passes the divergence audit (every anti-toolbox hit recorded
      in `DESIGN.json.extensions.divergence.anti_toolbox_hits` with a
      brand-specific justification).
-5. **Composes `stardust/prototypes/home.html`** (the viewer) per
-   `before-after-shell.md`:
-   - Two-iframe layout (50/50 default split).
-   - CURRENT iframe loads the live URL with screenshot fallback.
-   - PROPOSED iframe loads `home-proposed.html` via relative path.
-   - Header strip with swap / approve / stash / live-mode action
-     buttons and a link to `direction.md`.
-6. **Opens the viewer** in the default browser.
-7. Marks the page `prototyped` in `state.json` (NOT `approved` —
-   approval is a separate explicit step).
-8. Invokes `$impeccable live` against `home-proposed.html` for
+5. **Opens `stardust/prototypes/home-proposed.html`** in the
+   default browser (`open` macOS, `xdg-open` Linux, `start ""`
+   Windows). No separate viewer file is composed.
+6. Marks the page `prototyped` in `state.json` (NOT `approved` —
+   approval is a separate explicit step, signalled in chat by
+   "approve home" or "approve").
+7. Invokes `$impeccable live` against `home-proposed.html` for
    iteration unless `--no-iterate` was passed.
-9. Reports the file paths and the next-step hint.
+8. Reports the proposed-file path and the next-step hint.

--- a/plugins/stardust/skills/extract/reference/current-state-schema.md
+++ b/plugins/stardust/skills/extract/reference/current-state-schema.md
@@ -147,7 +147,7 @@ Capture rules in `playwright-recipe.md` § Capture list (7-bis). These
 fields are what migrate consumes to render real body copy under
 each section heading; without them every body region falls back to
 the placeholder-with-signature treatment (per `prototype/reference/
-before-after-shell.md` § Content sourcing hierarchy) even when the
+proposed-file-shell.md` § Content sourcing hierarchy) even when the
 source page had real prose to reuse.
 
 ## § CTAs

--- a/plugins/stardust/skills/extract/reference/ia-extraction.md
+++ b/plugins/stardust/skills/extract/reference/ia-extraction.md
@@ -221,7 +221,8 @@ audit trail is complete and the user can review what was dropped.
 ## Slug derivation
 
 Slugs are filesystem-friendly identifiers used as keys in `state.json`,
-filenames in `current/pages/<slug>.json`, and `prototypes/<slug>.html`.
+filenames in `current/pages/<slug>.json`, and
+`prototypes/<slug>-proposed.html`.
 
 Algorithm:
 

--- a/plugins/stardust/skills/migrate/SKILL.md
+++ b/plugins/stardust/skills/migrate/SKILL.md
@@ -36,7 +36,7 @@ sidecars.
 - `--allow-placeholder` — allow migration of pages whose
   proposed/archetype files contain `[data-placeholder]`
   elements (per
-  `skills/prototype/reference/before-after-shell.md` § Content
+  `skills/prototype/reference/proposed-file-shell.md` § Content
   sourcing hierarchy). Default refuses; use this flag only when
   shipping placeholders is intentional (internal staging review).
 - `--strict-canon` — refuse approvals that conflict with canon.

--- a/plugins/stardust/skills/prepare-migration/SKILL.md
+++ b/plugins/stardust/skills/prepare-migration/SKILL.md
@@ -171,9 +171,9 @@ establishes canon; subsequent approvals extend it (with conflicts
 logged as deviations by default).
 
 This phase typically takes the longest — each archetype goes
-through the full prototype loop (shape brief, craft, viewer,
-iterate, approve). Stream progress to the user as each archetype
-lands.
+through the full prototype loop (shape brief, craft, open in
+browser, iterate, approve). Stream progress to the user as each
+archetype lands.
 
 Surface the summary and gate.
 

--- a/plugins/stardust/skills/prototype/SKILL.md
+++ b/plugins/stardust/skills/prototype/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: prototype
-description: Render side-by-side before/after prototypes that compare a page on the current website to the proposed redesign, then iterate the proposed page via the impeccable craft loop. Per-page, idempotent, stale-aware. Use when the user asks for a redesign prototype, a before/after comparison, a design preview, a page mockup, a visual diff of the redesign, or invokes /stardust:prototype.
+description: Render a proposed redesign of a page on the current website as a self-contained static HTML file, then iterate via the impeccable craft loop. Per-page, idempotent, stale-aware. Use when the user asks for a redesign prototype, a before/after comparison, a design preview, a page mockup, a visual diff of the redesign, or invokes /stardust:prototype.
 license: Apache-2.0
 ---
 
 # stardust:prototype
 
-For each `directed` page, render a **proposed redesign** (a self-contained
-static HTML file) and a **before/after viewer** that loads the current
-page and the proposed redesign side-by-side. Iterate the proposed file
-via `$impeccable live`. Mark `approved` once the user signs off.
+For each `directed` page, render a **proposed redesign** as a
+self-contained static HTML file at
+`stardust/prototypes/<slug>-proposed.html`. Open the file in the
+browser; iterate via `$impeccable live`. Mark `approved` once the
+user signs off in the conversation.
 
 `prototype` is not a renderer of its own design — it composes the
 target spec written by `direct` (`PRODUCT.md`, `DESIGN.md`,
@@ -25,9 +26,9 @@ is delegated to `$impeccable craft` and `$impeccable live`.
   direction change. Default behaviour without this flag is to skip
   stale pages and surface the count.
 - `--all` — prototype every `directed` page including stale ones.
-- `--no-iterate` — write the initial proposed render and the viewer,
-  open the viewer in the browser, but **do not** invoke
-  `$impeccable live`. The user iterates manually later.
+- `--no-iterate` — write the initial proposed render and open it in
+  the browser, but **do not** invoke `$impeccable live`. The user
+  iterates manually later.
 - `--no-critique` — skip the automatic post-render critique +
   audit pass (Phase 2.5). Default behaviour runs both
   `impeccable critique` and `impeccable audit` and gates
@@ -39,15 +40,25 @@ is delegated to `$impeccable craft` and `$impeccable live`.
 - `--skip-adapt-audit` — skip Phase 5.5 (Adapt for mobile) on
   approval. Default behaviour runs `$impeccable adapt` against
   the approved variant and gates downstream `migrate` and
-  `--publish-sample` on the mobile-adapt audit (per
-  `reference/before-after-shell.md` § Mobile-adapt audit). Use
-  this flag for explicit desktop-only demo runs; the proposed
-  file's `_provenance.adapt[]` records `adapt: skipped (user)`
-  so downstream consumers see the override.
+  `--publish-sample` on the mobile-adapt audit (per § Mobile-adapt
+  audit below and `reference/proposed-file-shell.md`). Use this
+  flag for explicit desktop-only demo runs; the proposed file's
+  `_provenance.adapt[]` records `adapt: skipped (user)` so
+  downstream consumers see the override.
 - `--adapt-variant <id>` — extend the adapt pass to a non-primary
   variant. Default Phase 5.5 only adapts the variant the user
   approves (or the variant flagged `isPrimary: true`); pass this
   flag to adapt B / C / etc. on demand.
+- `--no-hamburger` — opt out of the stock mobile-nav collapse
+  pattern. Phase 5.5's adapt audit still runs; if it refuses on
+  `horizontal-overflow-at-360px` or `nav-readability-floor`, the
+  agent surfaces the refusal but does **not** auto-apply the stock
+  hamburger. Migrate and `--publish-sample` still gate on the audit,
+  so the user is on the hook to remediate with their own pattern
+  (priority+overflow, bottom nav, bespoke drawer — see
+  `reference/mobile-nav-collapse.md` § Alternative patterns). The
+  flag records `navCollapse: skipped (user, --no-hamburger)` in
+  `_provenance.adapt[]`.
 - `--publish-sample <slug>` — submit the named slug to the
   stardust showcase. Triggers the publish-sample sub-flow
   documented in `reference/publish-sample.md`: eligibility checks,
@@ -93,7 +104,8 @@ is delegated to `$impeccable craft` and `$impeccable live`.
    silently propagates the synthesis into the rendered prototype.
    Surface `Provenance OK on N pages` once the check passes.
 6. Read `stardust/current/DESIGN.md` (the descriptive snapshot of the
-   existing site, used by the viewer's CURRENT side fallback path).
+   existing site, used as a fallback reference during render when the
+   proposed file needs to mirror an aspect of the captured surface).
 
 ## Delegation mechanic
 
@@ -154,7 +166,7 @@ plugin uninstalled, sandbox without skill access):
    proposed file with `renderedVia: stardust-direct (impeccable
    unavailable, --no-impeccable)` in provenance and **every
    non-trivial section** wrapped in the placeholder visual signature
-   per `reference/before-after-shell.md` § Content sourcing
+   per `reference/proposed-file-shell.md` § Content sourcing
    hierarchy. The output is a sketch, not a deliverable; migrate
    refuses to ship it without `--allow-placeholder`.
 
@@ -163,7 +175,7 @@ Stardust's job inside Phase 2 is therefore:
 - Compose the inputs craft needs (page content from
   `current/pages/<slug>.json`, target spec from `DESIGN.md` /
   `DESIGN.json`, hard constraints from `direction.md`, content
-  sourcing rules from `reference/before-after-shell.md` § Content
+  sourcing rules from `reference/proposed-file-shell.md` § Content
   sourcing hierarchy).
 - Invoke craft via the Skill tool.
 - Validate the result against the contract (`:root` block, data
@@ -221,7 +233,7 @@ This recalibration of stale-flagging is documented in
 ### Phase 2 — Render the proposed page
 
 Render `stardust/prototypes/<slug>-proposed.html` per
-`reference/before-after-shell.md` § Required structure. Hard
+`reference/proposed-file-shell.md` § Required structure. Hard
 requirements there:
 
 - `:root` token block as the first content of the first `<style>`
@@ -232,7 +244,7 @@ requirements there:
 - Self-contained: no external CSS, no external JS.
 - Content preserved from the current page (hero copy, CTAs, nav,
   body) unless `direction.md` authorises content changes.
-- **Content sourcing hierarchy** (`reference/before-after-shell.md`
+- **Content sourcing hierarchy** (`reference/proposed-file-shell.md`
   § Content sourcing hierarchy): every literal value rendered must
   come from `current/pages/<slug>.json`, then voice samples, then
   direction-authorised changes — or be rendered with the mandatory
@@ -264,7 +276,7 @@ After craft returns, validate the output:
   reflex slop).
 - **Content sourcing scan** — every literal value in the rendered
   output traces to one of the allowed sources
-  (`reference/before-after-shell.md` § Content sourcing hierarchy).
+  (`reference/proposed-file-shell.md` § Content sourcing hierarchy).
   Any value that doesn't is either wrapped in a `[data-placeholder]`
   element with the mandatory visual signature, or the validation
   fails. Build the `_provenance.unsourcedContent[]` list during
@@ -275,8 +287,8 @@ the user with the specific rule violated and a suggested fix.
 
 ### Phase 2.5 — Validate via critique + audit
 
-Before composing the viewer, run **two parallel validators**
-against the rendered proposed file: `critique` and `audit`. They
+Before opening the proposed file in the browser, run **two parallel
+validators** against the rendered proposed file: `critique` and `audit`. They
 are explicitly designed as a complementary pair — critique
 covers *design* (AI-slop reflexes, hierarchy, brand fit,
 cognitive load); audit covers *technical correctness*
@@ -356,7 +368,7 @@ Procedure:
    validator.** If the merged-and-deduped findings list (after
    the brand-faithful auto-dismiss) contains any P0 or P1, do
    **not** mark the page `prototyped` in `state.json` yet. The
-   proposed file is on disk; the viewer can render it; but the
+   proposed file is on disk and openable in the browser, but the
    page stays in `directed` until either:
    - The agent fixes the issue (run a chat-driven impeccable
      command per Phase 4 iteration paths, then re-run Phase 2.5).
@@ -394,23 +406,17 @@ mark the page `prototyped` — the user will need to run both
 validators manually before approving. Surface the gap loudly in
 the report so the user doesn't forget.
 
-### Phase 3 — Compose the viewer
-
-Render `stardust/prototypes/<slug>.html` per
-`reference/before-after-shell.md` § `<slug>.html`. Two-iframe layout,
-header strip with action buttons, footer strip with direction title.
-
-Resolve the CURRENT pane source per the resolution order in the
-reference: screenshot first (default — always works), live URL via
-"Try live" toggle (opt-in), landmarks-text fallback only when the
-screenshot is missing. Resolve the PROPOSED iframe source as a
-relative path to `<slug>-proposed.html`.
-
 ### Phase 4 — Open and iterate
 
-1. Open the viewer in the default browser
-   (`open` macOS, `xdg-open` Linux, `start ""` Windows). Skip in
-   pipeline-automation mode.
+(Phase numbering skips 3; the former Phase 3 — *Compose the viewer*
+— was removed when the per-page before/after viewer was dropped.
+Cross-references throughout the docs still name Phases 4, 5, 5.5.)
+
+1. Open the just-written or just-updated `<slug>-proposed.html` (or
+   the user-chosen variant suffix when N > 1) in the default
+   browser (`open` macOS, `xdg-open` Linux, `start ""` Windows). If
+   multiple files were written in one run, open the primary variant
+   only. Skip in pipeline-automation mode.
 2. Mark the page `prototyped` in `state.json` — **gated on the
    Phase 2.5 critique + audit result**. If either validator
    returned ≥1 P0 or P1 finding (after the brand-faithful
@@ -476,8 +482,8 @@ across its lifetime.
 3. **Direct impeccable invocation.** The user runs an impeccable
    command directly — `$impeccable bolder
    stardust/prototypes/home-proposed.html`. Stardust isn't in the
-   loop; the viewer iframes whatever's on disk. This is fine and
-   documented as a supported escape hatch.
+   loop; the browser tab reloads whatever's on disk. This is fine
+   and documented as a supported escape hatch.
 
 The "open and reasoned" principle from the master skill applies to
 path 2: the agent reasons publicly about the phrase before running
@@ -488,9 +494,9 @@ command.
 
 Approval is **explicit**. Stardust does not auto-approve.
 
-The user signals approval by clicking the "Approve" button in the
-viewer header (which posts a message the agent listens for) or by
-saying "approve home" / "approve" in the conversation.
+The user signals approval by saying **"approve <slug>"** or simply
+**"approve"** in the conversation. The agent confirms the slug
+before writing state, then proceeds.
 
 On approval:
 
@@ -503,13 +509,12 @@ On approval:
 3. Clear any `stale` flag on the page.
 4. **Run Phase 5.5 — Adapt for mobile** (below) on the variant
    the user is signing off on. Approval does not complete until
-   the adapt pass lands; the viewer's "Approve" button surfaces
-   this as one extra step rather than a separate user gesture.
+   the adapt pass lands; surface it as one extra step in the
+   approval report rather than a separate user gesture.
 5. Print:
    ```
    home: approved
      proposed: stardust/prototypes/home-proposed.html
-     viewer:   stardust/prototypes/home.html
      mobile:   adapted (4 @media rules at 640/768/1024/1280)
 
    Next: $stardust migrate home  (write final redesigned static HTML)
@@ -586,6 +591,37 @@ Refuse the file when **any** of:
   — `@media (max-width: 1024px)` as the *narrowest* breakpoint
   is the recognisable shape of "didn't actually adapt for
   phones." Adapt should produce at least one rule at ≤ 640px.
+- **At a 360px-wide rendered viewport:** a landmark causes
+  `scrollWidth > clientWidth` on `document.documentElement` or
+  `document.body`. Refusal code:
+  `audit/responsive: horizontal-overflow-at-360px`. The captured
+  shrink-the-nav adapt move recurringly fails this — the prototype
+  derived from birrificiolambrate.com totalled ~447px of header
+  content inside a 430px viewport even after font + gap
+  reductions.
+- **At a 360px-wide rendered viewport:** the computed `font-size`
+  of any descendant of a `<nav>` inside a `<header>` is below
+  11px. Refusal code:
+  `audit/responsive: nav-readability-floor`. The 11px floor is
+  the minimum legible body size on phones; anything below reads
+  as "unreadable but technically fits."
+- **At a 360px-wide rendered viewport:** the computed `gap` (or
+  `column-gap`) of any flex/grid `<nav>` inside a `<header>` is
+  below 10px. Same refusal code
+  (`audit/responsive: nav-readability-floor`). The 10px floor is
+  what keeps adjacent links visually distinct as separate touch
+  targets.
+
+The last three conditions require actually rendering the file —
+they can't be inferred from CSS text. The canonical check is a
+small Playwright snippet (`fixtures/mobile-nav-audit.mjs`) the
+agent runs against the file at 360×800. Audit messages must
+include a pointer to the stock-template doc and the
+`--no-hamburger` opt-out so the reader knows the remediation:
+
+> Suggested fix: apply the stock hamburger pattern
+>   skills/prototype/reference/mobile-nav-collapse.md
+> Or pass `--no-hamburger` to skip auto-apply.
 
 Pass `--skip-adapt-audit` to the prototype invocation when the
 user explicitly wants a desktop-only render (a presales demo
@@ -598,6 +634,61 @@ When the audit refuses, the page does **not** demote from
 `approved` (the approval already landed); but the report carries
 the failure prominently and migrate / publish-sample will refuse
 to consume the file until it passes.
+
+#### Mobile nav collapse
+
+When the audit refuses on either of the nav-related codes above
+(`horizontal-overflow-at-360px` or `nav-readability-floor`), and
+the user did **not** pass `--no-hamburger`, the agent applies the
+stock CSS-only hamburger pattern documented in
+`reference/mobile-nav-collapse.md`. Procedure:
+
+1. Inject the stock pattern into the file (HTML + CSS + ≤10-line
+   inline `<script>` for a11y). The header gains
+   `data-nav-collapse="hamburger"` so downstream consumers can
+   detect the pattern is applied (see
+   `skills/stardust/reference/data-attributes.md`).
+
+   **Source order is load-bearing.** The base
+   `.ds-nav-burger { display: none; ... }` rule must be placed at
+   the **top** of the `<style>` block (right after the `:root`
+   token block, before any `@media` rules), not appended at the
+   bottom. Same selector + same specificity means the later
+   declaration wins; if the base is appended *after* the
+   `@media (max-width: 640px)` override, the burger stays hidden
+   at every viewport and the file silently regresses to the
+   bare-nav failure mode. This bug was caught during the
+   greenfield-beermaker dogfood at
+   `stardust/prototypes/home-proposed-C2.html` — an early draft
+   appended the block at the bottom and the burger never
+   appeared.
+
+2. **Run the post-injection ordering check** before re-running
+   the audit. The check is a small `awk` one-liner documented in
+   `reference/mobile-nav-collapse.md` § Source order — it asserts
+   the base `.ds-nav-burger` rule appears at a lower line number
+   than the first `@media (max-width: 640px)` rule. Exit 0 =
+   correct ordering; exit 1 = regression. On regression, fix the
+   ordering and re-run the check; do not proceed to step 3 with
+   a known-bad file.
+
+3. Re-run the audit. If the audit passes, continue with the
+   `_provenance.adapt[]` entry recording the pre/post findings
+   and `navCollapse: hamburger (stock)`.
+
+4. If the audit still refuses (rare — the most likely cause is a
+   wordmark itself wider than 360px), surface the residual
+   finding and wait for direction. Do not iterate further without
+   user input.
+
+With `--no-hamburger`: skip step 1; the audit refusal stands and
+the user remediates separately. With `--skip-adapt-audit`: the
+audit doesn't run at all, so neither does this auto-apply.
+
+The stock pattern is the default; `reference/mobile-nav-collapse.md`
+§ Alternative patterns documents priority+overflow, bottom nav,
+and side-drawer as valid alternatives the user can request, but
+the agent does not pick between them autonomously.
 
 ### Stale handling
 
@@ -619,9 +710,7 @@ flag and update `againstDirection` to the new active direction.
 | Path                                          | Purpose                                       |
 |-----------------------------------------------|-----------------------------------------------|
 | `stardust/prototypes/<slug>-shape.md`         | Per-page compositional brief (Phase 1 output, craft input). |
-| `stardust/prototypes/<slug>.html`             | Before/after viewer (user-facing review surface). |
-| `stardust/prototypes/<slug>-proposed.html`    | Proposed redesign (live-mode iteration target, migration source). |
-| `stardust/prototypes/<slug>-proposed-stash-<ts>.html` | (Optional) Prior proposed version, when user clicks "Stash". |
+| `stardust/prototypes/<slug>-proposed.html`    | Proposed redesign (live-mode iteration target, migration source, user-facing review surface). |
 | `stardust/state.json`                         | Updated with page status and approval history. |
 | `DESIGN.json`                                 | Updated with `extensions.divergence.anti_toolbox_hits` and any audit amendments from this prototype's render. |
 
@@ -633,12 +722,6 @@ flag and update `againstDirection` to the new active direction.
 - **Validation failure (:root block missing, data attributes missing,
   unjustified anti-toolbox hit, impeccable rule violation).** Do not
   write the file. Surface the specific failure and a suggested fix.
-- **CURRENT pane has no screenshot.** Fall through to live URL (if
-  the screenshot file is missing post-extract), then to landmarks
-  text. Note the fallback in the viewer header strip. The default
-  pane source is the screenshot per `reference/before-after-shell.md`
-  § Iframes; the live URL is opt-in via the "Try live" toggle for
-  CSP reasons (`STARDUST-FEEDBACK.md F-001`).
 - **`$impeccable live` not available.** Fall back to `--no-iterate`
   behaviour and tell the user the iteration step requires impeccable
   live.
@@ -654,7 +737,7 @@ are last-write-wins; warn the user if they explicitly try.
 When invoked with `--prep`, prototype runs an extended pass that
 fills page-type gaps and writes canon. Discovery-mode runs are
 unchanged: per-slug shape brief, render via `$impeccable craft`,
-viewer, iterate, approve.
+open in browser, iterate, approve.
 
 `--prep` adds three things on top of the standard procedure:
 
@@ -752,12 +835,20 @@ Default mode is unchanged.
   DESIGN.md.
 - `reference/canon-extraction.md` — the five-step canon-extraction
   procedure performed on prototype approval in `--prep` mode.
-- `reference/before-after-shell.md` — viewer + proposed file
-  schemas and required structure.
+- `reference/proposed-file-shell.md` — proposed-file schema and
+  required structure (`:root` token block, data attributes,
+  provenance, content sourcing hierarchy, mobile-adapt audit).
 - `reference/publish-sample.md` — `--publish-sample` sub-flow:
   eligibility checks, file staging, PR creation against the
   upstream stardust showcase. Lands the prototype as a public
   sample at `https://{owner}.github.io/stardust-2/`.
+- `reference/mobile-nav-collapse.md` — stock CSS-only hamburger
+  pattern Phase 5.5 auto-applies when the Mobile-adapt audit
+  refuses on `horizontal-overflow-at-360px` or
+  `nav-readability-floor`. Carries the copy-pasteable
+  HTML+CSS+JS, the audit smoke-test command, the
+  `--no-hamburger` opt-out, and the alternative-pattern
+  vocabulary.
 - `skills/stardust/reference/token-contract.md` — `:root` token
   block (cross-cutting, used by prototype + migrate).
 - `skills/stardust/reference/data-attributes.md` — structural data

--- a/plugins/stardust/skills/prototype/fixtures/mobile-nav-audit.mjs
+++ b/plugins/stardust/skills/prototype/fixtures/mobile-nav-audit.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// mobile-nav-audit.mjs — runtime check for the three new Mobile-adapt
+// audit conditions documented in skills/prototype/SKILL.md
+// § Mobile-adapt audit. Renders an HTML file at 360px and reports:
+//
+//   (a) audit/responsive: horizontal-overflow-at-360px
+//   (b) audit/responsive: nav-readability-floor   (nav descendant font < 11px)
+//   (c) audit/responsive: nav-readability-floor   (nav gap/column-gap < 10px)
+//
+// Exit 0 when no findings; exit 1 when any finding fires.
+//
+// Usage:
+//   node skills/prototype/fixtures/mobile-nav-audit.mjs <file.html>
+//
+// Requires Playwright:
+//   npm i -D playwright
+//   npx playwright install chromium
+
+import { resolve, isAbsolute } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const FONT_FLOOR_PX   = 11;
+const GAP_FLOOR_PX    = 10;
+const VIEWPORT_WIDTH  = 360;
+const VIEWPORT_HEIGHT = 800;
+
+const fileArg = process.argv[2];
+if (!fileArg) {
+  console.error('Usage: node mobile-nav-audit.mjs <file.html>');
+  process.exit(2);
+}
+
+let chromium;
+try {
+  ({ chromium } = await import('playwright'));
+} catch {
+  console.error('mobile-nav-audit: Playwright is required.');
+  console.error('  npm i -D playwright && npx playwright install chromium');
+  process.exit(2);
+}
+
+const abs = isAbsolute(fileArg) ? fileArg : resolve(process.cwd(), fileArg);
+const url = pathToFileURL(abs).toString();
+
+const browser = await chromium.launch();
+try {
+  const context = await browser.newContext({
+    viewport: { width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT },
+  });
+  const page = await context.newPage();
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.evaluate(() => document.documentElement.offsetHeight);
+
+  const findings = await page.evaluate(({ FONT_FLOOR_PX, GAP_FLOOR_PX, VIEWPORT_WIDTH }) => {
+    const out = [];
+
+    // (a) Horizontal overflow on documentElement / body
+    const docOver  = document.documentElement.scrollWidth - document.documentElement.clientWidth;
+    const bodyOver = document.body.scrollWidth - document.body.clientWidth;
+    if (docOver > 0 || bodyOver > 0) {
+      let culprit = null;
+      for (const el of document.querySelectorAll('header, footer, nav, main')) {
+        const r = el.getBoundingClientRect();
+        if (r.right > VIEWPORT_WIDTH + 0.5) { culprit = el; break; }
+      }
+      out.push({
+        code: 'audit/responsive: horizontal-overflow-at-360px',
+        detail: docOver > 0
+          ? `documentElement.scrollWidth - clientWidth = ${docOver}px`
+          : `body.scrollWidth - clientWidth = ${bodyOver}px`,
+        landmark: culprit
+          ? culprit.tagName.toLowerCase() +
+            (culprit.dataset.section ? `[data-section="${culprit.dataset.section}"]` : '')
+          : null,
+      });
+    }
+
+    // Honor display:none / visibility:hidden up the ancestor chain
+    const isHidden = (el) => {
+      let cur = el;
+      while (cur && cur.nodeType === 1) {
+        const cs = getComputedStyle(cur);
+        if (cs.display === 'none' || cs.visibility === 'hidden') return true;
+        cur = cur.parentElement;
+      }
+      return false;
+    };
+
+    // (b) and (c) — only navs that live inside a <header>
+    const navsInHeader = document.querySelectorAll('header nav');
+    for (const nav of navsInHeader) {
+      if (isHidden(nav)) continue;
+
+      // (c) gap on flex/grid <nav>
+      const nv = getComputedStyle(nav);
+      const isAxisContainer =
+        nv.display === 'flex' || nv.display === 'inline-flex' ||
+        nv.display === 'grid' || nv.display === 'inline-grid';
+      if (isAxisContainer) {
+        const col = parseFloat(nv.columnGap) || 0;
+        const row = parseFloat(nv.rowGap) || 0;
+        // For a horizontal nav, column-gap is the load-bearing one;
+        // for a grid that wraps, rowGap can also bite. Take the smaller
+        // positive value when both are set.
+        const candidates = [col, row].filter((v) => v > 0);
+        const effective = candidates.length ? Math.min(...candidates) : 0;
+        if (effective > 0 && effective < GAP_FLOOR_PX) {
+          out.push({
+            code: 'audit/responsive: nav-readability-floor',
+            detail: `<nav> ${col > 0 && row > 0 ? 'gap' : (col > 0 ? 'column-gap' : 'row-gap')} is ${effective}px (< ${GAP_FLOOR_PX}px floor)`,
+            selector: 'header nav',
+          });
+        }
+      }
+
+      // (b) font-size on any descendant of <nav>
+      for (const el of nav.querySelectorAll('*')) {
+        if (isHidden(el)) continue;
+        const fs = parseFloat(getComputedStyle(el).fontSize);
+        if (fs && fs < FONT_FLOOR_PX) {
+          out.push({
+            code: 'audit/responsive: nav-readability-floor',
+            detail: `<${el.tagName.toLowerCase()}> inside <nav> has font-size ${fs}px (< ${FONT_FLOOR_PX}px floor)`,
+            selector: `header nav ${el.tagName.toLowerCase()}`,
+          });
+          break;
+        }
+      }
+    }
+
+    return out;
+  }, { FONT_FLOOR_PX, GAP_FLOOR_PX, VIEWPORT_WIDTH });
+
+  if (findings.length === 0) {
+    console.log(`✓ ${fileArg} — audit clean at ${VIEWPORT_WIDTH}px`);
+    process.exit(0);
+  }
+
+  console.error(`✗ ${fileArg} — ${findings.length} finding(s) at ${VIEWPORT_WIDTH}px:`);
+  for (const f of findings) {
+    console.error(`  - ${f.code}`);
+    console.error(`      ${f.detail}`);
+    if (f.landmark) console.error(`      landmark: ${f.landmark}`);
+    if (f.selector) console.error(`      selector: ${f.selector}`);
+  }
+  console.error('\nSuggested fix: apply the stock hamburger pattern');
+  console.error('  skills/prototype/reference/mobile-nav-collapse.md');
+  console.error('Or pass --no-hamburger to skip auto-apply.');
+  process.exit(1);
+} finally {
+  await browser.close();
+}

--- a/plugins/stardust/skills/prototype/fixtures/mobile-nav-broken-example.html
+++ b/plugins/stardust/skills/prototype/fixtures/mobile-nav-broken-example.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- stardust:fixture
+    purpose: negative case for mobile-nav-collapse audit
+    pattern: NONE (raw horizontal nav, font and gap shrunk under floor)
+    expects: refuses on horizontal-overflow-at-360px AND nav-readability-floor
+  -->
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Mobile nav broken · stardust fixture</title>
+  <style>
+    :root {
+      --heading-font-family: 'Georgia', 'Times New Roman', serif;
+      --body-font-family: 'Helvetica Neue', system-ui, sans-serif;
+      --body: 16px;
+      --body-sm: 14px;
+      --color-bg: #f7f3ec;
+      --color-fg: #1a1a1a;
+      --color-accent: #c2410c;
+      --spacing-md: 16px;
+      --spacing-lg: 24px;
+    }
+
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body {
+      background: var(--color-bg);
+      color: var(--color-fg);
+      font-family: var(--body-font-family);
+    }
+
+    /* Header — raw horizontal nav, no collapse */
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--spacing-md);
+      padding: var(--spacing-md) var(--spacing-lg);
+      border-bottom: 1px solid var(--color-fg);
+    }
+
+    .wordmark {
+      font-family: var(--heading-font-family);
+      font-size: 22px;
+      font-weight: 700;
+      color: var(--color-fg);
+      text-decoration: none;
+      white-space: nowrap;
+    }
+
+    nav {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-md);
+    }
+    nav a {
+      color: var(--color-fg);
+      text-decoration: none;
+      font-size: var(--body);
+      white-space: nowrap;
+    }
+
+    /* The "shrink until it fits" anti-pattern — still overflows AND
+       breaches the readability floor */
+    @media (max-width: 640px) {
+      nav { gap: 6px; }       /* sub-10px gap — FAIL condition (c) */
+      nav a { font-size: 10px; } /* sub-11px font — FAIL condition (b) */
+      /* No collapse, no hamburger — header overflows at 360px — FAIL (a) */
+    }
+
+    main { padding: 48px 24px; }
+    h1 { font-family: var(--heading-font-family); margin: 0 0 16px; }
+  </style>
+</head>
+<body>
+
+  <header data-section="header"
+          data-intent="navigation"
+          data-layout="contained">
+    <a class="wordmark" href="/">Wasatch Back Beerworks</a>
+    <nav aria-label="Main">
+      <a href="/beers">Beers</a>
+      <a href="/taproom">Taproom</a>
+      <a href="/events">Events</a>
+      <a href="/visit">Visit</a>
+      <a href="/contact">Contact</a>
+    </nav>
+  </header>
+
+  <main>
+    <h1>The mountain brewery on Main Street.</h1>
+    <p>Same page as the good fixture, with the nav shrunk into the
+       unreadable-and-still-overflowing failure mode.</p>
+  </main>
+
+</body>
+</html>

--- a/plugins/stardust/skills/prototype/fixtures/mobile-nav-collapse-example.html
+++ b/plugins/stardust/skills/prototype/fixtures/mobile-nav-collapse-example.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- stardust:fixture
+    purpose: positive case for mobile-nav-collapse audit
+    pattern: stock hamburger (skills/prototype/reference/mobile-nav-collapse.md)
+    expects: passes mobile-nav-audit.mjs at 360px
+  -->
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Mobile nav collapse · stardust fixture</title>
+  <style>
+    :root {
+      --heading-font-family: 'Georgia', 'Times New Roman', serif;
+      --body-font-family: 'Helvetica Neue', system-ui, sans-serif;
+
+      --heading-xxl: 64px;
+      --heading-xl:  44px;
+      --heading-lg:  32px;
+      --heading-md:  22px;
+      --body:        16px;
+      --body-sm:     14px;
+
+      --line-height-heading: 1.1;
+      --line-height-body:    1.55;
+
+      --color-bg:     #f7f3ec;
+      --color-fg:     #1a1a1a;
+      --color-accent: #c2410c;
+
+      --spacing-xs:  4px;
+      --spacing-sm:  8px;
+      --spacing-md:  16px;
+      --spacing-lg:  24px;
+      --spacing-xl:  48px;
+      --spacing-2xl: 96px;
+
+      --section-padding: 96px;
+      --max-width:       1200px;
+      --radius:          8px;
+
+      --dur-state:  180ms;
+      --ease-snap:  cubic-bezier(0.2, 0, 0, 1);
+    }
+
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body {
+      background: var(--color-bg);
+      color: var(--color-fg);
+      font-family: var(--body-font-family);
+      font-size: var(--body);
+      line-height: var(--line-height-body);
+    }
+
+    /* Header — stock mobile-nav-collapse pattern */
+    header[data-nav-collapse="hamburger"] {
+      position: relative;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--spacing-md);
+      padding: var(--spacing-md) var(--spacing-lg);
+      border-bottom: 1px solid var(--color-fg);
+    }
+
+    .ds-wordmark {
+      font-family: var(--heading-font-family);
+      font-size: 22px;
+      font-weight: 700;
+      color: var(--color-fg);
+      text-decoration: none;
+      letter-spacing: -0.01em;
+    }
+
+    .ds-nav-toggle {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    .ds-nav-burger { display: none; }
+
+    .ds-nav {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-md);
+      font-family: var(--body-font-family);
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    .ds-nav a {
+      color: var(--color-fg);
+      text-decoration: none;
+      font-size: var(--body);
+      padding: 4px 0;
+    }
+    .ds-nav a:hover { color: var(--color-accent); }
+
+    @media (max-width: 640px) {
+      .ds-nav-burger {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        cursor: pointer;
+        padding: 10px 14px;
+        font-family: var(--body-font-family);
+        font-size: var(--body-sm);
+        color: var(--color-fg);
+        background: transparent;
+        border: 1px solid currentColor;
+        border-radius: var(--radius);
+        user-select: none;
+      }
+      .ds-nav-burger-icon {
+        width: 16px;
+        height: 12px;
+        position: relative;
+      }
+      .ds-nav-burger-icon::before,
+      .ds-nav-burger-icon::after {
+        content: "";
+        position: absolute;
+        left: 0; right: 0;
+        height: 2px;
+        background: currentColor;
+      }
+      .ds-nav-burger-icon::before { top: 0; }
+      .ds-nav-burger-icon::after  { bottom: 0; }
+
+      .ds-nav {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0;
+        padding: var(--spacing-md) var(--spacing-lg);
+        background: var(--color-bg);
+        border-top: 1px solid var(--color-fg);
+        transform: translateY(-8px);
+        opacity: 0;
+        visibility: hidden;
+        pointer-events: none;
+        transition: transform var(--dur-state) var(--ease-snap),
+                    opacity   var(--dur-state) var(--ease-snap),
+                    visibility 0s linear var(--dur-state);
+        z-index: 10;
+      }
+      .ds-nav a {
+        padding: 12px 0;
+        font-size: var(--body);
+        border-bottom: 1px solid color-mix(in srgb, var(--color-fg) 12%, transparent);
+      }
+      .ds-nav a:last-child { border-bottom: 0; }
+
+      .ds-nav-toggle:checked ~ .ds-nav {
+        transform: translateY(0);
+        opacity: 1;
+        visibility: visible;
+        pointer-events: auto;
+        transition: transform var(--dur-state) var(--ease-snap),
+                    opacity   var(--dur-state) var(--ease-snap),
+                    visibility 0s linear 0s;
+      }
+
+      .ds-nav-burger:focus-visible,
+      .ds-nav a:focus-visible {
+        outline: 2px solid var(--color-accent);
+        outline-offset: 2px;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .ds-nav,
+      .ds-nav-toggle:checked ~ .ds-nav {
+        transition: none;
+      }
+    }
+
+    /* Body — minimal hero so the file looks like a real page */
+    main {
+      max-width: var(--max-width);
+      margin: 0 auto;
+      padding: var(--spacing-2xl) var(--spacing-lg);
+    }
+    h1 {
+      font-family: var(--heading-font-family);
+      font-size: var(--heading-xl);
+      line-height: var(--line-height-heading);
+      margin: 0 0 var(--spacing-md);
+      letter-spacing: -0.02em;
+    }
+    p { max-width: 60ch; }
+
+    @media (max-width: 640px) {
+      main { padding: var(--spacing-xl) var(--spacing-md); }
+      h1 { font-size: var(--heading-lg); }
+    }
+  </style>
+</head>
+<body>
+
+  <header data-section="header"
+          data-intent="navigation"
+          data-layout="contained"
+          data-nav-collapse="hamburger">
+    <a class="ds-wordmark" href="/">Wasatch Back</a>
+
+    <input type="checkbox" id="ds-nav-toggle" class="ds-nav-toggle">
+    <label class="ds-nav-burger"
+           for="ds-nav-toggle"
+           role="button"
+           tabindex="0"
+           aria-controls="ds-nav-list"
+           aria-expanded="false">
+      <span class="ds-nav-burger-icon" aria-hidden="true"></span>
+      <span class="ds-nav-burger-label">Menu</span>
+    </label>
+
+    <nav id="ds-nav-list" class="ds-nav" aria-label="Main">
+      <a href="/beers">Beers</a>
+      <a href="/taproom">Taproom</a>
+      <a href="/events">Events</a>
+      <a href="/visit">Visit</a>
+      <a href="/contact">Contact</a>
+    </nav>
+  </header>
+
+  <main>
+    <h1>The mountain brewery on Main Street.</h1>
+    <p>Park City&rsquo;s working-class brewery. Six rotating taps,
+       a stone-floor taproom, and a tab that never closes too early.
+       This is a fixture page used to demonstrate the stock mobile
+       nav collapse pattern at 360px.</p>
+  </main>
+
+  <script>
+  (() => {
+    const t = document.getElementById('ds-nav-toggle');
+    const b = document.querySelector('.ds-nav-burger');
+    if (!t || !b) return;
+    const sync = () => b.setAttribute('aria-expanded', t.checked);
+    t.addEventListener('change', sync); sync();
+    addEventListener('keydown', e => { if (e.key === 'Escape' && t.checked) { t.checked = false; sync(); b.focus(); } });
+  })();
+  </script>
+
+</body>
+</html>

--- a/plugins/stardust/skills/prototype/reference/mobile-nav-collapse.md
+++ b/plugins/stardust/skills/prototype/reference/mobile-nav-collapse.md
@@ -1,0 +1,494 @@
+# Mobile nav collapse
+
+The stock pattern stardust applies during `$impeccable adapt` (Phase 5.5)
+when the header's horizontal nav cannot survive a 360px viewport. The
+adapt step's audit refuses files that overflow, shrink nav type below
+11px, or compress nav gap below 10px; this doc is the canonical
+remediation the agent reaches for unless the user opted out with
+`--no-hamburger`.
+
+## Why this exists
+
+Captured site chrome typically carries 4–6 nav links plus a wordmark
+plus a cart/account affordance. At desktop this fits; at 360px–430px
+the nav competes with the wordmark for horizontal space. Two failure
+modes recurred across brands before this pattern existed:
+
+1. The adapt pass shrank `nav` font-size and `gap` until the row
+   fit. The shrunk nav became unreadable (font ~9–10px, gaps 8–10px).
+2. Some sites still horizontally overflowed despite the shrink. A
+   real instance: the Wasatch Back Beerworks prototype derived from
+   birrificiolambrate.com — header content totaled ~447px inside a
+   430px viewport even after font and gap reductions, leaving a
+   visible empty column.
+
+Both are pipeline bugs, not site bugs. They recur on every brand
+with a moderately-sized nav. This pattern centralises the fix.
+
+## When this applies
+
+`$impeccable adapt`, invoked from `stardust:prototype` Phase 5.5,
+runs the Mobile-adapt audit (see `skills/prototype/SKILL.md`
+§ Mobile-adapt audit). The audit refuses the file when, at 360px:
+
+- A landmark causes `scrollWidth > clientWidth` on
+  `document.documentElement` or `document.body`
+  (`audit/responsive: horizontal-overflow-at-360px`).
+- A `<nav>` descendant inside `<header>` has computed `font-size`
+  below 11px (`audit/responsive: nav-readability-floor`).
+- A flex/grid `<nav>` inside `<header>` has computed `gap` (or
+  `column-gap`) below 10px (`audit/responsive: nav-readability-floor`).
+
+On any refusal, and when the user did not pass `--no-hamburger`,
+the agent injects the stock pattern below into the file, marks the
+header with `data-nav-collapse="hamburger"`, and re-runs the audit.
+If the audit then passes, the run continues. If it still fails
+(e.g. the wordmark itself is wider than 360px), the agent surfaces
+the residual finding and waits for direction.
+
+## The stock pattern
+
+A CSS-only `<input type="checkbox">` + `<label for>` toggle plus a
+≤10-line inline `<script>` that syncs `aria-expanded` and wires
+Escape-to-close. Self-contained, no framework, no external CSS.
+
+### HTML
+
+The `<header>` carries `data-nav-collapse="hamburger"` so downstream
+consumers (the audit re-run, future migrate steps) can detect the
+pattern is already applied:
+
+```html
+<header data-section="header"
+        data-intent="navigation"
+        data-layout="contained"
+        data-nav-collapse="hamburger">
+  <a class="ds-wordmark" href="/">Brand</a>
+
+  <input type="checkbox" id="ds-nav-toggle" class="ds-nav-toggle">
+  <label class="ds-nav-burger"
+         for="ds-nav-toggle"
+         role="button"
+         tabindex="0"
+         aria-controls="ds-nav-list"
+         aria-expanded="false">
+    <span class="ds-nav-burger-icon" aria-hidden="true"></span>
+    <span class="ds-nav-burger-label">Menu</span>
+  </label>
+
+  <nav id="ds-nav-list" class="ds-nav" aria-label="Main">
+    <a href="/products">Products</a>
+    <a href="/about">About</a>
+    <a href="/visit">Visit</a>
+    <a href="/contact">Contact</a>
+  </nav>
+</header>
+
+<script>
+(() => {
+  const t = document.getElementById('ds-nav-toggle');
+  const b = document.querySelector('.ds-nav-burger');
+  if (!t || !b) return;
+  const sync = () => b.setAttribute('aria-expanded', t.checked);
+  t.addEventListener('change', sync); sync();
+  addEventListener('keydown', e => { if (e.key === 'Escape' && t.checked) { t.checked = false; sync(); b.focus(); } });
+})();
+</script>
+```
+
+### CSS
+
+The pattern reads tokens from the page's `:root` block (see
+`skills/stardust/reference/token-contract.md`) and falls back to
+system values for any token a project hasn't defined.
+
+```css
+/* Header positioning anchor for the slide-down panel */
+header[data-nav-collapse="hamburger"] {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md, 16px);
+}
+
+/* The checkbox is the state holder; never visible */
+.ds-nav-toggle {
+  position: absolute;
+  width: 1px; height: 1px;
+  margin: -1px; padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Above 640px: horizontal nav, no burger */
+.ds-nav-burger {
+  display: none;
+}
+.ds-nav {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md, 16px);
+  font-family: var(--body-font-family, system-ui, sans-serif);
+}
+.ds-nav a {
+  color: var(--color-fg, #111);
+  text-decoration: none;
+  font-size: var(--body, 1rem);
+}
+
+@media (max-width: 640px) {
+  /* Show burger button */
+  .ds-nav-burger {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    padding: 10px 14px;
+    font-family: var(--body-font-family, system-ui, sans-serif);
+    font-size: var(--body-sm, 0.9375rem);
+    color: var(--color-fg, #111);
+    background: transparent;
+    border: 1px solid currentColor;
+    border-radius: var(--radius, 8px);
+    user-select: none;
+  }
+  .ds-nav-burger-icon {
+    width: 16px;
+    height: 12px;
+    position: relative;
+  }
+  .ds-nav-burger-icon::before,
+  .ds-nav-burger-icon::after {
+    content: "";
+    position: absolute;
+    left: 0; right: 0;
+    height: 2px;
+    background: currentColor;
+  }
+  .ds-nav-burger-icon::before { top: 0; }
+  .ds-nav-burger-icon::after  { bottom: 0; }
+
+  /* Slide-down panel — full-width, anchored to header bottom */
+  .ds-nav {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    padding: var(--spacing-md, 16px);
+    background: var(--color-bg, #fff);
+    border-top: 1px solid var(--color-fg, #111);
+    transform: translateY(-8px);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: transform var(--dur-state, 180ms) var(--ease-snap, cubic-bezier(0.2, 0, 0, 1)),
+                opacity   var(--dur-state, 180ms) var(--ease-snap, cubic-bezier(0.2, 0, 0, 1)),
+                visibility 0s linear var(--dur-state, 180ms);
+  }
+  .ds-nav a {
+    padding: 12px 0;
+    font-size: var(--body, 1rem);
+    border-bottom: 1px solid color-mix(in srgb, var(--color-fg, #111) 12%, transparent);
+  }
+  .ds-nav a:last-child { border-bottom: 0; }
+
+  /* Open state — sibling selector off the checkbox */
+  .ds-nav-toggle:checked ~ .ds-nav {
+    transform: translateY(0);
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transition: transform var(--dur-state, 180ms) var(--ease-snap, cubic-bezier(0.2, 0, 0, 1)),
+                opacity   var(--dur-state, 180ms) var(--ease-snap, cubic-bezier(0.2, 0, 0, 1)),
+                visibility 0s linear 0s;
+  }
+
+  /* Focus-visible — brand accent for the focus ring */
+  .ds-nav-burger:focus-visible {
+    outline: 2px solid var(--color-accent, #f4c01b);
+    outline-offset: 2px;
+  }
+  .ds-nav a:focus-visible {
+    outline: 2px solid var(--color-accent, #f4c01b);
+    outline-offset: 2px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ds-nav,
+  .ds-nav-toggle:checked ~ .ds-nav {
+    transition: none;
+  }
+}
+```
+
+Only `transform`, `opacity`, and `visibility` are animated — no
+layout properties — per impeccable's motion rules.
+
+## Source order (load-bearing)
+
+The base `.ds-nav-burger { display: none; ... }` block **must
+precede** the `@media (max-width: 640px) { ... }` block that flips
+it to `display: inline-flex`. Same selector, same specificity →
+the later declaration wins. If the base is appended *after* the
+media query, the burger stays hidden at every viewport, no
+warning, no error — the file silently regresses to the bare-nav
+failure mode this whole pattern exists to fix.
+
+Place the stock pattern's CSS at the **top of the stylesheet**,
+right after the `:root` token block and before any existing
+`@media` rules. Concretely:
+
+```
+<style>
+  :root { ... }                       /* tokens */
+  /* === Stock mobile-nav-collapse pattern === */
+  header[data-nav-collapse="hamburger"] { ... }
+  .ds-nav-toggle { ... }
+  .ds-nav-burger { display: none; ... }     /* base — first */
+  .ds-nav { ... }
+  /* ...component styles for the rest of the page... */
+  @media (max-width: 640px) { ... }         /* override — later */
+  @media (prefers-reduced-motion: reduce) { ... }
+</style>
+```
+
+When `$impeccable adapt` injects the stock pattern, it must place
+the base rules above the file's existing `@media` rules — not at
+the bottom of the `<style>` block where most agents would
+naturally append.
+
+### Post-injection grep check
+
+After injection, the agent runs this one-shot check to confirm
+ordering. Exit 0 = correct, exit 1 = base appears after the media
+query (regression):
+
+```bash
+awk '
+  /@media[[:space:]]*\(max-width:[[:space:]]*640px\)/ && !media_line {
+    media_line = NR
+  }
+  /\.ds-nav-burger[[:space:]]*\{/ && depth == 0 && !base_line {
+    base_line = NR
+  }
+  /\{/ { depth += gsub(/\{/, "{") }
+  /\}/ { depth -= gsub(/\}/, "}") }
+  END {
+    if (!base_line)  { print "MISSING base .ds-nav-burger rule";          exit 1 }
+    if (!media_line) { print "MISSING @media (max-width: 640px) rule";    exit 1 }
+    if (base_line > media_line) {
+      print "WRONG ORDER: base at line " base_line ", @media at " media_line
+      print "Base must appear BEFORE the media query — same specificity = later wins."
+      exit 1
+    }
+    print "OK: base at " base_line ", @media at " media_line
+  }
+' "$file"
+```
+
+Run this as the last step of the injection. A failure here means
+the agent placed the base block in the wrong spot — fix the
+ordering and re-run rather than shipping a silently-regressed
+file.
+
+Caught during manual dogfood on
+`stardust/prototypes/home-proposed-C2.html` (greenfield-beermaker)
+where an early draft appended the base block after the media
+queries and the burger never appeared at 360px. The audit's
+overflow check would still fail in that case (the bare nav still
+overflows), but the operator wastes a cycle diagnosing what
+should be a deterministic ordering bug.
+
+## Token inheritance
+
+The pattern reads the following from the page's `:root` block. Every
+reference includes a fallback so the pattern stays self-sufficient
+when a project hasn't declared the token.
+
+| Token                   | Fallback                         | Where used                |
+|-------------------------|----------------------------------|---------------------------|
+| `--color-bg`            | `#fff`                           | Open-panel background     |
+| `--color-fg`            | `#111`                           | Nav link, divider, border |
+| `--color-accent`        | `#f4c01b`                        | Focus ring                |
+| `--body-font-family`    | `system-ui, sans-serif`          | Nav + burger label        |
+| `--body`                | `1rem`                           | Nav link size             |
+| `--body-sm`             | `0.9375rem`                      | Burger label size         |
+| `--spacing-md`          | `16px`                           | Panel padding, header gap |
+| `--radius`              | `8px`                            | Burger button corner      |
+| `--dur-state`           | `180ms`                          | Open/close transition     |
+| `--ease-snap`           | `cubic-bezier(0.2, 0, 0, 1)`     | Open/close easing         |
+
+`--dur-state` and `--ease-snap` are **not** in the stardust `:root`
+token contract — they are inherited from impeccable's motion
+defaults when present, and the inline fallback covers the case
+where they aren't.
+
+## Accessibility checklist
+
+The stock pattern satisfies:
+
+- **Labelled control.** The visible burger (`<label>`) is associated
+  with the state checkbox via `for="ds-nav-toggle"`. Click and
+  keyboard activation both toggle the checkbox.
+- **`aria-controls`.** The label points at the nav list ID
+  (`aria-controls="ds-nav-list"`) so assistive tech can announce
+  the controlled region.
+- **`aria-expanded`.** Synced to the checkbox's `:checked` state by
+  the inline script. Without the script the attribute would never
+  update; documented as the rationale for bending the no-JS
+  preference here.
+- **Focus visible.** The burger and every nav link have a brand
+  `--color-accent` focus ring; `:focus-visible` so keyboard users
+  see it and pointer users don't.
+- **Keyboard escape.** Pressing Escape while the menu is open
+  closes it and returns focus to the burger button (≤3 lines of
+  the inline script).
+- **Reduced motion.** `@media (prefers-reduced-motion: reduce)`
+  drops the transition.
+- **Tab order.** Wordmark → burger label → (open) nav items. The
+  hidden checkbox is not focusable (visually-hidden + label
+  delegation).
+- **No focus trap leak.** The pattern doesn't trap focus inside the
+  open panel — Tab continues into the rest of the page. This is
+  deliberate; trapping focus requires more JS and complicates the
+  static contract. A future variant can add a trap if needed for
+  modal-style behavior.
+
+## Opt-out: `--no-hamburger`
+
+The user can opt out of the stock collapse:
+
+```
+$stardust prototype <slug> --no-hamburger
+```
+
+Behavior with the flag:
+
+- Phase 5.5's adapt pass runs normally.
+- The Mobile-adapt audit still runs. If it refuses (overflow / sub-11px
+  font / sub-10px gap), the agent surfaces the refusal but does
+  **not** auto-apply the stock pattern. The page stays approved (the
+  approval already landed) but migrate and `--publish-sample` will
+  refuse to consume the file until the audit clears — the user has
+  to remediate via their own pattern (see § Alternatives) and re-run
+  prototype.
+- The `_provenance.adapt[]` entry records
+  `navCollapse: skipped (user, --no-hamburger)` so downstream
+  consumers see the override.
+
+Use the flag when:
+
+- The site is desktop-only by design (presales demo, internal
+  dashboard, etc. — `--skip-adapt-audit` is the heavier hammer for
+  this case, but `--no-hamburger` keeps the rest of the audit).
+- The brand carries a non-hamburger pattern (priority+overflow, bottom
+  nav, bespoke drawer) that the user wants to author themselves.
+
+## Alternative patterns (not stocked)
+
+The stock template is the **default**. Other collapse patterns are
+valid and have their place, but stardust doesn't auto-apply them —
+the agent reaches for them only when the user asks. They're listed
+here so the agent has a vocabulary to suggest when the stock pattern
+doesn't fit.
+
+### Priority + overflow
+
+The nav keeps the top N items horizontally and pushes the rest
+behind a "More" trailing button that opens a small dropdown. Works
+well when there's a clear primary-vs-secondary order in the nav
+items and a strong reason to keep the visible items inline.
+Costs more CSS than the stock pattern and needs JS to compute the
+overflow boundary on resize. Not stocked because the boundary
+computation has no idiomatic CSS-only equivalent.
+
+### Bottom nav
+
+A fixed-position nav band at the bottom of the viewport carrying
+3–5 top-level icons. App-shell territory; appropriate for sites
+designed around frequent navigation (e-commerce, news indexes).
+Costs a permanent ~56px of viewport. Not stocked because it changes
+the page's information architecture, not just its responsive
+behavior — that's a direction-level decision, not an adapt-pass
+decision.
+
+### Side drawer
+
+A horizontal slide-in from the left or right edge of the viewport.
+Visually a stronger reveal than the slide-down panel, common in
+SaaS and editorial sites. Stocked alternative considered; rejected
+for v1 because swipe-to-dismiss requires more JS than the stock
+pattern's ≤10 lines, and CSS-only slide-in feels uncanny without
+the swipe affordance. Revisit when the JS budget changes.
+
+## Constraints the pattern respects
+
+- **No glassmorphism.** Open panel is a solid `--color-bg`, not a
+  blurred backdrop.
+- **No gradient text.** Burger label is a flat color.
+- **No side-stripe borders.** Panel uses a single hairline top
+  border, not a decorative side stripe.
+- **No shadow-as-elevation.** Panel separates from page content via
+  the hairline border and the `--color-bg` color block, not a
+  drop shadow.
+- **No layout-property animation.** Only `transform`, `opacity`,
+  and `visibility` transition.
+- **No new dependencies.** No npm package; no external CSS or JS.
+
+## Files involved
+
+- `skills/prototype/reference/mobile-nav-collapse.md` — this doc.
+- `skills/prototype/fixtures/mobile-nav-collapse-example.html` —
+  a complete fixture demonstrating the pattern. Use as a visual
+  reference and as the positive case for the audit smoke test.
+- `skills/prototype/fixtures/mobile-nav-broken-example.html` —
+  the same page without the collapse. Negative case: the audit
+  must refuse it at 360px.
+- `skills/prototype/fixtures/mobile-nav-audit.mjs` — Playwright
+  smoke test. Renders a file at 360px, evaluates the three
+  conditions, exits 0 on clean and 1 on findings.
+
+## Running the smoke test
+
+```
+cd plugins/stardust
+node skills/prototype/fixtures/mobile-nav-audit.mjs \
+     skills/prototype/fixtures/mobile-nav-collapse-example.html
+# → exit 0, no findings
+
+node skills/prototype/fixtures/mobile-nav-audit.mjs \
+     skills/prototype/fixtures/mobile-nav-broken-example.html
+# → exit 1, prints overflow + nav-readability-floor findings
+```
+
+Requires Playwright (`npm i -D playwright`) and a Chromium install
+(`npx playwright install chromium`). The script is a thin wrapper —
+the audit conditions are the load-bearing piece, and they're
+literal CSSOM reads against the rendered DOM.
+
+## Provenance
+
+When the stock pattern is applied, `_provenance.adapt[]` records:
+
+```yaml
+- at: 2026-05-13T10:42:00Z
+  by: impeccable:adapt (via stardust:prototype Phase 5.5)
+  breakpoints: [360, 640, 768, 1024, 1280]
+  rules: 6
+  navCollapse: hamburger (stock)
+  audit:
+    - pre:   horizontal-overflow-at-360px (147px overflow)
+    - pre:   nav-readability-floor (font 10px, gap 6px)
+    - post:  pass
+```
+
+The pre/post entries let a reviewer see what triggered the
+remediation and that the remediation cleared the audit.

--- a/plugins/stardust/skills/prototype/reference/page-shape-brief.md
+++ b/plugins/stardust/skills/prototype/reference/page-shape-brief.md
@@ -88,7 +88,7 @@ register: brand
    `… PEOPLE HOUSED · …`, `… GRANTED · …`, `… CENTERS · …`. **All
    four numerals are placeholders** — current/pages/home.json
    provides no statistics. Render with the placeholder visual
-   signature per `before-after-shell.md` § Content sourcing
+   signature per `proposed-file-shell.md` § Content sourcing
    hierarchy.
 4. **threshold band** (system-component role: `cta-band`) — site-
    wide block, see `_brand-extraction.json#crossPromo`. Render the

--- a/plugins/stardust/skills/prototype/reference/proposed-file-shell.md
+++ b/plugins/stardust/skills/prototype/reference/proposed-file-shell.md
@@ -1,138 +1,20 @@
-# Before/after shell
+# Proposed-file shell
 
-Stardust's prototype output is **two files per page**, written under
-`stardust/prototypes/`:
+Stardust's prototype output is a **single file per page**, written at
+`stardust/prototypes/<slug>-proposed.html`. It's the self-contained
+redesign of the page — what the user opens in the browser to review,
+what `$impeccable live` iterates on, what `$stardust migrate` later
+re-derives from `DESIGN.md`.
 
-```
-stardust/prototypes/
-├── <slug>.html             # the viewer (before/after side-by-side)
-└── <slug>-proposed.html    # the proposed redesign on its own
-```
-
-The viewer is the user-facing artifact. The proposed file is the
-isolated redesign — what `$impeccable live` iterates on, what `migrate`
-later re-derives from DESIGN.md.
-
-Two files because:
-- **Live mode targets a single file.** `$impeccable live` injects its
-  picker into a running page. A standalone `<slug>-proposed.html`
-  gives it a clean target.
-- **Approval clarity.** The user reviews the viewer; the artifact that
-  carries the design decisions is the proposed file.
-- **Migration source.** `migrate` reads the proposed file's `:root`
-  block and structural data attributes to seed the migrated page,
-  even though it re-renders from DESIGN.md (the proposed file is the
-  agent's record of what it intended).
+There is no per-page before/after viewer. The proposed file is the
+artifact; comparing to the current page happens by switching browser
+tabs (the captured screenshot at
+`stardust/current/assets/screenshots/<slug>.png` or the live URL from
+`state.json`).
 
 ---
 
-## `<slug>.html` — the viewer
-
-A self-contained HTML file that loads the current and proposed pages
-side-by-side in iframes. No external CSS, no external JS, no
-analytics, no fonts.
-
-### Layout
-
-- Two-column flex layout, 50/50 by default.
-- Header strip (~48px) with: page slug, side labels ("CURRENT" left,
-  "PROPOSED" right), action buttons ("swap sides", "approve",
-  "stash"), provenance link.
-- Footer strip (~32px) with the resolved direction title (one line)
-  and a link to `stardust/direction.md`.
-- Body fills the remaining height with two `<iframe>`s.
-- A divider between iframes is draggable (CSS resize). The user can
-  shift the split.
-
-### Iframes
-
-**Left (CURRENT).**
-Source resolution order (screenshot-default):
-
-1. **Screenshot** at
-   `stardust/current/assets/screenshots/<slug>.png` displayed in an
-   `<img>`. **Default.** Always works, no embedding question, no CSP
-   risk.
-2. **Live URL** from `state.json` (`pages[<slug>].url`), exposed as
-   an opt-in "Try live" toggle in the viewer header strip. Loads
-   in a sandboxed iframe with
-   `sandbox="allow-scripts allow-same-origin"`.
-3. **Landmarks-text fallback** — render the page's captured
-   `landmarks` summary as a text-only outline. Used only when the
-   screenshot is missing AND the live URL is unreachable.
-
-The screenshot-default order is a flip from v0.1, which loaded the
-live URL first and fell back to screenshot only on network failure.
-Most production sites send `Content-Security-Policy: frame-ancestors`
-that silently blocks iframe embedding (no `onerror` event fires —
-the iframe just paints empty), so the v0.1 chain produced a blank
-CURRENT pane on the majority of real sites tested
-(`STARDUST-FEEDBACK.md F-001`). The screenshot is already captured
-during extract per `playwright-recipe.md` § Capture list (14); using
-it as the default eliminates the failure mode entirely.
-
-The "Try live" toggle remains useful when reviewing a page that
-*does* allow embedding (own staging environments, sites without
-CSP, localhost), or when the user wants to test interactive
-behavior. The toggle replaces the current iframe with the live URL
-inline; if it fails to load (CSP block, offline, login wall), the
-toggle button surfaces a "site refused embedding" notice and
-reverts to screenshot.
-
-**Right (PROPOSED).**
-Source: `srcdoc` of the relative path to `<slug>-proposed.html` (or
-direct iframe src when served by `$impeccable live`'s helper server).
-Always reachable; lives next to the viewer on disk.
-
-Both iframes inherit the viewport from the parent page, so the design
-is reviewed at the user's actual screen width — not at a fixed 1440px.
-
-### Provenance
-
-First child of `<head>`:
-
-```html
-<!-- stardust:provenance
-  writtenBy:        stardust:prototype
-  writtenAt:        2026-04-25T16:42:00Z
-  page:             home
-  pageUrl:          https://example.com/
-  proposedFile:     ./home-proposed.html
-  againstDirection: stardust/direction.md (Active 2026-04-25T15:42:00Z)
-  readArtifacts:
-    - stardust/current/pages/home.json
-    - DESIGN.md
-    - DESIGN.json
-  synthesizedInputs: []
-  stardustVersion:  0.2.0
--->
-```
-
-### Action buttons (header strip)
-
-- **Swap sides.** Toggles which iframe is left vs right. Helpful
-  when comparing big visual moves — sometimes the new design "feels"
-  bigger when it's on the right; swap to check.
-- **Approve.** Marks this prototype `approved` in `state.json`. The
-  agent confirms before writing.
-- **Stash.** Saves the current `<slug>-proposed.html` as
-  `<slug>-proposed-stash-<ts>.html` so the next iteration starts
-  fresh without losing this version.
-- **Open in `$impeccable live`.** A copy-paste command snippet for
-  starting an iteration session against `<slug>-proposed.html`.
-
-The action buttons are HTML buttons with inline JS that posts to
-`window.parent` or copies a command to the clipboard — they do not
-require a server.
-
----
-
-## `<slug>-proposed.html` — the proposed redesign
-
-A complete, self-contained HTML page. The thing the user is
-ultimately approving.
-
-### Required structure
+## Required structure
 
 ```html
 <!DOCTYPE html>
@@ -160,7 +42,7 @@ ultimately approving.
 </html>
 ```
 
-### Hard requirements
+## Hard requirements
 
 The proposed file must satisfy:
 
@@ -169,6 +51,17 @@ The proposed file must satisfy:
    includes it), inline the `@font-face` with a Google Fonts CSS
    `@import` is acceptable for prototyping but not for migrate
    output.
+
+   **Inline `<script>` exception — mobile nav a11y.** When Phase 5.5
+   applies the stock hamburger pattern (per
+   `mobile-nav-collapse.md`), the file carries a ≤10-line inline
+   `<script>` that syncs `aria-expanded` on the burger button and
+   wires Escape-to-close. This is the one place stardust's "no JS"
+   preference bends, and only for assistive-tech support. The
+   rationale lives in `mobile-nav-collapse.md` § Accessibility
+   checklist. No other inline scripts are permitted. The fixture
+   at `skills/prototype/fixtures/mobile-nav-collapse-example.html`
+   shows the exact script.
 2. **`:root` token block** as the first content of the first
    `<style>`. See `skills/stardust/reference/token-contract.md`.
 3. **Structural data attributes** on every section. See
@@ -218,7 +111,7 @@ The proposed file must satisfy:
    *demands* but the page *does not provide* (stat rows, addresses,
    testimonial quotes, etc.).
 
-### Content sourcing hierarchy
+## Content sourcing hierarchy
 
 Every literal value rendered into `<slug>-proposed.html` — every
 heading, paragraph, CTA label, statistic, address, quote, name,
@@ -233,7 +126,7 @@ attributed to a real person who never said it. For a real nonprofit
 or any production site this is a serious harm — invented content
 looks authoritative once rendered.
 
-#### Allowed sources, in priority order
+### Allowed sources, in priority order
 
 1. **`stardust/current/pages/<slug>.json`** — the captured page.
    Use values verbatim. Headings, body copy, CTA labels, navigation
@@ -268,7 +161,7 @@ likely to be demanded by a redesign template (stat rows,
 testimonial cards, contact panels, pricing tables) without the
 captured page providing them.
 
-#### PLACEHOLDER visual signature (mandatory)
+### PLACEHOLDER visual signature (mandatory)
 
 When the new design demands content the captured page does not
 provide, render it as a placeholder element with **all** of:
@@ -297,7 +190,7 @@ The visual signature is not optional and must remain visible in
 screenshots. The reviewer must be unable to mistake a placeholder
 for real content.
 
-#### Provenance log of unsourced content
+### Provenance log of unsourced content
 
 Add an `unsourcedContent[]` array to the proposed file's provenance
 listing every placeholder element rendered, with the reason:
@@ -318,7 +211,7 @@ unsourcedContent:
 This list is the canonical record of what needs to be sourced
 before the prototype becomes a production deliverable.
 
-#### Migrate guard
+### Migrate guard
 
 `migrate` reads the proposed file's `unsourcedContent[]` and the
 DOM's `[data-placeholder]` elements. If any are present, migrate
@@ -330,7 +223,7 @@ acknowledged that the deployable site will contain placeholder
 markers visible to end users. Spec for the migrate guard lives in
 `skills/migrate/SKILL.md` § Failure modes.
 
-### Provenance
+## Provenance
 
 ```html
 <!-- stardust:provenance
@@ -358,30 +251,14 @@ elements per § Content sourcing hierarchy.
 
 ---
 
-## How they're written
-
-`$stardust prototype <slug>` writes both files in a single pass:
-
-1. Render `<slug>-proposed.html` first (the heavy lift).
-2. Then write `<slug>.html` (the viewer) referencing the proposed
-   file by relative path.
-
-Re-iterations rewrite `<slug>-proposed.html` only; the viewer file is
-unchanged unless the page slug or proposed filename changes.
-
----
-
 ## Stale handling
 
-When `direction.md` changes, the prototype's provenance comment lists
-a `againstDirection` that is no longer the active direction.
-`state.json` flags the page `stale: true`. The viewer surfaces this
-in the header strip:
+When `direction.md` changes, the prototype's provenance comment
+lists an `againstDirection` that is no longer the active direction.
+`state.json` flags the page `stale: true`. Re-runs of
+`$stardust prototype <slug>` skip the page by default; pass
+`--refresh-stale` to re-prototype.
 
-```
-[STALE] direction changed at 2026-04-26T09:00:00Z
-        run: $stardust prototype <slug> --refresh-stale
-```
-
-The user can still open and review a stale prototype — it is a valid
-artifact representing the prior direction. They opt into refreshing.
+The user can still open and review a stale prototype — it is a
+valid artifact representing the prior direction. They opt into
+refreshing when ready.

--- a/plugins/stardust/skills/prototype/reference/publish-sample.md
+++ b/plugins/stardust/skills/prototype/reference/publish-sample.md
@@ -77,13 +77,10 @@ combine into a single "not eligible" message.
    - For each file, parse the `<!-- stardust:provenance -->`
      comment block in `<head>`.
    - A file is a candidate variant for the named slug if its
-     `page:` field equals `<slug>` and it is **not** the viewer
-     (the viewer's `writtenBy:` says `stardust:prototype`'s
-     viewer pass, while a proposed file's `writtenBy:` is plain
-     `stardust:prototype` or `stardust:prototype/iterate`; the
-     viewer also lacks a top-level `<!DOCTYPE html><html>` body
-     section because it's iframe-shelled. The cheaper detection
-     is the absence of `<iframe` tags in the body).
+     `page:` field equals `<slug>`. (Earlier versions of the
+     flow needed to disambiguate proposed files from a
+     per-page viewer; the viewer was dropped, so any prototypes
+     file with a matching `page:` is a proposed file.)
    - Variant id resolution: read the file's `<head>` `<meta
      name="variant" content="A">` if present; else read the
      filename for a single uppercase letter token (matches
@@ -415,7 +412,7 @@ The publish flow already verified these — reviewer can spot-check.
 - [x] `meta.json#direction.palette.source` resolves to the picked
       palette.
 - [x] Every `proposed-*.html` file is self-contained per
-      `before-after-shell.md` § Required structure.
+      `proposed-file-shell.md` § Required structure.
 
 ### Reviewer checklist
 

--- a/plugins/stardust/skills/stardust/reference/artifact-map.md
+++ b/plugins/stardust/skills/stardust/reference/artifact-map.md
@@ -80,8 +80,7 @@ stardust/
 │       └── media/                    # extracted images, with original URLs
 ├── prototypes/
 │   ├── <slug>-shape.md               # per-page compositional brief (page-level deployment record)
-│   ├── <slug>.html                   # before/after viewer (user-facing review surface)
-│   └── <slug>-proposed.html          # proposed redesign on its own (live-mode iteration target, migration source)
+│   └── <slug>-proposed.html          # proposed redesign (live-mode iteration target, migration source, user-facing review surface)
 └── migrated/                         # deployable static HTML site
     ├── index.html                    # the home page (slug "home" -> root)
     ├── _meta.json                    # sidecar JSON (full reasoning trace) — one per migrated page
@@ -163,26 +162,18 @@ the **deployment** of that system to a specific page. A direction
 change invalidates the system; the brief is content-aware-stale
 only when the system change makes its composition impossible.
 
-### `stardust/prototypes/<slug>.html` and `<slug>-proposed.html`
-Owner: `$stardust prototype`. Two files per page (see
-`skills/prototype/reference/before-after-shell.md` for the contract):
+### `stardust/prototypes/<slug>-proposed.html`
+Owner: `$stardust prototype`. One file per page — the **proposed
+redesign on its own**: self-contained, complete HTML page rendered
+against the target `DESIGN.md`. The user opens it in the browser to
+review; `$impeccable live` iterates on it; `$stardust migrate` later
+re-derives from it for the final migrated page. Full contract in
+`skills/prototype/reference/proposed-file-shell.md`.
 
-- **`<slug>.html`** — the **viewer**. Self-contained HTML with two
-  iframes side-by-side: left = current page (live URL, screenshot
-  fallback, or landmarks-text fallback), right = the proposed
-  redesign (loaded from `<slug>-proposed.html`). Header strip with
-  swap/approve/stash/live-mode actions. The user-facing review
-  surface.
-- **`<slug>-proposed.html`** — the **proposed redesign on its own**.
-  Self-contained, complete HTML page rendered against the target
-  `DESIGN.md`. The file `$impeccable live` iterates on; the file
-  `$stardust migrate` later re-derives from for the final migrated
-  page.
-
-Both carry provenance blocks in `<head>`. The proposed file's
-provenance lists the active direction it was rendered against; when
-direction changes, the page is flagged `stale` in `state.json` and
-the viewer surfaces the staleness in the header strip.
+The file carries a provenance block in `<head>` listing the active
+direction it was rendered against; when direction changes the page
+is flagged `stale` in `state.json` and re-runs of `prototype` skip
+it unless `--refresh-stale` is passed.
 
 ### `stardust/migrated/`
 Owner: `$stardust migrate`. A deployable static HTML site. The slug →

--- a/plugins/stardust/skills/stardust/reference/data-attributes.md
+++ b/plugins/stardust/skills/stardust/reference/data-attributes.md
@@ -145,6 +145,27 @@ mechanically rather than re-deriving structure.
   `migrate`'s run summary; user resolves by extracting the
   missing page and re-migrating, or accepts the broken link.
 
+### Mobile-collapse marker
+
+- **`data-nav-collapse="hamburger"`** — on `<header>` when the
+  stock mobile-nav collapse pattern is applied during Phase 5.5
+  (`skills/prototype/SKILL.md` § Mobile-adapt audit /
+  `skills/prototype/reference/mobile-nav-collapse.md`).
+  Downstream consumers detect the marker to avoid re-applying or
+  re-checking the same collapse — the Mobile-adapt audit, the
+  migrate re-derivation, and any future shared-component
+  extractor read it as "this header already collapses; pass
+  through verbatim."
+
+  Possible values: `"hamburger"` (the stocked stock pattern). Future
+  values may include `"priority-overflow"`, `"bottom-nav"`,
+  `"drawer"` if those alternatives gain stock treatments; today
+  the agent does not auto-apply them and therefore does not write
+  the marker.
+
+  Absent on headers that already fit at 360px without a collapse
+  (e.g. a 2-link nav at desktop type sizes).
+
 ## Examples
 
 ```html
@@ -228,6 +249,11 @@ v0.2.0.
 — ship with the migrate-template-canon refactor. Additive: every
 v2-only consumer continues to work; v2.1-aware consumers gain the
 template/module/slot/canon surface.
+
+**v2.2 additive set.** `data-nav-collapse` — ships with the
+mobile-nav-collapse pattern (`reference/mobile-nav-collapse.md`).
+Additive on `<header>`; absent for headers that didn't need a
+collapse.
 
 New attributes can be added in a backward-compatible way; renaming
 existing ones requires a version bump.

--- a/plugins/stardust/skills/stardust/reference/doctor.md
+++ b/plugins/stardust/skills/stardust/reference/doctor.md
@@ -116,7 +116,7 @@ artifact must declare what wrote it and what it read.
   no-confirm fast-path)`) is reported as a *fast-path bypass*.
 - **D-103** — `PRODUCT.md`, `DESIGN.md`, and `DESIGN.json` exist at the
   project root when any prototype exists. (Catches: skipping direct.)
-- **D-104** — Every `prototypes/<slug>.html` has a paired
+- **D-104** — Every `prototypes/<slug>-proposed.html` has a paired
   `prototypes/<slug>-shape.md` brief (per
   `prototype/reference/page-shape-brief.md`). (Catches: skipping shape.)
 - **D-105** — Each artifact's `_provenance.reads[]` references files

--- a/plugins/stardust/skills/stardust/reference/state-machine.md
+++ b/plugins/stardust/skills/stardust/reference/state-machine.md
@@ -45,7 +45,7 @@ and resumable. The state file is `stardust/state.json`. It is written by
       "stale": false,
       "staleReason": null,
       "currentStatePath": "stardust/current/pages/home.json",
-      "prototypePath":    "stardust/prototypes/home.html",
+      "prototypePath":    "stardust/prototypes/home-proposed.html",
       "migratedPath":     null
     }
   ]
@@ -67,7 +67,7 @@ move the state, it flags it.
 |--------------|-------------------------------------------------------------------------|-------------------------|
 | `extracted`  | Crawled and parsed. `current/pages/<slug>.json` exists.                 | `stardust:extract`      |
 | `directed`   | Direction `direction.md` resolved; this page is in scope of the direction. | `stardust:direct`     |
-| `prototyped` | A before/after prototype exists at `prototypes/<slug>.html`.            | `stardust:prototype`    |
+| `prototyped` | A proposed-redesign prototype exists at `prototypes/<slug>-proposed.html`. | `stardust:prototype` |
 | `approved`   | The user explicitly approved the prototype.                             | `stardust:prototype`    |
 | `migrated`   | Final redesigned static HTML written to `migrated/<slug>.html`.         | `stardust:migrate`      |
 


### PR DESCRIPTION
## Summary

Two related changes to `stardust:prototype` landing together.

### Mobile-nav collapse (additive)

- Stock CSS-only hamburger pattern auto-applied by Phase 5.5 when the Mobile-adapt audit refuses at 360px (overflow, sub-11px nav font, or sub-10px nav gap).
- Three new audit conditions in `skills/prototype/SKILL.md` § Mobile-adapt audit; runtime-checked via the Playwright snippet at `skills/prototype/fixtures/mobile-nav-audit.mjs`.
- Canonical pattern doc at `skills/prototype/reference/mobile-nav-collapse.md` — HTML, CSS, ≤10-line a11y JS, source-order check, `--no-hamburger` opt-out, alternative patterns.
- New `data-nav-collapse=\"hamburger\"` attribute on `<header>` (v2.2 additive in `data-attributes.md`).
- Positive + negative fixtures verify the audit end-to-end.

### Drop the per-page before/after viewer (BREAKING)

- Phase 3 (*Compose the viewer*) removed; the proposed file is opened directly in the browser.
- Approval is now chat-only: **\"approve \<slug>\"** or **\"approve\"**.
- `skills/prototype/reference/before-after-shell.md` → `proposed-file-shell.md`, stripped to the proposed-file contract (viewer half, iframe chain, action buttons, stash mechanic all dropped).
- `state-machine.md` `prototypePath` repointed at `-proposed.html`; `doctor.md` D-104 pairs `-proposed.html` with `-shape.md`; `artifact-map.md` drops the `<slug>.html` row; `publish-sample.md` simplifies variant discovery (no more \"is not the viewer\" disambiguation); `evals/prototype-before-after` rewritten to expect a single proposed file.

## BREAKING CHANGE

`stardust:prototype` no longer composes the per-page viewer at `stardust/prototypes/<slug>.html`. Anyone scripting on top of that file existing on disk should switch to `stardust/prototypes/<slug>-proposed.html` (the `prototypePath` in `state.json` now points there directly). The approval gesture moves from the viewer's Approve button to a chat-only **\"approve \<slug>\"** / **\"approve\"**.

## Test plan

- [ ] Re-install stardust locally and run `/stardust:prototype <slug>` against a real captured site with a 5+ link nav. Verify Phase 5.5 audit refuses on bare horizontal nav and auto-applies the stock hamburger.
- [ ] Run `mobile-nav-audit.mjs` against `mobile-nav-collapse-example.html` (must exit 0) and `mobile-nav-broken-example.html` (must exit 1 with all three findings).
- [ ] Open `/Users/paolo/stardust/greenfield-beermaker/stardust/prototypes/home-proposed-C2.html` and confirm it passes the new audit + ordering check.
- [ ] Confirm a fresh `stardust:prototype` run opens `<slug>-proposed.html` directly (no viewer file written).
- [ ] Approval via chat (\"approve home\") moves state to `approved` and `prototypePath` reads as `-proposed.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)