### PR TITLE
ci: tighten tessl-review path filter, raise threshold to 80, and log in with TESSL_TOKEN

### DIFF
--- a/.github/workflows/tessl-review.yml
+++ b/.github/workflows/tessl-review.yml
@@ -44,30 +44,6 @@ jobs:
 
             DIRS=$(echo "$DIRS" | xargs)  # trim whitespace
 
-            # Check for unmatched changes under plugins/
-            UNMATCHED=false
-            for changed_file in $CHANGED_FILES; do
-              case "$changed_file" in
-                plugins/*)
-                  MATCHED=false
-                  for skill_dir in $ALL_SKILL_DIRS; do
-                    case "$changed_file" in
-                      "$skill_dir"/*) MATCHED=true; break ;;
-                    esac
-                  done
-                  if [ "$MATCHED" = "false" ]; then
-                    UNMATCHED=true
-                    break
-                  fi
-                  ;;
-              esac
-            done
-
-            if [ "$UNMATCHED" = "true" ]; then
-              echo "Unmatched changes under plugins/ detected — reviewing all skills"
-              DIRS=$(find plugins -name SKILL.md -exec dirname {} \; 2>/dev/null | tr "\n" " " | xargs)
-            fi
-
             if [ -z "$DIRS" ]; then
               echo "skip=true" >> "$GITHUB_OUTPUT"
               echo "No skill files changed."
@@ -93,7 +69,7 @@ jobs:
       - name: Review skills
         if: steps.detect.outputs.skip != 'true'
         run: |
-          THRESHOLD=50
+          THRESHOLD=80
           PASS=0
           FAIL=0
           SUMMARY_FILE=$(mktemp)

--- a/.github/workflows/tessl-review.yml
+++ b/.github/workflows/tessl-review.yml
@@ -15,6 +15,8 @@ jobs:
           fetch-depth: 0
 
       - uses: tesslio/setup-tessl@v2
+        with:
+          token: ${{ secrets.TESSL_TOKEN }}
 
       - name: Detect changed skills
         id: detect


### PR DESCRIPTION
## Summary

Three small changes to `.github/workflows/tessl-review.yml`:

1. **Path filter now actually filters.** The previous "unmatched changes under `plugins/` ⇒ review all skills" fallback fired whenever a PR touched any non-skill file under `plugins/` (e.g. a publisher-level `README.md`), effectively bypassing the path filter. Confirmed on run [#26564129379](https://github.com/adobe/skills/actions/runs/26564129379) for `feat/java21-migration-skill` where a single-skill PR expanded to reviewing 90+ skills. The fallback is removed; non-skill files under `plugins/` are now simply ignored.
2. **Score threshold raised** from `50` → `80`.
3. **Logged-in reviews.** Pass `secrets.TESSL_TOKEN` to `tesslio/setup-tessl@v2` so `tessl skill review` covers all supporting files instead of only `SKILL.md`. Same-repo PRs and pushes to `main` get full coverage; fork PRs silently fall back to the existing SKILL.md-only behavior.

## Behavior after this change

- PRs: only skill directories whose files actually changed are reviewed.
- Push to `main`: still reviews all skills (unchanged).
- Failing skill = score `< 80%` (was `< 50%`).

## Notes / follow-ups

- `tessl-lint.yml` and `tessl-eval.yml` contain the same "unmatched ⇒ run everything" fallback. Out of scope here — flag for a follow-up if you want them tightened too.
- Raising the threshold to 80 may surface currently-passing skills as failing on the next push to `main`; recent logs showed several skills in the 50–79% range.
- No `environment:` gating was added for `TESSL_TOKEN` (unlike `tessl-eval.yml`, which uses `environment: eval`). Gating would force reviewer approval on every PR push and break review-check UX. If a softer-than-`eval` environment policy is desired for review, that's a config follow-up.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author