### PR TITLE
feat(stardust): four-scope CSS organization for mechanical block extraction

### DIFF
--- a/plugins/stardust/evals/README.md
+++ b/plugins/stardust/evals/README.md
@@ -36,6 +36,10 @@ v2 evals without modification.
 | `migrate-multi-template/`    | Phase 4 (`migrate`)       | Three render branches (Path A / A′ / B) + canon + modules + bespoke-slot promotion + broken-link reporting + color-reservation refusal. |
 | `migrate-self-contained-bundle/` | Phase 4 (`migrate`)   | Self-contained zip-and-deploy bundle — six asset detection shapes, nine edge cases, six acceptance criteria, state.json `migrate` block with `selfContained: true`. |
 | `intent-reasoning-style/`    | Master skill principle    | "Open and reasoned" — vague phrases get clarified, never silently mapped to commands. Pending direction persisted.          |
+| `css-four-scope-global/`     | Phase 2 (`prototype`)     | Discipline 11 GLOBAL scope — marker comments for tokens / resets / default-content / compound utility / motion; unscoped-class refusal path.       |
+| `css-four-scope-section/`    | Phase 2 (`prototype`)     | Discipline 11 SECTION scope — marker names matching data-section, token override + default-content override grouping, cascade, orphan refusal.    |
+| `css-four-scope-block/`      | Phase 2 (`prototype`)     | Discipline 11 BLOCK scope — data-module + data-template fold into BLOCK, internals don't bleed to default-content, dead-block refusal.            |
+| `css-four-scope-default-content/` | Phase 2 (`prototype`)| Discipline 11 default-content scope — direct-child combinator load-bearing, canonical element set, isolation from block internals.                 |
 
 ## Coverage map
 
@@ -45,6 +49,7 @@ v2 evals without modification.
 | Layer 2 — navigator orchestrator (4 phases)  | `extract-multipage`, `direct-from-phrase`, `prototype-before-after`, `migrate-incremental` |
 | Layer 3 — migration tooling (per-page, incremental, idempotent) | `migrate-incremental`, `migrate-multi-template`                |
 | Layer 3 — migrate output contract (self-contained bundle)   | `migrate-self-contained-bundle`                                 |
+| Layer 3 — four-scope CSS extraction contract (Discipline 11) | `css-four-scope-global`, `css-four-scope-section`, `css-four-scope-block`, `css-four-scope-default-content` |
 
 The cross-cutting properties are pinned across multiple evals:
 

--- a/plugins/stardust/evals/README.md
+++ b/plugins/stardust/evals/README.md
@@ -36,10 +36,10 @@ v2 evals without modification.
 | `migrate-multi-template/`    | Phase 4 (`migrate`)       | Three render branches (Path A / A′ / B) + canon + modules + bespoke-slot promotion + broken-link reporting + color-reservation refusal. |
 | `migrate-self-contained-bundle/` | Phase 4 (`migrate`)   | Self-contained zip-and-deploy bundle — six asset detection shapes, nine edge cases, six acceptance criteria, state.json `migrate` block with `selfContained: true`. |
 | `intent-reasoning-style/`    | Master skill principle    | "Open and reasoned" — vague phrases get clarified, never silently mapped to commands. Pending direction persisted.          |
-| `css-four-scope-global/`     | Phase 2 (`prototype`)     | Discipline 11 GLOBAL scope — marker comments for tokens / resets / default-content / compound utility / motion; unscoped-class refusal path.       |
-| `css-four-scope-section/`    | Phase 2 (`prototype`)     | Discipline 11 SECTION scope — marker names matching data-section, token override + default-content override grouping, cascade, orphan refusal.    |
-| `css-four-scope-block/`      | Phase 2 (`prototype`)     | Discipline 11 BLOCK scope — data-module + data-template fold into BLOCK, internals don't bleed to default-content, dead-block refusal.            |
-| `css-four-scope-default-content/` | Phase 2 (`prototype`)| Discipline 11 default-content scope — direct-child combinator load-bearing, canonical element set, isolation from block internals.                 |
+| `css-four-scope-global/`     | Phase 3 (`prototype`)     | Discipline 11 GLOBAL scope — marker comments for tokens / resets / default-content / compound utility / motion; unscoped-class refusal path.       |
+| `css-four-scope-section/`    | Phase 3 (`prototype`)     | Discipline 11 SECTION scope — marker names matching data-section, token override + default-content override grouping, cascade, orphan refusal.    |
+| `css-four-scope-block/`      | Phase 3 (`prototype`)     | Discipline 11 BLOCK scope — data-module + data-template fold into BLOCK, internals don't bleed to default-content, dead-block refusal.            |
+| `css-four-scope-default-content/` | Phase 3 (`prototype`)| Discipline 11 default-content scope — direct-child combinator load-bearing, canonical element set, isolation from block internals.                 |
 
 ## Coverage map
 

