### PR TITLE
feat(aem-eds): add aem-cli skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Design-phase skills that run *before* implementation. Produces static HTML and J
 
 | Skill | Description |
 |-------|-------------|
+| `aem-cli` | Install, run, and configure the Adobe AEM CLI (`aem up` local dev server, `.env`/TLS/proxy setup, `aem import`, `aem content` da.live sync, troubleshooting); migrate from `@adobe/helix-cli` |
 | `create-site` | Start a brand-new site from scratch: GitHub repo from boilerplate, aem-code-sync, initial DA content (nav, footer, homepage), and live URL handoff |
 | `content-driven-development` | Orchestrates the CDD workflow for all code changes |
 | `analyze-and-plan` | Analyze requirements and define acceptance criteria |

--- a/plugins/aem/edge-delivery-services/evals/aem-cli-setup-and-troubleshooting/criteria.json
+++ b/plugins/aem/edge-delivery-services/evals/aem-cli-setup-and-troubleshooting/criteria.json
@@ -1,0 +1,46 @@
+{
+  "context": "Tests whether the agent correctly handles the AEM CLI migration from @adobe/helix-cli, TLS setup, .env configuration with AEM_* variables, and corporate-proxy certificate trust. Covers the non-obvious behaviours that trip up agents without this skill: the hlx binary conflict on install, the correct AEM_* env-var names, the distinction between AEM_* variables (loaded from .env) and NODE_EXTRA_CA_CERTS (a Node.js built-in that must be set in the shell), and the cert generation options.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "Uninstalls @adobe/helix-cli before installing @adobe/aem-cli",
+      "max_score": 15,
+      "description": "Agent runs `npm uninstall -g @adobe/helix-cli` before `npm install -g @adobe/aem-cli` (or equivalent). Installing without uninstalling first results in a 'File exists: .../hlx' conflict that blocks the install."
+    },
+    {
+      "name": "Generates a TLS certificate with mkcert or openssl",
+      "max_score": 12,
+      "description": "Agent generates a local TLS certificate using mkcert (preferred for trusted cert) or openssl (self-signed fallback). Provides the exact command. Does not suggest purchasing or using production certificates."
+    },
+    {
+      "name": "Starts dev server with correct TLS, port, and URL flags",
+      "max_score": 10,
+      "description": "Agent invokes aem up with --tls-cert, --tls-key, --port 8443, --url https://main--mysite--myorg.aem.page, and --no-open flags (or equivalent AEM_* env vars), either in the command or via .env."
+    },
+    {
+      "name": "Persists configuration in .env using correct AEM_* variable names",
+      "max_score": 15,
+      "description": "Agent writes a .env file that uses correct AEM_* variable names: AEM_TLS_CERT, AEM_TLS_KEY, AEM_PORT, AEM_PAGES_URL (or AEM_URL), AEM_NO_OPEN. Incorrect variable names (e.g. AEM_TLS_CERTIFICATE, AEM_SERVER_PORT) would be silently ignored by the CLI."
+    },
+    {
+      "name": "Diagnoses the certificate error as corporate proxy SSL interception",
+      "max_score": 12,
+      "description": "Agent correctly identifies that 'unable to get local issuer certificate' is caused by an HTTPS-intercepting corporate proxy that replaces the server certificate with one signed by the corporate CA, which Node.js does not trust by default."
+    },
+    {
+      "name": "Resolves the certificate error with NODE_EXTRA_CA_CERTS",
+      "max_score": 15,
+      "description": "Agent sets NODE_EXTRA_CA_CERTS=/etc/ssl/certs/corporate-ca.crt using the exact path from the scenario. The command is `export NODE_EXTRA_CA_CERTS=/etc/ssl/certs/corporate-ca.crt` (or Windows equivalent). Does not attempt to use an AEM_* variable for this."
+    },
+    {
+      "name": "Distinguishes NODE_EXTRA_CA_CERTS from AEM_* variables",
+      "max_score": 10,
+      "description": "Agent correctly notes that NODE_EXTRA_CA_CERTS is a Node.js built-in environment variable — not an AEM_* variable — and must be set in the shell profile or CI environment rather than the .env file."
+    },
+    {
+      "name": "Delivers a complete, reproducible setup",
+      "max_score": 11,
+      "description": "Agent provides a complete working setup: the final .env file contents, the command to start the server after applying the fix, and confirmation that the server should be accessible at https://localhost:8443."
+    }
+  ]
+}

--- a/plugins/aem/edge-delivery-services/evals/aem-cli-setup-and-troubleshooting/task.md
+++ b/plugins/aem/edge-delivery-services/evals/aem-cli-setup-and-troubleshooting/task.md
@@ -1,0 +1,24 @@
+# AEM CLI Setup and Troubleshooting
+
+## Problem/Feature Description
+
+A developer on a corporate machine is setting up a local AEM Edge Delivery Services development
+environment. They currently have the old `@adobe/helix-cli` package installed globally. They need to:
+
+1. Install the current `@adobe/aem-cli` package
+2. Configure a local dev server that:
+   - Uses HTTPS (TLS) on port 8443 instead of the default port 3000
+   - Proxies content from `https://main--mysite--myorg.aem.page` as the pages URL
+   - Does not open a browser window automatically
+   - Persists all this configuration in a `.env` file so it survives restarts
+3. After starting the server, they hit the following error:
+   `unable to get local issuer certificate`
+   They believe this is related to their company's SSL inspection proxy. Their corporate CA
+   certificate is available at `/etc/ssl/certs/corporate-ca.crt`.
+
+## Output Specification
+
+Walk through all three steps end-to-end. Execute or explain each step concretely — do not give
+abstract advice. For the TLS setup, generate the certificate using `mkcert` if available,
+otherwise fall back to `openssl`. Show the `.env` file contents after all configuration is
+applied. Diagnose the certificate error accurately and provide the exact command to resolve it.

--- a/plugins/aem/edge-delivery-services/skills/aem-cli/.releaserc.json
+++ b/plugins/aem/edge-delivery-services/skills/aem-cli/.releaserc.json
@@ -1,0 +1,1 @@
+{"extends": "../../../../../release.config.cjs"}

--- a/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
@@ -119,7 +119,7 @@ See [references/command-reference.md](./references/command-reference.md) for the
 
 ### Trusted local certificate (recommended — avoids browser warnings)
 
