### PR TITLE
fix(aem-workflow): expert audit pass against live AEM 6.5 LTS for wor…

### DIFF
--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/SKILL.md
@@ -24,22 +24,22 @@ Production-grade debugging for AEM Granite Workflow engine, launcher, Inbox, Sli
 
 ---
 
-## Step 1: Map symptom to runbook
+## Step 1: Map symptom to first action
 
-| Symptom | symptom_id | Runbook | First action |
-|---------|------------|---------|--------------|
-| Workflow stuck (not advancing) | workflow_stuck_not_progressing | runbook-workflow-stuck.md | Open instance; note current step type. No work item → stale. |
-| Task not in Inbox | task_not_in_inbox | runbook-task-not-in-inbox.md | Confirm Participant step; assignee = logged-in user; Inbox filters. |
-| Workflow not starting (launcher) | workflow_not_starting_launcher | runbook-launcher-not-starting.md | Launcher enabled; path/event match payload. |
-| Workflow fails or shows error | workflow_fails_or_shows_error | runbook-workflow-fails-or-shows-error.md | Instance history; error.log for instance ID; payload and process. |
-| Step failed, retries exhausted | step_failed_retries_exhausted | runbook-failed-work-items.md | Logs → process.label → JMX `retryFailedWorkItems` or Inbox retry. |
-| Stale (no current work item) | stale_workflow_no_work_item | runbook-stale-workflows.md | JMX `countStaleWorkflows` → `restartStaleWorkflows(dryRun=true)`. |
-| Repository bloat / too many instances | repository_bloat_too_many_instances | runbook-purge-and-cleanup.md | JMX `purgeCompleted(dryRun=true)` or Purge Scheduler. |
-| User cannot see or complete item | user_cannot_see_or_complete_item | runbook-inbox-and-permissions.md | Assignee/initiator/superuser; enforce flags. |
-| Cannot delete model | cannot_delete_model | runbook-model-delete-and-update.md | JMX `countRunningWorkflows` → terminate → delete. |
-| Slow throughput / queue backlog | slow_throughput_queue_backlog | runbook-job-throughput-and-concurrency.md | JMX `returnSystemJobInfo`; `queue.maxparallel` on Granite Workflow Queue; Sling thread pool. |
-| Auto-advancement not working | workflow_auto_advance_failure | runbook-job-throughput-and-concurrency.md | Check `default` thread pool saturation; Sling Scheduler; timeout jobs. |
-| New workflow not working | workflow_setup_validation | runbook-validate-workflow-setup.md | Model sync, launcher, process registration, permissions. |
+| Symptom | symptom_id | First action |
+|---------|------------|--------------|
+| Workflow stuck (not advancing) | workflow_stuck_not_progressing | Open instance; note current step type. No work item → stale. |
+| Task not in Inbox | task_not_in_inbox | Confirm Participant step; assignee = logged-in user; Inbox filters. |
+| Workflow not starting (launcher) | workflow_not_starting_launcher | Launcher enabled; path/event match payload. |
+| Workflow fails or shows error | workflow_fails_or_shows_error | Instance history; error.log for instance ID; payload and process. |
+| Step failed, retries exhausted | step_failed_retries_exhausted | Logs → process.label → JMX `retryFailedWorkItems` or Inbox retry. |
+| Stale (no current work item) | stale_workflow_no_work_item | JMX `countStaleWorkflows` → `restartStaleWorkflows(dryRun=true)`. |
+| Repository bloat / too many instances | repository_bloat_too_many_instances | JMX `purgeCompleted(dryRun=true)` or Purge Scheduler. |
+| User cannot see or complete item | user_cannot_see_or_complete_item | Assignee/initiator/superuser; enforce flags. |
+| Cannot delete model | cannot_delete_model | JMX `countRunningWorkflows` → terminate → delete. |
+| Slow throughput / queue backlog | slow_throughput_queue_backlog | JMX `returnSystemJobInfo`; `queue.maxparallel` on Granite Workflow Queue; Sling thread pool. |
+| Auto-advancement not working | workflow_auto_advance_failure | Check `default` thread pool saturation; Sling Scheduler; timeout jobs. |
+| New workflow not working | workflow_setup_validation | Model sync, launcher, process registration, permissions. |
 
 ---
 
