### PR TITLE
feat(migration): align skill with updated MCP tool names and empty-pattern result handling

### DIFF
--- a/plugins/aem/cloud-service/skills/migration/SKILL.md
+++ b/plugins/aem/cloud-service/skills/migration/SKILL.md
@@ -114,7 +114,15 @@ the user's go-ahead by re-calling the helper with `offset: paging.nextOffset`. S
 
 ### CAM via MCP (summary)
 
-Use **`fetch-cam-bpa-findings`** only after **`list-projects`** and **explicit user confirmation** of which project row to use (prefer **`projectId`** from that list). Do not pass an unconfirmed project name string. **Full tool schemas, REST notes, retries, and error handling:** [references/cam-mcp.md](references/cam-mcp.md).
+Use **`fetch-cam-bpa-findings-by-pattern`** for code-transformer pattern flows (scheduler,
+assetApi, eventListener, resourceChangeListener, eventHandler) and
+**`fetch-cam-bpa-findings-by-importance`** when the user instead asks "what are the
+critical/major/advisory/info findings?" (returns the latest BPA report's authoritative
+`_COUNT_<code>` rows at one importance level, sorted by descending count). Either tool
+requires **explicit user confirmation** of the project before being called — ask the user
+for their CAM project name or ID; the tools resolve it internally (prefer **`projectId`**
+when known). Do not pass an unconfirmed project name string. **Full tool schemas, REST notes, retries, and error handling:**
+[references/cam-mcp.md](references/cam-mcp.md).
 
 ### What the user might say
 
@@ -237,8 +245,8 @@ After finishing the batch, summarise **for this batch only**:
 - If `paging.hasMore === false`, say the pattern is done and move to the overall session report.
 
 **Stop and wait for the user.** Do not automatically start the next batch. Only call
-`getBpaFindings` (or `fetch-cam-bpa-findings`) again when the user explicitly requests it,
-and pass `offset: paging.nextOffset` unchanged.
+`getBpaFindings` (or `fetch-cam-bpa-findings-by-pattern`) again when the user explicitly
+requests it, and pass `offset: paging.nextOffset` unchanged.
 
 ### Manual flow (no BPA)
 

--- a/plugins/aem/cloud-service/skills/migration/references/cam-mcp.md
+++ b/plugins/aem/cloud-service/skills/migration/references/cam-mcp.md
@@ -88,6 +88,13 @@ The MCP server is **not** required to implement paging; the helper batches clien
     severity?: string;
   }>;
   summary?: Record<string, number>;