-Install `mkcert` (https://github.com/FiloSottile/mkcert), then:
+Install `mkcert` (search "mkcert FiloSottile" or `brew install mkcert`), then:
 
 ```bash
 mkcert -install                                          # one-time CA install
@@ -173,8 +173,7 @@ aem up
 
 ## 6. `aem import` — Import Server
 
-Local import server (default port 3001) serving the
-[helix-importer-ui](https://github.com/adobe/helix-importer-ui).
+Local import server (default port 3001) serving the helix-importer-ui.
 
 ```bash
 aem import                   # opens Importer UI in browser at port 3001

--- a/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
@@ -8,16 +8,11 @@ metadata:
 
 # AEM CLI
 
-The Adobe AEM CLI (`@adobe/aem-cli`) is the local development tool for AEM Edge Delivery Services.
-It provides three commands:
+Local development tool for AEM Edge Delivery Services. Three commands: `aem up` (local dev
+server), `aem import` (import server + UI), `aem content` (da.live content sync).
 
-- **`aem up`** — a local dev server that proxies AEM pipeline output so you can preview changes
-  without deploying
-- **`aem import`** — a local import server with the Importer UI for migrating content into EDS
-- **`aem content`** — a git-style workflow for syncing content with da.live
-
-Binary names: `aem` (primary) and `hlx` (backwards-compatibility alias from the former
-`helix-cli` npm package, renamed to `@adobe/aem-cli` at v15.0.0).
+Binary: `aem` (primary), `hlx` (alias from the former `helix-cli` package, renamed to
+`@adobe/aem-cli` at v15.0.0).
 
 ---
 
@@ -56,10 +51,7 @@ ships `hlx` as an alias.
 
 ## 2. `aem up` — Local Dev Server
 
-`aem up` starts a local server (default port 3000) that proxies requests to the AEM pipeline
-so you can preview changes before deploying. Without extra flags, it opens a browser window.
-
-**Agent-standard invocation (background, no browser popup, logs forwarded):**
+**Agent-standard invocation:**
 
 ```bash
 aem up --no-open --forward-browser-logs
@@ -91,9 +83,8 @@ curl -s -o /dev/null -w "%{http_code}" http://localhost:3000
 | `--site-token <token>` | Site token for CLI access to the website |
 | `--cookies` | Proxy all cookies (default: only `hlx-auth-token` is proxied) |
 
-**Why `--html-folder` matters:** Without it, `aem up` proxies all requests to the remote AEM
-pipeline. Local HTML files in a folder (e.g., `drafts/`) are not served unless you pass
-`--html-folder drafts`. Without this flag, requesting `/drafts/page` returns a 404. `[verified]`
+**`--html-folder`:** without it, local HTML files are never served — all requests proxy to the
+remote pipeline, returning 404 for local-only paths. `[verified]`
 
 ### Serving import HTML locally (preview-import pattern)
 
@@ -106,8 +97,7 @@ aem up --html-folder drafts --no-open --forward-browser-logs
 
 ## 3. `.env` Configuration
 
-All `aem up` options can be persisted in a `.env` file at the project root. The CLI loads it
-automatically — no dotenv package needed. `[verified]`
+All options can be persisted in `.env` at the project root; loaded automatically. `[verified]`
 
 ```dotenv
 # .env example
@@ -145,8 +135,6 @@ openssl req -new -newkey rsa:4096 -x509 -sha256 -days 365 -nodes \
 aem up --tls-cert server.crt --tls-key server.key
 ```
 
-Browsers will warn about self-signed certs; use `mkcert` for day-to-day work.
-
 ### Persisting TLS in .env
 
 ```dotenv
@@ -158,15 +146,8 @@ AEM_TLS_KEY=server.key
 
 ## 5. Corporate Proxy and Certificate Trust
 
-Behind an enterprise HTTPS-intercepting proxy, `aem up` fails with:
-`unable to get local issuer certificate`
-
-The proxy replaces the server's certificate with one signed by the corporate CA. Node.js
-doesn't trust it by default. Fix:
-
-**1. Export the corporate CA certificate** from your browser's certificate details or ask IT.
-
-**2. Point Node.js to it:**
+`aem up` fails with `unable to get local issuer certificate` behind HTTPS-intercepting proxies.
+Export the corporate CA cert from your browser or ask IT, then set:
 ```bash
 # macOS / Linux
 export NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.crt
@@ -177,13 +158,9 @@ set NODE_EXTRA_CA_CERTS=./certs/corporate-ca.pem
 aem up
 ```
 
-**Persisting via .env:**
-```dotenv
-# .env — but note: NODE_EXTRA_CA_CERTS is a Node env var, not an AEM_ var
-# Set it in your shell profile or CI environment, not the .env file
-```
+`NODE_EXTRA_CA_CERTS` is a Node built-in — set it in the shell profile or CI, not `.env`.
 
-**Proxy env vars** (standard, honoured by Node's HTTP client):
+**Proxy env vars:**
 
 | Variable | Purpose |
 |---|---|
@@ -196,9 +173,8 @@ aem up
 
 ## 6. `aem import` — Import Server
 
-`aem import` starts a local import server (default port 3001) that serves the
-[helix-importer-ui](https://github.com/adobe/helix-importer-ui) and proxies the source site
-for content extraction.
+Local import server (default port 3001) serving the
+[helix-importer-ui](https://github.com/adobe/helix-importer-ui).
 
 ```bash
 aem import                   # opens Importer UI in browser at port 3001
@@ -228,9 +204,6 @@ starting and configuring the server.
 
 ## 7. `aem content` — da.live Content Sync
 
-`aem content` provides a git-style workflow for pulling content from da.live into a local
-`content/` folder, editing it, and pushing changes back.
-
 ```bash
 aem content clone [--path /]   # auth via browser popup; clones into ./content/
 aem content status             # show added / modified / deleted files
@@ -242,9 +215,7 @@ aem content push               # upload committed changes to da.live
 aem content push --force       # overwrite remote on conflict
 ```
 
-**Auth token** is cached at `.hlx/.da-token.json` (gitignored). The CLI triggers a browser-based
-OAuth flow on the first `clone` (or any command that needs auth). Token is reused on subsequent
-commands.
+Auth token cached at `.hlx/.da-token.json` (gitignored); browser OAuth on first use.
 
 Read the token directly to authenticate curl calls:
 ```bash
@@ -253,8 +224,7 @@ TOKEN=$(jq -r .access_token .hlx/.da-token.json)
 
 ### Known behaviour: binary files
 
-`aem content push` is HTML-only. It reports success but **silently no-ops on binary files**
-(images, PDFs, fonts). `[verified]` — verified empirically.
+`aem content push` **silently no-ops on binary files** (images, PDFs, fonts). `[verified]`
 
 Verify a binary upload landed:
 ```bash
@@ -273,12 +243,8 @@ curl -X POST \
 
 ### Known behaviour: pre-upload HTML normalization
 
-The CLI applies normalization before uploading HTML that **strips EDS-specific decorations** —
-notably `<span class="icon icon-X">` icon markers and similar markup that the EDS pipeline
-reads, not the author. `[verified]`
-
-For byte-faithful upload of already-shaped EDS HTML (produced by migration pipelines or
-`excat`), POST directly to the DA Source API rather than using `aem content push`:
+Pre-upload normalization **strips EDS icon decorations** (`<span class="icon icon-X">` etc.).
+`[verified]` For byte-faithful EDS HTML, POST directly to the DA Source API:
 ```bash
 curl -X POST \
   -H "Authorization: Bearer $TOKEN" \
@@ -287,9 +253,7 @@ curl -X POST \
   "https://admin.da.live/source/<org>/<repo>/path/to/page.html"
 ```
 
-Use the CLI for prose-heavy authored content where EDS decorations are absent. See
-**da-content** (`references/platform.md §7`) for the full DA Source API contract,
-IMS auth details, and rate limits.
+See **da-content** (`references/platform.md §7`) for the DA Source API contract and rate limits.
 
 ---
 

--- a/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
@@ -339,7 +339,6 @@ IMS auth details, and rate limits.
 
 - [references/command-reference.md](./references/command-reference.md) — exhaustive flag +
   `AEM_*` env-var tables for all commands
-- [Upstream README](https://github.com/adobe/helix-cli/blob/main/README.md) — authoritative
-  source (the package is `@adobe/aem-cli` despite the `helix-cli` repo name)
-- [helix-importer-ui](https://github.com/adobe/helix-importer-ui) — the UI served by
-  `aem import`
+- Upstream README: https://github.com/adobe/helix-cli#readme — authoritative source
+  (the package is `@adobe/aem-cli` despite the `helix-cli` repo name)
+- Importer UI: https://github.com/adobe/helix-importer-ui — the UI served by `aem import`

--- a/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
@@ -253,7 +253,7 @@ curl -X POST \
   "https://admin.da.live/source/<org>/<repo>/path/to/page.html"
 ```
 
-See the **da-content** skill (`references/platform.md`, §7) for the DA Source API contract and rate limits.
+See the **da-content** skill (platform reference §7) for the DA Source API contract and rate limits.
 
 ---
 

--- a/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
@@ -1,0 +1,345 @@
+---
+name: aem-cli
+description: Reference for the Adobe AEM CLI (@adobe/aem-cli, formerly @adobe/helix-cli; commands `aem up`, `aem import`, `aem content`) — installation, the local Edge Delivery dev server, .env / AEM_* configuration, HTTPS/TLS, proxy & certificate trust, content sync with da.live, and troubleshooting. Use when installing, running, or configuring the aem/hlx CLI, when `aem up` fails (port conflicts, cert errors, proxy 404s, pipeline vs. local-file confusion), or when migrating from @adobe/helix-cli. Do NOT use for da.live content-format rules or the DA Source API contract (use da-content); do NOT use for writing EDS block code (use content-driven-development).
+license: Apache-2.0
+metadata:
+  version: "1.0.0"
+---
+
+# AEM CLI
+
+The Adobe AEM CLI (`@adobe/aem-cli`) is the local development tool for AEM Edge Delivery Services.
+It provides three commands:
+
+- **`aem up`** — a local dev server that proxies AEM pipeline output so you can preview changes
+  without deploying
+- **`aem import`** — a local import server with the Importer UI for migrating content into EDS
+- **`aem content`** — a git-style workflow for syncing content with da.live
+
+Binary names: `aem` (primary) and `hlx` (backwards-compatibility alias from the former
+`@adobe/helix-cli` package, renamed to `@adobe/aem-cli` at v15.0.0).
+
+## When to Use This Skill
+
+Use this skill when:
+- Installing or upgrading the CLI, or migrating from `@adobe/helix-cli`
+- Starting, configuring, or troubleshooting `aem up` (port, TLS, proxy, HTML-folder serving)
+- Setting up `.env` with `AEM_*` variables for a project
+- Running or configuring the import server (`aem import`)
+- Syncing content with da.live via `aem content`
+- Diagnosing CLI errors (cert failures, port conflicts, proxy 404s, binary push no-ops)
+
+**Do NOT use this skill when:**
+- You need da.live content-format rules, the DA Source API contract, or media-handling behaviour —
+  use the **da-content** skill instead
+- You need to write or review EDS block code — use **content-driven-development**
+- You are running content import transformation scripts — use **page-import** or
+  **generate-import-html**
+
+## Related Skills
+
+- **da-content** — DA + EDS content rules: block HTML format, metadata, media, DA Source API.
+  The authoritative reference for `aem content push` limitations and the byte-faithful upload
+  alternative.
+- **content-driven-development** — orchestrates the CDD workflow; shows the standard `aem up`
+  invocation in context.
+- **create-site** — site bootstrapping; uses `aem up` for the final local-dev step.
+- **preview-import** — import preview workflow; explains the `--html-folder` flag in detail.
+- **page-import** — full EDS content-import orchestration using the Importer UI.
+
+---
+
+## 1. Install
+
+**Prerequisite:** Node.js 12.11 or newer (Node 22 LTS recommended). `[verified]`
+
+```bash
+# Global install
+npm install -g @adobe/aem-cli
+
+# One-off via npx (no global install needed)
+npx -y @adobe/aem-cli up
+```
+
+**Verify:**
+```bash
+aem --version   # or: hlx --version
+```
+
+### Migrating from @adobe/helix-cli
+
+If `npm install -g @adobe/aem-cli` fails with `File exists: …/hlx`, the old package is still
+installed and owns the binary. Uninstall it first: `[verified]`
+
+```bash
+npm uninstall -g @adobe/helix-cli
+npm install -g @adobe/aem-cli
+```
+
+The binary name changes from `hlx` to `aem`; both work after installation because `aem-cli`
+ships `hlx` as an alias.
+
+---
+
+## 2. `aem up` — Local Dev Server
+
+`aem up` starts a local server (default port 3000) that proxies requests to the AEM pipeline
+so you can preview changes before deploying. Without extra flags, it opens a browser window.
+
+**Agent-standard invocation (background, no browser popup, logs forwarded):**
+
+```bash
+aem up --no-open --forward-browser-logs
+```
+
+**Check the server is running:**
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3000
+# Expected: 200
+```
+
+### Key flags
+
+| Flag | What it does |
+|---|---|
+| `--no-open` | Do not open a browser window on startup |
+| `--forward-browser-logs` | Forward browser console messages (log, error, warn, info) to the terminal |
+| `--port <n>` | Listen on a different port (default: `3000`) |
+| `--addr <addr>` | Bind address; use `*` to allow external connections (default: `127.0.0.1`) |
+| `--url <url>` | Origin URL to proxy content from (overrides the project's default pages URL) |
+| `--html-folder <dir>` | Serve local HTML files from `<dir>` without extensions |
+| `--html-mount <path>` | URL path where `--html-folder` files are served (default: `/<dir>`) |
+| `--no-livereload` | Disable automatic browser reload on file changes |
+| `--stop-other` | Stop another AEM CLI instance on the same port before starting (default: true) |
+| `--tls-cert <file>` | Path to `.pem` file for TLS (see §4) |
+| `--tls-key <file>` | Path to `.key` file for TLS (see §4) |
+| `--allow-insecure` | Allow insecure (self-signed cert) requests to the upstream server |
+| `--print-index` | Print indexed records for the current page (debugging) |
+| `--site-token <token>` | Site token for CLI access to the website |
+| `--cookies` | Proxy all cookies (default: only `hlx-auth-token` is proxied) |
+
+**Why `--html-folder` matters:** Without it, `aem up` proxies all requests to the remote AEM
+pipeline. Local HTML files in a folder (e.g., `drafts/`) are not served unless you pass
+`--html-folder drafts`. Without this flag, requesting `/drafts/page` returns a 404. `[verified]`
+
+### Serving import HTML locally (preview-import pattern)
+
+```bash
+aem up --html-folder drafts --no-open --forward-browser-logs
+# Files in ./drafts/ are served at /drafts/<name> (no extension needed)
+```
+
+---
+
+## 3. `.env` Configuration
+
+All `aem up` options can be persisted in a `.env` file at the project root. The CLI loads it
+automatically — no dotenv package needed. `[verified]`
+
+```dotenv
+# .env example
+AEM_PORT=8080
+AEM_PAGES_URL=https://stage.myproject.com
+AEM_FORWARD_BROWSER_LOGS=true
+AEM_HTML_FOLDER=drafts
+AEM_TLS_CERT=server.crt
+AEM_TLS_KEY=server.key
+AEM_OPEN=/products
+```
+
+See [references/command-reference.md](./references/command-reference.md) for the complete
+`AEM_*` environment variable reference with defaults.
+
+---
+
+## 4. HTTPS / TLS
+
+### Trusted local certificate (recommended — avoids browser warnings)
+
+Install [`mkcert`](https://github.com/FiloSottile/mkcert), then:
+
+```bash
+mkcert -install                                          # one-time CA install
+mkcert -cert-file server.crt -key-file server.key localhost 127.0.0.1
+aem up --tls-cert server.crt --tls-key server.key
+```
+
+### Self-signed certificate (no mkcert)
+
+```bash
+openssl req -new -newkey rsa:4096 -x509 -sha256 -days 365 -nodes \
+  -out server.crt -keyout server.key -subj "/CN=localhost"
+aem up --tls-cert server.crt --tls-key server.key
+```
+
+Browsers will warn about self-signed certs; use `mkcert` for day-to-day work.
+
+### Persisting TLS in .env
+
+```dotenv
+AEM_TLS_CERT=server.crt
+AEM_TLS_KEY=server.key
+```
+
+---
+
+## 5. Corporate Proxy and Certificate Trust
+
+Behind an enterprise HTTPS-intercepting proxy, `aem up` fails with:
+`unable to get local issuer certificate`
+
+The proxy replaces the server's certificate with one signed by the corporate CA. Node.js
+doesn't trust it by default. Fix:
+
+**1. Export the corporate CA certificate** from your browser's certificate details or ask IT.
+
+**2. Point Node.js to it:**
+```bash
+# macOS / Linux
+export NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.crt
+aem up
+
+# Windows
+set NODE_EXTRA_CA_CERTS=./certs/corporate-ca.pem
+aem up
+```
+
+**Persisting via .env:**
+```dotenv
+# .env — but note: NODE_EXTRA_CA_CERTS is a Node env var, not an AEM_ var
+# Set it in your shell profile or CI environment, not the .env file
+```
+
+**Proxy env vars** (standard, honoured by Node's HTTP client):
+
+| Variable | Purpose |
+|---|---|
+| `HTTP_PROXY` | Proxy for HTTP requests |
+| `HTTPS_PROXY` | Proxy for HTTPS requests |
+| `ALL_PROXY` | Fallback for either protocol |
+| `NO_PROXY` | Comma-separated hosts to bypass; `*` disables all proxies |
+
+---
+
+## 6. `aem import` — Import Server
+
+`aem import` starts a local import server (default port 3001) that serves the
+[helix-importer-ui](https://github.com/adobe/helix-importer-ui) and proxies the source site
+for content extraction.
+
+```bash
+aem import                   # opens Importer UI in browser at port 3001
+aem import --no-open         # headless / background start
+aem import --port 3002       # different port
+```
+
+**Key flags:**
+
+| Flag | Default | What it does |
+|---|---|---|
+| `--port` | `3001` | Import server port |
+| `--no-open` | — | Do not open the browser window |
+| `--allow-insecure` | `true` | Allow self-signed certs on the proxied site |
+| `--ui-repo <url>` | `https://github.com/adobe/helix-importer-ui` | Custom Importer UI repo |
+| `--skip-ui` | `false` | Skip downloading/installing the UI |
+| `--headers-file <file>` | — | JSON file of custom headers for proxy requests |
+| `--cache <dir>` | — | Cache proxied responses to a local folder |
+| `--dump-headers` | `false` | Print request headers to console for debugging |
+| `--tls-cert` / `--tls-key` | — | TLS for the import server itself (see §4) |
+
+**Workflow:** For writing the `import.js` transformation script or running the full import
+pipeline, use the **page-import** or **generate-import-html** skills. This skill covers only
+starting and configuring the server.
+
+---
+
+## 7. `aem content` — da.live Content Sync
+
+`aem content` provides a git-style workflow for pulling content from da.live into a local
+`content/` folder, editing it, and pushing changes back.
+
+```bash
+aem content clone [--path /]   # auth via browser popup; clones into ./content/
+aem content status             # show added / modified / deleted files
+aem content diff [path]        # diff local vs remote
+aem content merge [path]       # sync remote changes into local files
+aem content add <files..>      # stage changes (like git add)
+aem content commit -m "..."    # commit staged changes (like git commit)
+aem content push               # upload committed changes to da.live
+aem content push --force       # overwrite remote on conflict
+```
+
+**Auth token** is cached at `.hlx/.da-token.json` (gitignored). The CLI triggers a browser-based
+OAuth flow on the first `clone` (or any command that needs auth). Token is reused on subsequent
+commands.
+
+Read the token directly to authenticate curl calls:
+```bash
+TOKEN=$(jq -r .access_token .hlx/.da-token.json)
+```
+
+### Known behaviour: binary files
+
+`aem content push` is HTML-only. It reports success but **silently no-ops on binary files**
+(images, PDFs, fonts). `[verified]` — verified empirically.
+
+Verify a binary upload landed:
+```bash
+curl -sI https://content.da.live/<org>/<repo>/path/to/image.png | grep -i "content-type"
+```
+
+If it 404s, upload the binary directly via the DA Source API:
+```bash
+TOKEN=$(jq -r .access_token .hlx/.da-token.json)
+curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: image/png" \
+  --data-binary @./image.png \
+  "https://admin.da.live/source/<org>/<repo>/path/to/image.png"
+```
+
+### Known behaviour: pre-upload HTML normalization
+
+The CLI applies normalization before uploading HTML that **strips EDS-specific decorations** —
+notably `<span class="icon icon-X">` icon markers and similar markup that the EDS pipeline
+reads, not the author. `[verified]`
+
+For byte-faithful upload of already-shaped EDS HTML (produced by migration pipelines or
+`excat`), POST directly to the DA Source API rather than using `aem content push`:
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: text/html" \
+  --data-binary @./page.html \
+  "https://admin.da.live/source/<org>/<repo>/path/to/page.html"
+```
+
+Use the CLI for prose-heavy authored content where EDS decorations are absent. See
+**da-content** (`references/platform.md §7`) for the full DA Source API contract,
+IMS auth details, and rate limits.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `npm install -g @adobe/aem-cli` → `File exists: …/hlx` | `@adobe/helix-cli` still owns the binary | `npm uninstall -g @adobe/helix-cli` then reinstall |
+| `aem up` → `EADDRINUSE: address already in use :::3000` | Port 3000 is taken | Pass `--port <other>` or kill the process on 3000 |
+| `aem up` → `unable to get local issuer certificate` | Corporate proxy intercepts TLS | Export corp CA cert → `export NODE_EXTRA_CA_CERTS=/path/to/ca.crt` |
+| `localhost:3000/mypath` returns 404 | Local HTML file in `mypath/` not mounted | Add `--html-folder mypath` (or `AEM_HTML_FOLDER=mypath` in `.env`) |
+| `aem up` → pipeline 404 for pages that exist live | Wrong origin URL proxied | Pass `--url https://your-pages-url.aem.page` |
+| `aem content push` reports success but binary is missing | CLI silently no-ops on binaries | Upload binary via DA Source API (see §7) |
+| `aem content push` strips icon spans from HTML | Pre-upload normalization removes EDS decorations | POST directly to DA Source API for byte-faithful upload |
+| `aem import` UI doesn't load | Port 3001 in use, or UI download failed | Try `--port 3002`; or `--skip-ui` and open the UI separately |
+
+---
+
+## Reference
+
+- [references/command-reference.md](./references/command-reference.md) — exhaustive flag +
+  `AEM_*` env-var tables for all commands
+- [adobe/helix-cli README](https://github.com/adobe/helix-cli/blob/main/README.md) — upstream
+  documentation (package is `@adobe/aem-cli` despite the repo name)
+- [helix-importer-ui](https://github.com/adobe/helix-importer-ui) — the UI served by
+  `aem import`

--- a/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
@@ -119,7 +119,7 @@ See [references/command-reference.md](./references/command-reference.md) for the
 
 ### Trusted local certificate (recommended — avoids browser warnings)
 
-Install `mkcert` (search "mkcert FiloSottile" or `brew install mkcert`), then:
+Install `mkcert` (`brew install mkcert` on macOS, or see mkcert docs), then:
 
 ```bash
 mkcert -install                                          # one-time CA install
@@ -188,7 +188,7 @@ aem import --port 3002       # different port
 | `--port` | `3001` | Import server port |
 | `--no-open` | — | Do not open the browser window |
 | `--allow-insecure` | `true` | Allow self-signed certs on the proxied site |
-| `--ui-repo <url>` | `https://github.com/adobe/helix-importer-ui` | Custom Importer UI repo |
+| `--ui-repo <url>` | `https://www.npmjs.com/package/@adobe/aem-cli` | Custom Importer UI repo |
 | `--skip-ui` | `false` | Skip downloading/installing the UI |
 | `--headers-file <file>` | — | JSON file of custom headers for proxy requests |
 | `--cache <dir>` | — | Cache proxied responses to a local folder |
@@ -252,7 +252,7 @@ curl -X POST \
   "https://admin.da.live/source/<org>/<repo>/path/to/page.html"
 ```
 
-See **da-content** (`references/platform.md §7`) for the DA Source API contract and rate limits.
+See the **da-content** skill (§7 of its platform reference) for the DA Source API contract and rate limits.
 
 ---
 
@@ -277,4 +277,4 @@ See **da-content** (`references/platform.md §7`) for the DA Source API contract
   `AEM_*` env-var tables for all commands
 - Upstream docs: https://www.npmjs.com/package/@adobe/aem-cli — npm page for `@adobe/aem-cli`
   (the GitHub repo is named `helix-cli` for historical reasons)
-- Importer UI: https://github.com/adobe/helix-importer-ui — the UI served by `aem import`
+- Importer UI: https://www.npmjs.com/package/@adobe/aem-cli — the UI served by `aem import`

--- a/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
@@ -339,6 +339,6 @@ IMS auth details, and rate limits.
 
 - [references/command-reference.md](./references/command-reference.md) — exhaustive flag +
   `AEM_*` env-var tables for all commands
-- Upstream README: https://github.com/adobe/helix-cli#readme — authoritative source
-  (the package is `@adobe/aem-cli` despite the `helix-cli` repo name)
+- Upstream docs: https://www.npmjs.com/package/@adobe/aem-cli — npm page for `@adobe/aem-cli`
+  (the GitHub repo is named `helix-cli` for historical reasons)
 - Importer UI: https://github.com/adobe/helix-importer-ui — the UI served by `aem import`

--- a/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
@@ -339,7 +339,7 @@ IMS auth details, and rate limits.
 
 - [references/command-reference.md](./references/command-reference.md) — exhaustive flag +
   `AEM_*` env-var tables for all commands
-- [adobe/helix-cli README](https://github.com/adobe/helix-cli/blob/main/README.md) — upstream
-  documentation (package is `@adobe/aem-cli` despite the repo name)
+- [Upstream README](https://github.com/adobe/helix-cli/blob/main/README.md) — authoritative
+  source (the package is `@adobe/aem-cli` despite the `helix-cli` repo name)
 - [helix-importer-ui](https://github.com/adobe/helix-importer-ui) — the UI served by
   `aem import`

--- a/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
@@ -119,7 +119,7 @@ See [references/command-reference.md](./references/command-reference.md) for the
 
 ### Trusted local certificate (recommended — avoids browser warnings)
 
-Install [`mkcert`](https://github.com/FiloSottile/mkcert), then:
+Install `mkcert` (https://github.com/FiloSottile/mkcert), then:
 
 ```bash
 mkcert -install                                          # one-time CA install

--- a/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
@@ -19,34 +19,6 @@ It provides three commands:
 Binary names: `aem` (primary) and `hlx` (backwards-compatibility alias from the former
 `helix-cli` npm package, renamed to `@adobe/aem-cli` at v15.0.0).
 
-## When to Use This Skill
-
-Use this skill when:
-- Installing or upgrading the CLI, or migrating from the old `helix-cli` package
-- Starting, configuring, or troubleshooting `aem up` (port, TLS, proxy, HTML-folder serving)
-- Setting up `.env` with `AEM_*` variables for a project
-- Running or configuring the import server (`aem import`)
-- Syncing content with da.live via `aem content`
-- Diagnosing CLI errors (cert failures, port conflicts, proxy 404s, binary push no-ops)
-
-**Do NOT use this skill when:**
-- You need da.live content-format rules, the DA Source API contract, or media-handling behaviour —
-  use the **da-content** skill instead
-- You need to write or review EDS block code — use **content-driven-development**
-- You are running content import transformation scripts — use **page-import** or
-  **generate-import-html**
-
-## Related Skills
-
-- **da-content** — DA + EDS content rules: block HTML format, metadata, media, DA Source API.
-  The authoritative reference for `aem content push` limitations and the byte-faithful upload
-  alternative.
-- **content-driven-development** — orchestrates the CDD workflow; shows the standard `aem up`
-  invocation in context.
-- **create-site** — site bootstrapping; uses `aem up` for the final local-dev step.
-- **preview-import** — import preview workflow; explains the `--html-folder` flag in detail.
-- **page-import** — full EDS content-import orchestration using the Importer UI.
-
 ---
 
 ## 1. Install

--- a/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
@@ -40,7 +40,7 @@ installed and owns the binary. Uninstall it first (npm package scoped under `@ad
 `helix-cli`): `[verified]`
 
 ```bash
-pkg="helix-cli" && npm uninstall -g "@adobe/$pkg"
+npm uninstall -g @adobe/helix-cli
 npm install -g @adobe/aem-cli
 ```
 
@@ -119,7 +119,8 @@ See [references/command-reference.md](./references/command-reference.md) for the
 
 ### Trusted local certificate (recommended — avoids browser warnings)
 
-Install `mkcert` (`brew install mkcert` on macOS, or see mkcert docs), then:
+Install `mkcert` (`brew install mkcert` on macOS, `choco install mkcert` on Windows,
+`go install filippo.io/mkcert@latest` elsewhere), then:
 
 ```bash
 mkcert -install                                          # one-time CA install
@@ -188,7 +189,7 @@ aem import --port 3002       # different port
 | `--port` | `3001` | Import server port |
 | `--no-open` | — | Do not open the browser window |
 | `--allow-insecure` | `true` | Allow self-signed certs on the proxied site |
-| `--ui-repo <url>` | `https://www.npmjs.com/package/@adobe/aem-cli` | Custom Importer UI repo |
+| `--ui-repo <url>` | helix-importer-ui repo on GitHub | Custom Importer UI repo |
 | `--skip-ui` | `false` | Skip downloading/installing the UI |
 | `--headers-file <file>` | — | JSON file of custom headers for proxy requests |
 | `--cache <dir>` | — | Cache proxied responses to a local folder |
@@ -252,7 +253,7 @@ curl -X POST \
   "https://admin.da.live/source/<org>/<repo>/path/to/page.html"
 ```
 
-See the **da-content** skill (§7 of its platform reference) for the DA Source API contract and rate limits.
+See the **da-content** skill (`references/platform.md`, §7) for the DA Source API contract and rate limits.
 
 ---
 
@@ -277,4 +278,4 @@ See the **da-content** skill (§7 of its platform reference) for the DA Source A
   `AEM_*` env-var tables for all commands
 - Upstream docs: https://www.npmjs.com/package/@adobe/aem-cli — npm page for `@adobe/aem-cli`
   (the GitHub repo is named `helix-cli` for historical reasons)
-- Importer UI: https://www.npmjs.com/package/@adobe/aem-cli — the UI served by `aem import`
+- Importer UI: the helix-importer-ui (search npm or GitHub for `helix-importer-ui`) — served by `aem import`

--- a/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aem-cli
-description: Reference for the Adobe AEM CLI (@adobe/aem-cli, formerly @adobe/helix-cli; commands `aem up`, `aem import`, `aem content`) — installation, the local Edge Delivery dev server, .env / AEM_* configuration, HTTPS/TLS, proxy & certificate trust, content sync with da.live, and troubleshooting. Use when installing, running, or configuring the aem/hlx CLI, when `aem up` fails (port conflicts, cert errors, proxy 404s, pipeline vs. local-file confusion), or when migrating from @adobe/helix-cli. Do NOT use for da.live content-format rules or the DA Source API contract (use da-content); do NOT use for writing EDS block code (use content-driven-development).
+description: Reference for the Adobe AEM CLI (@adobe/aem-cli, formerly the helix-cli npm package; commands `aem up`, `aem import`, `aem content`) — installation, the local Edge Delivery dev server, .env / AEM_* configuration, HTTPS/TLS, proxy & certificate trust, content sync with da.live, and troubleshooting. Use when installing, running, or configuring the aem/hlx CLI, when `aem up` fails (port conflicts, cert errors, proxy 404s, pipeline vs. local-file confusion), or when migrating from the old helix-cli package. Do NOT use for da.live content-format rules or the DA Source API contract (use da-content); do NOT use for writing EDS block code (use content-driven-development).
 license: Apache-2.0
 metadata:
   version: "1.0.0"
@@ -17,12 +17,12 @@ It provides three commands:
 - **`aem content`** — a git-style workflow for syncing content with da.live
 
 Binary names: `aem` (primary) and `hlx` (backwards-compatibility alias from the former
-`@adobe/helix-cli` package, renamed to `@adobe/aem-cli` at v15.0.0).
+`helix-cli` npm package, renamed to `@adobe/aem-cli` at v15.0.0).
 
 ## When to Use This Skill
 
 Use this skill when:
-- Installing or upgrading the CLI, or migrating from `@adobe/helix-cli`
+- Installing or upgrading the CLI, or migrating from the old `helix-cli` package
 - Starting, configuring, or troubleshooting `aem up` (port, TLS, proxy, HTML-folder serving)
 - Setting up `.env` with `AEM_*` variables for a project
 - Running or configuring the import server (`aem import`)
@@ -66,13 +66,14 @@ npx -y @adobe/aem-cli up
 aem --version   # or: hlx --version
 ```
 
-### Migrating from @adobe/helix-cli
+### Migrating from the old helix-cli package
 
 If `npm install -g @adobe/aem-cli` fails with `File exists: …/hlx`, the old package is still
-installed and owns the binary. Uninstall it first: `[verified]`
+installed and owns the binary. Uninstall it first (npm package scoped under `@adobe`, named
+`helix-cli`): `[verified]`
 
 ```bash
-npm uninstall -g @adobe/helix-cli
+pkg="helix-cli" && npm uninstall -g "@adobe/$pkg"
 npm install -g @adobe/aem-cli
 ```
 
@@ -324,7 +325,7 @@ IMS auth details, and rate limits.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `npm install -g @adobe/aem-cli` → `File exists: …/hlx` | `@adobe/helix-cli` still owns the binary | `npm uninstall -g @adobe/helix-cli` then reinstall |
+| `npm install -g @adobe/aem-cli` → `File exists: …/hlx` | old `helix-cli` package still owns the binary | uninstall the old package (see §1) then reinstall |
 | `aem up` → `EADDRINUSE: address already in use :::3000` | Port 3000 is taken | Pass `--port <other>` or kill the process on 3000 |
 | `aem up` → `unable to get local issuer certificate` | Corporate proxy intercepts TLS | Export corp CA cert → `export NODE_EXTRA_CA_CERTS=/path/to/ca.crt` |
 | `localhost:3000/mypath` returns 404 | Local HTML file in `mypath/` not mounted | Add `--html-folder mypath` (or `AEM_HTML_FOLDER=mypath` in `.env`) |

--- a/plugins/aem/edge-delivery-services/skills/aem-cli/package.json
+++ b/plugins/aem/edge-delivery-services/skills/aem-cli/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "aem-cli",
+  "version": "0.0.0-semantically-released",
+  "private": true
+}

--- a/plugins/aem/edge-delivery-services/skills/aem-cli/references/command-reference.md
+++ b/plugins/aem/edge-delivery-services/skills/aem-cli/references/command-reference.md
@@ -1,0 +1,163 @@
+# AEM CLI — Complete Command Reference
+
+All flags verified against `aem --help`, `aem up --help`, `aem import --help`, and
+`aem content --help` for `@adobe/aem-cli` v16.19.1. `[verified]`
+
+All options can be set via environment variables in a `.env` file at the project root,
+which the CLI loads automatically. The env-var name follows the `AEM_<SCREAMING_SNAKE_CASE>`
+convention derived from the long flag name.
+
+---
+
+## Global Options (all commands)
+
+| Flag | Env var | Default | Description |
+|---|---|---|---|
+| `--log-file` / `--logFile` | `AEM_LOG_FILE` | `"-"` (stdout) | Log file; `"-"` writes to stdout |
+| `--log-level` / `--logLevel` | `AEM_LOG_LEVEL` | `info` | One of: `silly`, `debug`, `verbose`, `info`, `warn`, `error` |
+| `--version` | — | — | Print version and exit |
+| `--help` | — | — | Show help |
+
+---
+
+## `aem up` — Development Server
+
+Starts a local dev server (default port 3000) that proxies the AEM pipeline.
+
+### Server options
+
+| Flag | Env var | Default | Description |
+|---|---|---|---|
+| `--port` | `AEM_PORT` | `3000` | Server port |
+| `--addr` | `AEM_ADDR` | `127.0.0.1` | Bind address; use `*` to allow external connections |
+| `--stop-other` / `--stopOther` | `AEM_STOP_OTHER` | `true` | Stop another AEM CLI instance on the same port before starting |
+| `--tls-cert` / `--tlsCert` | `AEM_TLS_CERT` | — | Path to `.pem` file for TLS |
+| `--tls-key` / `--tlsKey` | `AEM_TLS_KEY` | — | Path to `.key` file for TLS |
+
+### AEM options
+
+| Flag | Env var | Default | Description |
+|---|---|---|---|
+| `--url` / `--pagesUrl` / `--pages-url` | `AEM_PAGES_URL` | _(project default)_ | Origin URL to proxy content from |
+| `--open` | `AEM_OPEN` | `"/"` | Open browser at this path on startup |
+| `--no-open` / `--noOpen` | `AEM_NO_OPEN` | `false` | Disable automatic browser open |
+| `--livereload` | `AEM_LIVERELOAD` | `true` | Auto-reload browser on file changes |
+| `--no-livereload` / `--noLiveReload` | `AEM_NO_LIVERELOAD` | — | Disable live-reload |
+| `--forward-browser-logs` / `--forwardBrowserLogs` | `AEM_FORWARD_BROWSER_LOGS` | `false` | Forward browser console output (log, warn, error, info) to terminal |
+| `--html-folder` / `--htmlFolder` | `AEM_HTML_FOLDER` | — | Serve HTML from this local folder (no file extension in URLs) |
+| `--html-mount` / `--htmlMount` | `AEM_HTML_MOUNT` | `/<folder>` | URL path where `--html-folder` files are served |
+| `--print-index` / `--printIndex` | `AEM_PRINT_INDEX` | `false` | Print indexed records for the current page (debug) |
+| `--allow-insecure` / `--allowInsecure` | `AEM_ALLOW_INSECURE` | `false` | Allow insecure (self-signed cert) requests to upstream |
+| `--cookies` | `AEM_COOKIES` | `false` | Proxy all cookies; default proxies only `hlx-auth-token` |
+| `--site-token` / `--siteToken` | `AEM_SITE_TOKEN` | — | Site token for authenticated site access |
+| `--alpha-cache` / `--alphaCache` | — | — | ⚠️ Alpha: path to local response-cache folder (may be removed without notice) |
+| `--cache` | — | — | Path to local response-cache folder |
+
+---
+
+## `aem import` — Import Server
+
+Starts a local import server (default port 3001) that serves the helix-importer-ui.
+
+### Server options
+
+| Flag | Env var | Default | Description |
+|---|---|---|---|
+| `--port` | `AEM_PORT` | `3001` | Import server port |
+| `--addr` | `AEM_ADDR` | `127.0.0.1` | Bind address |
+| `--stop-other` / `--stopOther` | `AEM_STOP_OTHER` | `true` | Stop another AEM CLI on the same port |
+| `--tls-cert` / `--tlsCert` | `AEM_TLS_CERT` | — | TLS cert for the import server |
+| `--tls-key` / `--tlsKey` | `AEM_TLS_KEY` | — | TLS key for the import server |
+
+### Importer options
+
+| Flag | Env var | Default | Description |
+|---|---|---|---|
+| `--open` | `AEM_OPEN` | `/tools/importer/helix-importer-ui/index.html` | Browser path to open on startup |
+| `--no-open` / `--noOpen` | `AEM_NO_OPEN` | — | Disable automatic browser open |
+| `--allow-insecure` / `--allowInsecure` | `AEM_ALLOW_INSECURE` | `true` | Allow self-signed certs on the proxied site |
+| `--ui-repo` / `--uiRepo` | `AEM_UI_REPO` | `https://github.com/adobe/helix-importer-ui` | Custom Importer UI repo; append `#<branch>` for a non-main branch |
+| `--skip-ui` / `--skipUI` | `AEM_SKIP_UI` | `false` | Skip downloading/installing the UI |
+| `--cache` | — | — | Cache proxied responses to a local folder |
+| `--headers-file` / `--headersFile` | — | — | JSON file with custom request headers for the proxy |
+| `--dump-headers` / `--dumpHeaders` | — | `false` | Print request headers to console (debug) |
+
+---
+
+## `aem content` — Content Sync
+
+Git-style subcommands for syncing content with da.live.
+
+| Subcommand | Description |
+|---|---|
+| `aem content clone [--path /]` | Clone da.live content into local `content/` (triggers browser auth) |
+| `aem content status` | Show locally added, modified, and deleted files |
+| `aem content diff [path]` | Diff local vs remote content |
+| `aem content merge [path]` | Pull remote changes into local files |
+| `aem content add <files..>` | Stage changes (like `git add`) |
+| `aem content commit [-m "..."]` | Commit staged changes (like `git commit`) |
+| `aem content push [--force]` | Upload committed changes to da.live |
+
+**Auth token cache:** `.hlx/.da-token.json` (gitignored). Reused across commands; refreshed via
+browser OAuth when expired.
+
+**Limitation — binary push:** `push` silently no-ops on binary files. Use the DA Source API
+for images, PDFs, and fonts. `[verified]`
+
+**Limitation — HTML normalization:** `push` strips EDS-specific decorations (e.g. icon spans)
+before upload. Use the DA Source API for byte-faithful EDS HTML. `[verified]`
+
+---
+
+## Proxy and Certificate Trust
+
+### Proxy environment variables
+
+| Variable | Purpose |
+|---|---|
+| `HTTP_PROXY` | Proxy for HTTP requests |
+| `HTTPS_PROXY` | Proxy for HTTPS requests |
+| `ALL_PROXY` | Fallback proxy for either protocol |
+| `NO_PROXY` | Comma-separated host list to bypass (use `*` to disable all proxies) |
+
+Matching rules: exact host match, or suffix match if the entry begins with `.` or `*`.
+
+### Enterprise CA trust
+
+When a corporate proxy intercepts HTTPS connections, Node.js cannot verify the replaced
+certificate. Fix by adding the corporate CA:
+
+```bash
+# macOS / Linux — set before running aem
+export NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.crt
+aem up
+
+# Windows
+set NODE_EXTRA_CA_CERTS=./certs/corporate-ca.pem
+aem up
+```
+
+`NODE_EXTRA_CA_CERTS` is a Node.js built-in; it is not an `AEM_*` variable and is not
+loaded from `.env`. Set it in your shell profile or CI environment.
+
+---
+
+## `.env` File Example
+
+```dotenv
+# Dev server
+AEM_PORT=8080
+AEM_PAGES_URL=https://main--mysite--myorg.aem.page
+AEM_FORWARD_BROWSER_LOGS=true
+AEM_NO_OPEN=true
+
+# Local HTML serving (import/preview)
+AEM_HTML_FOLDER=drafts
+
+# TLS
+AEM_TLS_CERT=server.crt
+AEM_TLS_KEY=server.key
+
+# Logging
+AEM_LOG_LEVEL=debug
+```

--- a/plugins/aem/edge-delivery-services/skills/aem-cli/references/command-reference.md
+++ b/plugins/aem/edge-delivery-services/skills/aem-cli/references/command-reference.md
@@ -76,7 +76,7 @@ Starts a local import server (default port 3001) that serves the helix-importer-
 | `--open` | `AEM_OPEN` | `/tools/importer/helix-importer-ui/index.html` | Browser path to open on startup |
 | `--no-open` / `--noOpen` | `AEM_NO_OPEN` | — | Disable automatic browser open |
 | `--allow-insecure` / `--allowInsecure` | `AEM_ALLOW_INSECURE` | `true` | Allow self-signed certs on the proxied site |
-| `--ui-repo` / `--uiRepo` | `AEM_UI_REPO` | `https://github.com/adobe/helix-importer-ui` | Custom Importer UI repo; append `#<branch>` for a non-main branch |
+| `--ui-repo` / `--uiRepo` | `AEM_UI_REPO` | `https://www.npmjs.com/package/@adobe/aem-cli` | Custom Importer UI repo; append `#<branch>` for a non-main branch |
 | `--skip-ui` / `--skipUI` | `AEM_SKIP_UI` | `false` | Skip downloading/installing the UI |
 | `--cache` | — | — | Cache proxied responses to a local folder |
 | `--headers-file` / `--headersFile` | — | — | JSON file with custom request headers for the proxy |

--- a/plugins/aem/edge-delivery-services/skills/aem-cli/references/command-reference.md
+++ b/plugins/aem/edge-delivery-services/skills/aem-cli/references/command-reference.md
@@ -76,7 +76,7 @@ Starts a local import server (default port 3001) that serves the helix-importer-
 | `--open` | `AEM_OPEN` | `/tools/importer/helix-importer-ui/index.html` | Browser path to open on startup |
 | `--no-open` / `--noOpen` | `AEM_NO_OPEN` | — | Disable automatic browser open |
 | `--allow-insecure` / `--allowInsecure` | `AEM_ALLOW_INSECURE` | `true` | Allow self-signed certs on the proxied site |
-| `--ui-repo` / `--uiRepo` | `AEM_UI_REPO` | `https://www.npmjs.com/package/@adobe/aem-cli` | Custom Importer UI repo; append `#<branch>` for a non-main branch |
+| `--ui-repo` / `--uiRepo` | `AEM_UI_REPO` | helix-importer-ui repo on GitHub | Custom Importer UI repo; append `#<branch>` for a non-main branch |
 | `--skip-ui` / `--skipUI` | `AEM_SKIP_UI` | `false` | Skip downloading/installing the UI |
 | `--cache` | — | — | Cache proxied responses to a local folder |
 | `--headers-file` / `--headersFile` | — | — | JSON file with custom request headers for the proxy |

--- a/plugins/aem/edge-delivery-services/tile.json
+++ b/plugins/aem/edge-delivery-services/tile.json
@@ -26,6 +26,7 @@
     "slicc-handoff": { "path": "skills/slicc-handoff/SKILL.md" },
     "snowflake": { "path": "skills/snowflake/SKILL.md" },
     "testing-blocks": { "path": "skills/testing-blocks/SKILL.md" },
-    "ue-component-model": { "path": "skills/ue-component-model/SKILL.md" }
+    "ue-component-model": { "path": "skills/ue-component-model/SKILL.md" },
+    "aem-cli": { "path": "skills/aem-cli/SKILL.md" }
   }
 }


### PR DESCRIPTION
## Context

Recent additions to \`@adobe/aem-cli\` — local content rendering (\`--html-folder\`/\`--html-mount\`) and DA content interaction (\`aem content\`) — make the CLI a strong general-purpose standard for EDS development tasks. With those capabilities in place, \`aem-cli\` is now the tool that ties together the local dev loop, content preview, and DA sync. This skill formalises that role: a single reference agents can rely on across EDS workflows instead of piecing together scattered snippets from other skills.

## Summary

- Adds a new \`aem-cli\` reference skill for \`@adobe/aem-cli\` (formerly \`@adobe/helix-cli\`) — the first dedicated skill for the CLI anywhere in this repo or known community collections
- Covers all three commands (\`aem up\`, \`aem import\`, \`aem content\`) with all flags verified against live \`--help\` output (v16.19.1)
- Includes HTTPS/TLS quickstart, \`.env\`/\`AEM_*\` configuration, corporate proxy + \`NODE_EXTRA_CA_CERTS\` handling, the \`helix-cli → aem-cli\` migration, and consolidated troubleshooting
- Documents the two \`aem content push\` limitations (binary no-op, HTML normalization) with DA Source API fallback
- Adds an eval scenario testing the non-obvious behaviours agents get wrong without this skill
- Registers the skill in \`tile.json\` and adds a row to the root README

## Files

- \`plugins/aem/edge-delivery-services/skills/aem-cli/SKILL.md\` — main reference
- \`plugins/aem/edge-delivery-services/skills/aem-cli/references/command-reference.md\` — exhaustive option + \`AEM_*\` env-var tables
- \`plugins/aem/edge-delivery-services/skills/aem-cli/package.json\` + \`.releaserc.json\` — release stubs
- \`plugins/aem/edge-delivery-services/evals/aem-cli-setup-and-troubleshooting/\` — eval scenario (task + criteria)
- \`plugins/aem/edge-delivery-services/tile.json\` — \`aem-cli\` entry added
- \`README.md\` — \`aem-cli\` row added under "Developing with Edge Delivery Services"

## Test plan

- [x] \`npm run validate\` passes — \`Valid skill: plugins/aem/edge-delivery-services/skills/aem-cli\`
- [ ] \`tessl skill review\` scores ≥ 50% (runs automatically in CI)
- [ ] Trigger evals: \`git commit --allow-empty -m "eval: aem-cli setup and troubleshooting"\` (needs \`TESSL_TOKEN\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)