### PR TITLE
fix(ci): make tessl-lint sticky comment non-fatal for fork PRs

### DIFF
--- a/.github/workflows/tessl-lint.yml
+++ b/.github/workflows/tessl-lint.yml
@@ -237,10 +237,10 @@ jobs:
 
             if [ -n "$EXISTING_ID" ]; then
               echo "Updating existing sticky comment $EXISTING_ID"
-              gh api -X PATCH "repos/$REPO/issues/comments/$EXISTING_ID" --input "$PAYLOAD_FILE" >/dev/null
+              gh api -X PATCH "repos/$REPO/issues/comments/$EXISTING_ID" --input "$PAYLOAD_FILE" >/dev/null || echo "::warning::Could not update PR comment (token may be read-only for fork PRs)"
             else
               echo "Creating new sticky comment"
-              gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" --input "$PAYLOAD_FILE" >/dev/null
+              gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" --input "$PAYLOAD_FILE" >/dev/null || echo "::warning::Could not post PR comment (token may be read-only for fork PRs)"
             fi
           fi
 


### PR DESCRIPTION
## Summary

- Fork PRs receive a read-only `GITHUB_TOKEN` regardless of the workflow's `permissions: pull-requests: write` block. The `gh api -X POST` call that creates the sticky tessl-lint summary comment then 403s, exit-1'ing the whole job even when the lint itself passes.
- Makes both the POST and PATCH calls non-fatal with `|| echo "::warning::..."`. The job result now reflects the actual lint outcome rather than a GitHub API permission restriction.

Opening a PR for an existing branch that already had this fix committed; surfaced again on #137 (a fork PR) where lint passed `Total: 2, Passed: 2, Failed: 0` but the job was red because the comment step 403'd.

## Test plan

- [ ] Trigger workflow on a same-repo branch — verify sticky comment still posts/updates as before
- [ ] Re-run tessl-lint on #137 after merge — verify job goes green and a `::warning::` is emitted instead of a hard failure
- [ ] Verify step summary still renders the per-tile table on both same-repo and fork PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)