### PR TITLE
Add app-builder cursor plugin metadata

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "adobe-skills",
+  "owner": {
+    "name": "Adobe"
+  },
+  "metadata": {
+    "description": "Official Adobe Skills for AI Agents",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "app-builder",
+      "source": "plugins/app-builder",
+      "description": "Development, customization, testing, and deployment skills for Adobe App Builder projects"
+    }
+  ]
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,9 @@
 # Claude plugin marketplace config
 /.claude-plugin/                                      @shsteimer @trieloff
 
+# Cursor plugin marketplace config
+/.cursor-plugin/                                      @shsteimer @trieloff
+
 # AEM Edge Delivery Services (Sean Steimer is primary author of all skills)
 /plugins/aem/edge-delivery-services/                   @shsteimer
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ gh extension install ai-ecoverse/gh-upskill
 gh upskill adobe/skills --all
 ```
 
+### Cursor (preview)
+
+The `app-builder` plugin includes a Cursor-native manifest at `plugins/app-builder/.cursor-plugin/plugin.json` as the pilot for Cursor distribution. Other plugins will gain Cursor support once the pattern is validated. To install locally for development:
+
+```bash
+cp -R plugins/app-builder ~/.cursor/plugins/local/app-builder
+# Then in Cursor: Cmd+Shift+P → Developer: Reload Window
+```
+
 ## Available Skills
 
 ### For Business

--- a/README.md
+++ b/README.md
@@ -34,9 +34,12 @@ gh upskill adobe/skills --all
 The `app-builder` plugin includes a Cursor-native manifest at `plugins/app-builder/.cursor-plugin/plugin.json` as the pilot for Cursor distribution. Other plugins will gain Cursor support once the pattern is validated. To install locally for development:
 
 ```bash
-cp -R plugins/app-builder ~/.cursor/plugins/local/app-builder
+mkdir -p ~/.cursor/plugins/local/app-builder
+cp -R plugins/app-builder/. ~/.cursor/plugins/local/app-builder/
 # Then in Cursor: Cmd+Shift+P → Developer: Reload Window
 ```
+
+Verify the plugin loaded via **Cursor Settings → Plugins** (it should appear with all six App Builder skills). The skills are also visible in **Settings → Rules** under "Agent Decides".
 
 ## Available Skills
 

--- a/plugins/app-builder/.cursor-plugin/plugin.json
+++ b/plugins/app-builder/.cursor-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "app-builder",
+  "version": "1.0.0",
+  "description": "Development, customization, testing, and deployment skills for Adobe App Builder projects. Covers project initialization, action scaffolding, React Spectrum UI scaffolding, Jest unit and integration testing, Playwright E2E testing, and GitHub Actions / Azure DevOps / GitLab CI deployment pipelines.",
+  "author": {
+    "name": "Adobe"
+  },
+  "homepage": "https://github.com/adobe/skills",
+  "repository": "https://github.com/adobe/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "adobe",
+    "app-builder",
+    "aio",
+    "adobe-io-runtime",
+    "react-spectrum",
+    "playwright",
+    "jest",
+    "github-actions",
+    "aem",
+    "experience-cloud"
+  ]
+}

--- a/plugins/app-builder/.cursor-plugin/plugin.json
+++ b/plugins/app-builder/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "app-builder",
+  "displayName": "Adobe App Builder",
   "version": "1.0.0",
   "description": "Development, customization, testing, and deployment skills for Adobe App Builder projects. Covers project initialization, action scaffolding, React Spectrum UI scaffolding, Jest unit and integration testing, Playwright E2E testing, and GitHub Actions / Azure DevOps / GitLab CI deployment pipelines.",
   "author": {
@@ -19,5 +20,6 @@
     "github-actions",
     "aem",
     "experience-cloud"
-  ]
+  ],
+  "skills": "./skills/"
 }


### PR DESCRIPTION
Introduce a new cursor plugin metadata file at plugins/app-builder/.cursor-plugin/plugin.json describing the adobe-app-builder skill set (version 1.0.0). Includes author, homepage, repository, Apache-2.0 license, and keywords covering project initialization, React Spectrum, testing (Jest, Playwright), and CI/CD deployment workflows.

