### PR TITLE
fix(release): filter release notes and version bumps to skill directory

### DIFF
--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,12 +1,13 @@
 const path = require("path");
 const pkg = require(path.resolve("package.json"));
 const name = pkg.name;
+const pathFilteredAnalyzer = path.resolve(__dirname, "scripts/path-filtered-analyzer.cjs");
 
 module.exports = {
   branches: ["main"],
   tagFormat: name + "-v${version}",
   plugins: [
-    ["@semantic-release/commit-analyzer", {
+    [pathFilteredAnalyzer, {
       releaseRules: [
         { type: "docs", release: "patch" },
         { type: "refactor", release: "patch" },
@@ -14,7 +15,9 @@ module.exports = {
         { type: "perf", release: "patch" }
       ]
     }],
-    "@semantic-release/release-notes-generator",
+    ["@semantic-release/release-notes-generator", {
+      gitRawCommitsOpts: { path: "." }
+    }],
     ["@semantic-release/changelog", {
       changelogFile: "CHANGELOG.md"
     }],

--- a/scripts/path-filtered-analyzer.cjs
+++ b/scripts/path-filtered-analyzer.cjs
@@ -1,0 +1,28 @@
+// Wraps @semantic-release/commit-analyzer with path filtering so only commits
+// touching the current skill directory influence the version bump decision.
+// Without this, a breaking change in an unrelated skill would force a major bump here.
+const { execSync } = require("child_process");
+
+module.exports = {
+  async analyzeCommits(pluginConfig, context) {
+    const { analyzeCommits } = await import("@semantic-release/commit-analyzer");
+    const { commits, lastRelease } = context;
+
+    try {
+      const from = lastRelease && lastRelease.gitHead;
+      const range = from ? `${from}..HEAD` : "HEAD";
+      const out = execSync(`git log ${range} --format=%H -- .`, {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      });
+      const relevant = new Set(out.trim().split("\n").filter(Boolean));
+      const filteredContext = {
+        ...context,
+        commits: commits.filter((c) => relevant.has(c.hash)),
+      };
+      return analyzeCommits(pluginConfig, filteredContext);
+    } catch {
+      return analyzeCommits(pluginConfig, context);
+    }
+  },
+};

--- a/scripts/path-filtered-analyzer.cjs
+++ b/scripts/path-filtered-analyzer.cjs
@@ -1,27 +1,26 @@
 // Wraps @semantic-release/commit-analyzer with path filtering so only commits
 // touching the current skill directory influence the version bump decision.
 // Without this, a breaking change in an unrelated skill would force a major bump here.
-const { execSync } = require("child_process");
+const { execFileSync } = require("child_process");
 
 module.exports = {
   async analyzeCommits(pluginConfig, context) {
     const { analyzeCommits } = await import("@semantic-release/commit-analyzer");
-    const { commits, lastRelease } = context;
+    const { commits, lastRelease, logger } = context;
 
     try {
       const from = lastRelease && lastRelease.gitHead;
-      const range = from ? `${from}..HEAD` : "HEAD";
-      const out = execSync(`git log ${range} --format=%H -- .`, {
-        cwd: process.cwd(),
-        encoding: "utf8",
-      });
+      const args = ["log", "--format=%H", "--", "."];
+      if (from) args.splice(1, 0, `${from}..HEAD`);
+      const out = execFileSync("git", args, { cwd: process.cwd(), encoding: "utf8" });
       const relevant = new Set(out.trim().split("\n").filter(Boolean));
       const filteredContext = {
         ...context,
         commits: commits.filter((c) => relevant.has(c.hash)),
       };
       return analyzeCommits(pluginConfig, filteredContext);
-    } catch {
+    } catch (err) {
+      logger.warn("path-filtered-analyzer: git log failed, falling back to all commits: %s", err.message);
       return analyzeCommits(pluginConfig, context);
     }
   },


### PR DESCRIPTION
## Summary

- Each skill's CHANGELOG and GitHub release body was including all commits from the entire repo since its last tag — unrelated skills like `stardust`, `migration`, `aem-workflow` would appear in `scrape-webpage`'s release notes
- Unrelated `feat!` breaking changes were also triggering spurious major version bumps in unaffected skills
- Fix by adding path filtering at both stages: commit analysis (version bump decision) and note generation (CHANGELOG / release body)

## Changes

**`release.config.cjs`**
- Replaces `@semantic-release/commit-analyzer` with a local wrapper that pre-filters `context.commits` to hashes touching the skill's directory before delegating to the real analyzer
- Adds `gitRawCommitsOpts: { path: "." }` to `@semantic-release/release-notes-generator` so `git log` is scoped to the skill directory when building the changelog

**`scripts/path-filtered-analyzer.cjs`**
- Thin CJS wrapper around `@semantic-release/commit-analyzer`
- Runs `git log <from>..HEAD --format=%H -- .` from `process.cwd()` (the skill dir) to get relevant commit hashes, filters the context, then delegates with the same `releaseRules` config
- Falls back to unfiltered behavior if the git command fails

## Test plan

- [ ] Merge a PR that touches only one skill and confirm its release notes contain only commits for that skill's directory
- [ ] Confirm a `feat!` in one skill does not trigger a major bump in an unrelated skill
- [ ] Confirm skills with no changes are still skipped by the release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)