### PR TITLE
feat(aem-workflow): rewrite workflow-debugging skill for AEM Cloud Se…

### DIFF
--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/SKILL.md
@@ -24,22 +24,22 @@ Production-grade debugging for AEM Granite Workflow engine, launcher, Inbox, Sli
 
 ---
 
-## Step 1: Map symptom to runbook
+## Step 1: Map symptom to first action
 
-| Symptom | symptom_id | Runbook | First action |
-|---------|------------|---------|--------------|
-| Workflow stuck (not advancing) | workflow_stuck_not_progressing | runbook-workflow-stuck.md | Open instance; note current step type. No work item → stale. |
-| Task not in Inbox | task_not_in_inbox | runbook-task-not-in-inbox.md | Confirm Participant step; assignee = logged-in user; Inbox filters. |
-| Workflow not starting (launcher) | workflow_not_starting_launcher | runbook-launcher-not-starting.md | Launcher enabled; path/event match payload. |
-| Workflow fails or shows error | workflow_fails_or_shows_error | runbook-workflow-fails-or-shows-error.md | Instance history; error.log for instance ID; payload and process. |
-| Step failed, retries exhausted | step_failed_retries_exhausted | runbook-failed-work-items.md | Logs → process.label → JMX `retryFailedWorkItems` or Inbox retry. |
-| Stale (no current work item) | stale_workflow_no_work_item | runbook-stale-workflows.md | JMX `countStaleWorkflows` → `restartStaleWorkflows(dryRun=true)`. |
-| Repository bloat / too many instances | repository_bloat_too_many_instances | runbook-purge-and-cleanup.md | JMX `purgeCompleted(dryRun=true)` or Purge Scheduler. |
-| User cannot see or complete item | user_cannot_see_or_complete_item | runbook-inbox-and-permissions.md | Assignee/initiator/superuser; enforce flags. |
-| Cannot delete model | cannot_delete_model | runbook-model-delete-and-update.md | JMX `countRunningWorkflows` → terminate → delete. |
-| Slow throughput / queue backlog | slow_throughput_queue_backlog | runbook-job-throughput-and-concurrency.md | JMX `returnSystemJobInfo`; `queue.maxparallel` on Granite Workflow Queue; Sling thread pool. |
-| Auto-advancement not working | workflow_auto_advance_failure | runbook-job-throughput-and-concurrency.md | Check `default` thread pool saturation; Sling Scheduler; timeout jobs. |
-| New workflow not working | workflow_setup_validation | runbook-validate-workflow-setup.md | Model sync, launcher, process registration, permissions. |
+| Symptom | symptom_id | First action |
+|---------|------------|--------------|
+| Workflow stuck (not advancing) | workflow_stuck_not_progressing | Open instance; note current step type. No work item → stale. |
+| Task not in Inbox | task_not_in_inbox | Confirm Participant step; assignee = logged-in user; Inbox filters. |
+| Workflow not starting (launcher) | workflow_not_starting_launcher | Launcher enabled; path/event match payload. |
+| Workflow fails or shows error | workflow_fails_or_shows_error | Instance history; error.log for instance ID; payload and process. |
+| Step failed, retries exhausted | step_failed_retries_exhausted | Logs → process.label → JMX `retryFailedWorkItems` or Inbox retry. |
+| Stale (no current work item) | stale_workflow_no_work_item | JMX `countStaleWorkflows` → `restartStaleWorkflows(dryRun=true)`. |
+| Repository bloat / too many instances | repository_bloat_too_many_instances | JMX `purgeCompleted(dryRun=true)` or Purge Scheduler. |
+| User cannot see or complete item | user_cannot_see_or_complete_item | Assignee/initiator/superuser; enforce flags. |
+| Cannot delete model | cannot_delete_model | JMX `countRunningWorkflows` → terminate → delete. |
+| Slow throughput / queue backlog | slow_throughput_queue_backlog | JMX `returnSystemJobInfo`; `queue.maxparallel` on Granite Workflow Queue; Sling thread pool. |
+| Auto-advancement not working | workflow_auto_advance_failure | Check `default` thread pool saturation; Sling Scheduler; timeout jobs. |
+| New workflow not working | workflow_setup_validation | Model sync, launcher, process registration, permissions. |
 
 ---
 
@@ -58,10 +58,9 @@ Thread dumps on 6.5 / AMS are obtained via **jstack** or by requesting from AMS 
 
 ### 3a. Sling `default` thread pool (critical path)
 
-The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool fires:
-- `com/adobe/granite/workflow/timeout/job` (auto-advancement)
+The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool runs:
 - Oak observation events
-- All Quartz-scheduled jobs
+- All Quartz-scheduled jobs — including the workflow timeout-detection scheduler that emits `com/adobe/granite/workflow/timeout/job` events to the Sling Job system (the job itself then runs on the Granite Workflow Queue, see Step 3c)
 
 **Check the Sling Thread Pools status page (`/system/console/status-slingthreadpools`):**
 
@@ -69,7 +68,7 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 |-------|---------|---------|
 | active count | < max pool size | **= max pool size** (saturated) |
 | block policy | RUN | **ABORT** (rejects tasks when full) |
-| max pool size | ≥ 20 | Low values starve schedulers |
+| max pool size | sized for workload | OOTB on AEM 6.5 LTS is **5/5** (Apache Sling default). Bump to 20+ in OSGi config for environments with many custom periodic schedulers, otherwise schedulers can starve. |
 
 **If active count = max pool size AND block policy = ABORT:**
 - New scheduled tasks (including workflow timeout/auto-advance jobs) are **silently rejected**
@@ -108,9 +107,9 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 ### 3d. Sling Scheduler
 
 **Check the Sling Scheduler status page (`/system/console/status-slingscheduler`):**
-- Verify `com/adobe/granite/workflow/timeout/job` scheduled jobs exist
-- `nextFireTime: null` → job already fired or deregistered
-- Verify which ThreadPool the scheduler uses (should be `default`)
+- This page lists Quartz-style schedulers, not Sling Job topics. On OOTB AEM 6.5 LTS the workflow-related entry visible here is the periodic `WorkflowStatsMBean` collector (used by the Statistics MBean) — its `nextFireTime` should be in the near future; `nextFireTime: null` means the trigger was deregistered.
+- The `com/adobe/granite/workflow/timeout/job` topic itself is a **Sling Job**, not a Quartz job — check it on the Sling Jobs page (`/system/console/slingevent`), not here.
+- Confirm `ApacheSlingdefault` uses `ThreadPool: default` — that's how the periodic timeout-detection scheduler reaches the workflow engine.
 
 ---
 
@@ -139,14 +138,17 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 | Config | Property | Check |
 |--------|----------|-------|
 | WorkflowSessionFactory | `cq.workflow.job.retry` | Default 3; increase for flaky steps |
-| Apache Sling Job Queue Configuration (Granite Workflow Queue) | `queue.maxparallel` | Workflow parallelism. Default 1; increase for throughput. The `cq.workflow.job.max.procs` property shown on WorkflowSessionFactory has no runtime effect — do not rely on it |
-| WorkflowSessionFactory | `granite.workflow.enforceWorkitemAssigneePermissions` | true = only assignee sees items |
-| WorkflowSessionFactory | `granite.workflow.enforceWorkflowInitiatorPermissions` | true = only initiator can terminate |
-| WorkflowSessionFactory | `cq.workflow.superuser` | Must include admin users/groups |
-| DefaultThreadPool (default) | `block policy` | ABORT can reject timeout jobs; prefer RUN |
-| DefaultThreadPool (default) | `max pool size` | 20 default; increase if many schedulers |
-| Granite Workflow Queue | `queue.maxparallel` | 0.5 OOTB (50% of CPU cores); increase for throughput. Verify at `/system/console/configMgr/org.apache.sling.event.jobs.QueueConfiguration~workflow` |
-| Purge Scheduler | `scheduledpurge.daysold` | 30 default; tune per environment |
+| WorkflowSessionFactory | `cq.workflow.superuser` | Must include admin users/groups (OOTB list includes `admin`, `administrators`, `workflow-process-service`, `workflow-service`, `workflow-administrators`, `wcm-workflow-service`) |
+| WorkflowSessionFactory | `granite.workflow.enforceWorkitemAssigneePermissions` | true (OOTB) = only assignee sees items |
+| WorkflowSessionFactory | `granite.workflow.enforceWorkflowInitiatorPermissions` | true (OOTB) = only initiator (or superuser) can terminate/suspend/resume |
+| WorkflowSessionFactory | `granite.workflow.inboxQuerySize` | Max work items returned per Inbox query. OOTB 2000; raise if heavy users hit the cap |
+| WorkflowSessionFactory | `granite.workflow.maxPurgeSaveThreshold` | OOTB 20 — commit after this many purged instances. Raise carefully to reduce JCR overhead during large purges |
+| WorkflowSessionFactory | `granite.workflow.maxPurgeQueryCount` | OOTB 1000 — JCR query batch size during purge. Tune with above |
+| Granite Workflow Queue (`org.apache.sling.event.jobs.QueueConfiguration~workflow`) | `queue.maxparallel` | **Real parallelism knob.** OOTB on AEM 6.5 LTS is `0.5` (50% of CPU cores). Adobe's *Workflows Best Practices* recommends **between half and three-quarters of processor cores**. `cq.workflow.job.max.procs` displayed in Felix Config Manager is an **orphaned metatype label** with no code path that reads it (verified against source on `release/660` and `prod/cq660`) — do not rely on it. Verify the running value at `/system/console/configMgr/org.apache.sling.event.jobs.QueueConfiguration~workflow` |
+| DefaultThreadPool (`name=default`) | `block policy` | OOTB `RUN`. `ABORT` would silently drop workflow timeout jobs — keep `RUN` unless you have a specific reason |
+| DefaultThreadPool (`name=default`) | `max pool size` | **OOTB on AEM 6.5 LTS is 5** (Apache Sling default). Bump to 20+ for environments with many custom periodic schedulers; otherwise the pool can starve under load |
+| Purge Scheduler (`com.adobe.granite.workflow.purge.Scheduler`) | `scheduledpurge.daysold` | 30 default; tune per environment. Factory PID — deploy one config per schedule |
+| Purge Scheduler | `scheduledpurge.workflowStatus` | Array-typed; e.g. `["COMPLETED"]` |
 
 ---
 
