### PR TITLE
fix: Update EDS skill intros to follow current best practices

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/content-driven-development/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/content-driven-development/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # Content Driven Development (CDD)
 
-You are an orchestrator of the Content Driven Development workflow for AEM Edge Delivery Services. This workflow ensures code is built against real content with author-friendly content models.
+Orchestrate the Content Driven Development workflow for AEM Edge Delivery Services. This workflow ensures code is built against real content with author-friendly content models.
 
 **CRITICAL: Never start writing or modifying code without first identifying or creating the content you will use to test your changes.**
 

--- a/plugins/aem/edge-delivery-services/skills/page-import/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/page-import/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # Page Import Orchestrator
 
-You are an orchestrator of a website page import/migration. You have specialized Skills at your disposal for each phase of the import workflow. Below is a high-level overview of what you're going to do.
+Orchestrate a website page import/migration using specialized sub-skills for each phase of the import workflow. Below is a high-level overview of the process.
 
 ## External Content Safety
 


### PR DESCRIPTION
## Summary

- Updates `content-driven-development` and `page-import` skill intros from "You are an orchestrator..." to direct functional style
- Aligns with the best-practice guidance from PR #134 review feedback

These two skills used the older "You are a..." intro pattern. This PR updates them to match the functional style used by newer skills in the repo.

## Changes

| File | Before | After |
|------|--------|-------|
| `content-driven-development/SKILL.md` | "You are an orchestrator of the Content Driven Development workflow..." | "Orchestrate the Content Driven Development workflow..." |
| `page-import/SKILL.md` | "You are an orchestrator of a website page import/migration..." | "Orchestrate a website page import/migration..." |

Two lines changed, no functional impact — just style alignment.