--- a/plugins/stardust/evals/css-four-scope-block/criteria.json
+++ b/plugins/stardust/evals/css-four-scope-block/criteria.json
@@ -1,0 +1,15 @@
+{
+  "name": "css-four-scope-block",
+  "total": 100,
+  "criteria": [
+    { "id": "activated",              "weight": 5,  "description": "The stardust:prototype skill was invoked and Discipline 11 was applied at craft time." },
+    { "id": "marker_block_named",     "weight": 15, "description": "Every BLOCK marker carries a name matching a data-module or data-template attribute value present in the DOM. Format: /* === BLOCK: <name> === */." },
+    { "id": "data_module_in_block",   "weight": 10, "description": "[data-module=\"X\"] selectors and their descendants live under the matching BLOCK: X marker." },
+    { "id": "data_template_in_block", "weight": 15, "description": "[data-template=\"Y\"] selectors and their descendants live under a BLOCK: Y marker (page-template scope folds into BLOCK; no separate TEMPLATE marker introduced)." },
+    { "id": "block_internals_classify_as_block","weight":10, "description": "Element selectors deep-descended inside [data-module=\"X\"] (e.g., [data-module=\"X\"] h2, [data-module=\"X\"] [data-slot=\"phone\"]) classify as BLOCK, not default-content. The direct-child combinator does not protect block internals." },
+    { "id": "refuses_dead_block",     "weight": 20, "description": "Given a BLOCK marker whose name has no matching data-module or data-template in the DOM, the validator refuses the write with a structured message naming the unmatched block, the nearest Levenshtein match, and cross-link to Discipline 11." },
+    { "id": "no_block_leak",          "weight": 15, "description": "No [data-module] or [data-template] selector appears under a GLOBAL or SECTION marker; conversely, no SECTION or GLOBAL selectors appear under a BLOCK marker." },
+    { "id": "extraction_mechanical",  "weight": 5,  "description": "The rendered file's block-grouped rules are extractable to blocks/<name>/<name>.css by marker comment alone, with no LLM judgment per rule — confirmed by running the pseudocode extraction in Discipline 11's downstream section against the rendered file." },
+    { "id": "no_eds_references",      "weight": 5,  "description": "No mention of EDS, AEM, localhost:3000, dev servers, or framework targets in outputs or narration." }
+  ]
+}

--- a/plugins/stardust/evals/css-four-scope-block/task.md
+++ b/plugins/stardust/evals/css-four-scope-block/task.md
@@ -1,0 +1,38 @@
+# Eval: four-scope CSS — BLOCK classification
+
+## Setup
+
+Stardust v0.10.0+ with Discipline 11 in `prototype/SKILL.md`.
+A captured site with at least two `data-module` instances in the DOM
+(e.g., `hotline-211` and `donate-band`) and one `data-template`
+instance at the page root (e.g., `data-template="article"`).
+
+## User prompt
+
+"Render a prototype for the home page. Include the 211 hotline
+module and the donate-band module; the page uses the article
+template."
+
+## Expected behavior
+
+The `stardust:prototype` skill is invoked. Phase 2 craft produces a
+proposed file whose first `<style>` block:
+
+1. Carries a `/* === BLOCK: hotline-211 === */` marker before any
+   `[data-module="hotline-211"] { ... }` rule, with the marker's
+   name matching the DOM's `data-module` value.
+2. Carries a separate `/* === BLOCK: donate-band === */` group with
+   its own selectors.
+3. Carries a `/* === BLOCK: article === */` group for the
+   `data-template="article"` rules (page-template scope folds into
+   BLOCK per Discipline 11 — no separate TEMPLATE scope).
+4. Block-internal default-content selectors (e.g.,
+   `[data-module="hotline-211"] h2`) classify as BLOCK, not
+   default-content (the direct-child combinator does not protect
+   them — by design, blocks own their internals).
+5. Refuses to write when a BLOCK marker's name has no matching
+   `data-module` or `data-template` value in the DOM (dead-block /
+   typo detection); the refusal names the unmatched block, the
+   nearest match by Levenshtein, and points to Discipline 11.
+6. No `data-module` or `data-template` selectors leak into SECTION
+   or GLOBAL groups.

