### PR TITLE
fix(aem-workflow): correct workflow-debugging skill in workflow-debugging

### DIFF
--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/SKILL.md
@@ -102,7 +102,7 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 
 **Check Granite Workflow Queue configuration:**
 - Type: Topic Round Robin
-- Max Parallel: 1 (default; consider increasing for throughput)
+- Max Parallel: 0.5 OOTB on AEM 6.5 LTS (50% of available CPU cores). Increase for throughput on bursty workloads. Verify the running value at `/system/console/configMgr/org.apache.sling.event.jobs.QueueConfiguration~workflow` before assuming.
 - Max Retries: 10
 
 ### 3d. Sling Scheduler
@@ -145,7 +145,7 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 | WorkflowSessionFactory | `cq.workflow.superuser` | Must include admin users/groups |
 | DefaultThreadPool (default) | `block policy` | ABORT can reject timeout jobs; prefer RUN |
 | DefaultThreadPool (default) | `max pool size` | 20 default; increase if many schedulers |
-| Granite Workflow Queue | Max Parallel | 1 default; increase for throughput |
+| Granite Workflow Queue | `queue.maxparallel` | 0.5 OOTB (50% of CPU cores); increase for throughput. Verify at `/system/console/configMgr/org.apache.sling.event.jobs.QueueConfiguration~workflow` |
 | Purge Scheduler | `scheduledpurge.daysold` | 30 default; tune per environment |
 
 ---

--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/SKILL.md
@@ -37,7 +37,7 @@ Production-grade debugging for AEM Granite Workflow engine, launcher, Inbox, Sli
 | Repository bloat / too many instances | repository_bloat_too_many_instances | runbook-purge-and-cleanup.md | JMX `purgeCompleted(dryRun=true)` or Purge Scheduler. |
 | User cannot see or complete item | user_cannot_see_or_complete_item | runbook-inbox-and-permissions.md | Assignee/initiator/superuser; enforce flags. |
 | Cannot delete model | cannot_delete_model | runbook-model-delete-and-update.md | JMX `countRunningWorkflows` → terminate → delete. |
-| Slow throughput / queue backlog | slow_throughput_queue_backlog | runbook-job-throughput-and-concurrency.md | JMX `returnSystemJobInfo`; max.procs; Sling thread pool. |
+| Slow throughput / queue backlog | slow_throughput_queue_backlog | runbook-job-throughput-and-concurrency.md | JMX `returnSystemJobInfo`; `queue.maxparallel` on Granite Workflow Queue; Sling thread pool. |
 | Auto-advancement not working | workflow_auto_advance_failure | runbook-job-throughput-and-concurrency.md | Check `default` thread pool saturation; Sling Scheduler; timeout jobs. |
 | New workflow not working | workflow_setup_validation | runbook-validate-workflow-setup.md | Model sync, launcher, process registration, permissions. |
 
@@ -121,7 +121,7 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 | `Error executing workflow step` | Process step exception | Check stack; fix process code or payload |
 | `getProcess for '<name>' failed` | No WorkflowProcess registered | Deploy bundle; match `process.label` |
 | `Cannot archive workitem` | Archive failure → stale risk | JMX `restartStaleWorkflows` |
-| `refreshing the session since we had to wait for a lock` | Lock contention | Increase `cq.workflow.job.max.procs`; reduce parallelism |
+| `refreshing the session since we had to wait for a lock` | Lock contention | Tune `queue.maxparallel` on the Granite Workflow Queue (Apache Sling Job Queue Configuration); reduce concurrent writes to the same path |
 | `Terminate failed` / `Resume failed` / `Suspend failed` | Permissions (not initiator/superuser) | Check `enforceWorkflowInitiatorPermissions`; add to superusers |
 | `PathNotFoundException` (workflow/payload) | Payload/launcher path missing | Verify payload exists; check launcher config path |
 | `Error adding launcher config` | Launcher config path not created | Create `/conf/global/settings/workflow/launcher/config` |
@@ -139,7 +139,7 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 | Config | Property | Check |
 |--------|----------|-------|
 | WorkflowSessionFactory | `cq.workflow.job.retry` | Default 3; increase for flaky steps |
