### PR TITLE
chore(codeowners): assign /.cursor-plugin/ to @arjuncooliitr

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 /.claude-plugin/                                      @shsteimer @trieloff
 
 # Cursor plugin marketplace config
-/.cursor-plugin/                                      @shsteimer @trieloff
+/.cursor-plugin/                                      @arjuncooliitr
 
 # AEM Edge Delivery Services (Sean Steimer is primary author of all skills)
 /plugins/aem/edge-delivery-services/                   @shsteimer


### PR DESCRIPTION
## Why

The `/.cursor-plugin/` directory is currently owned by `@shsteimer` and `@trieloff` in CODEOWNERS, but neither has contributed to it.

Git history shows the directory was created in a single commit ([`f522a67`](https://github.com/adobe/skills/commit/f522a67a4cec7beff35166fb6aecb9de9e36f80d), *"Add Cursor plugin marketplace and CODEOWNERS"*) entirely by **@arjuncooliitr** (Arjun Gupta). That same commit added the CODEOWNERS line assigning ownership to others rather than himself.

## What

Reassign `/.cursor-plugin/` ownership to its actual author, matching the pattern used for other single-author plugins (e.g. `app-builder` → `@pkumargaddam`, `project-management` → `@asthabh23`).

```diff
-/.cursor-plugin/                                      @shsteimer @trieloff
+/.cursor-plugin/                                      @arjuncooliitr
```

## Note

If `@arjuncooliitr` does not yet have write access to `adobe/skills`, GitHub will flag this entry as invalid and skip code-owner review requests for the path. Please confirm his access before merging.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author