--- a/plugins/stardust/evals/css-four-scope-default-content/criteria.json
+++ b/plugins/stardust/evals/css-four-scope-default-content/criteria.json
@@ -1,0 +1,15 @@
+{
+  "name": "css-four-scope-default-content",
+  "total": 100,
+  "criteria": [
+    { "id": "activated",              "weight": 5,  "description": "The stardust:prototype skill was invoked and Discipline 11 was applied at craft time." },
+    { "id": "direct_child_combinator","weight": 15, "description": "All rules under /* === GLOBAL: default-content === */ use the direct-child combinator (section > <el>). The combinator is load-bearing per Discipline 11." },
+    { "id": "canonical_element_set",  "weight": 10, "description": "Default-content selectors target only the canonical element set: h1-h6, p, ul, ol, li, img, picture, figure, figcaption, a, blockquote, hr. Other elements (div, span, custom tags) refuse." },
+    { "id": "section_override_grouping","weight":15, "description": "Per-section default-content overrides (section[data-section=\"X\"] > <el>) live inside the matching SECTION group, NOT under GLOBAL: default-content." },
+    { "id": "isolation_verified",     "weight": 15, "description": "Block internals (e.g., [data-module=\"team-roster\"] h2) are NOT styled by section > h2 — the direct-child combinator stops at the section's direct children. Verified by render or computed-style inspection." },
+    { "id": "refuses_descendant_combinator","weight":20, "description": "Given an element selector under GLOBAL: default-content that uses the descendant combinator instead of direct-child (e.g., section p { ... }), the validator refuses with a message naming the selector, suggesting section > p, and cross-linking Discipline 11." },
+    { "id": "cascade_token_pickup",   "weight": 10, "description": "When a section redefines a token (e.g., --heading-xxl), the section's default-content elements pick up the redefined value via cascade — verified by render or computed style." },
+    { "id": "no_block_leak_to_default","weight": 5, "description": "No selector starting with [data-module] or [data-template] appears under GLOBAL: default-content." },
+    { "id": "no_eds_references",      "weight": 5,  "description": "No mention of EDS, AEM, localhost:3000, dev servers, or framework targets in outputs or narration." }
+  ]
+}