-| WorkflowSessionFactory | `cq.workflow.job.max.procs` | -1 = CPU cores; increase for throughput |
+| Apache Sling Job Queue Configuration (Granite Workflow Queue) | `queue.maxparallel` | Workflow parallelism. Default 1; increase for throughput. The `cq.workflow.job.max.procs` property shown on WorkflowSessionFactory has no runtime effect — do not rely on it |
 | WorkflowSessionFactory | `granite.workflow.enforceWorkitemAssigneePermissions` | true = only assignee sees items |
 | WorkflowSessionFactory | `granite.workflow.enforceWorkflowInitiatorPermissions` | true = only initiator can terminate |
 | WorkflowSessionFactory | `cq.workflow.superuser` | Must include admin users/groups |
@@ -157,7 +157,7 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 | Retry failed work item | JMX `retryFailedWorkItems` or Inbox Retry |
 | Restart stale workflows | JMX `restartStaleWorkflows(dryRun=true)` then execute |
 | Purge completed | JMX `purgeCompleted(dryRun=true)` or Purge Scheduler |
-| Increase parallelism | Felix Console: `cq.workflow.job.max.procs`; or OSGi config in repo |
+| Increase parallelism | Felix Console: `queue.maxparallel` on the Granite Workflow Queue (Apache Sling Job Queue Configuration); or OSGi config in repo |
 | Fix thread pool exhaustion | Restart instance (immediate); fix stuck scheduler code; change block policy to RUN |
 | Fix process not found | Deploy bundle; `process.label` must match; Sync model |
 | Fix auto-advancement | Verify `default` pool not saturated; timeout jobs scheduled; block policy = RUN |

--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/SKILL.md
@@ -166,12 +166,14 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 
 ## Step 7: Key JMX MBeans
 
+All workflow maintenance and diagnostic operations live on a single MBean: `com.adobe.granite.workflow:type=Maintenance`. A separate MBean — `com.adobe.granite.workflow:type=Statistics` — exposes time-series workflow execution metrics for trend analysis.
+
 | MBean | Operations | Purpose |
 |-------|------------|---------|
-| `com.adobe.granite.workflow:type=Maintenance` | `purgeCompleted(dryRun)`, `countRunningWorkflows`, `countStaleWorkflows`, `restartStaleWorkflows(dryRun)` | Purge, stale detection and restart |
-| `com.adobe.granite.workflow:type=Repository` | `retryFailedWorkItems`, `returnSystemJobInfo`, `returnWorkflowQueueInfo` | Retry, queue/job diagnostics |
+| `com.adobe.granite.workflow:type=Maintenance` | `purgeCompleted(model, days, dryRun)`, `purgeActive(model, days, dryRun)`, `countRunningWorkflows(model)`, `countCompletedWorkflows(model)`, `countStaleWorkflows(model)`, `restartStaleWorkflows(model)`, `retryFailedWorkItems(dryRun, model)`, `returnSystemJobInfo`, `returnWorkflowQueueInfo`, `returnWorkflowJobTopicInfo`, `returnFailedWorkflowCount(model)`, `terminateFailedInstances`, `fetchModelList` | Purge, stale detection/restart, retry failed items, failure handling, queue/job diagnostics, model enumeration |
+| `com.adobe.granite.workflow:type=Statistics` | `getResults`, `clearRecords`; plus `get`/`set` accessors for `DataLifeTime`, `DataFidelityTime`, `DataProcessRate`, `DataRate` | Time-series workflow execution statistics |
 
-**Always use `dryRun=true` first before executing destructive operations.**
+**Always use `dryRun=true` first before executing destructive purge or retry operations.**
 
 ---
 

--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/SKILL.md
@@ -63,7 +63,7 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 - Oak observation events
 - All Quartz-scheduled jobs
 
-**Check in `039_Sling_Thread_Pools.txt` or thread pool console:**
+**Check the Sling Thread Pools status page (`/system/console/status-slingthreadpools`):**
 
 | Field | Healthy | Problem |
 |-------|---------|---------|
@@ -75,20 +75,20 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 - New scheduled tasks (including workflow timeout/auto-advance jobs) are **silently rejected**
 - This is the #1 cause of auto-advancement failure
 
-**Check in thread dump (`042_Threads.txt` or `043_Threads__via_JStack_.txt`):**
+**Check the Threads status page (`/system/console/status-Threads`) or the jstack thread dump (`/system/console/status-jstack-threaddump`):**
 - Search for `sling-default-` threads
 - If all threads show same stack (e.g. stuck on HTTP call, database, or external service), that's the blocking culprit
 - Note `elapsed` time — threads stuck for hours indicate a hung external call without timeout
 
 ### 3b. Sling Job thread pool
 