@@ -170,7 +172,7 @@ All workflow maintenance and diagnostic operations live on a single MBean: `com.
 
 | MBean | Operations | Purpose |
 |-------|------------|---------|
-| `com.adobe.granite.workflow:type=Maintenance` | `purgeCompleted(model, days, dryRun)`, `purgeActive(model, days, dryRun)`, `countRunningWorkflows(model)`, `countCompletedWorkflows(model)`, `countStaleWorkflows(model)`, `restartStaleWorkflows(model)`, `retryFailedWorkItems(dryRun, model)`, `returnSystemJobInfo`, `returnWorkflowQueueInfo`, `returnWorkflowJobTopicInfo`, `returnFailedWorkflowCount(model)`, `terminateFailedInstances`, `fetchModelList` | Purge, stale detection/restart, retry failed items, failure handling, queue/job diagnostics, model enumeration |
+| `com.adobe.granite.workflow:type=Maintenance` | `purgeCompleted(model [optional], days, dryRun)`, `purgeActive(model [optional], days, dryRun)`, `countRunningWorkflows(model [optional])`, `countCompletedWorkflows(model [optional])`, `countStaleWorkflows(model [optional])`, `restartStaleWorkflows(model [optional], dryRun)`, `retryFailedWorkItems(dryRun, model [optional])`, `terminateFailedInstances(restart, dryRun, model [optional])`, `returnSystemJobInfo()`, `returnWorkflowQueueInfo()`, `returnWorkflowJobTopicInfo()`, `returnFailedWorkflowCount(model [optional])`, `returnFailedWorkflowCountPerModel()`, `listRunningWorkflowsPerModel()`, `listCompletedWorkflowsPerModel()`, `fetchModelList()` | Purge, stale detection/restart, retry failed items, bulk terminate, queue/job diagnostics, per-model counts and enumeration |
 | `com.adobe.granite.workflow:type=Statistics` | `getResults`, `clearRecords`; plus `get`/`set` accessors for `DataLifeTime`, `DataFidelityTime`, `DataProcessRate`, `DataRate` | Time-series workflow execution statistics |
 
 **Always use `dryRun=true` first before executing destructive purge or retry operations.**
@@ -187,9 +189,9 @@ All workflow maintenance and diagnostic operations live on a single MBean: `com.
 1. Custom scheduler (e.g. `AccessTokenScheduler`) makes blocking HTTP call without timeout
 2. `concurrent = true` allows overlapping executions on each cron trigger
 3. Each stuck execution consumes a `default` pool thread indefinitely