--- a/plugins/stardust/evals/css-four-scope-default-content/task.md
+++ b/plugins/stardust/evals/css-four-scope-default-content/task.md
@@ -1,0 +1,45 @@
+# Eval: four-scope CSS — default-content classification
+
+## Setup
+
+Stardust v0.10.0+ with Discipline 11 in `prototype/SKILL.md`.
+A captured site with at least one section that mixes default prose
+(direct-child `h2` + `p`) and a `[data-module]` whose internals
+include an `h2` (so we can verify the direct-child combinator
+isolates default-content rules from block internals).
+
+## User prompt
+
+"Render a prototype where the about section has a default heading
+and paragraph, and a 'team-roster' module with a heading inside."
+
+## Expected behavior
+
+The `stardust:prototype` skill is invoked. Phase 2 craft produces a
+proposed file whose first `<style>` block:
+
+1. Carries an `/* === GLOBAL: default-content === */` marker before
+   the site-wide default-content rules.
+2. Default-content rules use the direct-child combinator (`>`):
+   `section > h1`, `section > p`, `section > ul`, etc. Element
+   selectors WITHOUT the combinator (e.g., `section h1`, plain `h1`)
+   either refuse the write or are explicitly allowed only under
+   GLOBAL: resets.
+3. Per-section default-content overrides
+   (`section[data-section="about"] > h2 { ... }`) live inside the
+   matching SECTION group, not under GLOBAL: default-content.
+4. Rendering verifies isolation: the team-roster module's `h2`
+   inside `[data-module="team-roster"]` is NOT styled by
+   `section > h2` (the direct-child combinator stops at the
+   section's direct children). Block authors style the team-roster
+   `h2` under their own BLOCK: team-roster group.
+5. Refuses to write when an element selector under
+   GLOBAL: default-content lacks the direct-child combinator (e.g.,
+   `section p { ... }` with descendant combinator instead of
+   `section > p`), naming the offending selector and the
+   remediation.
+6. Default-content selectors are restricted to the canonical
+   element set: h1–h6, p, ul, ol, li, img, picture, figure,
+   figcaption, a, blockquote, hr. Other elements (div, span, custom
+   tags) refuse under GLOBAL: default-content (they belong in BLOCK
+   or as a section-internal rule).

--- a/plugins/stardust/evals/css-four-scope-global/criteria.json
+++ b/plugins/stardust/evals/css-four-scope-global/criteria.json
@@ -1,0 +1,15 @@
+{
+  "name": "css-four-scope-global",
+  "total": 100,
+  "criteria": [
+    { "id": "activated",              "weight": 5,  "description": "The stardust:prototype skill was invoked and Discipline 11 was applied at craft time." },
+    { "id": "marker_tokens",          "weight": 15, "description": "The proposed file's <style> block opens with /* === GLOBAL: tokens === */ immediately preceding the :root declaration." },
+    { "id": "marker_resets",          "weight": 10, "description": "An /* === GLOBAL: resets === */ marker precedes the html/body/main element selectors." },
+    { "id": "marker_default_content", "weight": 15, "description": "An /* === GLOBAL: default-content === */ marker precedes the section > <el> default-content rules; all default-content rules use the direct-child combinator." },
+    { "id": "marker_compound_utility","weight": 10, "description": "When canon.css applies, an /* === GLOBAL: compound utility === */ marker precedes canon.css classes (.btn-primary, .card, .link, form inputs)." },
+    { "id": "marker_motion",          "weight": 10, "description": "When cinematic motion applies, an /* === GLOBAL: motion === */ marker precedes @keyframes definitions; motion tokens land under GLOBAL: tokens (no fifth scope introduced)." },
+    { "id": "refuses_unscoped_class", "weight": 20, "description": "Given a page-specific class selector with no scoping prefix (e.g., .headline { ... } not under GLOBAL: compound utility), the validator refuses the write with a structured message naming the selector, line number, and cross-link to Discipline 11." },
+    { "id": "refusal_message_shape",  "weight": 10, "description": "The refusal message offers the four remediation options (compound utility / section-scoped / block-scoped / default-content) verbatim per the Discipline 11 spec." },
+    { "id": "no_eds_references",      "weight": 5,  "description": "No mention of EDS, AEM, localhost:3000, dev servers, or framework targets in outputs or narration." }
+  ]
+}

--- a/plugins/stardust/evals/css-four-scope-global/task.md
+++ b/plugins/stardust/evals/css-four-scope-global/task.md
@@ -1,0 +1,40 @@
+# Eval: four-scope CSS — GLOBAL classification
+
+## Setup
+
+Stardust v0.10.0+ with Discipline 11 in `prototype/SKILL.md`.
+A captured site with a single page, ready for `$stardust prototype`.
+DESIGN.md tokens cover the standard set (color, type, spacing).
+
+## User prompt
+
+"Render a prototype for the home page."
+
+## Expected behavior
+
+The `stardust:prototype` skill is invoked. Phase 2 craft produces a
+proposed file whose first `<style>` block:
+
+1. Opens with the `/* === GLOBAL: tokens === */` marker preceding
+   the `:root` block.
+2. Carries a `/* === GLOBAL: resets === */` marker preceding any
+   `html`, `body`, `main` selectors.
+3. Carries a `/* === GLOBAL: default-content === */` marker preceding
+   the section-direct-child selectors (`section > h1`, `section > p`,
+   etc.).
+4. (When canon.css applies) carries a
+   `/* === GLOBAL: compound utility === */` marker preceding
+   canon.css classes (`.btn-primary`, `.card`, `.link`).
+5. (When cinematic motion applies) carries a
+   `/* === GLOBAL: motion === */` marker preceding any `@keyframes`
+   definitions.
+6. Refuses to write the file when a class selector (e.g.,
+   `.headline`) is present without one of:
+   - placement under a `GLOBAL: compound utility` marker (canon.css
+     class lifted because used across templates), OR
+   - section-scoping prefix (`section[data-section="X"] .headline`),
+     OR
+   - block-scoping prefix (`[data-module="Y"] .headline`).
+
+The refusal message names the unscoped selector, its line number,
+and points to `skills/prototype/SKILL.md § Discipline 11`.

--- a/plugins/stardust/evals/css-four-scope-section/criteria.json
+++ b/plugins/stardust/evals/css-four-scope-section/criteria.json
@@ -1,0 +1,14 @@
+{
+  "name": "css-four-scope-section",
+  "total": 100,
+  "criteria": [
+    { "id": "activated",              "weight": 5,  "description": "The stardust:prototype skill was invoked and Discipline 11 was applied at craft time." },
+    { "id": "marker_section_named",   "weight": 15, "description": "Every SECTION marker carries a name matching a data-section attribute value present in the DOM. Format: /* === SECTION: <name> === */." },
+    { "id": "section_token_overrides","weight": 15, "description": "Per-section token redefinitions live inside their matching SECTION group, not under GLOBAL: tokens. Each section's tokens are contiguous." },
+    { "id": "section_default_override","weight": 15, "description": "Per-section default-content overrides (section[data-section=\"X\"] > <el>) live inside the same SECTION group as the token redefinitions for that section." },
+    { "id": "cascade_works",          "weight": 15, "description": "The section's default-content elements resolve token values against the section's lifted redefinitions (cascade verified by render — e.g., hero h1 picks up section[data-section=\"hero\"]'s --heading-xxl)." },
+    { "id": "refuses_orphan_section", "weight": 20, "description": "Given a SECTION marker whose name does not match any data-section in the DOM, the validator refuses the write with a structured message naming the unmatched section, the nearest Levenshtein match, and cross-link to Discipline 11." },
+    { "id": "no_section_leak_to_block","weight":10, "description": "No SECTION-scoped rule selector starts with [data-module] or [data-template] (those classify as BLOCK, not SECTION)." },
+    { "id": "no_eds_references",      "weight": 5,  "description": "No mention of EDS, AEM, localhost:3000, dev servers, or framework targets in outputs or narration." }
+  ]
+}

--- a/plugins/stardust/evals/css-four-scope-section/task.md
+++ b/plugins/stardust/evals/css-four-scope-section/task.md
@@ -1,0 +1,36 @@
+# Eval: four-scope CSS — SECTION classification
+
+## Setup
+
+Stardust v0.10.0+ with Discipline 11 in `prototype/SKILL.md`.
+A captured site with at least two sections needing token redefinition
+— typically a hero with a brand-accent background plus a features
+section with a different palette.
+
+## User prompt
+
+"Render a prototype for the home page; hero section uses the accent
+palette, features section uses the neutral palette."
+
+## Expected behavior
+
+The `stardust:prototype` skill is invoked. Phase 2 craft produces a
+proposed file whose first `<style>` block:
+
+1. Carries a `/* === SECTION: hero === */` marker before any
+   `section[data-section="hero"] { ... }` rule, with the marker's
+   name (`hero`) matching the DOM's `data-section` attribute.
+2. Places per-section token redefinition (e.g., `--color-bg`,
+   `--heading-xxl`) inside the SECTION group.
+3. Places per-section default-content overrides
+   (`section[data-section="hero"] > h1 { ... }`) inside the same
+   SECTION group (still classifies as section scope per Discipline
+   11; the > selector is allowed at section depth).
+4. Carries a separate `/* === SECTION: features === */` group with
+   the features section's token redefinitions.
+5. Cascade works: the hero's `h1` resolves `var(--heading-xxl)`
+   against the hero section's lifted value, not the global default.
+6. Refuses to write when a section-scoped rule's SECTION marker
+   doesn't match the DOM's `data-section` value (typo / orphaned
+   section detection); the refusal names the unmatched section name
+   and the nearest match by Levenshtein distance.

--- a/plugins/stardust/skills/prototype/SKILL.md
+++ b/plugins/stardust/skills/prototype/SKILL.md
@@ -402,10 +402,11 @@ the user with the specific rule violated and a suggested fix.
 
 #### Craft-time disciplines (pre-write validators)
 
-Three disciplines fire on the rendered file *before* it lands on
+Four disciplines fire on the rendered file *before* it lands on
 disk. These run after craft returns its output and before the file
 is written; failure refuses the write with a substitute proposal
-(Discipline 6) or a rule citation (7, 8).
+(Discipline 6), a rule citation (7, 8), or a structured
+classification refusal (11).
 
 **Discipline 6 — Reflex-reject font pre-flight.** Grep the
 declared `font-family` declarations against the reject list in
@@ -520,6 +521,15 @@ The four scopes:
   headings inside the module subtree without colliding with
   defaults.
 
+Scope-to-marker-prefix mapping: `global` → `GLOBAL` (with one of
+the GLOBAL sub-names below); `section` → `SECTION: <data-section
+value>`; `block` → `BLOCK: <data-module or data-template value>`;
+`default-content` → `GLOBAL: default-content` when site-global,
+otherwise nested inside `SECTION: <name>` alongside its section's
+token overrides. Media queries fold into their owning scope's
+group, OR stand alone as `MEDIA: <breakpoint>` when site-global —
+`MEDIA` is a marker prefix, not a scope.
+
 Inheritance falls out of the cascade for free: a default-content
 rule reads custom properties resolved against the surrounding
 section's redefinition. No engineered machinery is required.
@@ -542,13 +552,14 @@ and `<name>`:
   block-specific media queries live inside their owning group; a
   site-global media block lives between groups.
 
-The validator regex over the `<style>` text:
+The validator regex over the `<style>` text, matched per line:
 
-    /\* === (GLOBAL|SECTION|BLOCK|MEDIA): ([^=]+) === \*/
+    /\* === (GLOBAL|SECTION|BLOCK|MEDIA): ([^=\n]+) === \*/
 
 Each rule is matched against its preceding marker; rules without a
 preceding marker, or with a selector that does not match the
-marker's scope, refuse the write.
+marker's scope, refuse the write. Markers whose `<name>` contains
+`=` or a newline refuse on grounds of malformed marker.
 
 Refusal message format:
 
@@ -571,7 +582,7 @@ detection): the offending selector and the suggested module name
 (nearest match by Levenshtein) appear in the refusal message.
 
 **Motion CSS classifies into the four scopes (no fifth scope).** When