-**Check `Apache Sling Job Thread Pool`** in `039_Sling_Thread_Pools.txt`:
+**Check `Apache Sling Job Thread Pool`** in the Sling Thread Pools status page:
 - active count vs max pool size
 - If saturated, Sling Jobs cannot execute (workflow jobs stall)
 
 ### 3c. Granite Workflow Queue
 
-**Check in `027_Sling_Jobs.txt`:**
+**Check the Sling Jobs page (`/system/console/slingevent`):**
 
 | Field | Healthy | Problem |
 |-------|---------|---------|
@@ -107,7 +107,7 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 
 ### 3d. Sling Scheduler
 
-**Check in `034_Sling_Scheduler.txt`:**
+**Check the Sling Scheduler status page (`/system/console/status-slingscheduler`):**
 - Verify `com/adobe/granite/workflow/timeout/job` scheduled jobs exist
 - `nextFireTime: null` → job already fired or deregistered
 - Verify which ThreadPool the scheduler uses (should be `default`)
@@ -134,7 +134,7 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 
 ## Step 5: Configuration checklist
 
-**In Felix Console (OSGi) or `003_Configurations.txt` from config status ZIP:**
+**In Felix Console → OSGi → Configuration (`/system/console/configMgr`):**
 
 | Config | Property | Check |
 |--------|----------|-------|
@@ -193,11 +193,11 @@ All workflow maintenance and diagnostic operations live on a single MBean: `com.
 7. Auto-advancement never happens
 
 **Diagnosis checklist:**
-- [ ] `039_Sling_Thread_Pools.txt`: Pool `default` → active count = max pool size?
-- [ ] `039_Sling_Thread_Pools.txt`: Pool `default` → block policy = ABORT?
-- [ ] Thread dump: All `sling-default-*` threads stuck on same stack?
-- [ ] `027_Sling_Jobs.txt`: Workflow job topic has high Failed Jobs?
-- [ ] `034_Sling_Scheduler.txt`: ThreadPool = `default` for `ApacheSlingdefault`?
+- [ ] Sling Thread Pools page (`/system/console/status-slingthreadpools`): Pool `default` → active count = max pool size?
+- [ ] Sling Thread Pools page: Pool `default` → block policy = ABORT?
+- [ ] Threads page (`/system/console/status-Threads`) or jstack: All `sling-default-*` threads stuck on same stack?
+- [ ] Sling Jobs page (`/system/console/slingevent`): Workflow job topic has high Failed Jobs?
+- [ ] Sling Scheduler page (`/system/console/status-slingscheduler`): ThreadPool = `default` for `ApacheSlingdefault`?
 
 **Fix:** Restart instance (immediate); fix scheduler code (add HTTP timeout, set `concurrent=false`); change pool policy to RUN; increase pool size.
 

--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/reference.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/reference.md
@@ -28,7 +28,7 @@ Quick pointers used by the workflow-debugging skill. For full runbooks and proce
 
 | Item | Where |
 |------|--------|
-| Workflow parallelism | WorkflowSessionFactory → `cq.workflow.job.max.procs` |
+| Workflow parallelism | Apache Sling Job Queue Configuration → "Granite Workflow Queue" → `queue.maxparallel`. Note: the `cq.workflow.job.max.procs` property displayed under WorkflowSessionFactory has no runtime effect |
 | Retry | WorkflowSessionFactory → `cq.workflow.job.retry` |
 | Purge | WorkflowOperationsMBean (`com.adobe.granite.workflow:type=Maintenance`) or Purge Scheduler |
 | Stale restart | JMX: `countStaleWorkflows`, `restartStaleWorkflows(dryRun` then execute) |


### PR DESCRIPTION
Motivation:
The skill's own thread-pool section at SKILL.md:105 already mentions Max Parallel correctly; the four cq.workflow.job.max.procs references contradicted that and were misleading customers.

- SKILL.md: 4 references to cq.workflow.job.max.procs replaced with queue.maxparallel on the Granite Workflow Queue
- reference.md: parallelism row updated to point to the correct OSGi config (Apache Sling Job Queue Configuration)

<!--- Provide a general summary of your changes in the Title above -->

## Description

The real parallelism control is `queue.maxparallel` on the **Granite Workflow Queue** — an instance of the Apache Sling Job Queue Configuration. Updating this property 
  does affect runtime concurrency.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

      

## How Has This Been Tested?

 - Local AEM 6.5 LTS author instance 
  - Verified OSGi configuration via Felix Console JSON endpoints (`/system/console/configMgr/...`)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