@@ -58,10 +58,9 @@ Thread dumps on 6.5 / AMS are obtained via **jstack** or by requesting from AMS 
 
 ### 3a. Sling `default` thread pool (critical path)
 
-The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool fires:
-- `com/adobe/granite/workflow/timeout/job` (auto-advancement)
+The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool runs:
 - Oak observation events
-- All Quartz-scheduled jobs
+- All Quartz-scheduled jobs — including the workflow timeout-detection scheduler that emits `com/adobe/granite/workflow/timeout/job` events to the Sling Job system (the job itself then runs on the Granite Workflow Queue, see Step 3c)
 
 **Check the Sling Thread Pools status page (`/system/console/status-slingthreadpools`):**
 
@@ -69,7 +68,7 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 |-------|---------|---------|
 | active count | < max pool size | **= max pool size** (saturated) |
 | block policy | RUN | **ABORT** (rejects tasks when full) |
-| max pool size | ≥ 20 | Low values starve schedulers |
+| max pool size | sized for workload | OOTB on AEM 6.5 LTS is **5/5** (Apache Sling default). Bump to 20+ in OSGi config for environments with many custom periodic schedulers, otherwise schedulers can starve. |
 
 **If active count = max pool size AND block policy = ABORT:**
 - New scheduled tasks (including workflow timeout/auto-advance jobs) are **silently rejected**
@@ -108,9 +107,9 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 ### 3d. Sling Scheduler
 
 **Check the Sling Scheduler status page (`/system/console/status-slingscheduler`):**
-- Verify `com/adobe/granite/workflow/timeout/job` scheduled jobs exist
-- `nextFireTime: null` → job already fired or deregistered
-- Verify which ThreadPool the scheduler uses (should be `default`)
+- This page lists Quartz-style schedulers, not Sling Job topics. On OOTB AEM 6.5 LTS the workflow-related entry visible here is the periodic `WorkflowStatsMBean` collector (used by the Statistics MBean) — its `nextFireTime` should be in the near future; `nextFireTime: null` means the trigger was deregistered.
+- The `com/adobe/granite/workflow/timeout/job` topic itself is a **Sling Job**, not a Quartz job — check it on the Sling Jobs page (`/system/console/slingevent`), not here.
+- Confirm `ApacheSlingdefault` uses `ThreadPool: default` — that's how the periodic timeout-detection scheduler reaches the workflow engine.
 
 ---
 
@@ -139,14 +138,17 @@ The Sling Scheduler `ApacheSlingdefault` uses `ThreadPool: default`. This pool f
 | Config | Property | Check |
 |--------|----------|-------|
 | WorkflowSessionFactory | `cq.workflow.job.retry` | Default 3; increase for flaky steps |