-`--cinematic` is engaged (per Phase 2.4 of Discipline 9), motion CSS
+`--cinematic` is engaged (per Phase 2.4 — motion application), motion CSS
 still follows the four-scope rule:
 
 - Motion tokens (`--motion-duration-*`, `--motion-easing-*`) live in

--- a/plugins/stardust/skills/prototype/SKILL.md
+++ b/plugins/stardust/skills/prototype/SKILL.md
@@ -485,6 +485,120 @@ expressive position.
 The tier is declared in the run invocation; persisted in
 `_provenance.fidelity`. Default is `quick`.
 
+**Discipline 11 — Four-scope CSS organization.** Every rule in the
+proposed file's `<style>` block (including canon.css contents injected
+at migrate time) classifies into exactly one of four scopes, grouped
+contiguously, preceded by a machine-parseable marker comment. The
+discipline makes downstream block extraction mechanical instead of
+LLM-driven: a converter can split rules to `styles/styles.css` and
+`blocks/<name>/<name>.css` by reading marker comments, without
+LLM judgment per rule.
+
+The four scopes:
+
+- **`global`** — `:root` declarations; `html` / `body` / `main`
+  element selectors; class selectors not preceded by a
+  `[data-section]` / `[data-module]` / `[data-template]` attribute
+  selector. canon.css classes (`.btn-primary`, `.card`, `.link`,
+  form inputs) and `@keyframes` definitions also land here.
+- **`section`** — selector starts with `section[data-section="X"]`
+  (or `[data-section="X"]`). Descendants of the section selector
+  still classify as `section`. Typical use: token redefinition that
+  cascades to default-content within the section.
+- **`block`** — selector starts with `[data-module="X"]` or
+  `[data-template="X"]`. Both fold into BLOCK because both extract
+  1:1 to a downstream block file. Descendants of the module/template
+  selector classify as `block`.
+- **`default-content`** — direct-child selectors of the form
+  `section > <el>` or `section[data-section="X"] > <el>` where
+  `<el>` is one of: `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `p`, `ul`,
+  `ol`, `li`, `img`, `picture`, `figure`, `figcaption`, `a`,
+  `blockquote`, `hr`. The direct-child combinator (`>`) is
+  load-bearing: it isolates default-content rules from block
+  internals (`section > h1` does NOT match an `h1` deep-descended
+  inside a `[data-module]`). Block authors style their own
+  headings inside the module subtree without colliding with
+  defaults.
+
+Inheritance falls out of the cascade for free: a default-content
+rule reads custom properties resolved against the surrounding
+section's redefinition. No engineered machinery is required.
+
+Marker comments are mandatory and machine-parseable. Format:
+
+    /* === <SCOPE>: <name|kind> === */
+
+Where `<SCOPE>` is one of `GLOBAL` / `SECTION` / `BLOCK` / `MEDIA`
+and `<name>`:
+
+- `GLOBAL`: one of `tokens` / `resets` / `default-content` /
+  `motion` (`@keyframes` definitions) / `compound utility` (the
+  canon.css block injected at migrate time) / `section-defaults`
+  (the escape hatch for rules that span sections).
+- `SECTION`: matches the `data-section` attribute value.
+- `BLOCK`: matches the `data-module` or `data-template` attribute
+  value.
+- `MEDIA`: describes the breakpoint, e.g. `≤ 640px`. Section- or
+  block-specific media queries live inside their owning group; a
+  site-global media block lives between groups.
+
+The validator regex over the `<style>` text:
+
+    /\* === (GLOBAL|SECTION|BLOCK|MEDIA): ([^=]+) === \*/
+
+Each rule is matched against its preceding marker; rules without a
+preceding marker, or with a selector that does not match the
+marker's scope, refuse the write.
+
+Refusal message format:
+
+    unscoped CSS rule: `<selector> { ... }` at line N
+
+    A page-specific rule must be one of:
+      - canon.css class (lifted because used across templates), OR
+      - section-scoped (`section[data-section="X"] .foo`), OR
+      - block-scoped (`[data-module="Y"] .foo`), OR
+      - default-content (`section > h1` if it's a default heading
+        style).
+
+    Pick one and re-render. See
+      skills/prototype/reference/proposed-file-shell.md § Four-scope CSS
+      skills/stardust/reference/data-attributes.md § Why
+
+Block rules whose `data-module` / `data-template` value has no
+matching element in the rendered DOM also refuse (typo / dead-block
+detection): the offending selector and the suggested module name
+(nearest match by Levenshtein) appear in the refusal message.
+
+**Motion CSS classifies into the four scopes (no fifth scope).** When
+`--cinematic` is engaged (per Phase 2.4 of Discipline 9), motion CSS
+still follows the four-scope rule:
+
+- Motion tokens (`--motion-duration-*`, `--motion-easing-*`) live in
+  the `:root` block under `GLOBAL: tokens`.
+- `@keyframes` definitions live under `GLOBAL: motion`.
+- Section-scoped motion (a section that animates its background on
+  enter) lives under its `SECTION: <name>` group.
+- Block-scoped motion (a hover transform on a card) lives under its
+  `BLOCK: <name>` group.
+- The cinematic prototype file (`<slug>-cinematic.html`) carries the
+  same four-scope organization as the static prototype.
+
+The motion subsystem inherits the same downstream contract; no new
+extraction logic is required for cinematic pages.
+
+**Site-global escape hatch.** Rules that legitimately span scopes
+(e.g., `section { padding: var(--section-padding); }` applies to
+every section in the page) live in `GLOBAL: resets` or a dedicated
+`GLOBAL: section-defaults` group. The escape hatch keeps the
+discipline from forcing absurd duplication; the downstream converter
+treats `section-defaults` as global default rules in styles.css.
+
+**Grandfathering.** Discipline 11 fires at craft time. Existing
+prototypes that pass current critique + audit + adapt remain valid
+until re-craft. The discipline applies to new craft output; old
+output is not retroactively invalidated.
+
 ### Phase 2.4 — Motion application (when `--cinematic`)
 
 Fires only when `--cinematic` (with or without an explicit

--- a/plugins/stardust/skills/prototype/reference/canon-extraction.md
+++ b/plugins/stardust/skills/prototype/reference/canon-extraction.md
@@ -85,6 +85,17 @@ and is unlikely to recur (e.g., `.home-hero-asymmetric-grid`)
 stays in the prototype's inline styles. A class that's clearly
 the site's button language is lifted.
 
+**Naming alignment with the four-scope CSS organization.** The
+canon.css output is the **`GLOBAL: compound utility`** group of
+the four-scope organization per
+`skills/prototype/SKILL.md` § Discipline 11. The Selection rule
+above is unchanged; the relabeling is cosmetic — it lets the
+downstream converter recognize canon.css rules by the same marker
+comment grammar that classifies every other rule in the prototype's
+`<style>` block. canon.css authoring rules continue to govern
+*which* compound utilities land here; Discipline 11 governs *how*
+they appear in the `<style>` block.
+
 ### 3. Pinned tokens — JSON in DESIGN.json
 
 DESIGN.md tokens may be ranges or have a default-with-corridor

--- a/plugins/stardust/skills/prototype/reference/proposed-file-shell.md
+++ b/plugins/stardust/skills/prototype/reference/proposed-file-shell.md
@@ -25,10 +25,30 @@ tabs (the captured screenshot at
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title><!-- page title from current/pages/<slug>.json --></title>
   <style>
+    /* === GLOBAL: tokens === */
     /* The :root token contract — see skills/stardust/reference/token-contract.md */
     :root { ... }
-    /* component-level styles, derived from DESIGN.json components */
-    /* ... */
+
+    /* === GLOBAL: resets === */
+    html, body, main { ... }
+
+    /* === GLOBAL: default-content === */
+    section > h1, section > h2, section > h3, section > h4, section > h5, section > h6 { ... }
+    section > p, section > ul, section > ol, section > li { ... }
+    section > a, section > img, section > picture, section > blockquote { ... }
+
+    /* canon.css injected here at migrate time — === GLOBAL: compound utility === */
+    .btn-primary { ... } .card { ... } .link { ... }
+
+    /* === SECTION: hero === */
+    section[data-section="hero"] { ... }       /* token redefinition */
+    section[data-section="hero"] > h1 { ... }  /* per-section default-content override */
+
+    /* === BLOCK: hotline-211 === */
+    [data-module="hotline-211"] { ... }
+    [data-module="hotline-211"] [data-slot="phone"] { ... }
+
+    /* See skills/prototype/SKILL.md § Discipline 11 — Four-scope CSS organization */
   </style>
 </head>
 <body>
@@ -110,6 +130,18 @@ The proposed file must satisfy:
    contract — including how to handle content the new design
    *demands* but the page *does not provide* (stat rows, addresses,
    testimonial quotes, etc.).
+
+8. **Four-scope CSS organization.** Every rule in the file's
+   first `<style>` block classifies into one of four scopes —
+   `global`, `section`, `block`, or `default-content` — grouped
+   contiguously and preceded by a marker comment of the form
+   `/* === <SCOPE>: <name> === */`. The discipline is the
+   downstream-extraction contract: a future EDS converter splits
+   rules to `styles/styles.css` and `blocks/<name>/<name>.css`
+   by reading these markers without LLM judgment per rule. Full
+   classification rules, refusal messages, motion CSS guidance,
+   and the site-global escape hatch live in
+   `skills/prototype/SKILL.md` § Discipline 11.
 
 ## Content sourcing hierarchy
 

--- a/plugins/stardust/skills/stardust/reference/data-attributes.md
+++ b/plugins/stardust/skills/stardust/reference/data-attributes.md
@@ -25,7 +25,26 @@ Three reasons:
 3. **Downstream consumers.** A future `aem-eds-from-stardust` skill
    (out of scope here) will map sections to EDS blocks. The data
    attributes are the contract that lets a separate plugin ingest
-   stardust's output without re-parsing semantics.
+   stardust's output without re-parsing semantics. Specifically:
+
+   - **`data-module`** is the **block primitive** — each
+     `data-module="X"` in the DOM corresponds 1:1 to a downstream
+     EDS block file `blocks/X/X.css`.
+   - **`data-template`** maps to a page template; for downstream
+     CSS extraction it folds into the same BLOCK scope as
+     `data-module` (per
+     `skills/prototype/SKILL.md` § Discipline 11).
+   - **`data-section`** scopes per-section token overrides that
+     cascade to default-content within the section.
+   - Section descendants of the form `section > <el>` (where
+     `<el>` is `h1`–`h6`, `p`, `ul`, `ol`, `li`, `img`, `picture`,
+     `figure`, `figcaption`, `a`, `blockquote`, `hr`) are the
+     **default-content selector pattern** — these CSS rules live
+     in `styles/styles.css` and provide un-blocked-prose styling
+     inside sections.
+
+   See `skills/prototype/SKILL.md` § Discipline 11 for the full
+   four-scope CSS organization that makes EDS extraction mechanical.
 
 ## Where they go
 

--- a/plugins/stardust/skills/stardust/reference/migrate-output-format.md
+++ b/plugins/stardust/skills/stardust/reference/migrate-output-format.md
@@ -109,6 +109,31 @@ contexts without rewriting at deploy time**:
 The contract is **one shape, works everywhere**. There is no
 alternative mode.
 
+## Four-scope CSS organization
+
+The migrated page's first `<style>` block follows the four-scope
+organization per `skills/prototype/SKILL.md` § Discipline 11. Every
+rule is grouped under a `/* === <SCOPE>: <name> === */` marker
+comment, where `<SCOPE>` is one of `GLOBAL` / `SECTION` / `BLOCK` /
+`MEDIA`.
+
+Downstream consumers (e.g., a future `aem-eds-from-stardust` skill)
+can rely on these markers to extract block CSS to
+`blocks/<name>/<name>.css` mechanically, with no per-rule LLM
+judgment required. The extraction algorithm is straightforward
+regex over the `<style>` text:
+
+- `GLOBAL: tokens` / `resets` / `default-content` / `compound utility`
+  / `motion` / `section-defaults` → `styles/styles.css`
+- `SECTION: <name>` → scoped block in `styles/styles.css`
+- `BLOCK: <name>` → `blocks/<name>/<name>.css`
+- `MEDIA: <breakpoint>` → preserved as media-query wrapper in its
+  owning group, or as a site-global block in `styles/styles.css`
+
+canon.css, when injected at migrate time, lands as the
+`GLOBAL: compound utility` group inside the same `<style>` block
+(per `skills/prototype/reference/canon-extraction.md` § 2).
+
 ## `_meta.json` sidecar contract
 
 Schema in `skills/migrate/reference/migration-procedure.md` §

--- a/plugins/stardust/skills/stardust/reference/token-contract.md
+++ b/plugins/stardust/skills/stardust/reference/token-contract.md
@@ -128,7 +128,12 @@ vocabulary across all prototypes and migrated pages.
 
 ## Per-section overrides
 
-Local tokens may override the root for a single section:
+Per-section overrides are the **canonical SECTION pattern of the
+four-scope CSS organization** (see
+`skills/prototype/SKILL.md` § Discipline 11). A section redefines
+any token to customize its visual context; the cascade propagates
+the redefinition to default-content rules and to any blocks nested
+within the section.
 
 ```css
 section[data-section="hero"] {
@@ -141,6 +146,12 @@ Per-section overrides must respect impeccable's contrast rules (WCAG
 AA min) and be reasoned in the prototype's provenance comment. They
 are normal — the token contract is the **inheritance default**, not a
 ceiling.
