### PR TITLE
fix(stardust): close 3 Tessl orphaned-reference warnings

### DIFF
--- a/plugins/stardust/skills/distill/SKILL.md
+++ b/plugins/stardust/skills/distill/SKILL.md
@@ -323,3 +323,8 @@ Every artifact distill writes carries a provenance block with at
 minimum: `writtenBy: stardust:distill`, `writtenAt: <ISO-8601>`,
 `readArtifacts: [...]` (every sample file consumed),
 `consumedBy: "stardust:direct — Mode B anchor resolution"`.
+
+## References
+
+- [`reference/samples-brief-format.md`](reference/samples-brief-format.md) — the narrative-brief format the SAMPLES.md output follows.
+- [`reference/trait-matrix-schema.md`](reference/trait-matrix-schema.md) — the per-sample and cross-sample schema the trait-matrix.json output follows.

--- a/plugins/stardust/skills/prototype/SKILL.md
+++ b/plugins/stardust/skills/prototype/SKILL.md
@@ -1323,6 +1323,21 @@ Default mode is unchanged.
   reduced-motion override completeness, no-JS state, multi-
   viewport scroll-driven check). Reusable Playwright probe
   patterns documented inline.
+- `reference/motion-registers.md` — five brand-faithful motion
+  registers (`arrival`, `kinetic-display`, `live-systems`,
+  `editorial`, `kinetic-grid`) and the selection heuristic that
+  maps PRODUCT.md Brand Personality traits to a register.
+  Consumed by Phase 2.4 (motion application).
+- `reference/motion-stack.md` — technology choice for cinematic
+  prototypes: Lenis + CSS keyframes + rAF + IntersectionObserver.
+  Why not GSAP. Bundle policy + Lenis pinning procedure.
+- `reference/motion-attributes.md` — `data-*` vocabulary the
+  cinematic runtime consumes (`[data-anim]`, `[data-tile-anim]`,
+  `[data-countup]`, `[data-flip]`, `[data-fill]`, `[data-split]`,
+  `[data-parallax]`). Annotated per the active register.
+- `reference/motion-runtime.md` — the canonical inline runtime
+  script that powers every cinematic prototype. Single source of
+  truth; embedded verbatim during Phase 2.4.
 - `reference/fidelity-refined-pass.md` — concrete CSS recipes for
   the `--fidelity=refined` craft micro-pass (Discipline 8).
 - `reference/anti-template-bank.md` — worked examples of the
@@ -1337,20 +1352,20 @@ Default mode is unchanged.
   a strong structural `compositionDelta` (passes Discipline 10).
 - `fixtures/composition-delta-trivial.md` — example shape brief
   with token-only deltas (fails Discipline 10).
-- `skills/stardust/reference/token-contract.md` — `:root` token
+- `../stardust/reference/token-contract.md` — `:root` token
   block (cross-cutting, used by prototype + migrate).
-- `skills/stardust/reference/data-attributes.md` — structural data
+- `../stardust/reference/data-attributes.md` — structural data
   attribute vocabulary (cross-cutting, used by prototype + migrate).
-- `skills/stardust/reference/divergence-toolkit.md` —
+- `../stardust/reference/divergence-toolkit.md` —
   anti-mediocrity rules consumed during render and iteration.
-- `skills/stardust/reference/intent-dimensions.md` — the 7-axis
+- `../stardust/reference/intent-dimensions.md` — the 7-axis
   vocabulary used to read a chat-driven refinement phrase
   (iteration path 2).
-- `skills/stardust/reference/impeccable-command-map.md` — when to
+- `../stardust/reference/impeccable-command-map.md` — when to
   reach for each impeccable command. Consulted during chat-driven
   iteration (path 2) to pick the command for a refinement phrase.
-- `skills/stardust/reference/state-machine.md` — page lifecycle
+- `../stardust/reference/state-machine.md` — page lifecycle
   and stale rules.
-- `skills/stardust/reference/artifact-map.md` — provenance shape.
+- `../stardust/reference/artifact-map.md` — provenance shape.
 - impeccable's `reference/craft.md` and `reference/live.md` — the
   underlying impeccable commands stardust delegates to.


### PR DESCRIPTION
## Summary

Closes three low-risk Tessl skill-review orphan warnings from the 0.10.0 PR. No behavior changes — additive references and path corrections.

## What changes

- **`distill/SKILL.md`** — added a `## References` section. distill was the only skill without one, leaving its two reference files (`samples-brief-format.md`, `trait-matrix-schema.md`) discoverable only by directory inspection.
- **`prototype/SKILL.md` References** — added the four cinematic motion docs that shipped in 0.9.0 but weren't listed alongside `motion-validation.md`: `motion-registers.md`, `motion-stack.md`, `motion-attributes.md`, `motion-runtime.md`.
- **`prototype/SKILL.md` References** — switched cross-skill paths from `skills/stardust/reference/X.md` (absolute-style, Tessl can't resolve) to `../stardust/reference/X.md` (the convention already used by `stardust/SKILL.md` and `uplift/SKILL.md`). Affects 7 entries.

## Out of scope (intentionally)

The Tessl review flagged 44 orphaned files; this PR addresses 3 specific gaps. The remaining ~40 orphans appear to stem from how Tessl traces markdown links — inline mentions like `` `reference/X.md` `` in prose don't count, only explicit markdown link syntax does. A blanket reformat across 7 SKILL.md files is deferred to a separate discoverability PR to avoid mechanical-edit risk.

Also out of scope:
- Files outside spec dirs (`fixtures/`, `palettes/`) — moving them risks breaking script references.
- SKILL.md token-cap warnings on `direct` (17.7k) and `prototype` (16k) — content surgery on critical skills.

## Test plan

- [ ] CI passes (especially Tessl review).
- [ ] Confirm `distill` is no longer flagged as "no References section".
- [ ] Confirm `prototype/SKILL.md`'s cross-skill links resolve to `../stardust/reference/*.md` files that exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)