### PR TITLE
fix(stardust): fix opening prototyped pages from SLICC browser plugin

### DIFF
--- a/plugins/stardust/skills/prototype/SKILL.md
+++ b/plugins/stardust/skills/prototype/SKILL.md
@@ -1042,9 +1042,7 @@ Cross-references throughout the docs still name Phases 4, 5, 5.5.)
    the `open <vfs-path>` shell command. This routes VFS paths through
    the preview service worker — **do not use `playwright-cli open`**
    for local prototype files, as it bypasses the preview service worker
-   and produces a FILE NOT FOUND error. If multiple files were written
-   in one run, open the primary variant only. Skip in
-   pipeline-automation mode.
+   and produces a FILE NOT FOUND error. Skip in pipeline-automation mode.
 2. Mark the page `prototyped` in `state.json` — **gated on the
    Phase 2.5 critique + Phase 2.6 audit + Phase 2.7 adapt +
    Phase 2.8 motion validation (when fired) result** (Discipline 9).

--- a/plugins/stardust/skills/prototype/SKILL.md
+++ b/plugins/stardust/skills/prototype/SKILL.md
@@ -1038,10 +1038,13 @@ Single-variant runs (N = 1) skip Discipline 10 entirely.
 Cross-references throughout the docs still name Phases 4, 5, 5.5.)
 
 1. Open the just-written or just-updated `<slug>-proposed.html` (or
-   the user-chosen variant suffix when N > 1) in the default
-   browser (`open` macOS, `xdg-open` Linux, `start ""` Windows). If
-   multiple files were written in one run, open the primary variant
-   only. Skip in pipeline-automation mode.
+   the user-chosen variant suffix when N > 1) in the browser using
+   the `open <vfs-path>` shell command. This routes VFS paths through
+   the preview service worker — **do not use `playwright-cli open`**
+   for local prototype files, as it bypasses the preview service worker
+   and produces a FILE NOT FOUND error. If multiple files were written
+   in one run, open the primary variant only. Skip in
+   pipeline-automation mode.
 2. Mark the page `prototyped` in `state.json` — **gated on the
    Phase 2.5 critique + Phase 2.6 audit + Phase 2.7 adapt +
    Phase 2.8 motion validation (when fired) result** (Discipline 9).

--- a/plugins/stardust/skills/uplift/SKILL.md
+++ b/plugins/stardust/skills/uplift/SKILL.md
@@ -311,8 +311,17 @@ Multi-variant rendering is driven by the presence of multiple
 
 After all three prototypes mark `prototyped` in `state.json`:
 
-1. **Open all three in the browser** (`open <slug>-A-proposed.html
-   <slug>-B-proposed.html <slug>-C-cinematic.html`).
+1. **Open all three in the browser** using the `open` shell command (not
+   `playwright-cli open`) so VFS paths are served via the preview service
+   worker:
+   ```
+   open stardust/prototypes/<slug>-A-proposed.html
+   open stardust/prototypes/<slug>-B-proposed.html
+   open stardust/prototypes/<slug>-C-cinematic.html
+   ```
+   `playwright-cli open` bypasses the preview service worker and produces
+   a FILE NOT FOUND error for VFS paths. Always use `open <vfs-path>` for
+   local prototype files.
 2. **Print the three-pitch summary** in the chat:
 
    ```


### PR DESCRIPTION
## Description

Use `open <vfs-path>`, not `playwright-cli open`, for prototype previews.

VFS-backed prototype files must be opened with the `open` shell command so the preview service worker resolves the path. `playwright-cli open` bypasses the worker and yields FILE NOT FOUND. Update prototype and uplift SKILL.md to spell this out.

## Motivation and Context

Opening a newly generated stardust page from the SLICC browser plugin doesn't work.

## How Has This Been Tested?

Using SLICC.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