-| Apache Sling Job Queue Configuration (Granite Workflow Queue) | `queue.maxparallel` | Workflow parallelism. Default 1; increase for throughput. The `cq.workflow.job.max.procs` property shown on WorkflowSessionFactory has no runtime effect — do not rely on it |
-| WorkflowSessionFactory | `granite.workflow.enforceWorkitemAssigneePermissions` | true = only assignee sees items |
-| WorkflowSessionFactory | `granite.workflow.enforceWorkflowInitiatorPermissions` | true = only initiator can terminate |
-| WorkflowSessionFactory | `cq.workflow.superuser` | Must include admin users/groups |
-| DefaultThreadPool (default) | `block policy` | ABORT can reject timeout jobs; prefer RUN |
-| DefaultThreadPool (default) | `max pool size` | 20 default; increase if many schedulers |
-| Granite Workflow Queue | `queue.maxparallel` | 0.5 OOTB (50% of CPU cores); increase for throughput. Verify at `/system/console/configMgr/org.apache.sling.event.jobs.QueueConfiguration~workflow` |
-| Purge Scheduler | `scheduledpurge.daysold` | 30 default; tune per environment |
+| WorkflowSessionFactory | `cq.workflow.superuser` | Must include admin users/groups (OOTB list includes `admin`, `administrators`, `workflow-process-service`, `workflow-service`, `workflow-administrators`, `wcm-workflow-service`) |
+| WorkflowSessionFactory | `granite.workflow.enforceWorkitemAssigneePermissions` | true (OOTB) = only assignee sees items |
+| WorkflowSessionFactory | `granite.workflow.enforceWorkflowInitiatorPermissions` | true (OOTB) = only initiator (or superuser) can terminate/suspend/resume |
+| WorkflowSessionFactory | `granite.workflow.inboxQuerySize` | Max work items returned per Inbox query. OOTB 2000; raise if heavy users hit the cap |
+| WorkflowSessionFactory | `granite.workflow.maxPurgeSaveThreshold` | OOTB 20 — commit after this many purged instances. Raise carefully to reduce JCR overhead during large purges |
+| WorkflowSessionFactory | `granite.workflow.maxPurgeQueryCount` | OOTB 1000 — JCR query batch size during purge. Tune with above |
+| Granite Workflow Queue (`org.apache.sling.event.jobs.QueueConfiguration~workflow`) | `queue.maxparallel` | **Real parallelism knob.** OOTB on AEM 6.5 LTS is `0.5` (50% of CPU cores). Adobe's *Workflows Best Practices* recommends **between half and three-quarters of processor cores**. `cq.workflow.job.max.procs` displayed in Felix Config Manager is an **orphaned metatype label** with no code path that reads it (verified against source on `release/660` and `prod/cq660`) — do not rely on it. Verify the running value at `/system/console/configMgr/org.apache.sling.event.jobs.QueueConfiguration~workflow` |
+| DefaultThreadPool (`name=default`) | `block policy` | OOTB `RUN`. `ABORT` would silently drop workflow timeout jobs — keep `RUN` unless you have a specific reason |
+| DefaultThreadPool (`name=default`) | `max pool size` | **OOTB on AEM 6.5 LTS is 5** (Apache Sling default). Bump to 20+ for environments with many custom periodic schedulers; otherwise the pool can starve under load |
+| Purge Scheduler (`com.adobe.granite.workflow.purge.Scheduler`) | `scheduledpurge.daysold` | 30 default; tune per environment. Factory PID — deploy one config per schedule |
+| Purge Scheduler | `scheduledpurge.workflowStatus` | Array-typed; e.g. `["COMPLETED"]` |
 
 ---
 
@@ -170,7 +172,7 @@ All workflow maintenance and diagnostic operations live on a single MBean: `com.
 
 | MBean | Operations | Purpose |
 |-------|------------|---------|
-| `com.adobe.granite.workflow:type=Maintenance` | `purgeCompleted(model, days, dryRun)`, `purgeActive(model, days, dryRun)`, `countRunningWorkflows(model)`, `countCompletedWorkflows(model)`, `countStaleWorkflows(model)`, `restartStaleWorkflows(model)`, `retryFailedWorkItems(dryRun, model)`, `returnSystemJobInfo`, `returnWorkflowQueueInfo`, `returnWorkflowJobTopicInfo`, `returnFailedWorkflowCount(model)`, `terminateFailedInstances`, `fetchModelList` | Purge, stale detection/restart, retry failed items, failure handling, queue/job diagnostics, model enumeration |
+| `com.adobe.granite.workflow:type=Maintenance` | `purgeCompleted(model [optional], days, dryRun)`, `purgeActive(model [optional], days, dryRun)`, `countRunningWorkflows(model [optional])`, `countCompletedWorkflows(model [optional])`, `countStaleWorkflows(model [optional])`, `restartStaleWorkflows(model [optional], dryRun)`, `retryFailedWorkItems(dryRun, model [optional])`, `terminateFailedInstances(restart, dryRun, model [optional])`, `returnSystemJobInfo()`, `returnWorkflowQueueInfo()`, `returnWorkflowJobTopicInfo()`, `returnFailedWorkflowCount(model [optional])`, `returnFailedWorkflowCountPerModel()`, `listRunningWorkflowsPerModel()`, `listCompletedWorkflowsPerModel()`, `fetchModelList()` | Purge, stale detection/restart, retry failed items, bulk terminate, queue/job diagnostics, per-model counts and enumeration |
 | `com.adobe.granite.workflow:type=Statistics` | `getResults`, `clearRecords`; plus `get`/`set` accessors for `DataLifeTime`, `DataFidelityTime`, `DataProcessRate`, `DataRate` | Time-series workflow execution statistics |
 
 **Always use `dryRun=true` first before executing destructive purge or retry operations.**
@@ -187,9 +189,9 @@ All workflow maintenance and diagnostic operations live on a single MBean: `com.
 1. Custom scheduler (e.g. `AccessTokenScheduler`) makes blocking HTTP call without timeout
 2. `concurrent = true` allows overlapping executions on each cron trigger
 3. Each stuck execution consumes a `default` pool thread indefinitely