+
+In the prototype's `<style>` block, per-section override blocks live
+under a `/* === SECTION: <name> === */` marker comment per Discipline
+11, where `<name>` matches the `data-section` attribute value. This
+pairs the override mechanically to the matching DOM element, making
+it extractable to `styles/styles.css` downstream.
 
 ## Editability
 


### PR DESCRIPTION
## Summary

Adds **Discipline 11 — Four-scope CSS organization** to stardust's
prototype skill. Every CSS rule in a rendered prototype classifies
into one of four scopes (`global` / `section` / `block` /
`default-content`), preceded by a machine-parseable marker comment
`/* === <SCOPE>: <name> === */`. The discipline makes downstream
EDS block extraction mechanical instead of LLM-driven.

- Spec-only PR; no JavaScript added. The validator is agent-implemented
  at craft time (same pattern as Disciplines 6 / 7 / 8 today).
- Page-template-level CSS (`[data-template="X"]`) folds into BLOCK
  scope — no separate TEMPLATE scope.
- Motion CSS (added in stardust v0.10.0) classifies into the same four
  scopes: motion tokens → `GLOBAL: tokens`, `@keyframes` → `GLOBAL:
  motion`, per-block motion → `BLOCK`. No fifth scope introduced.
- Grandfathered: existing approved prototypes remain valid until
  re-craft.

