### PR TITLE
fix(ci): grant pull-requests: write so release success step can comment on PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   issues: write
+  pull-requests: write
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

Follow-up to #144. The release workflow that just published `slicc-handoff-v1.0.1` succeeded at creating the GitHub release, but the `success` step of `@semantic-release/github` failed with:

> Not allowed to add a comment to the issue/PR #144.

(Visible in [run 26256538929](https://github.com/adobe/skills/actions/runs/26256538929).) The release artifacts themselves are fine — only the courtesy "this PR is included in version X.Y.Z" comment on the merged PR did not post.

## Root cause

`.github/workflows/release.yml` granted `contents: write` and `issues: write`, but PR comments go through the **pull requests** API surface, which requires its own permission. Per the [`@semantic-release/github` README](https://www.npmjs.com/package/@semantic-release/github), when using `GITHUB_TOKEN` all three permissions are required:

- `contents: write` — publish a GitHub release
- `issues: write` — comment on released **issues**
- `pull-requests: write` — comment on released **pull requests**

The first two were enough for everything except commenting on the merged PR, which is exactly what failed.

## Change

One line added to the top-level `permissions:` block. No other changes.

```yaml
 permissions:
   contents: write
   issues: write
+  pull-requests: write
```

## Test plan

- [x] `git diff origin/main` shows exactly one added line.
- [ ] After merge, the next release-triggering push to `main` produces a release whose `success` step posts a comment on the included PR without error (will be observable in the next "Release Skills" workflow run).

## Why not retroactively fix the missing comment on #144

`@semantic-release/github`'s `success` step only runs as part of a release. It will not retroactively comment on PRs from past releases; it only comments on PRs included in the *current* release. So we can't recover the missing comment on #144 — only ensure future releases post their comments correctly.

---

Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author