+  /**
+   * Present when a specific pattern was requested but has no findings in the
+   * latest BPA report (e.g. "No 'scheduler' findings in the latest BPA report
+   * for project <id>."). `targets` will be an empty array. This is a successful
+   * response — the report exists, there are just no findings for this pattern.
+   */
+  message?: string;
 }
 ```
 
@@ -172,4 +179,5 @@ helper caches the response to disk and slices from the cache on subsequent calls
 | Network / timeout | Once | Retry after ~2s, then quote error verbatim and stop if still failing. |
 | 5xx | Once | Retry after ~2s, then quote error verbatim and stop if still failing. |
 | 400 | No | Quote error verbatim; stop; ask user to fix parameters or pick another path. |
-| 200 empty targets | No | Report honestly; stop. Offer options (other pattern, CSV, explicit files) **only** as choices for the user — do not start editing the repo without BPA targets unless the user picks manual files. |
+| `success: true`, empty `targets`, `message` present (specific pattern, no findings) | No | Show the `message` verbatim (e.g. *"No 'scheduler' findings in the latest BPA report for project X."*). Offer options — other pattern, CSV, explicit files — **only** as choices; do not start editing the repo without BPA targets unless the user picks manual files. |
+| `success: false`, empty `targets` (`pattern: "all"` or error) | No | Quote `error` verbatim; stop. Offer options (other pattern, CSV, explicit files) **only** as choices for the user. |

--- a/plugins/aem/cloud-service/skills/migration/references/cam-mcp.md
+++ b/plugins/aem/cloud-service/skills/migration/references/cam-mcp.md
@@ -6,7 +6,7 @@ Read this file when **fetching BPA targets via MCP** instead of a CSV or cached 
 
 1. Agent asks the user for their **CAM project name or ID**.
 2. **You confirm** the project name or ID (the agent should not guess or infer it).
-3. Agent calls **`fetch-cam-bpa-findings`** **once** with the confirmed project and the **one pattern** for this session (`scheduler`, `assetApi`, etc., or `all` then filtered). The MCP server returns all findings for that pattern.
+3. Agent calls **`fetch-cam-bpa-findings-by-pattern`** **once** with the confirmed project and the **one pattern** for this session (`scheduler`, `assetApi`, etc., or `all` then filtered). The MCP server returns all findings for that pattern.
 4. `bpa-findings-helper.js` caches the response to
    `<collectionsDir>/mcp/<projectId>/<pattern>.json` and applies the batch slice (default 5) client-side.
 5. Agent processes that batch, reports progress (`returned / total`), then stops. The user says whether to continue.
@@ -16,7 +16,7 @@ See [Batching](#batching) below for the full contract.
 
 ### Project name and ID — non-negotiable
 
-- **Never** call **`fetch-cam-bpa-findings`** with a `projectId` or `projectName` that the user has not **explicitly confirmed**.
+- **Never** call **`fetch-cam-bpa-findings-by-pattern`** or **`fetch-cam-bpa-findings-by-importance`** with a `projectId` or `projectName` that the user has not **explicitly confirmed**.
 - If the tool returns a "project not found" error, **quote the error verbatim**, and ask the user to provide the correct project name or ID — do not guess or retry with a fuzzy match.
 - **Do not** infer the CAM project from the open workspace, repository name, or sample code (e.g. WKND) when using MCP.
 
@@ -53,12 +53,12 @@ If your MCP server documentation adds other error prefixes or codes with the sam
 ## Rules before any tool call
 
 1. **Ask the user** for their CAM project name or ID. Do not guess from the workspace or sample code.
-2. **Wait for explicit confirmation**, then call **`fetch-cam-bpa-findings`** using the **confirmed** `projectId` (preferred) or `projectName`.
-3. Map the session's **single pattern** to the tool's `pattern` argument (`scheduler`, `assetApi`, `eventListener`, `resourceChangeListener`, `eventHandler`, or `all`). If you used `all`, filter `targets` to the active pattern.
+2. **Wait for explicit confirmation**, then call **`fetch-cam-bpa-findings-by-pattern`** (for code-transformer pattern flows) or **`fetch-cam-bpa-findings-by-importance`** (for "what are the critical/major findings?" requests) using the **confirmed** `projectId` (preferred) or `projectName`.
+3. For pattern flows: map the session's **single pattern** to the tool's `pattern` argument (`scheduler`, `assetApi`, `eventListener`, `resourceChangeListener`, `eventHandler`, or `all`). If you used `all`, filter `targets` to the active pattern.
 
-## Tool: `fetch-cam-bpa-findings`
+## Tool: `fetch-cam-bpa-findings-by-pattern`
 
-The only MCP tool registered by the server. It can also resolve a project name to a project ID internally (via the CAM projects API), so a separate `list-projects` call is not needed — pass `projectName` or `projectId`.
+Pattern-axis tool registered by the server. It can also resolve a project name to a project ID internally (via the CAM projects API), so a separate `list-projects` call is not needed — pass `projectName` or `projectId`.
 
 **Request (illustrative — confirm against live MCP tool schema):**
 
@@ -125,6 +125,59 @@ const resp = await fetchCamBpaFindings({
 
 ---
 
+## Tool: `fetch-cam-bpa-findings-by-importance`
+
+Importance-axis tool registered by the server. Returns all findings at one importance
+level (`CRITICAL`, `MAJOR`, `ADVISORY`, or `INFO`) from the **latest** BPA report
+uploaded to the project, sourced from the BPA's authoritative `_COUNT_<code>` rollup rows
+and pre-sorted by descending count.
+
+Use this tool when the user asks open-ended questions like *"what are the critical
+findings?"* or *"show me the major issues"*, rather than a code-transformer migration
+flow (those use `fetch-cam-bpa-findings-by-pattern`). The same project-confirmation
+guardrails apply: never call it with an unconfirmed `projectId` / `projectName`.
+
+**Request (illustrative — confirm against live MCP tool schema):**
+
+```typescript
+{
+  importance: "CRITICAL" | "MAJOR" | "ADVISORY" | "INFO";  // required
+  projectId?: string;   // CAM project ID; either this or projectName must be provided
+  projectName?: string; // human-readable name; resolved to projectId via CAM /projects API
+  environment?: "dev" | "stage" | "prod";  // defaults to "prod"
+}
+```
+
+**Backed by:** `GET /projects/{projectId}/bpaReportCodeTransformerData/findings/{importance}`
+
+**Success response:**
+
+```typescript
+{
+  success: true;
+  importance: "CRITICAL" | "MAJOR" | "ADVISORY" | "INFO";
+  environment?: "dev" | "stage" | "prod";
+  projectId: string;
+  reportId: string | null;
+  reportTime: number | null;  // epoch millis from BpaOverview, when available
+  findings: Array<{
+    code: string;          // e.g. "_COUNT_ACV"
+    type: string;          // e.g. "_count.assets.health"
+    subtype: string;       // e.g. "missing.original.rendition"
+    importance: "CRITICAL" | "MAJOR" | "ADVISORY" | "INFO";
+    count: number;
+  }>;
+}
+```
+
+A 404 from the backend (no BPA report uploaded yet) is mapped to `success: true` with
+`findings: []` and `reportId: null`.
+
+**Error response:** same shape as `fetch-cam-bpa-findings-by-pattern` (`success: false`,
+`error`, optional `troubleshooting` / `suggestion`). Apply the same retry table.
+
+---
+
 ## Batching
 
 The migration skill processes BPA findings in **batches of 5** by default. Batching is
@@ -146,7 +199,7 @@ helper caches the response to disk and slices from the cache on subsequent calls
 
 ### Agent rules
 
-1. Call `fetch-cam-bpa-findings` **once** per `(projectId, pattern)` — the helper does this
+1. Call `fetch-cam-bpa-findings-by-pattern` **once** per `(projectId, pattern)` — the helper does this
    the first time the agent invokes `getBpaFindings` on the MCP path.
 2. After each batch the helper returns, process **only** those findings, then **stop**:
    *"Processed 5 of 137 scheduler findings. Reply `continue` for the next batch, or name

--- a/plugins/aem/cloud-service/skills/migration/scripts/bpa-findings-helper.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/bpa-findings-helper.js
@@ -52,7 +52,7 @@ function readMcpCache(collectionsDir, projectId, pattern) {
 }
 
 /** Persist an MCP fetch to disk as the read model for subsequent paging. */
-function writeMcpCache(collectionsDir, projectId, pattern, environment, targets) {
+function writeMcpCache(collectionsDir, projectId, pattern, environment, targets, mcpMessage) {
   const file = mcpCachePath(collectionsDir, projectId, pattern);
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, JSON.stringify({
@@ -61,7 +61,8 @@ function writeMcpCache(collectionsDir, projectId, pattern, environment, targets)
     pattern,
     environment,
     fetchedAt: new Date().toISOString(),
-    targets
+    targets,
+    ...(mcpMessage ? { mcpMessage } : {})
   }, null, 2));
 }
 
@@ -129,7 +130,7 @@ async function getFromMcp({ pattern, projectId, environment, mcpFetcher, collect
         };
       }
       const targets = Array.isArray(mcp.targets) ? mcp.targets : [];
-      writeMcpCache(collectionsDir, projectId, pattern, environment, targets);
+      writeMcpCache(collectionsDir, projectId, pattern, environment, targets, mcp.message);
       cache = readMcpCache(collectionsDir, projectId, pattern);
     } catch (error) {
       return {
@@ -147,12 +148,13 @@ async function getFromMcp({ pattern, projectId, environment, mcpFetcher, collect
   }
 
   const { targets, paging } = paginate(cache.targets, { offset, limit });
+  const defaultMessage = `Using MCP cache for project ${projectId} (fetched ${formatTimestamp(cache.fetchedAt)}).`;
   return {
     success: true,
     source: 'mcp-server',
     projectId,
     environment,
-    message: `Using MCP cache for project ${projectId} (fetched ${formatTimestamp(cache.fetchedAt)}).`,
+    message: (cache.targets.length === 0 && cache.mcpMessage) ? cache.mcpMessage : defaultMessage,
     targets,
     paging
   };

--- a/plugins/aem/cloud-service/skills/migration/scripts/bpa-findings-helper.test.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/bpa-findings-helper.test.js
@@ -334,6 +334,42 @@ test('MCP cache files are keyed by (projectId, pattern) — different keys do no
   assert.ok(fs.existsSync(path.join(dir, 'mcp', 'proj-B', 'scheduler.json')));
 });
 
+test('MCP path: success:true with empty targets propagates message and caches', async () => {
+  const dir = tempDir();
+  const mcpFetcher = async () => ({
+    success: true,
+    targets: [],
+    summary: { schedulerCount: 0 },
+    message: "No 'scheduler' findings in the latest BPA report for project proj-X."
+  });
+  const r = await getBpaFindings('scheduler', {
+    collectionsDir: dir,
+    projectId: 'proj-X',
+    mcpFetcher
+  });
+  assert.equal(r.success, true);
+  assert.equal(r.source, 'mcp-server');
+  assert.equal(r.targets.length, 0);
+  assert.equal(r.paging.total, 0);
+  assert.equal(r.paging.hasMore, false);
+  assert.ok(r.message.includes("No 'scheduler' findings"), 'message should reflect empty pattern result');
+
+  const cacheFile = path.join(dir, 'mcp', 'proj-X', 'scheduler.json');
+  assert.ok(fs.existsSync(cacheFile), 'cache file should be written even for empty results');
+
+  // Second call should read cache and not invoke fetcher again.
+  let fetcherCalled = false;
+  const deadFetcher = async () => { fetcherCalled = true; return { success: true, targets: [] }; };
+  const r2 = await getBpaFindings('scheduler', {
+    collectionsDir: dir,
+    projectId: 'proj-X',
+    mcpFetcher: deadFetcher
+  });
+  assert.equal(fetcherCalled, false, 'fetcher must not be called when cache exists');
+  assert.equal(r2.success, true);
+  assert.ok(r2.message.includes("No 'scheduler' findings"), 'cached message should persist');
+});
+
 test('MCP path: second session reuses the cache across processes (no fetch)', async () => {
   const dir = tempDir();
   const fA = mkCountingMcpFetcher(8);

--- a/plugins/aem/cloud-service/skills/migration/scripts/unified-collection-reader.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/unified-collection-reader.js
@@ -56,6 +56,7 @@ class BpaResult {
     this.projectId = 'unified-collection';
     this.targets = [];
     this.summary = {};
+    this.message = null;
     this.error = null;
     this.errorDetails = null;
     this.troubleshooting = [];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Two related changes to the AEM Cloud Service migration skill, driven by updates to the aem-cloud-migration MCP server:

1. MCP tool rename and new importance tool documentation

All references to fetch-cam-bpa-findings updated to fetch-cam-bpa-findings-by-pattern throughout SKILL.md and references/cam-mcp.md
New ## Tool: fetch-cam-bpa-findings-by-importance section added to cam-mcp.md documenting the request/response shape, backend endpoint (GET /projects/{projectId}/bpaReportCodeTransformerData/findings/{importance}), and when to use it (open-ended "what are the critical/major findings?" queries vs pattern migration flows)
SKILL.md CAM via MCP summary updated to describe both tools and their distinct use cases

2. Empty-pattern result handling (success: true + message)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
The MCP server introduced two breaking changes that required skill alignment:
1. Tool rename — using the old tool name fetch-cam-bpa-findings would fail at runtime once the server is updated. The skill must reference the correct tool names so the agent calls the right endpoints.

2. Misleading empty-pattern error — when a user's project had a BPA report but no findings for a specific pattern (e.g. no scheduler usage), the old success: false response caused the agent to tell the user to "upload a BPA report" — even though a report clearly existed. The fix returns success: true + an accurate message, and the skill layer now propagates that message correctly.

## How Has This Been Tested?

1. bpa-findings-helper.test.js updated and passing — 19/19 tests pass (node --test bpa-findings-helper.test.js)
2. New test MCP path: success:true with empty targets propagates message and caches covers:
      success: true returned when MCP gives empty targets + message
      Message propagated correctly on first call
      Cache file written even for empty result
      Message persists from cache on second call without re-invoking the fetcher
3. Verified no stale fetch-cam-bpa-findings references remain in the skill files

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