## Files changed

| File | Change |
|---|---|
| `plugins/stardust/skills/prototype/SKILL.md` | New Discipline 11 |
| `plugins/stardust/skills/prototype/reference/proposed-file-shell.md` | Example `<style>` block updated; Hard requirement 8 added |
| `plugins/stardust/skills/stardust/reference/token-contract.md` | § Per-section overrides re-framed as canonical SECTION pattern |
| `plugins/stardust/skills/stardust/reference/data-attributes.md` | § Why expanded — `data-module` named as block primitive |
| `plugins/stardust/skills/prototype/reference/canon-extraction.md` | canon.css relabeled as `GLOBAL: compound utility` (cosmetic) |
| `plugins/stardust/skills/stardust/reference/migrate-output-format.md` | Four-scope guarantee documented |
| `plugins/stardust/evals/css-four-scope-{global,section,block,default-content}/` | Four new evals (one per scope) |
| `plugins/stardust/evals/README.md` | Indexes the four new evals |

## Test plan

- [x] `npm run validate` passes locally
- [ ] Tessl Skill Review on CI scores ≥ 50%
- [x] Each new eval's `criteria.json` validates: total == sum of weights == 100
- [x] Cross-link from every modified file to `skills/prototype/SKILL.md § Discipline 11` resolves to a human reader (the section exists)
- [ ] No orphaned-reference warnings introduced

> Note: The `ai-generated` label did not previously exist in this repo. It was created (purple, #B19CD9) per CONTRIBUTING.md and applied to this PR. If the maintainer prefers a different color or description, please adjust.

Refs #147