-4. All 20 threads consumed → pool saturated
-5. Block policy = ABORT → new Quartz jobs rejected silently
-6. Workflow timeout jobs (`com/adobe/granite/workflow/timeout/job`) cannot fire
+4. All pool threads consumed (OOTB on AEM 6.5 LTS that's only **5**; environments hardened for throughput typically run with 20+) → pool saturated
+5. If block policy has been changed to `ABORT` (OOTB is `RUN`), new Quartz triggers are rejected silently; on `RUN` they instead pile up on the caller thread and back-pressure the dispatch
+6. The workflow timeout-detection scheduler cannot dispatch new `com/adobe/granite/workflow/timeout/job` events
 7. Auto-advancement never happens
 
 **Diagnosis checklist:**

--- a/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/reference.md
+++ b/plugins/aem/6.5-lts/skills/aem-workflow/workflow-debugging/reference.md
@@ -1,26 +1,8 @@
 # AEM Workflow Debugging – Reference (6.5 LTS / AMS)
 
-Quick pointers used by the workflow-debugging skill. For full runbooks and procedures, use the paths below inside this repo.
-
----
-
-## Runbook locations (relative to repo root)
-
-| Runbook | Path |
-|---------|------|
-| Decision guide (symptom → runbook) | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-decision-guide.md` |
-| Debugging index (machine-readable) | `aem-agent-marketplace-workflow-knowledge-base/docs/debugging-index.md` |
-| Workflow stuck | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-workflow-stuck.md` |
-| Task not in Inbox | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-task-not-in-inbox.md` |
-| Launcher not starting | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-launcher-not-starting.md` |
-| Workflow fails / error | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-workflow-fails-or-shows-error.md` |
-| Failed work items | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-failed-work-items.md` |
-| Stale workflows | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-stale-workflows.md` |
-| Purge and cleanup | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-purge-and-cleanup.md` |
-| Inbox and permissions | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-inbox-and-permissions.md` |
-| Model delete/update | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-model-delete-and-update.md` |
-| Job throughput / concurrency | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-job-throughput-and-concurrency.md` |
-| Validate workflow setup | `aem-agent-marketplace-workflow-knowledge-base/runbooks/runbook-validate-workflow-setup.md` |
+Quick pointers used by the workflow-debugging skill. Use the SKILL.md Step 1
+symptom table for the symptom → first-action map; the entries below are for
+quick access to JMX/config, diagnostic tools, log patterns, and external docs.
 
 ---
 
@@ -46,12 +28,16 @@ Quick pointers used by the workflow-debugging skill. For full runbooks and proce
 | Config Status ZIP | Felix Console → Status → Configuration Status | Full config dump, thread pools, Sling Jobs, schedulers |
 | Thread dump | jstack or AMS support request | Thread analysis |
 | Workflow Console | /libs/cq/workflow/admin/console/content/instances.html | Instance status, work items, history |
-| Sling Job Console | /system/console/slingjobs | Queue depth, failed jobs, active jobs |
+| Sling Jobs page | /system/console/slingevent | Queue depth, failed jobs, active jobs, topic statistics |
+| Sling Thread Pools | /system/console/status-slingthreadpools | Per-pool active count, max size, block policy |
+| Threads | /system/console/status-Threads | Live thread states with stacks |
+| jstack thread dump | /system/console/status-jstack-threaddump | jstack-style snapshot |
+| Sling Scheduler | /system/console/status-slingscheduler | Quartz-scheduled jobs and their ThreadPool |
 | Inbox | /aem/inbox | Retry failed work items, complete tasks |
 
 ---
 
-## Log patterns (see also docs/error-patterns.md)
+## Log patterns
 
 - `Error executing workflow step` – Process/step exception
 - `getProcess for '<name>' failed` – Process not registered


### PR DESCRIPTION
…kflow-debugging

All claims re-validated against an OOTB AEM 6.5 LTS instance, Adobe's official Workflows Best Practices documentation, and Granite Workflow source on release/660 and prod/cq660.

SKILL.md
- Step 1: drop the dead 'Runbook' column; the runbook-*.md filenames it pointed at do not exist in the repo (the 'First action' column already carries the actionable command for each symptom)
- Step 3a: the default Sling thread pool runs Quartz schedulers; it does not itself 'fire' com/adobe/granite/workflow/timeout/job — that is a Sling Job topic dispatched by a JobConsumer. Reword to reflect the scheduler -> Sling Job hand-off. Drop the bogus 'max pool size >= 20' healthy threshold: OOTB on AEM 6.5 LTS the default pool is 5/5 (Apache Sling default), with a note that hardened environments typically bump it to 20+
- Step 3d: the workflow timeout job is a Sling Job topic, not visible on /system/console/status-slingscheduler. Reword to point at /system/console/slingevent for the topic itself; only the periodic WorkflowStatsMBean Quartz job is visible on the scheduler page on OOTB 6.5 LTS
- Step 5: drop the duplicated queue.maxparallel row that also wrongly said 'Default 1' (OOTB is 0.5). Correct the DefaultThreadPool max pool size default from 20 to 5. Add four useful WorkflowSessionFactory properties verified live and against source: inboxQuerySize, maxPurgeSaveThreshold, maxPurgeQueryCount, and the OOTB superuser group list. Add a Purge Scheduler row for the array-typed scheduledpurge.workflowStatus. Reframe cq.workflow.job.max.procs as an orphaned metatype label with no Java code path that reads it (verified against release/660 and prod/cq660 source — the property exists only in metatype.properties as an i18n UI label) and surface Adobe's documented recommended range of half-to-three-quarters of processor cores
- Step 7: complete the Maintenance MBean signatures to match the live MBean — restartStaleWorkflows(model [optional], dryRun); retryFailedWorkItems(dryRun, model [optional]); terminateFailedInstances(restart, dryRun, model [optional]). Add the three useful per-model ops present on the live MBean but not documented: listRunningWorkflowsPerModel, listCompletedWorkflowsPerModel, returnFailedWorkflowCountPerModel
- Step 8 Pattern A: replace 'All 20 threads consumed' with the accurate OOTB number (5), with the same hardening caveat. Clarify the block- policy behavior — OOTB is RUN, so the ABORT-driven silent drop only occurs in environments where the policy has been changed

reference.md
- Drop the 'Runbook locations (relative to repo root)' table; those aem-agent-marketplace-workflow-knowledge-base/runbooks/* paths are not bundled with this repo, so the table was a dead pointer
- Drop the 'see also docs/error-patterns.md' hint for the same reason
- Fix the broken /system/console/slingjobs entry (404 on AEM 6.5 LTS; the canonical Sling Jobs page is /system/console/slingevent)
- Add four diagnostic-tool rows that are referenced from the SKILL.md but were not in this index: Sling Thread Pools, Threads, jstack thread dump, Sling Scheduler

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