-4. All 20 threads consumed → pool saturated
-5. Block policy = ABORT → new Quartz jobs rejected silently
-6. Workflow timeout jobs (`com/adobe/granite/workflow/timeout/job`) cannot fire
+4. All pool threads consumed (OOTB on AEM 6.5 LTS that's only **5**; environments hardened for throughput typically run with 20+) → pool saturated
+5. If block policy has been changed to `ABORT` (OOTB is `RUN`), new Quartz triggers are rejected silently; on `RUN` they instead pile up on the caller thread and back-pressure the dispatch
+6. The workflow timeout-detection scheduler cannot dispatch new `com/adobe/granite/workflow/timeout/job` events
 7. Auto-advancement never happens
 
 **Diagnosis checklist:**

--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/reference.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/reference.md
@@ -1,26 +1,8 @@
 # AEM Workflow Debugging – Reference (6.5 LTS / AMS)
 
-Quick pointers used by the workflow-debugging skill. For full runbooks and procedures, use the paths below inside this repo.
-
----
-
-## Runbook locations (relative to repo root)
-
-| Runbook | Path |
-|---------|------|
-| Decision guide (symptom → runbook) | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-decision-guide.md` |
-| Debugging index (machine-readable) | `aem-agent-marketplace-workflow-knowledge-base/docs/debugging-index.md` |
-| Workflow stuck | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-workflow-stuck.md` |
-| Task not in Inbox | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-task-not-in-inbox.md` |
-| Launcher not starting | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-launcher-not-starting.md` |
-| Workflow fails / error | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-workflow-fails-or-shows-error.md` |
-| Failed work items | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-failed-work-items.md` |
-| Stale workflows | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-stale-workflows.md` |
-| Purge and cleanup | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-purge-and-cleanup.md` |
-| Inbox and permissions | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-inbox-and-permissions.md` |
-| Model delete/update | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-model-delete-and-update.md` |
-| Job throughput / concurrency | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-job-throughput-and-concurrency.md` |
-| Validate workflow setup | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-validate-workflow-setup.md` |
+Quick pointers used by the workflow-debugging skill. Use the SKILL.md Step 1
+symptom table for the symptom → first-action map; the entries below are for
+quick access to JMX/config, diagnostic tools, log patterns, and external docs.
 
 ---
 
@@ -46,12 +28,16 @@ Quick pointers used by the workflow-debugging skill. For full runbooks and proce
 | Config Status ZIP | Felix Console → Status → Configuration Status | Full config dump, thread pools, Sling Jobs, schedulers |
 | Thread dump | jstack or AMS support request | Thread analysis |
 | Workflow Console | /libs/cq/workflow/admin/console/content/instances.html | Instance status, work items, history |
-| Sling Job Console | /system/console/slingjobs | Queue depth, failed jobs, active jobs |
+| Sling Jobs page | /system/console/slingevent | Queue depth, failed jobs, active jobs, topic statistics |
+| Sling Thread Pools | /system/console/status-slingthreadpools | Per-pool active count, max size, block policy |
+| Threads | /system/console/status-Threads | Live thread states with stacks |
+| jstack thread dump | /system/console/status-jstack-threaddump | jstack-style snapshot |
+| Sling Scheduler | /system/console/status-slingscheduler | Quartz-scheduled jobs and their ThreadPool |
 | Inbox | /aem/inbox | Retry failed work items, complete tasks |
 
 ---
 
-## Log patterns (see also docs/error-patterns.md)
+## Log patterns
 
 - `Error executing workflow step` – Process/step exception
 - `getProcess for '<name>' failed` – Process not registered

--- a/plugins/aem/cloud-service/skills/aem-workflow/workflow-debugging/SKILL.md
+++ b/plugins/aem/cloud-service/skills/aem-workflow/workflow-debugging/SKILL.md
@@ -1,18 +1,33 @@
 ---
 name: workflow-debugging
-description: Debug AEM Workflow issues on AEM as a Cloud Service including stuck workflows, failed steps, missing Inbox tasks, launcher failures, stale instances, thread pool exhaustion, queue backlogs, purge failures, and permissions errors. Use when the user reports workflow problems on Cloud Service, asks why a workflow is stuck or failed, needs step-by-step troubleshooting, or provides thread dumps, configuration output, or Sling Job console output for analysis.
+description: Debug AEM Workflow issues on AEM as a Cloud Service — stuck workflows, failed steps, missing Inbox tasks, launcher failures, stale instances, thread pool exhaustion, queue backlogs, purge failures, and permissions errors. Use when the user reports workflow problems on Cloud Service, asks why a workflow is stuck or failed, needs step-by-step troubleshooting, or provides thread dumps, configuration status output, or Sling Job console output for analysis.
 license: Apache-2.0
 ---
 
 # AEM Workflow Debugging — Cloud Service
 
-Production-grade debugging for AEM Granite Workflow engine, launcher, Inbox, Sling Jobs, thread pools, and purge on **AEM as a Cloud Service**.
+Production-grade debugging for the AEM Granite Workflow engine, launcher, Inbox, Sling Jobs, thread pools, and purge on **AEM as a Cloud Service (AEMaaCS)**.
+
+## Audience
+
+AEMaaCS developers and operators (and the IDE LLM acting on their behalf) diagnosing stuck or failed workflows on a local AEMaaCS SDK or a cloud environment — Developer Console, Sling Job Console, and Cloud Manager Logs available; no production Felix Console JMX or filesystem access.
 
 ## Variant Scope
 
-- This skill is **cloud-service-only**.
-- No JMX access — use Developer Console, Cloud Manager logs, custom HTTP APIs.
-- Config changes require code in Git and Cloud Manager pipeline deploy.
+- AEM as a Cloud Service only.
+- **Not for AEM 6.5 LTS / AMS.** If the target is 6.5 LTS, stop and load the 6.5-lts variant of this skill — JMX-based remediation, Felix Console runtime config, AMS log filesystem access, and `jstack` thread dumps documented there do not apply on AEMaaCS.
+- **No JMX access on AEMaaCS production.** Diagnosis is read-only via Developer Console, Sling Job Console, and Cloud Manager Logs. **Never recommend JMX-based remediation** (`restartStaleWorkflows`, `purgeCompleted`, `terminate`, `retryFailedWorkItems`) — those are 6.5-LTS-only mechanisms. Use Inbox Retry, Purge Scheduler (OSGi config in Git), custom servlets like `StaleWorkflowServlet`, and Cloud Manager pipeline-driven config changes instead.
+- **All remediation lands via Git + Cloud Manager pipeline:** OSGi configs in `ui.config`, custom servlets in `core`, ACLs in `ui.apps/.../repoinit`. There is no Felix Console write access on cloud environments.
+- See [reference.md](reference.md) for runbook locations and diagnostic tool pointers.
+
+## Dependencies
+
+This skill is largely self-contained but routes back into the dev skills when the root cause is a code or model defect:
+
+- `workflow-development` — when the diagnosis is "process step throws / not registered / leaks resources"
+- `workflow-model-design` — when the diagnosis is "model has wrong split rule / missing transition / wrong step type"
+- `workflow-launchers` — when the diagnosis is "launcher not firing / re-trigger loop"
+- `workflow-triaging` — load instead of this skill if the user is mining Cloud Manager Logs across multiple environments rather than diagnosing one
 
 ---
 
@@ -32,12 +47,12 @@ Production-grade debugging for AEM Granite Workflow engine, launcher, Inbox, Sli
 | Task not in Inbox | task_not_in_inbox | runbook-task-not-in-inbox.md | Confirm Participant step; assignee = logged-in user; Inbox filters. |
 | Workflow not starting (launcher) | workflow_not_starting_launcher | runbook-launcher-not-starting.md | Launcher enabled; path/event match payload. |
 | Workflow fails or shows error | workflow_fails_or_shows_error | runbook-workflow-fails-or-shows-error.md | Instance history; error.log for instance ID; payload and process. |
-| Step failed, retries exhausted | step_failed_retries_exhausted | runbook-failed-work-items.md | Logs → process.label → Inbox retry. |
-| Stale (no current work item) | stale_workflow_no_work_item | runbook-stale-workflows.md | Custom API/script to detect and restart stale workflows. |
-| Repository bloat / too many instances | repository_bloat_too_many_instances | runbook-purge-and-cleanup.md | Purge Scheduler configuration. |
-| User cannot see or complete item | user_cannot_see_or_complete_item | runbook-inbox-and-permissions.md | Assignee/initiator/superuser; enforce flags. |
-| Cannot delete model | cannot_delete_model | runbook-model-delete-and-update.md | Count running workflows → terminate → delete. |
-| Slow throughput / queue backlog | slow_throughput_queue_backlog | runbook-job-throughput-and-concurrency.md | Sling Job statistics; max.procs; Sling thread pool. |
+| Step failed, retries exhausted | step_failed_retries_exhausted | runbook-failed-work-items.md | Logs → `process.label` → Inbox Retry, or bulk via custom servlet (see Step 6). |
+| Stale (no current work item) | stale_workflow_no_work_item | runbook-stale-workflows.md | Deploy a custom `StaleWorkflowServlet` to your `core` bundle; invoke with `?dryRun=true`. |
+| Repository bloat / too many instances | repository_bloat_too_many_instances | runbook-purge-and-cleanup.md | Purge Scheduler OSGi config in Git (PID: `com.adobe.granite.workflow.purge.Scheduler`). |
+| User cannot see or complete item | user_cannot_see_or_complete_item | runbook-inbox-and-permissions.md | Assignee / initiator / superuser group; `enforce*Permissions` flags. |
+| Cannot delete model | cannot_delete_model | runbook-model-delete-and-update.md | Count RUNNING instances via Workflow Console → terminate → delete model. |
+| Slow throughput / queue backlog | slow_throughput_queue_backlog | runbook-job-throughput-and-concurrency.md | Sling Job statistics; Granite Workflow Queue `queue.maxparallel`; Sling thread pool. |
 | Auto-advancement not working | workflow_auto_advance_failure | runbook-job-throughput-and-concurrency.md | Check `default` thread pool saturation; Sling Scheduler; timeout jobs. |
 | New workflow not working | workflow_setup_validation | runbook-validate-workflow-setup.md | Model sync, launcher, process registration, permissions. |
 
@@ -45,7 +60,7 @@ Production-grade debugging for AEM Granite Workflow engine, launcher, Inbox, Sli
 
 ## Step 2: Decision tree (workflow stuck)
 
-1. **No current work item?** → Stale. Use custom API/script to detect and restart stale workflows.
+1. **No current work item?** → Stale. Deploy a custom `StaleWorkflowServlet` to your `core` bundle; call `GET /bin/support/workflow/stale?dryRun=true` to enumerate, then `POST ...?dryRun=false` to restart.
 2. **Participant step** → Assignee exists? Inbox visible? Payload accessible? Dynamic participant resolver returning correct user?
 3. **Process step** → Search error.log for instance ID. Check: `process.label` registered, payload path exists, bundle active, no exception in `execute()`.
 4. **OR/AND Split** → Condition evaluates correctly? Routes exist? No dead-end branches? Model synced?
@@ -54,7 +69,7 @@ Production-grade debugging for AEM Granite Workflow engine, launcher, Inbox, Sli
 
 ## Step 3: Thread dump & thread pool analysis
 
-Thread dumps on Cloud Service are obtained via **Developer Console** or by requesting from support. Configuration output may also need to be requested from support.
+Thread dumps and status-producer output on AEMaaCS are obtained via **Developer Console → Status → Thread Dump / OSGi / Sling Jobs / Sling Scheduler**. For anything not exposed in Developer Console, open an Adobe Support ticket — **never** attempt to SSH into an AEMaaCS pod.
 
 ### 3a. Sling `default` thread pool (critical path)
 
@@ -102,7 +117,7 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 
 **Check Granite Workflow Queue configuration:**
 - Type: Topic Round Robin
-- Max Parallel: 1 (default; consider increasing for throughput)
+- Max Parallel: 1 (OOB default on AEMaaCS). Verify the running value at Developer Console → `/system/console/slingjobs` before assuming. Override via `org.apache.sling.event.jobs.QueueConfiguration-granitewfe.cfg.json` in Git if you need to increase it.
 - Max Retries: 10
 
 ### 3d. Sling Scheduler
@@ -123,7 +138,7 @@ Download error.log from **Cloud Manager** → Environments → Logs, or use log 
 | `Error executing workflow step` | Process step exception | Check stack; fix process code or payload |
 | `getProcess for '<name>' failed` | No WorkflowProcess registered | Deploy bundle; match `process.label` |
 | `Cannot archive workitem` | Archive failure → stale risk | Detect and restart stale workflows |
-| `refreshing the session since we had to wait for a lock` | Lock contention | Increase `cq.workflow.job.max.procs` via config in Git |
+| `refreshing the session since we had to wait for a lock` | Lock contention on `/var/workflow` | **Reduce** (not raise) parallelism — lower `queue.maxparallel` on the Granite Workflow Queue, or stagger launchers. Raising parallelism makes this worse. |
 | `Terminate failed` / `Resume failed` / `Suspend failed` | Permissions (not initiator/superuser) | Check `enforceWorkflowInitiatorPermissions`; add to superusers |
 | `PathNotFoundException` (workflow/payload) | Payload/launcher path missing | Verify payload exists; check launcher config path |
 | `Error adding launcher config` | Launcher config path not created | Create `/conf/global/settings/workflow/launcher/config` |
@@ -134,35 +149,61 @@ Download error.log from **Cloud Manager** → Environments → Logs, or use log 
 
 ---
 
-## Step 5: Configuration checklist
+## Step 5: Configuration checklist (Cloud Service — all via Git + pipeline)
 
-Config changes on Cloud Service require OSGi config files in the Git repository, deployed via Cloud Manager pipeline.
+Every config below is an OSGi JSON file under
+`ui.config/src/main/content/jcr_root/apps/<project>/osgiconfig/config.author/`
+(or `config.author.prod/` / `config.author.stage/` for run-mode scoping).
 
-| Config | Property | Check |
-|--------|----------|-------|
-| WorkflowSessionFactory | `cq.workflow.job.retry` | Default 3; increase for flaky steps |
-| WorkflowSessionFactory | `cq.workflow.job.max.procs` | -1 = CPU cores; increase for throughput |
-| WorkflowSessionFactory | `granite.workflow.enforceWorkitemAssigneePermissions` | true = only assignee sees items |
-| WorkflowSessionFactory | `granite.workflow.enforceWorkflowInitiatorPermissions` | true = only initiator can terminate |
-| WorkflowSessionFactory | `cq.workflow.superuser` | Must include admin users/groups |
-| DefaultThreadPool (default) | `block policy` | ABORT can reject timeout jobs; prefer RUN |
-| DefaultThreadPool (default) | `max pool size` | 20 default; increase if many schedulers |
-| Granite Workflow Queue | Max Parallel | 1 default; increase for throughput |
-| Purge Scheduler | `scheduledpurge.daysold` | 30 default; tune per environment |
+| Config file (PID) | Property | Guidance |
+|-------------------|----------|----------|
+| `com.adobe.granite.workflow.core.WorkflowSessionFactory.cfg.json` | `cq.workflow.job.retry` | Default `3`; raise for flaky external calls. |
+| `org.apache.sling.event.jobs.QueueConfiguration-<alias>.cfg.json` | `queue.maxparallel` | **Real parallelism knob** for workflow jobs (factory PID targeting topics `com/adobe/granite/workflow/job/*`). `cq.workflow.job.max.procs` is a myth — it is *not* a property on WorkflowSessionFactory (verified against source). |
+| `com.adobe.granite.workflow.core.WorkflowSessionFactory.cfg.json` | `granite.workflow.enforceWorkitemAssigneePermissions` | `true` = only the assignee can see / complete a work item. |
+| `com.adobe.granite.workflow.core.WorkflowSessionFactory.cfg.json` | `granite.workflow.enforceWorkflowInitiatorPermissions` | `true` = only the initiator (or superuser) can terminate / suspend / resume. |
+| `com.adobe.granite.workflow.core.WorkflowSessionFactory.cfg.json` | `cq.workflow.superuser` | **AEMaaCS specific:** point this at a **group** provisioned via `repoinit` (e.g. `workflow-administrators`), **not** hard-coded user IDs. Users are federated from IMS and rotate; groups are stable. Service-user mappings go in `org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-*.cfg.json`. |
+| `org.apache.sling.commons.threads.impl.DefaultThreadPool-default.cfg.json` | `blockPolicy` | `ABORT` silently drops workflow timeout jobs — prefer `RUN`. *See AEMaaCS caveat below this table.* |
+| `org.apache.sling.commons.threads.impl.DefaultThreadPool-default.cfg.json` | `maxPoolSize` | `20` default; raise to `50` if many custom schedulers compete with workflow timeout jobs. *See AEMaaCS caveat below this table.* |
+| `com.adobe.granite.workflow.purge.Scheduler-<alias>.cfg.json` | `scheduledpurge.workflowStatus` | **Array-typed.** Must be `["COMPLETED"]`, not `"COMPLETED"`. Also: this PID has **no** `scheduledpurge.cron` — scheduling is driven by the Granite Maintenance Task window; any `cron` property is silently ignored. |
+| `com.adobe.granite.workflow.purge.Scheduler-<alias>.cfg.json` | `scheduledpurge.daysold` | `30` default; tune per environment. Factory PID — deploy one file per purge schedule. |
+
+### AEMaaCS caveat — Sling DefaultThreadPool config may be platform-reserved
+
+Some Sling core configs are filtered or overridden by the AEMaaCS platform layer. The `DefaultThreadPool` config *may* land via pipeline and be silently ignored. **Always verify** after deploy:
+
+- Open `/system/console/status-threads` (Developer Console → Status → Threads).
+- Find the `default` pool row.
+- Confirm `maxPoolSize` and block policy reflect your config values.
+
+If the numbers don't change, the PID is Adobe-managed on your environment — **do not** try to work around it. Open an Adobe Support ticket, attach a thread dump and the thread-pool status, and request Engineering lift the pool size or change block policy for that environment.
+
+### Permission and identity gotchas specific to AEMaaCS
+
+- **Never** list IMS user IDs in `cq.workflow.superuser`. IMS principals change on re-invite. Reference a JCR group that `repoinit` creates. Correct repoinit syntax:
+  ```
+  create group workflow-administrators
+  add admin to group workflow-administrators
+  ```
+  The `group` keyword after `to` is **required** — without it the repoinit parser fails and the entire script aborts on startup.
+- Custom process steps that need elevated access must use a **service user** + `ServiceUserMapperImpl.amended-*.cfg.json`, not `resolver.adaptTo(Session.class)` + admin.
+- `enforceWorkflowInitiatorPermissions=true` + an initiator who is a rotated IMS user leaves workflows unterminable except by superuser. On Cloud Service, prefer superuser-group membership for anyone expected to recover workflows.
 
 ---
 
-## Step 6: Remediation quick reference
+## Step 6: Remediation quick reference (Cloud Service)
 
 | Action | Cloud Service approach |
-|--------|----------------------|
-| Retry failed work item | Inbox Retry; no JMX available |
-| Restart stale workflows | Custom API/script; no JMX available |
-| Purge completed | Purge Scheduler (OSGi config in Git) |
-| Increase parallelism | Config in Git: `cq.workflow.job.max.procs`; deploy via pipeline |
-| Fix thread pool exhaustion | Restart instance (immediate); fix stuck scheduler code; change block policy to RUN via config |
-| Fix process not found | Deploy bundle; `process.label` must match; Sync model |
-| Fix auto-advancement | Verify `default` pool not saturated; timeout jobs scheduled; block policy = RUN |
+|--------|------------------------|
+| Retry failed work item (single) | `/aem/inbox` → select failure → **Retry**. History and audit trail preserved. |
+| Retry failed work items (bulk) | **Preferred:** iterate `/aem/inbox` UI — single-item Retry preserves the original instance, its history, and its audit trail. **Not recommended:** a "bulk" servlet using `terminateWorkflow(wf)` + `startWorkflow(model, data)` — this creates a **new** instance and **loses** the original history, step durations, and comments. Only use the replay approach with explicit customer approval and *never* for audit-regulated workflows (pharma, finance, legal). |
+| Restart stale workflows | Deploy a custom `StaleWorkflowServlet` to your `core` bundle. Always invoke `GET /bin/support/workflow/stale?dryRun=true` first; confirm scope; then `POST ...?dryRun=false`. Scope with `&model=<modelId>` if you only want one model. |
+| Purge completed | Deploy `com.adobe.granite.workflow.purge.Scheduler-<alias>.cfg.json` with `scheduledpurge.workflowStatus=["COMPLETED"]` (array-typed) and `scheduledpurge.daysold=<N>`. Triggered by the **Granite Maintenance Task window** — this PID has **no** `scheduledpurge.cron`; any cron property is silently ignored. **Do not** reference `/libs/granite/operations/config/maintenance` — on AEMaaCS `/libs` is the read-only code layer. One purge config file per schedule. Deploy via pipeline. |
+| Increase parallelism | `queue.maxparallel` on `org.apache.sling.event.jobs.QueueConfiguration-<alias>.cfg.json` (topics: `com/adobe/granite/workflow/job/*`). The commonly cited `cq.workflow.job.max.procs` **does not exist** on `WorkflowSessionFactory` (verified against source) — do not waste a deployment on it. **Verify after deploy:** Developer Console → `/system/console/slingjobs` → find the **Granite Workflow Queue** row and confirm `queue.maxparallel` shows your value. If it still shows the OOB value (usually `1`), your override lost the `service.ranking` tiebreak — raise `service.ranking` in your override (e.g. from `100` to `1000`) and redeploy. If your ranking *matches* Adobe's OOB ranking exactly, Sling can register both queues against the same topic and occasionally execute a workflow step twice — always set a higher, non-equal ranking. Watch for `refreshing the session since we had to wait for a lock` after raising; if it appears, lower parallelism or stagger launchers. |
+| Fix thread pool exhaustion | Short-term: **open an Adobe Support ticket** requesting a pod restart for the affected environment — AEMaaCS does **not** expose a customer-facing restart action in Cloud Manager. Long-term, all via Git + pipeline: (1) fix the stuck scheduler (add HTTP timeouts; `@Component scheduler.concurrent=false`); (2) set `blockPolicy=RUN` in `org.apache.sling.commons.threads.impl.DefaultThreadPool-default.cfg.json`; (3) raise `maxPoolSize` to 50. Verify the thread-pool config actually applied — see the AEMaaCS caveat in Step 5. |
+| Fix process not found | Redeploy the `core` bundle; the `@Component process.label` must exactly match the model's Process step. Re-sync the workflow model from `/libs/cq/workflow/admin` after deploy. |
+| Fix auto-advancement | Verify `sling-default-*` pool not saturated in thread dump; `com/adobe/granite/workflow/timeout/job` present in Sling Scheduler output; `blockPolicy=RUN`. |
+
+> **Pod-restart reality on AEMaaCS:** Cloud Manager does **not** expose a customer-facing pod-restart or env-restart action. The only way a customer can trigger a restart is an Adobe Support ticket. A restart bounces the running author/publish node — in-flight authoring sessions are lost, active jobs are requeued, there is no hot-swap. Treat it as last-resort mitigation, not a fix, and always file the long-term code/config fix in the same support conversation.
 
 ---
 
@@ -188,7 +229,7 @@ Config changes on Cloud Service require OSGi config files in the Git repository,
 - [ ] Sling Jobs output: Workflow job topic has high Failed Jobs?
 - [ ] Sling Scheduler output: ThreadPool = `default` for `ApacheSlingdefault`?
 
-**Fix:** Restart instance (immediate); fix scheduler code (add HTTP timeout, set `concurrent=false`); change pool policy to RUN; increase pool size. All config changes via Git + pipeline.
+**Fix:** Request pod restart (immediate mitigation, coordinate with customer — see Step 6 caveat); commit scheduler fix (HTTP timeout, `scheduler.concurrent=false`) to Git; land `org.apache.sling.commons.threads.impl.DefaultThreadPool-default.cfg.json` with `blockPolicy=RUN` and `maxPoolSize=50`; deploy via Cloud Manager pipeline.
 
 ### Pattern B: High workflow job failure rate
 
@@ -196,7 +237,7 @@ Config changes on Cloud Service require OSGi config files in the Git repository,
 
 **Root cause:** Process step exception, payload deleted, or process not registered.
 
-**Diagnosis:** Search error.log (from Cloud Manager) for `Error executing workflow step` + model name. Check `process.label` in OSGi components.
+**Diagnosis:** Download or stream `error.log` from Cloud Manager → Environments → Logs; grep for `Error executing workflow step` + model name. Cross-check the `process.label` in Developer Console → OSGi → Components against the model's Process step.
 
 ### Pattern C: Stale workflows accumulating
 
@@ -204,10 +245,24 @@ Config changes on Cloud Service require OSGi config files in the Git repository,
 
 **Root cause:** `Cannot archive workitem` during transition; JCR session crash during step completion.
 
-**Diagnosis:** Search for `Cannot archive workitem` in Cloud Manager logs; use custom API to count stale workflows.
+**Diagnosis:** grep Cloud Manager logs for `Cannot archive workitem`. For live count, deploy a custom `StaleWorkflowServlet` and invoke `GET /bin/support/workflow/stale?dryRun=true` — it returns a JSON report without side effects.
+
+---
+
+## Routing back to dev skills
+
+Once diagnosis identifies a code or model defect (not an operational issue on a healthy implementation), route back into the development skills:
+
+| Diagnosis | Route to |
+|---|---|
+| Process step throws an exception, leaks resources, or is not registered | [workflow-development](../workflow-development/SKILL.md) |
+| Model has wrong OR-split rule, missing transition, wrong step type, or fails to deploy | [workflow-model-design](../workflow-model-design/SKILL.md) |
+| Launcher not firing, firing on wrong path, or causing a re-trigger loop | [workflow-launchers](../workflow-launchers/SKILL.md) |
+| Workflow not started by code/HTTP API, or starts on wrong payload type | [workflow-triggering](../workflow-triggering/SKILL.md) |
+| Diagnosis spans multiple environments or requires Cloud Manager Logs / log-mining across envs | [workflow-triaging](../workflow-triaging/SKILL.md) |
 
 ---
 
 ## References
 
-- For runbook locations: see [reference.md](reference.md)
+- For runbook locations and diagnostic tool pointers: see [reference.md](reference.md)

--- a/plugins/aem/cloud-service/skills/aem-workflow/workflow-debugging/SKILL.md
+++ b/plugins/aem/cloud-service/skills/aem-workflow/workflow-debugging/SKILL.md
@@ -39,22 +39,22 @@ This skill is largely self-contained but routes back into the dev skills when th
 
 ---
 
-## Step 1: Map symptom to runbook
+## Step 1: Map symptom to first action
 
-| Symptom | symptom_id | Runbook | First action |
-|---------|------------|---------|--------------|
-| Workflow stuck (not advancing) | workflow_stuck_not_progressing | runbook-workflow-stuck.md | Open instance; note current step type. No work item → stale. |
-| Task not in Inbox | task_not_in_inbox | runbook-task-not-in-inbox.md | Confirm Participant step; assignee = logged-in user; Inbox filters. |
-| Workflow not starting (launcher) | workflow_not_starting_launcher | runbook-launcher-not-starting.md | Launcher enabled; path/event match payload. |
-| Workflow fails or shows error | workflow_fails_or_shows_error | runbook-workflow-fails-or-shows-error.md | Instance history; error.log for instance ID; payload and process. |
-| Step failed, retries exhausted | step_failed_retries_exhausted | runbook-failed-work-items.md | Logs → `process.label` → Inbox Retry, or bulk via custom servlet (see Step 6). |
-| Stale (no current work item) | stale_workflow_no_work_item | runbook-stale-workflows.md | Deploy a custom `StaleWorkflowServlet` to your `core` bundle; invoke with `?dryRun=true`. |
-| Repository bloat / too many instances | repository_bloat_too_many_instances | runbook-purge-and-cleanup.md | Purge Scheduler OSGi config in Git (PID: `com.adobe.granite.workflow.purge.Scheduler`). |
-| User cannot see or complete item | user_cannot_see_or_complete_item | runbook-inbox-and-permissions.md | Assignee / initiator / superuser group; `enforce*Permissions` flags. |
-| Cannot delete model | cannot_delete_model | runbook-model-delete-and-update.md | Count RUNNING instances via Workflow Console → terminate → delete model. |
-| Slow throughput / queue backlog | slow_throughput_queue_backlog | runbook-job-throughput-and-concurrency.md | Sling Job statistics; Granite Workflow Queue `queue.maxparallel`; Sling thread pool. |
-| Auto-advancement not working | workflow_auto_advance_failure | runbook-job-throughput-and-concurrency.md | Check `default` thread pool saturation; Sling Scheduler; timeout jobs. |
-| New workflow not working | workflow_setup_validation | runbook-validate-workflow-setup.md | Model sync, launcher, process registration, permissions. |
+| Symptom | symptom_id | First action |
+|---------|------------|--------------|
+| Workflow stuck (not advancing) | workflow_stuck_not_progressing | Open instance; note current step type. No work item → stale. |
+| Task not in Inbox | task_not_in_inbox | Confirm Participant step; assignee = logged-in user; Inbox filters. |
+| Workflow not starting (launcher) | workflow_not_starting_launcher | Launcher enabled; path/event match payload. |
+| Workflow fails or shows error | workflow_fails_or_shows_error | Instance history; error.log for instance ID; payload and process. |
+| Step failed, retries exhausted | step_failed_retries_exhausted | Logs → `process.label` → Inbox Retry, or bulk via custom servlet (see Step 6). |
+| Stale (no current work item) | stale_workflow_no_work_item | Deploy a custom `StaleWorkflowServlet` to your `core` bundle; invoke with `?dryRun=true`. |
+| Repository bloat / too many instances | repository_bloat_too_many_instances | Purge Scheduler OSGi config in Git (PID: `com.adobe.granite.workflow.purge.Scheduler`). |
+| User cannot see or complete item | user_cannot_see_or_complete_item | Assignee / initiator / superuser group; `enforce*Permissions` flags. |
+| Cannot delete model | cannot_delete_model | Count RUNNING instances via Workflow Console → terminate → delete model. |
+| Slow throughput / queue backlog | slow_throughput_queue_backlog | Sling Job statistics; Granite Workflow Queue `queue.maxparallel`; Sling thread pool. |
+| Auto-advancement not working | workflow_auto_advance_failure | Check `default` thread pool saturation; Sling Scheduler; timeout jobs. |
+| New workflow not working | workflow_setup_validation | Model sync, launcher, process registration, permissions. |
 
 ---
 
@@ -73,18 +73,17 @@ Thread dumps and status-producer output on AEMaaCS are obtained via **Developer 
 
 ### 3a. Sling `default` thread pool (critical path)
 
-The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool fires:
-- `com/adobe/granite/workflow/timeout/job` (auto-advancement)
+The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool runs:
 - Oak observation events
-- All Quartz-scheduled jobs
+- All Quartz-scheduled jobs — including the workflow timeout-detection scheduler that emits `com/adobe/granite/workflow/timeout/job` events to the Sling Job system (the job itself then runs on the Granite Workflow Queue, see Step 3c)
 
-**Check in thread pool output:**
+**Check in thread pool output (Developer Console → Status → Sling Thread Pools, `/system/console/status-slingthreadpools`):**
 
 | Field | Healthy | Problem |
 |-------|---------|---------|
 | active count | < max pool size | **= max pool size** (saturated) |
 | block policy | RUN | **ABORT** (rejects tasks when full) |
-| max pool size | ≥ 20 | Low values starve schedulers |
+| max pool size | sized for workload | OOTB on the AEMaaCS SDK is **10/10**; production environments may differ. Bump in OSGi config when many custom periodic schedulers compete with workflow timeout detection. |
 
 **If active count = max pool size AND block policy = ABORT:**
 - New scheduled tasks (including workflow timeout/auto-advance jobs) are **silently rejected**
@@ -103,7 +102,7 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 
 ### 3c. Granite Workflow Queue
 
-**Check Sling Jobs output:**
+**Check the Sling Jobs page (`/system/console/slingevent`):**
 
 | Field | Healthy | Problem |
 |-------|---------|---------|
@@ -117,15 +116,15 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 
 **Check Granite Workflow Queue configuration:**
 - Type: Topic Round Robin
-- Max Parallel: 1 (OOB default on AEMaaCS). Verify the running value at Developer Console → `/system/console/slingjobs` before assuming. Override via `org.apache.sling.event.jobs.QueueConfiguration-granitewfe.cfg.json` in Git if you need to increase it.
+- Max Parallel: **`0.5` OOTB on the AEMaaCS SDK** (50% of available CPU cores). Adobe's *Workflows Best Practices* recommends **between half and three-quarters of processor cores**. Verify the running value at Developer Console → `/system/console/slingevent` before assuming. Override via `org.apache.sling.event.jobs.QueueConfiguration-<alias>.cfg.json` in Git if you need to raise it.
 - Max Retries: 10
 
 ### 3d. Sling Scheduler
 
-**Check Sling Scheduler output:**
-- Verify `com/adobe/granite/workflow/timeout/job` scheduled jobs exist
-- `nextFireTime: null` → job already fired or deregistered
-- Verify which ThreadPool the scheduler uses (should be `default`)
+**Check the Sling Scheduler page (Developer Console → Status → Sling Scheduler, `/system/console/status-slingscheduler`):**
+- This page lists Quartz-style schedulers, not Sling Job topics. The workflow-related entry visible here is the periodic `WorkflowStatsMBean` collector (used by the Statistics MBean). `nextFireTime: null` means the trigger was deregistered.
+- The `com/adobe/granite/workflow/timeout/job` topic itself is a **Sling Job**, not a Quartz job — check it on the Sling Jobs page (`/system/console/slingevent`), not here.
+- Confirm `ApacheSlingdefault` uses `ThreadPool: default` — that's how the periodic timeout-detection scheduler reaches the workflow engine.
 
 ---
 
@@ -158,12 +157,15 @@ Every config below is an OSGi JSON file under
 | Config file (PID) | Property | Guidance |
 |-------------------|----------|----------|
 | `com.adobe.granite.workflow.core.WorkflowSessionFactory.cfg.json` | `cq.workflow.job.retry` | Default `3`; raise for flaky external calls. |
-| `org.apache.sling.event.jobs.QueueConfiguration-<alias>.cfg.json` | `queue.maxparallel` | **Real parallelism knob** for workflow jobs (factory PID targeting topics `com/adobe/granite/workflow/job/*`). `cq.workflow.job.max.procs` is a myth — it is *not* a property on WorkflowSessionFactory (verified against source). |
+| `org.apache.sling.event.jobs.QueueConfiguration-<alias>.cfg.json` | `queue.maxparallel` | **Real parallelism knob** for workflow jobs (factory PID targeting topics `com/adobe/granite/workflow/job/*`). OOTB on the AEMaaCS SDK is `0.5` (50% of CPU cores); Adobe's *Workflows Best Practices* recommends **between half and three-quarters of processor cores**. `cq.workflow.job.max.procs` displayed in Felix Config Manager is an **orphaned metatype label** with no Java code path that reads it (verified against AEM source on `master`) — do not rely on it. |
 | `com.adobe.granite.workflow.core.WorkflowSessionFactory.cfg.json` | `granite.workflow.enforceWorkitemAssigneePermissions` | `true` = only the assignee can see / complete a work item. |
 | `com.adobe.granite.workflow.core.WorkflowSessionFactory.cfg.json` | `granite.workflow.enforceWorkflowInitiatorPermissions` | `true` = only the initiator (or superuser) can terminate / suspend / resume. |
 | `com.adobe.granite.workflow.core.WorkflowSessionFactory.cfg.json` | `cq.workflow.superuser` | **AEMaaCS specific:** point this at a **group** provisioned via `repoinit` (e.g. `workflow-administrators`), **not** hard-coded user IDs. Users are federated from IMS and rotate; groups are stable. Service-user mappings go in `org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-*.cfg.json`. |
+| `com.adobe.granite.workflow.core.WorkflowSessionFactory.cfg.json` | `granite.workflow.inboxQuerySize` | Max work items returned per Inbox query. OOTB `2000`; raise if heavy users hit the cap. |
+| `com.adobe.granite.workflow.core.WorkflowSessionFactory.cfg.json` | `granite.workflow.maxPurgeSaveThreshold` | OOTB `20` — commit after this many purged instances. Raise carefully to reduce JCR overhead during large purges. |
+| `com.adobe.granite.workflow.core.WorkflowSessionFactory.cfg.json` | `granite.workflow.maxPurgeQueryCount` | OOTB `1000` — JCR query batch size during purge. Tune with `maxPurgeSaveThreshold` above. |
 | `org.apache.sling.commons.threads.impl.DefaultThreadPool-default.cfg.json` | `blockPolicy` | `ABORT` silently drops workflow timeout jobs — prefer `RUN`. *See AEMaaCS caveat below this table.* |
-| `org.apache.sling.commons.threads.impl.DefaultThreadPool-default.cfg.json` | `maxPoolSize` | `20` default; raise to `50` if many custom schedulers compete with workflow timeout jobs. *See AEMaaCS caveat below this table.* |
+| `org.apache.sling.commons.threads.impl.DefaultThreadPool-default.cfg.json` | `maxPoolSize` | **OOTB on the AEMaaCS SDK is `10`** (factory entry for the `default` pool); production environments may differ. Raise to `50` if many custom schedulers compete with workflow timeout detection. *See AEMaaCS caveat below this table.* |
 | `com.adobe.granite.workflow.purge.Scheduler-<alias>.cfg.json` | `scheduledpurge.workflowStatus` | **Array-typed.** Must be `["COMPLETED"]`, not `"COMPLETED"`. Also: this PID has **no** `scheduledpurge.cron` — scheduling is driven by the Granite Maintenance Task window; any `cron` property is silently ignored. |
 | `com.adobe.granite.workflow.purge.Scheduler-<alias>.cfg.json` | `scheduledpurge.daysold` | `30` default; tune per environment. Factory PID — deploy one file per purge schedule. |
 
@@ -171,7 +173,7 @@ Every config below is an OSGi JSON file under
 
 Some Sling core configs are filtered or overridden by the AEMaaCS platform layer. The `DefaultThreadPool` config *may* land via pipeline and be silently ignored. **Always verify** after deploy:
 
-- Open `/system/console/status-threads` (Developer Console → Status → Threads).
+- Open `/system/console/status-Threads` (Developer Console → Status → Threads).
 - Find the `default` pool row.
 - Confirm `maxPoolSize` and block policy reflect your config values.
 
@@ -198,10 +200,10 @@ If the numbers don't change, the PID is Adobe-managed on your environment — **
 | Retry failed work items (bulk) | **Preferred:** iterate `/aem/inbox` UI — single-item Retry preserves the original instance, its history, and its audit trail. **Not recommended:** a "bulk" servlet using `terminateWorkflow(wf)` + `startWorkflow(model, data)` — this creates a **new** instance and **loses** the original history, step durations, and comments. Only use the replay approach with explicit customer approval and *never* for audit-regulated workflows (pharma, finance, legal). |
 | Restart stale workflows | Deploy a custom `StaleWorkflowServlet` to your `core` bundle. Always invoke `GET /bin/support/workflow/stale?dryRun=true` first; confirm scope; then `POST ...?dryRun=false`. Scope with `&model=<modelId>` if you only want one model. |
 | Purge completed | Deploy `com.adobe.granite.workflow.purge.Scheduler-<alias>.cfg.json` with `scheduledpurge.workflowStatus=["COMPLETED"]` (array-typed) and `scheduledpurge.daysold=<N>`. Triggered by the **Granite Maintenance Task window** — this PID has **no** `scheduledpurge.cron`; any cron property is silently ignored. **Do not** reference `/libs/granite/operations/config/maintenance` — on AEMaaCS `/libs` is the read-only code layer. One purge config file per schedule. Deploy via pipeline. |
-| Increase parallelism | `queue.maxparallel` on `org.apache.sling.event.jobs.QueueConfiguration-<alias>.cfg.json` (topics: `com/adobe/granite/workflow/job/*`). The commonly cited `cq.workflow.job.max.procs` **does not exist** on `WorkflowSessionFactory` (verified against source) — do not waste a deployment on it. **Verify after deploy:** Developer Console → `/system/console/slingjobs` → find the **Granite Workflow Queue** row and confirm `queue.maxparallel` shows your value. If it still shows the OOB value (usually `1`), your override lost the `service.ranking` tiebreak — raise `service.ranking` in your override (e.g. from `100` to `1000`) and redeploy. If your ranking *matches* Adobe's OOB ranking exactly, Sling can register both queues against the same topic and occasionally execute a workflow step twice — always set a higher, non-equal ranking. Watch for `refreshing the session since we had to wait for a lock` after raising; if it appears, lower parallelism or stagger launchers. |
+| Increase parallelism | `queue.maxparallel` on `org.apache.sling.event.jobs.QueueConfiguration-<alias>.cfg.json` (topics: `com/adobe/granite/workflow/job/*`). Adobe's *Workflows Best Practices* recommends staying between half and three-quarters of available CPU cores. The commonly cited `cq.workflow.job.max.procs` is an **orphaned metatype label** with no Java code path that reads it (verified against AEM source on `master`) — do not waste a deployment on it. **Verify after deploy:** Developer Console → `/system/console/slingevent` → find the **Granite Workflow Queue** row and confirm `queue.maxparallel` shows your value. If it still shows the OOTB value (`0.5` on the AEMaaCS SDK), your override lost the `service.ranking` tiebreak — raise `service.ranking` in your override (e.g. from `100` to `1000`) and redeploy. If your ranking *matches* Adobe's OOB ranking exactly, Sling can register both queues against the same topic and occasionally execute a workflow step twice — always set a higher, non-equal ranking. Watch for `refreshing the session since we had to wait for a lock` after raising; if it appears, lower parallelism or stagger launchers. |
 | Fix thread pool exhaustion | Short-term: **open an Adobe Support ticket** requesting a pod restart for the affected environment — AEMaaCS does **not** expose a customer-facing restart action in Cloud Manager. Long-term, all via Git + pipeline: (1) fix the stuck scheduler (add HTTP timeouts; `@Component scheduler.concurrent=false`); (2) set `blockPolicy=RUN` in `org.apache.sling.commons.threads.impl.DefaultThreadPool-default.cfg.json`; (3) raise `maxPoolSize` to 50. Verify the thread-pool config actually applied — see the AEMaaCS caveat in Step 5. |
 | Fix process not found | Redeploy the `core` bundle; the `@Component process.label` must exactly match the model's Process step. Re-sync the workflow model from `/libs/cq/workflow/admin` after deploy. |
-| Fix auto-advancement | Verify `sling-default-*` pool not saturated in thread dump; `com/adobe/granite/workflow/timeout/job` present in Sling Scheduler output; `blockPolicy=RUN`. |
+| Fix auto-advancement | Verify `sling-default-*` pool not saturated in thread dump; `com/adobe/granite/workflow/timeout/job` topic active on the Sling Jobs page (`/system/console/slingevent`) — it is a Sling Job topic, not a Sling Scheduler entry; `blockPolicy=RUN` on the `default` pool. |
 
 > **Pod-restart reality on AEMaaCS:** Cloud Manager does **not** expose a customer-facing pod-restart or env-restart action. The only way a customer can trigger a restart is an Adobe Support ticket. A restart bounces the running author/publish node — in-flight authoring sessions are lost, active jobs are requeued, there is no hot-swap. Treat it as last-resort mitigation, not a fix, and always file the long-term code/config fix in the same support conversation.
 
@@ -217,9 +219,9 @@ If the numbers don't change, the PID is Adobe-managed on your environment — **
 1. Custom scheduler makes blocking HTTP call without timeout
 2. `concurrent = true` allows overlapping executions on each cron trigger
 3. Each stuck execution consumes a `default` pool thread indefinitely
-4. All 20 threads consumed → pool saturated
-5. Block policy = ABORT → new Quartz jobs rejected silently
-6. Workflow timeout jobs (`com/adobe/granite/workflow/timeout/job`) cannot fire
+4. All pool threads consumed (OOTB on the AEMaaCS SDK that's `10`; production environments may differ) → pool saturated
+5. If block policy has been changed to `ABORT` (OOTB is `RUN`), new Quartz triggers are rejected silently; on `RUN` they instead pile up on the caller thread and back-pressure the dispatch
+6. The workflow timeout-detection scheduler cannot dispatch new `com/adobe/granite/workflow/timeout/job` events
 7. Auto-advancement never happens
 
 **Diagnosis checklist:**

--- a/plugins/aem/cloud-service/skills/aem-workflow/workflow-debugging/reference.md
+++ b/plugins/aem/cloud-service/skills/aem-workflow/workflow-debugging/reference.md
@@ -1,26 +1,62 @@
 # AEM Workflow Debugging – Reference (Cloud Service)
 
-Quick pointers used by the workflow-debugging skill. For full runbooks and procedures, use the paths below inside this repo.
+Quick pointers used by the workflow-debugging skill. All runbooks and supplementary
+docs are bundled under `references/` so the skill is self-contained.
+
+> **Cloud Service note:** the bundled runbooks were originally authored against
+> AEM 6.5 and still reference JMX MBeans. On AEMaaCS there is **no JMX access**.
+> Use the JMX → Cloud Service translation table below when a runbook tells you
+> to invoke a JMX operation. The diagnosis checklists in the runbooks still apply;
+> only the remediation mechanism changes.
 
 ---
 
-## Runbook locations (relative to repo root)
+## JMX → Cloud Service remediation translation
+
+| Runbook says (JMX) | Cloud Service equivalent |
+|--------------------|--------------------------|
+| `restartStaleWorkflows(dryRun)` | Deploy custom servlet (see `references/examples/StaleWorkflowServlet.java`) invoked via Developer Console / `curl` |
+| `countStaleWorkflows(model)` | Same custom servlet, `?dryRun=true` — returns `staleCount` in the JSON response |
+| `retryFailedWorkItems` | Inbox → Retry (per item); or custom servlet using `WorkflowSession.terminateWorkflow` + `startWorkflow` with the same payload for bulk |
+| `purgeCompleted(dryRun)` | Purge Scheduler config in Git → deploy via Cloud Manager pipeline (see `references/examples/com.adobe.granite.workflow.purge.Scheduler-*.cfg.json`) |
+| `returnSystemJobInfo` | Sling Job Console at `/system/console/slingjobs` (read-only) |
+| `returnWorkflowQueueInfo` | Sling Job Console → Granite Workflow Queue section |
+| JMX-based config tweaks (retry, superuser, assignee/initiator enforcement) | OSGi config JSON in Git under `ui.config/src/main/content/jcr_root/apps/.../osgiconfig/config(.author)/` deployed via pipeline — see `references/examples/com.adobe.granite.workflow.core.WorkflowSessionFactory.cfg.json`. |
+| Workflow parallelism (mis-cited as JMX or `max.procs` elsewhere) | Granite Workflow Queue via `org.apache.sling.event.jobs.QueueConfiguration-granitewfe.cfg.json` → `queue.maxparallel`. The `cq.workflow.job.max.procs` property does not exist. |
+
+---
+
+## Bundled runbooks (relative to this skill)
 
 | Runbook | Path |
 |---------|------|
-| Decision guide (symptom → runbook) | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-decision-guide.md` |
-| Debugging index (machine-readable) | `aem-agent-marketplace-workflow-knowledge-base/docs/debugging-index.md` |
-| Workflow stuck | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-workflow-stuck.md` |
-| Task not in Inbox | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-task-not-in-inbox.md` |
-| Launcher not starting | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-launcher-not-starting.md` |
-| Workflow fails / error | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-workflow-fails-or-shows-error.md` |
-| Failed work items | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-failed-work-items.md` |
-| Stale workflows | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-stale-workflows.md` |
-| Purge and cleanup | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-purge-and-cleanup.md` |
-| Inbox and permissions | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-inbox-and-permissions.md` |
-| Model delete/update | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-model-delete-and-update.md` |
-| Job throughput / concurrency | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-job-throughput-and-concurrency.md` |
-| Validate workflow setup | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-validate-workflow-setup.md` |
+| Decision guide (symptom → runbook) | `references/runbooks/runbook-decision-guide.md` |
+| Workflow stuck | `references/runbooks/runbook-workflow-stuck.md` |
+| Task not in Inbox | `references/runbooks/runbook-task-not-in-inbox.md` |
+| Launcher not starting | `references/runbooks/runbook-launcher-not-starting.md` |
+| Workflow fails / error | `references/runbooks/runbook-workflow-fails-or-shows-error.md` |
+| Failed work items | `references/runbooks/runbook-failed-work-items.md` |
+| Stale workflows | `references/runbooks/runbook-stale-workflows.md` |
+| Purge and cleanup | `references/runbooks/runbook-purge-and-cleanup.md` |
+| Inbox and permissions | `references/runbooks/runbook-inbox-and-permissions.md` |
+| Model delete/update | `references/runbooks/runbook-model-delete-and-update.md` |
+| Job throughput / concurrency | `references/runbooks/runbook-job-throughput-and-concurrency.md` |
+| Validate workflow setup | `references/runbooks/runbook-validate-workflow-setup.md` |
+
+---
+
+## Bundled supplementary docs and examples
+
+| Doc / example | Path | Purpose |
+|---------------|------|---------|
+| Debugging index | `references/docs/debugging-index.md` | symptom_id → runbook / logs |
+| Error patterns | `references/docs/error-patterns.md` | Full log-pattern catalog |
+| MBeans (reference only) | `references/docs/mbeans.md` | Historical JMX reference; translate via table above |
+| Stale workflow servlet (stub) | `references/examples/StaleWorkflowServlet.java` | Custom replacement for JMX `restartStaleWorkflows` |
+| Workflow session factory config | `references/examples/com.adobe.granite.workflow.core.WorkflowSessionFactory.cfg.json` | OSGi config example for retry / superuser / assignee + initiator enforcement. Does **not** include `cq.workflow.job.max.procs` — that property does not exist on this PID. |
+| Granite Workflow Queue config | `references/examples/org.apache.sling.event.jobs.QueueConfiguration-granitewfe.cfg.json` | Actual workflow parallelism knob (`queue.maxparallel`). Required override if you need to raise parallelism on AEMaaCS. |
+| Default thread pool config | `references/examples/org.apache.sling.commons.threads.impl.DefaultThreadPool-default.cfg.json` | OSGi config example for block policy and max pool size |
+| Purge scheduler config | `references/examples/com.adobe.granite.workflow.purge.Scheduler-completed.cfg.json` | Purge completed instances via Granite Maintenance Task window |
 
 ---
 
@@ -28,26 +64,30 @@ Quick pointers used by the workflow-debugging skill. For full runbooks and proce
 
 | Tool | Where | Purpose |
 |------|-------|---------|
-| Developer Console | AEM Cloud Service → Developer Console | Thread dumps, OSGi bundles, config |
-| Cloud Manager Logs | Cloud Manager → Environments → Logs | error.log, access.log download/streaming |
-| Workflow Console | /libs/cq/workflow/admin/console/content/instances.html | Instance status, work items, history |
-| Sling Job Console | /system/console/slingjobs | Queue depth, failed jobs, active jobs |
-| Inbox | /aem/inbox | Retry failed work items, complete tasks |
+| Developer Console | AEM Cloud Service → Developer Console | Thread dumps, OSGi bundles, config, status producers |
+| Cloud Manager Logs | Cloud Manager → Environments → Logs | `error.log`, `access.log`, `request.log` download/streaming |
+| Workflow Console | `/libs/cq/workflow/admin/console/content/instances.html` | Instance status, work items, history |
+| Sling Job Console | `/system/console/slingjobs` | Queue depth, failed jobs, active jobs (read-only) |
+| Inbox | `/aem/inbox` | Retry failed work items, complete tasks |
+
+Note: `/system/console/jmx` is **not** available on AEMaaCS production.
 
 ---
 
-## Log patterns (see also docs/error-patterns.md)
+## Log patterns (see `references/docs/error-patterns.md` for the full catalog)
 
-- `Error executing workflow step` – Process/step exception
-- `getProcess for '<name>' failed` – Process not registered
-- `Cannot archive workitem` – Stale risk
-- `refreshing the session since we had to wait for a lock` – Contention
-- `Terminate failed` / `Resume failed` / `Suspend failed` – Permissions
-- `PathNotFoundException` (workflow/payload) – Payload or launcher path
+- `Error executing workflow step` – process/step exception
+- `getProcess for '<name>' failed` – process not registered
+- `Cannot archive workitem` – stale risk
+- `refreshing the session since we had to wait for a lock` – contention
+- `Terminate failed` / `Resume failed` / `Suspend failed` – permissions
+- `PathNotFoundException` (workflow/payload) – payload or launcher path
 
 ---
 
 ## External docs (Experience League)
 
 - [Workflows overview (Cloud Service)](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/sites/authoring/workflows/overview)
-- [Workflow API (6.5 Javadoc, applies to Cloud)](https://developer.adobe.com/experience-manager/reference-materials/6-5/javadoc/com/adobe/granite/workflow/exec/Workflow.html)
+- [Workflow API (6.5 Javadoc — API is shared with AEMaaCS)](https://developer.adobe.com/experience-manager/reference-materials/6-5/javadoc/com/adobe/granite/workflow/exec/Workflow.html)
+- [AEMaaCS OSGi configuration](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/implementing/deploying/configuring-osgi)
+- [AEMaaCS repoinit](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/implementing/deploying/overview-repoinit)

--- a/plugins/aem/cloud-service/skills/aem-workflow/workflow-debugging/reference.md
+++ b/plugins/aem/cloud-service/skills/aem-workflow/workflow-debugging/reference.md
@@ -1,62 +1,8 @@
 # AEM Workflow Debugging – Reference (Cloud Service)
 
-Quick pointers used by the workflow-debugging skill. All runbooks and supplementary
-docs are bundled under `references/` so the skill is self-contained.
-
-> **Cloud Service note:** the bundled runbooks were originally authored against
-> AEM 6.5 and still reference JMX MBeans. On AEMaaCS there is **no JMX access**.
-> Use the JMX → Cloud Service translation table below when a runbook tells you
-> to invoke a JMX operation. The diagnosis checklists in the runbooks still apply;
-> only the remediation mechanism changes.
-
----
-
-## JMX → Cloud Service remediation translation
-
-| Runbook says (JMX) | Cloud Service equivalent |
-|--------------------|--------------------------|
-| `restartStaleWorkflows(dryRun)` | Deploy custom servlet (see `references/examples/StaleWorkflowServlet.java`) invoked via Developer Console / `curl` |
-| `countStaleWorkflows(model)` | Same custom servlet, `?dryRun=true` — returns `staleCount` in the JSON response |
-| `retryFailedWorkItems` | Inbox → Retry (per item); or custom servlet using `WorkflowSession.terminateWorkflow` + `startWorkflow` with the same payload for bulk |
-| `purgeCompleted(dryRun)` | Purge Scheduler config in Git → deploy via Cloud Manager pipeline (see `references/examples/com.adobe.granite.workflow.purge.Scheduler-*.cfg.json`) |
-| `returnSystemJobInfo` | Sling Job Console at `/system/console/slingjobs` (read-only) |
-| `returnWorkflowQueueInfo` | Sling Job Console → Granite Workflow Queue section |
-| JMX-based config tweaks (retry, superuser, assignee/initiator enforcement) | OSGi config JSON in Git under `ui.config/src/main/content/jcr_root/apps/.../osgiconfig/config(.author)/` deployed via pipeline — see `references/examples/com.adobe.granite.workflow.core.WorkflowSessionFactory.cfg.json`. |
-| Workflow parallelism (mis-cited as JMX or `max.procs` elsewhere) | Granite Workflow Queue via `org.apache.sling.event.jobs.QueueConfiguration-granitewfe.cfg.json` → `queue.maxparallel`. The `cq.workflow.job.max.procs` property does not exist. |
-
----
-
-## Bundled runbooks (relative to this skill)
-
-| Runbook | Path |
-|---------|------|
-| Decision guide (symptom → runbook) | `references/runbooks/runbook-decision-guide.md` |
-| Workflow stuck | `references/runbooks/runbook-workflow-stuck.md` |
-| Task not in Inbox | `references/runbooks/runbook-task-not-in-inbox.md` |
-| Launcher not starting | `references/runbooks/runbook-launcher-not-starting.md` |
-| Workflow fails / error | `references/runbooks/runbook-workflow-fails-or-shows-error.md` |
-| Failed work items | `references/runbooks/runbook-failed-work-items.md` |
-| Stale workflows | `references/runbooks/runbook-stale-workflows.md` |
-| Purge and cleanup | `references/runbooks/runbook-purge-and-cleanup.md` |
-| Inbox and permissions | `references/runbooks/runbook-inbox-and-permissions.md` |
-| Model delete/update | `references/runbooks/runbook-model-delete-and-update.md` |
-| Job throughput / concurrency | `references/runbooks/runbook-job-throughput-and-concurrency.md` |
-| Validate workflow setup | `references/runbooks/runbook-validate-workflow-setup.md` |
-
----
-
-## Bundled supplementary docs and examples
-
-| Doc / example | Path | Purpose |
-|---------------|------|---------|
-| Debugging index | `references/docs/debugging-index.md` | symptom_id → runbook / logs |
-| Error patterns | `references/docs/error-patterns.md` | Full log-pattern catalog |
-| MBeans (reference only) | `references/docs/mbeans.md` | Historical JMX reference; translate via table above |
-| Stale workflow servlet (stub) | `references/examples/StaleWorkflowServlet.java` | Custom replacement for JMX `restartStaleWorkflows` |
-| Workflow session factory config | `references/examples/com.adobe.granite.workflow.core.WorkflowSessionFactory.cfg.json` | OSGi config example for retry / superuser / assignee + initiator enforcement. Does **not** include `cq.workflow.job.max.procs` — that property does not exist on this PID. |
-| Granite Workflow Queue config | `references/examples/org.apache.sling.event.jobs.QueueConfiguration-granitewfe.cfg.json` | Actual workflow parallelism knob (`queue.maxparallel`). Required override if you need to raise parallelism on AEMaaCS. |
-| Default thread pool config | `references/examples/org.apache.sling.commons.threads.impl.DefaultThreadPool-default.cfg.json` | OSGi config example for block policy and max pool size |
-| Purge scheduler config | `references/examples/com.adobe.granite.workflow.purge.Scheduler-completed.cfg.json` | Purge completed instances via Granite Maintenance Task window |
+Quick pointers used by the workflow-debugging skill. Use the SKILL.md Step 1
+symptom table for the symptom → first-action map; the entries below are for
+quick access to diagnostic tools, log patterns, and external documentation.
 
 ---
 
@@ -67,27 +13,36 @@ docs are bundled under `references/` so the skill is self-contained.
 | Developer Console | AEM Cloud Service → Developer Console | Thread dumps, OSGi bundles, config, status producers |
 | Cloud Manager Logs | Cloud Manager → Environments → Logs | `error.log`, `access.log`, `request.log` download/streaming |
 | Workflow Console | `/libs/cq/workflow/admin/console/content/instances.html` | Instance status, work items, history |
-| Sling Job Console | `/system/console/slingjobs` | Queue depth, failed jobs, active jobs (read-only) |
+| Sling Jobs page | `/system/console/slingevent` | Queue depth, failed jobs, active jobs (read-only) |
+| Sling Thread Pools page | `/system/console/status-slingthreadpools` | Per-pool active count, max size, block policy |
+| Threads page | `/system/console/status-Threads` | Live thread states; full stacks |
+| Thread dump | `/system/console/status-jstack-threaddump` | jstack-style snapshot |
+| Sling Scheduler page | `/system/console/status-slingscheduler` | Scheduled jobs and their ThreadPool |
+| OSGi Configuration | `/system/console/configMgr` | Read and (on lower envs) edit OSGi configs |
 | Inbox | `/aem/inbox` | Retry failed work items, complete tasks |
 
-Note: `/system/console/jmx` is **not** available on AEMaaCS production.
+Note: `/system/console/jmx` is **not** available on AEMaaCS production. The same
+MBeans exist on the local AEMaaCS SDK, but production diagnosis must use the
+status producers above plus Cloud Manager logs.
 
 ---
 
-## Log patterns (see `references/docs/error-patterns.md` for the full catalog)
+## Log patterns
 
 - `Error executing workflow step` – process/step exception
-- `getProcess for '<name>' failed` – process not registered
-- `Cannot archive workitem` – stale risk
-- `refreshing the session since we had to wait for a lock` – contention
-- `Terminate failed` / `Resume failed` / `Suspend failed` – permissions
-- `PathNotFoundException` (workflow/payload) – payload or launcher path
+- `getProcess for '<name>' failed` – process not registered (`process.label` mismatch)
+- `Cannot archive workitem` – stale risk; archive failed during step transition
+- `refreshing the session since we had to wait for a lock` – contention; **reduce** `queue.maxparallel`, do not raise it
+- `Terminate failed` / `Resume failed` / `Suspend failed` – permissions (not initiator or superuser)
+- `PathNotFoundException` (workflow/payload) – payload deleted, or launcher config path missing
+- `RejectedExecutionException` – thread pool full with `blockPolicy=ABORT`; timeout jobs dropped
+- `retrys exceeded - remove isTransient` – transient workflow failed after `cq.workflow.job.retry` exhausted
 
 ---
 
-## External docs (Experience League)
+## External docs
 
-- [Workflows overview (Cloud Service)](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/sites/authoring/workflows/overview)
-- [Workflow API (6.5 Javadoc — API is shared with AEMaaCS)](https://developer.adobe.com/experience-manager/reference-materials/6-5/javadoc/com/adobe/granite/workflow/exec/Workflow.html)
-- [AEMaaCS OSGi configuration](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/implementing/deploying/configuring-osgi)
-- [AEMaaCS repoinit](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/implementing/deploying/overview-repoinit)
+- [Working with Workflows (Cloud Service)](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/sites/authoring/workflows/overview)
+- [Workflow API (AEMaaCS Javadoc)](https://developer.adobe.com/experience-manager/reference-materials/cloud-service/javadoc/com/adobe/granite/workflow/exec/Workflow.html)
+- [Configuring OSGi for AEM Cloud Service](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/implementing/deploying/configuring-osgi)
+- [AEMaaCS repoinit (Deploying overview → Repoinit)](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/implementing/deploying/overview#repoinit)


### PR DESCRIPTION
…rvice

- Add Audience, Variant Scope, and Dependencies sections
- Correct cq.workflow.job.max.procs myth: property does not exist on WorkflowSessionFactory; real parallelism knob is queue.maxparallel on the Granite Workflow Queue (org.apache.sling.event.jobs.QueueConfiguration)
- Fix lock contention guidance: reduce (not raise) queue.maxparallel
- Replace vague stale handling with StaleWorkflowServlet pattern
- Add concrete OSGi config file names and Git-based remediation paths
- Add AEMaaCS platform caveats: DefaultThreadPool may be reserved, pod-restart requires Support ticket, IMS identity gotchas
- Add Routing back to dev skills table
- Update reference.md with JMX to CS translation table and diagnostic tools

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
