### PR TITLE
feat(aem-65-lts): add Java 21 code migration skill with custom OpenRewrite recipes

### DIFF
--- a/plugins/aem/6.5-lts/.claude-plugin/plugin.json
+++ b/plugins/aem/6.5-lts/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "aem-6-5-lts",
-  "description": "All AEM 6.5 LTS skills: Workflow model design, development, triggering, launchers, debugging, and triaging; Dispatcher config authoring, advisory, incident response, performance tuning, and security hardening; and Replication agent configuration, content activation, API usage, and troubleshooting for AEM 6.5 LTS and AMS environments.",
+  "description": "All AEM 6.5 LTS skills: Java 21 code migration with OpenRewrite recipes and CLI tool; Workflow model design, development, triggering, launchers, debugging, and triaging; Dispatcher config authoring, advisory, incident response, performance tuning, and security hardening; and Replication agent configuration, content activation, API usage, and troubleshooting for AEM 6.5 LTS and AMS environments.",
   "version": "1.0.0",
   "author": {
     "name": "Adobe"
   },
   "repository": "https://github.com/adobe/skills",
   "license": "Apache-2.0",
-  "keywords": ["aem", "aem6.5", "6.5-lts", "ams", "dispatcher", "httpd", "apache", "workflow", "replication", "adobe"]
+  "keywords": ["aem", "aem6.5", "6.5-lts", "ams", "dispatcher", "httpd", "apache", "workflow", "replication", "adobe", "java21", "migration", "openrewrite", "lts"]
 }

--- a/plugins/aem/6.5-lts/skills/java21-migration/.gitignore
+++ b/plugins/aem/6.5-lts/skills/java21-migration/.gitignore
@@ -1,0 +1,17 @@
+# Maven build output
+target/
+*.class
+*.jar
+*.war
+
+# IDE files
+.idea/
+*.iml
+.vscode/
+.project
+.classpath
+.settings/
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/plugins/aem/6.5-lts/skills/java21-migration/README.md
+++ b/plugins/aem/6.5-lts/skills/java21-migration/README.md
@@ -1,0 +1,279 @@
+# AEM 6.5 LTS — Java 21 Migration Skill
+
+Automates the migration of AEM 6.5 LTS Maven projects from Java 8 or Java 11 to Java 21. The skill orchestrates three layers of transformation: deterministic AST-based recipe runs via custom OpenRewrite recipes, structural POM patching via the CLI tool, and AI-assisted resolution of the remaining compilation failures that automated tooling cannot predict.
+
+---
+
+## Problem This Solves
+
+AEM 6.5 LTS ships with a Java 21 runtime requirement, but most existing customer codebases were authored against Java 8 or Java 11. Upgrading is not a simple compiler flag change — it requires coordinated updates across:
+
+- Source and target compiler settings in every Maven module
+- Build plugins that broke or behaved differently under Java 21 (`SCRDescriptorBndPlugin`, older annotation processors)
+- Third-party libraries whose AEM-bundled versions were removed or replaced
+- Test dependencies, especially Mockito, which underwent major API changes between 1.x and 5.x
+- AEM UberJar coordinates, which changed to an `apis` classifier in 6.6.0
+
+Doing this manually across a large multi-module project is error-prone and time-consuming. This skill automates the deterministic parts and guides the AI agent through the non-deterministic remainder.
+
+---
+
+## Prerequisites
+
+### Required JDKs
+
+The migration tool needs all three JDK versions accessible on the machine:
+
+| Variable | Purpose |
+|---|---|
+| `JAVA8_HOME` | Baseline build verification (Java 8 projects) |
+| `JAVA11_HOME` | OpenRewrite execution (OpenRewrite requires JDK 11+) |
+| `JAVA21_HOME` | Intermediate and final builds |
+
+If your project is already on Java 11, `JAVA8_HOME` is not required.
+
+Set these in your shell profile or pass them directly as environment variables when invoking the workflow.
+
+### Maven
+
+- Version 3.9 or later
+- The `mvn` binary must be on `PATH`, or `MAVEN_HOME` must be set
+- Network access to Maven Central and the Adobe Public Repository
+
+A Maven settings template with both repositories pre-configured is available at `configs/maven-settings-template.xml`. Copy it to `~/.m2/settings.xml` or pass it via `-s` if your environment does not already have Adobe repository configuration.
+
+### Git
+
+- A clean working tree before starting (`git status` should show no uncommitted changes)
+- The migration commits to a branch named `java21-migration/<timestamp>` by default
+
+---
+
+## Quick Start
+
+### 1. Build the migration tool
+
+```bash
+cd $SKILL_DIR
+mvn clean install -DskipTests
+```
+
+This compiles both modules and produces the executable JAR:
+
+```
+aem65lts-migration-cli/target/aem65lts-migration-cli-1.0-SNAPSHOT.jar
+```
+
+### 2. Set environment variables
+
+```bash
+export JAVA8_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_xxx.jdk/Contents/Home
+export JAVA11_HOME=/Library/Java/JavaVirtualMachines/jdk-11.jdk/Contents/Home
+export JAVA21_HOME=/Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home
+export PROJECT_DIR=/path/to/your/aem-project
+export SKILL_DIR=/path/to/skills/plugins/aem/6.5-lts/skills/java21-migration
+export MIGRATE_JAR=$SKILL_DIR/aem65lts-migration-cli/target/aem65lts-migration-cli-1.0-SNAPSHOT.jar
+```
+
+### 3. Run the full migration
+
+```bash
+java -jar $MIGRATE_JAR full-migrate \
+  -r $PROJECT_DIR \
+  --javaHome $JAVA21_HOME \
+  --java11Home $JAVA11_HOME \
+  --sourceJavaHome $JAVA8_HOME
+```
+
+Or tell the agent to run the migration:
+
+```
+Run the AEM Java 21 migration workflow for my project at $PROJECT_DIR
+```
+
+The agent will follow `workflows/migrate.md` step by step, pausing to report blockers or request confirmation when required.
+
+### 4. Run individual steps
+
+Each command can be run in isolation:
+
+```bash
+# Analyze only — no changes made
+java -jar $MIGRATE_JAR analyze -r $PROJECT_DIR
+
+# Apply code modernization only (uses JDK 11 for OpenRewrite)
+java -jar $MIGRATE_JAR upgrade-code -r $PROJECT_DIR -j $JAVA11_HOME
+
+# Upgrade plugins only
+java -jar $MIGRATE_JAR upgrade-plugins -r $PROJECT_DIR -j $JAVA11_HOME
+
+# Upgrade dependencies
+java -jar $MIGRATE_JAR upgrade-dependencies -r $PROJECT_DIR -j $JAVA11_HOME
+
+# Migrate UberJar coordinates
+java -jar $MIGRATE_JAR upgrade-uberjar -r $PROJECT_DIR -j $JAVA11_HOME
+
+# Migrate test frameworks (Mockito)
+java -jar $MIGRATE_JAR upgrade-tests -r $PROJECT_DIR -j $JAVA21_HOME
+
+# Post-migration verification
+java -jar $MIGRATE_JAR verify -r $PROJECT_DIR
+```
+
+### 5. Review the output
+
+After a successful run the agent produces:
+
+- `report.md` — Summary of all changes made, grouped by category
+- `verification.json` — Machine-readable verification results
+- A git branch `java21-migration/<timestamp>` containing the migration commits
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    aem-migrate CLI                       │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌───────────┐  │
+│  │ analyze  │ │ upgrade- │ │ upgrade- │ │   full-   │  │
+│  │          │ │   code   │ │  tests   │ │  migrate  │  │
+│  └──────────┘ └──────────┘ └──────────┘ └───────────┘  │
+│         │            │            │            │         │
+│         └────────────┴────────────┴────────────┘        │
+│                          │                               │
+│               OpenRewriteRunner                          │
+│         (Maven Invoker → rewrite-maven-plugin)          │
+└─────────────────────┬───────────────────────────────────┘
+                      │
+    ┌─────────────────┼──────────────────┐
+    │                 │                  │
+    ▼                 ▼                  ▼
+┌─────────┐  ┌──────────────┐  ┌─────────────────┐
+│ Stock    │  │   Custom     │  │  Target AEM     │
+│ OpenRW   │  │   Recipes    │  │  Maven Project  │
+│ Recipes  │  │  (our JAR)   │  │  (customer)     │
+└─────────┘  └──────────────┘  └─────────────────┘
+```
+
+### Module Roles
+
+**`aem65lts-migration-recipes`** (`aem65lts-migration-recipes/`)
+Custom OpenRewrite recipes written in Java and packaged as a standard Maven JAR. These recipes are injected into the `rewrite-maven-plugin` classpath at runtime via the CLI tool. They extend the stock OpenRewrite recipe set with AEM-specific transformations: FileVault embedded artifact changes, BND plugin instruction removal, jakarta→javax reversion, and unsupported package detection.
+
+**`aem65lts-migration-cli`** (`aem65lts-migration-cli/`)
+A picocli-based CLI that wraps Maven Invoker API calls. Each command constructs the appropriate `rewrite-maven-plugin` invocation, injects the recipes JAR, passes the correct JDK, and streams Maven output back to the console. The `full-migrate` command sequences all individual commands into the complete 8-step pipeline.
+
+**AI-assisted fixing** (agent behavior guided by `references/migration-guardrails.md`)
+Addresses compilation failures that remain after the automated layers. The agent reads compiler output, identifies the root cause, applies a targeted fix, and re-runs the build. Guardrails prevent the agent from making changes that would appear to fix the build but break AEM runtime behaviour (for example, switching javax to jakarta).
+
+---
+
+## Directory Structure
+
+```
+java21-migration/
+├── SKILL.md                              # Skill metadata and pipeline overview
+├── README.md                             # This file
+├── pom.xml                               # Parent POM (two-module Maven project)
+├── aem65lts-migration-recipes/           # Module 1: custom OpenRewrite recipes
+│   ├── pom.xml
+│   └── src/main/java/...
+│       ├── RevertJakartaInAemSource.java
+│       ├── RemoveBndScrDescriptorPlugin.java
+│       ├── MigrateFileVaultEmbeddedArtifacts.java
+│       └── DetectUnsupportedPackages.java
+├── aem65lts-migration-cli/              # Module 2: picocli CLI wrapper
+│   ├── pom.xml
+│   └── src/main/java/...
+│       ├── MigrateCli.java              # Entry point, command registration
+│       ├── commands/
+│       │   ├── FullMigrateCommand.java
+│       │   ├── AnalyzeCommand.java
+│       │   ├── UpgradeCodeCommand.java
+│       │   └── ...
+│       └── OpenRewriteRunner.java       # Maven Invoker wrapper
+├── configs/                             # Migration configuration files
+│   ├── maven-settings-template.xml
+│   └── unsupported-apis.yaml
+├── references/                          # Technical reference documentation
+│   ├── migration-guardrails.md
+│   └── removed-bundles-remediation.md
+└── workflows/                           # Step-by-step migration workflows
+    └── migrate.md
+```
+
+---
+
+## Configuration
+
+### `configs/unsupported-apis.yaml`
+Defines packages that cause a hard stop (cannot migrate) versus packages that produce a warning (migration continues with a note). Edit this file to adjust thresholds for your project's risk tolerance.
+
+### `configs/maven-settings-template.xml`
+A ready-to-use Maven settings file with Adobe Public Repository and Maven Central configured. Copy to `~/.m2/settings.xml` if needed.
+
+---
+
+## Troubleshooting
+
+### "Blocker detected: unsupported package"
+
+The pre-migration analysis found usage of a package listed in `configs/unsupported-apis.yaml` under `hard_stop_packages`. The migration cannot proceed until this dependency is resolved. See the reason and remediation in the analysis output.
+
+### CLI fails with "Could not resolve plugin" during OpenRewrite steps
+
+Ensure network access to Maven Central is available, or add the `configs/maven-settings-template.xml` as your active Maven settings:
+
+```bash
+java -jar $MIGRATE_JAR upgrade-code \
+  -r $PROJECT_DIR \
+  -j $JAVA11_HOME \
+  --mavenSettings $SKILL_DIR/configs/maven-settings-template.xml
+```
+
+### Build fails with `javax.* cannot be resolved` after upgrade-code
+
+OpenRewrite's Java 17/21 migration recipes sometimes introduce `jakarta.*` imports. AEM 6.5 LTS does not use the Jakarta namespace. The `RevertJakartaInAemSource` recipe in the custom recipes module handles this automatically; if it did not run, re-run `upgrade-code`.
+
+### BND plugin errors after upgrade-plugins
+
+If `SCRDescriptorBndPlugin` was not fully removed, the `RemoveBndScrDescriptorPlugin` recipe should handle it. Re-run `upgrade-plugins` to retry.
+
+### JAR not found after `mvn clean install`
+
+Ensure the build ran from the project root (the directory containing the parent `pom.xml`). Both modules must compile successfully before the CLI JAR is available at `aem65lts-migration-cli/target/aem65lts-migration-cli-1.0-SNAPSHOT.jar`.
+
+### Final build still fails after 3 AI-assisted attempts
+
+This indicates a non-trivial migration issue that requires human review. The agent will hard-stop and provide:
+- The full compiler error
+- The files it attempted to fix
+- The guardrail that prevented further attempts
+
+Escalate to a senior engineer for manual remediation of those specific modules.
+
+---
+
+## FAQ
+
+**Q: Does this skill modify my source files in place?**
+Yes. All changes are applied directly to the working tree. The workflow requires a clean git status before starting so that all changes are attributable and reversible via `git checkout`.
+
+**Q: Can I run individual steps instead of the full pipeline?**
+Yes. Each command (`upgrade-code`, `upgrade-plugins`, etc.) is self-contained. Ensure prerequisite steps have already been completed before running a later step in isolation (for example, `upgrade-tests` should run after `upgrade-code` and an intermediate JDK 21 build).
+
+**Q: What if my project uses a monorepo layout?**
+Point `-r` at the root `pom.xml` directory. All recipes and CLI commands recurse into submodules automatically via the Maven multi-module reactor.
+
+**Q: Does the skill handle frontend Maven modules (npm/webpack)?**
+No. All Maven builds in this workflow use `-DskipFrontend=true`. Frontend build verification is outside the scope of this migration skill.
+
+**Q: Will this skill upgrade my AEM version?**
+No. This skill migrates Java source code and build configuration only. It does not change AEM service pack versions, content packages, or repository configuration.
+
+**Q: What happens to my Groovy Console scripts?**
+If your project bundles the Groovy Console, the `MigrateFileVaultEmbeddedArtifacts` recipe updates the group ID to `be.orbinson.aem` and sets version `19.0.8`. Existing Groovy scripts in the repository are not modified.
+
+**Q: Is Mockito migration mandatory?**
+No. The `upgrade-tests` step is marked non-fatal. If it fails, the workflow logs a warning and continues. You can migrate Mockito manually after the Java 21 migration is complete.

--- a/plugins/aem/6.5-lts/skills/java21-migration/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/java21-migration/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: java21-migration
+description: "[BETA] Use when the user needs to upgrade an AEM 6.5 LTS Maven project from Java 8 or Java 11 to Java 21, or mentions JDK 21, Java version upgrade, AEM 6.5 LTS migration, pom.xml compiler upgrade, deprecated Java API replacement, Mockito 1.x to 5.x migration, UberJar 6.6.0, bnd or maven-bundle-plugin upgrade, AEM modernization, or LTS code compatibility. Updates Maven compiler/source/target/release to 21, applies OpenRewrite Java 8 to 21 modernization recipes, swaps deprecated APIs, upgrades bnd, maven-bundle, maven-scr, filevault, JaCoCo, SpotBugs and Lombok plugins, migrates Core WCM Components, relocates Groovy Console coordinates, adds the apis classifier to UberJar 6.6.0, runs Mockito 1.x to 5.x progressive migration, sets .cloudmanager/java-version to 21, and verifies the resulting build. Beta skill: verify outputs before production use."
+license: Apache-2.0
+compatibility: Requires JDK 8, JDK 11, JDK 21 and Apache Maven 3.9+ on PATH or via JAVA8_HOME, JAVA11_HOME, JAVA21_HOME, and MAVEN_HOME environment variables. Built and run on AEM 6.5 LTS Maven projects.
+allowed-tools: Bash Read Write Edit Glob Grep
+metadata:
+  status: beta
+  version: 1.0.0
+  last-updated: 2026-06-03
+  triggers:
+    - "migrate to java 21"
+    - "java 21 migration"
+    - "aem lts migration"
+    - "upgrade java version"
+    - "java 8 to 21"
+    - "java 11 to 21"
+    - "modernize java"
+---
+
+> **Beta Skill**: This skill is in beta and under active development.
+> Results should be reviewed carefully before use in production.
+> Report issues at https://github.com/adobe/skills/issues
+
+# AEM 6.5 LTS — Java 21 Migration
+
+Migrate an AEM 6.5 LTS Maven project from Java 8 or 11 to Java 21. Use this skill when a user asks to "migrate to Java 21", "upgrade to AEM 6.5 LTS", "modernize an AEM 6.5 codebase", or similar.
+
+## Run This (5 commands)
+
+```bash
+# 0. Set context (caller provides AEM_PROJECT_PATH, JAVA8_HOME, JAVA11_HOME, JAVA21_HOME)
+SKILL_DIR="plugins/aem/6.5-lts/skills/java21-migration"
+
+# 1. Build the migration tool (once per checkout)
+mvn -f "$SKILL_DIR/pom.xml" clean install -DskipTests
+MIGRATE_JAR="$SKILL_DIR/aem65lts-migration-cli/target/aem65lts-migration-cli-1.0-SNAPSHOT.jar"
+
+# 2. Pre-flight check — exit 0 ready, 1 warnings, 2 blockers (STOP)
+java -jar "$MIGRATE_JAR" analyze -r "$AEM_PROJECT_PATH"
+
+# 3. Run the full 8-step pipeline
+java -jar "$MIGRATE_JAR" full-migrate \
+  -r "$AEM_PROJECT_PATH" \
+  --sourceJavaHome "$JAVA8_HOME" \
+  --java11Home   "$JAVA11_HOME" \
+  --javaHome     "$JAVA21_HOME"
+
+# 4. Verify and review
+java -jar "$MIGRATE_JAR" verify -r "$AEM_PROJECT_PATH"
+( cd "$AEM_PROJECT_PATH" && git diff --stat )
+```
+
+`full-migrate` runs eight steps end-to-end: validate, baseline build, `upgrade-code`, `upgrade-plugins`, `upgrade-dependencies` + `upgrade-uberjar`, set `.cloudmanager/java-version=21`, intermediate build, `upgrade-tests`. Each step can also be invoked individually (see `workflows/migrate.md`).
+
+## Failure Recovery
+
+| Failure | Do this | Reference |
+|---|---|---|
+| `analyze` exits 2 | STOP. Remove the unsupported package or escalate. | `references/migration-guardrails.md` |
+| Baseline build fails | Fix the source-version compile error first (max 3 retries). | `references/build-troubleshooting.md` |
+| `upgrade-code` fails | Re-run pinned to `--sourceJavaHome`; fall back to JDK 8 if JDK 11 cannot parse. | `references/openrewrite-commands.md` |
+| Intermediate build fails | AI-assisted fix within guardrails. **Never** swap javax→jakarta (max 3 retries). | `references/migration-guardrails.md` |
+| `upgrade-tests` fails | Non-fatal: log and continue. | `workflows/migrate.md` step 9 |
+| `verify` reports issues | Resolve each item, re-run `verify`, then commit. | `references/post-migration-checklist.md` |
+
+## Three Layers
+
+1. **OpenRewrite recipes** (`aem65lts-migration-recipes/` + bundled declarative composites under `aem65lts-migration-cli/src/main/resources/META-INF/config/openrewrite/recipes/`) — deterministic AST transforms for Java code, Mockito tests, POM dependencies, and plugin configuration. Idempotency is enforced by per-recipe unit tests.
+2. **CLI tool** (`aem65lts-migration-cli/`) — picocli wrapper exposing `analyze`, `upgrade-code`, `upgrade-tests`, `upgrade-uberjar`, `upgrade-plugins`, `upgrade-dependencies`, `full-migrate`, `verify`. The CLI is the only supported entry point — recipe artefact coordinates and active-recipe names are pinned in code so they cannot drift between runs.
+3. **AI-assisted fixes** — Claude resolves residual compile errors under the rules in `references/migration-guardrails.md` (max 3 retries per phase, attributed via `// aem-lts-migration: ai-fix`).
+
+## Hard Guardrails (read these before any fix)
+
+- **javax stays javax.** AEM 6.5 LTS does not export `jakarta.*`. A swap compiles but breaks at runtime.
+- **Unsupported packages → STOP.** Commerce, Communities, Granite Social, Screens, We.Retail, DAM PIM/rating, Search & Promote, MCM Campaign.
+- **Enforcer version floor only rises.** 1.8 → 11 → 21. Never lower.
+- **Removed runtime bundles.** Guava, Caffeine, Jetty, Commons-Collections 3 → embed or refactor (see `references/removed-bundles-remediation.md`).
+- **POM formatting is preserved by construction.** All POM edits go through OpenRewrite recipes, not text substitution.
+
+## What Changes
+
+| Item | Target |
+|---|---|
+| Java source/target/release | 21 |
+| AEM UberJar | 6.6.0 + `apis` classifier |
+| maven-bundle-plugin | 5.1.9 |
+| bnd-maven-plugin family | 6.4.0 |
+| maven-scr-plugin | 1.26.4 + `asm-analysis` 9.7.1 |
+| filevault-package-maven-plugin | 1.3.6 |
+| Core WCM Components | 2.30.4 |
+| Groovy Console coordinates | `be.orbinson.aem:*:19.0.8` |
+| Mockito + byte-buddy | 5.x + 1.15.x |
+| `.cloudmanager/java-version` | `21` |
+
+## Layout
+
+```
+java21-migration/
+├── SKILL.md, README.md
+├── pom.xml                         # parent reactor
+├── aem65lts-migration-recipes/     # custom OpenRewrite recipes (Java) + tests
+├── aem65lts-migration-cli/         # picocli CLI + bundled declarative recipe YAMLs
+├── configs/                        # settings.xml, toolchains.xml, analyzer rules
+├── references/                     # guardrails, troubleshooting, checklists
+└── workflows/migrate.md            # step-by-step playbook for the agent
+```

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/pom.xml
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.adobe.aem</groupId>
+        <artifactId>aem65lts-migration-tool</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>aem65lts-migration-cli</artifactId>
+    <packaging>jar</packaging>
+    <name>AEM 6.5 LTS Migration CLI</name>
+    <description>Picocli-based CLI wrapping OpenRewrite Maven plugin invocations for AEM 6.5 LTS migration</description>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>4.7.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-invoker</artifactId>
+            <version>3.3.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.adobe.aem.migration.cli.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/Main.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/Main.java
@@ -1,0 +1,40 @@
+package com.adobe.aem.migration.cli;
+
+import com.adobe.aem.migration.cli.commands.AnalyzeCommand;
+import com.adobe.aem.migration.cli.commands.FullMigrateCommand;
+import com.adobe.aem.migration.cli.commands.UpgradeCodeCommand;
+import com.adobe.aem.migration.cli.commands.UpgradeDependenciesCommand;
+import com.adobe.aem.migration.cli.commands.UpgradePluginsCommand;
+import com.adobe.aem.migration.cli.commands.UpgradeTestsCommand;
+import com.adobe.aem.migration.cli.commands.UpgradeUberJarCommand;
+import com.adobe.aem.migration.cli.commands.VerifyCommand;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "aem-migrate",
+    description = "AEM 6.5 LTS code migration tool — upgrades Maven projects from Java 8/11 to Java 21",
+    mixinStandardHelpOptions = true,
+    version = "1.0-SNAPSHOT",
+    subcommands = {
+        UpgradeCodeCommand.class,
+        UpgradeTestsCommand.class,
+        UpgradeUberJarCommand.class,
+        UpgradePluginsCommand.class,
+        UpgradeDependenciesCommand.class,
+        FullMigrateCommand.class,
+        AnalyzeCommand.class,
+        VerifyCommand.class
+    }
+)
+public class Main implements Runnable {
+
+    @Override
+    public void run() {
+        CommandLine.usage(this, System.out);
+    }
+
+    public static void main(String[] args) {
+        int exitCode = new CommandLine(new Main()).execute(args);
+        System.exit(exitCode);
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/commands/AbstractOpenRewriteCommand.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/commands/AbstractOpenRewriteCommand.java
@@ -1,0 +1,65 @@
+package com.adobe.aem.migration.cli.commands;
+
+import com.adobe.aem.migration.openrewrite.OpenRewriteRunner;
+import picocli.CommandLine;
+
+import java.io.File;
+import java.util.concurrent.Callable;
+
+public abstract class AbstractOpenRewriteCommand implements Callable<Integer> {
+
+    @CommandLine.Option(names = {"--repository-path", "-r"},
+                        description = "Path to the AEM Maven project", required = true)
+    protected File repositoryPath;
+
+    @CommandLine.Option(names = {"--javaHome", "-j"},
+                        description = "Path to JDK installation to use for the build")
+    protected String javaHome;
+
+    @CommandLine.Option(names = {"--dryRun", "-d"},
+                        description = "Run in dry-run mode (no changes applied)")
+    protected boolean dryRun;
+
+    protected abstract String getActiveRecipes();
+    protected abstract String getRecipeArtifactCoordinates();
+    protected String getConfigLocation() { return null; }
+
+    @Override
+    public Integer call() throws Exception {
+        validateRepositoryPath();
+
+        System.out.println("[aem-migrate] Running: " + getCommandName());
+        System.out.println("[aem-migrate] Repository: " + repositoryPath.getAbsolutePath());
+        System.out.println("[aem-migrate] JDK: " + (javaHome != null ? javaHome : "system default"));
+        System.out.println("[aem-migrate] Dry run: " + dryRun);
+
+        OpenRewriteRunner runner = new OpenRewriteRunner(repositoryPath, javaHome);
+
+        int exitCode = runner.runRecipe(
+            getActiveRecipes(),
+            getConfigLocation(),
+            getRecipeArtifactCoordinates(),
+            dryRun
+        );
+
+        if (exitCode == 0) {
+            System.out.println("[aem-migrate] " + getCommandName() + " completed successfully.");
+        } else {
+            System.err.println("[aem-migrate] " + getCommandName() + " failed with exit code: " + exitCode);
+        }
+
+        return exitCode;
+    }
+
+    protected abstract String getCommandName();
+
+    protected void validateRepositoryPath() {
+        if (!repositoryPath.exists() || !repositoryPath.isDirectory()) {
+            throw new IllegalArgumentException("Repository path does not exist: " + repositoryPath);
+        }
+        File pomFile = new File(repositoryPath, "pom.xml");
+        if (!pomFile.exists()) {
+            throw new IllegalArgumentException("No pom.xml found at: " + repositoryPath);
+        }
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/commands/AnalyzeCommand.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/commands/AnalyzeCommand.java
@@ -1,0 +1,158 @@
+package com.adobe.aem.migration.cli.commands;
+
+import com.adobe.aem.migration.cli.report.AnalysisReport;
+import com.adobe.aem.migration.cli.report.AnalysisReport.Finding;
+import com.adobe.aem.migration.cli.report.AnalysisReport.Severity;
+import picocli.CommandLine;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.stream.Stream;
+
+/**
+ * Pre-migration scan. Walks the project tree and produces a structured
+ * {@link AnalysisReport} listing every blocker (Tier 0 in
+ * {@code references/build-fix-constraints.md}) and every warning the
+ * downstream migration phases will need to address.
+ *
+ * <p>The exit code follows the standard CI convention:
+ *
+ * <ul>
+ *   <li>{@code 0} — ready, no blockers, no warnings.</li>
+ *   <li>{@code 1} — ready with warnings (e.g. removed-bundle imports the
+ *       agent must remediate manually).</li>
+ *   <li>{@code 2} — blocked, migration cannot proceed.</li>
+ * </ul>
+ *
+ * <p>By default the command emits a human-readable summary on stdout. The
+ * {@code --json} option swaps that for a single-line JSON document on
+ * stdout suitable for CI ingestion. The schema is documented in
+ * {@link AnalysisReport}.
+ */
+@CommandLine.Command(name = "analyze",
+                     description = "Analyze project for migration blockers and warnings")
+public class AnalyzeCommand implements Callable<Integer> {
+
+    @CommandLine.Option(names = {"--repository-path", "-r"},
+                        description = "Path to the AEM Maven project", required = true)
+    private File repositoryPath;
+
+    @CommandLine.Option(names = {"--json"},
+                        description = "Emit a machine-readable JSON report on stdout instead of the human summary")
+    private boolean json;
+
+    private static final String[] UNSUPPORTED_PACKAGES = {
+        "com.adobe.cq.commerce.", "com.adobe.cq.social.", "com.adobe.granite.social.",
+        "com.adobe.cq.screens.", "com.adobe.cq.sample.we.retail.",
+        "com.day.cq.dam.pim.", "com.day.cq.dam.rating.",
+        "com.adobe.cq.searchpromote.", "com.adobe.cq.mcm.campaign."
+    };
+
+    private static final String[] REMOVED_BUNDLE_PACKAGES = {
+        "com.google.common.", "com.github.benmanes.caffeine.",
+        "org.eclipse.jetty."
+    };
+
+    @Override
+    public Integer call() throws Exception {
+        AnalysisReport report = new AnalysisReport(repositoryPath.getAbsolutePath());
+
+        if (!repositoryPath.exists() || !new File(repositoryPath, "pom.xml").exists()) {
+            report.fatal("Invalid project: no pom.xml at " + repositoryPath.getAbsolutePath());
+            emit(report);
+            return 2;
+        }
+
+        report.detectedJavaVersion(detectJavaVersion());
+        report.findings(collectFindings(UNSUPPORTED_PACKAGES, Severity.BLOCKER));
+        report.findings(collectFindings(REMOVED_BUNDLE_PACKAGES, Severity.WARNING));
+        report.hasGit(new File(repositoryPath, ".git").exists());
+        report.hasCloudManagerConfig(new File(repositoryPath, ".cloudmanager").exists());
+
+        emit(report);
+        return report.exitCode();
+    }
+
+    private void emit(AnalysisReport report) {
+        if (json) {
+            System.out.println(report.toJson());
+        } else {
+            System.out.println(report.toHumanReadable());
+        }
+    }
+
+    private List<Finding> collectFindings(String[] packagePrefixes, Severity severity) throws IOException {
+        List<Finding> findings = new ArrayList<>();
+        try (Stream<Path> walk = Files.walk(repositoryPath.toPath())) {
+            for (Path javaFile : (Iterable<Path>) walk
+                    .filter(p -> p.toString().endsWith(".java"))
+                    .filter(p -> !p.toString().contains("/target/"))::iterator) {
+                String content = new String(Files.readAllBytes(javaFile));
+                String[] lines = content.split("\n", -1);
+                for (int i = 0; i < lines.length; i++) {
+                    String line = lines[i];
+                    if (!line.trim().startsWith("import ")) {
+                        continue;
+                    }
+                    for (String pkg : packagePrefixes) {
+                        if (line.contains("import " + pkg)) {
+                            findings.add(new Finding(
+                                    severity,
+                                    pkg,
+                                    repositoryPath.toPath().relativize(javaFile).toString(),
+                                    i + 1));
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        return findings;
+    }
+
+    private String detectJavaVersion() throws IOException {
+        Path cmFile = repositoryPath.toPath().resolve(".cloudmanager/java-version");
+        if (Files.exists(cmFile)) {
+            String version = new String(Files.readAllBytes(cmFile)).trim();
+            if (!version.isEmpty()) {
+                return version;
+            }
+        }
+
+        Path pomPath = repositoryPath.toPath().resolve("pom.xml");
+        String pomContent = new String(Files.readAllBytes(pomPath));
+
+        for (String prop : new String[]{"maven.compiler.source", "maven.compiler.release"}) {
+            int idx = pomContent.indexOf("<" + prop + ">");
+            if (idx >= 0) {
+                int start = idx + prop.length() + 2;
+                int end = pomContent.indexOf("</" + prop + ">", start);
+                if (end > start) {
+                    return pomContent.substring(start, end).trim();
+                }
+            }
+        }
+
+        if (pomContent.contains("<source>") && pomContent.contains("maven-compiler-plugin")) {
+            int pluginIdx = pomContent.indexOf("maven-compiler-plugin");
+            int sourceIdx = pomContent.indexOf("<source>", pluginIdx);
+            if (sourceIdx >= 0) {
+                int start = sourceIdx + 8;
+                int end = pomContent.indexOf("</source>", start);
+                if (end > start) {
+                    String val = pomContent.substring(start, end).trim();
+                    if (!val.startsWith("$")) {
+                        return val;
+                    }
+                }
+            }
+        }
+
+        return "unknown";
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/commands/FullMigrateCommand.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/commands/FullMigrateCommand.java
@@ -1,0 +1,186 @@
+package com.adobe.aem.migration.cli.commands;
+
+import com.adobe.aem.migration.openrewrite.OpenRewriteRunner;
+import picocli.CommandLine;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(name = "full-migrate",
+                     description = "Run complete AEM 6.5 LTS migration (all steps)")
+public class FullMigrateCommand implements Callable<Integer> {
+
+    @CommandLine.Option(names = {"--repository-path", "-r"},
+                        description = "Path to the AEM Maven project", required = true)
+    private File repositoryPath;
+
+    @CommandLine.Option(names = {"--javaHome", "-j"},
+                        description = "Path to JDK 21 installation")
+    private String javaHome;
+
+    @CommandLine.Option(names = {"--java11Home"},
+                        description = "Path to JDK 11 installation (used for OpenRewrite code migration)")
+    private String java11Home;
+
+    @CommandLine.Option(names = {"--sourceJavaHome"},
+                        description = "Path to source JDK (8 or 11) for initial build verification")
+    private String sourceJavaHome;
+
+    @CommandLine.Option(names = {"--dryRun", "-d"},
+                        description = "Run in dry-run mode")
+    private boolean dryRun;
+
+    @CommandLine.Option(names = {"--skip-tests"},
+                        description = "Skip running test upgrade (Mockito migration)",
+                        defaultValue = "false")
+    private boolean skipTests;
+
+    private static final String REWRITE_MIGRATE_JAVA = "org.openrewrite.recipe:rewrite-migrate-java:3.9.0";
+    private static final String REWRITE_TESTING = "org.openrewrite.recipe:rewrite-testing-frameworks:3.9.0";
+    private static final String CUSTOM_RECIPES = "com.adobe.aem:aem65lts-migration-recipes:1.0-SNAPSHOT";
+
+    @Override
+    public Integer call() throws Exception {
+        System.out.println("=== AEM 6.5 LTS Full Migration ===");
+        System.out.println("Repository: " + repositoryPath.getAbsolutePath());
+        System.out.println();
+
+        // Step 1: Validate project structure
+        System.out.println("[Step 1/8] Validating project structure...");
+        if (!validateProject()) return 1;
+
+        // Step 2: Initial build with source JDK
+        if (sourceJavaHome != null) {
+            System.out.println("[Step 2/8] Running baseline build with source JDK...");
+            OpenRewriteRunner baselineRunner = new OpenRewriteRunner(repositoryPath, sourceJavaHome);
+            int buildResult = baselineRunner.runBuild(true);
+            if (buildResult != 0) {
+                System.err.println("[FAIL] Baseline build failed. Fix compilation errors before migration.");
+                return 1;
+            }
+            System.out.println("[OK] Baseline build succeeded.");
+        } else {
+            System.out.println("[Step 2/8] Skipping baseline build (no --sourceJavaHome specified).");
+        }
+
+        // Step 3: Apply Java code modernization (use JDK 11 for OpenRewrite)
+        String orJavaHome = java11Home != null ? java11Home : javaHome;
+        System.out.println("[Step 3/8] Applying Java code modernization recipes...");
+        OpenRewriteRunner codeRunner = new OpenRewriteRunner(repositoryPath, orJavaHome);
+        int codeResult = codeRunner.runRecipe(
+                "aem.lts.migration.UpgradeToAEM65LTS",
+                null,
+                REWRITE_MIGRATE_JAVA + "," + CUSTOM_RECIPES,
+                dryRun
+        );
+        if (codeResult != 0) {
+            System.err.println("[WARN] Java code migration had issues (exit code: " + codeResult + ").");
+            System.err.println("       Continuing — build step will surface remaining errors.");
+        } else {
+            System.out.println("[OK] Java code modernization applied.");
+        }
+
+        // Step 4: Apply plugin version upgrades
+        System.out.println("[Step 4/8] Upgrading Maven build plugins...");
+        int pluginResult = codeRunner.runRecipe(
+                "aem.lts.migration.UpgradePluginVersions",
+                null,
+                CUSTOM_RECIPES,
+                dryRun
+        );
+        reportStepResult("Plugin upgrades", pluginResult);
+
+        // Step 5: Apply dependency version upgrades + UberJar migration
+        System.out.println("[Step 5/8] Upgrading dependencies and UberJar...");
+        int depResult = codeRunner.runRecipe(
+                "aem.lts.migration.UpgradeCommonLibraries,aem.lts.migration.UpdateUberJarVersion",
+                null,
+                CUSTOM_RECIPES,
+                dryRun
+        );
+        reportStepResult("Dependency upgrades", depResult);
+
+        // Step 6: Set .cloudmanager/java-version
+        System.out.println("[Step 6/8] Setting CloudManager Java version...");
+        setCloudManagerJavaVersion();
+
+        // Step 7: Intermediate build with JDK 21
+        if (!dryRun) {
+            System.out.println("[Step 7/8] Running intermediate build with JDK 21...");
+            OpenRewriteRunner buildRunner = new OpenRewriteRunner(repositoryPath, javaHome);
+            int intermediateResult = buildRunner.runBuild(true);
+            if (intermediateResult != 0) {
+                System.err.println("[WARN] Intermediate build failed. AI-assisted fixing may be needed.");
+            } else {
+                System.out.println("[OK] Intermediate build succeeded with JDK 21.");
+            }
+        }
+
+        // Step 8: Apply Mockito/test framework migration
+        if (!skipTests) {
+            System.out.println("[Step 8/8] Applying test framework migration (Mockito)...");
+            OpenRewriteRunner testRunner = new OpenRewriteRunner(repositoryPath, javaHome);
+            int testResult = testRunner.runRecipe(
+                    "aem.lts.migration.UpgradeTestingFrameworks",
+                    null,
+                    REWRITE_TESTING,
+                    dryRun
+            );
+            if (testResult != 0) {
+                System.out.println("[INFO] Test framework migration had issues. This is non-fatal.");
+            } else {
+                System.out.println("[OK] Test framework migration applied.");
+            }
+        } else {
+            System.out.println("[Step 8/8] Skipping test framework migration (--skip-tests).");
+        }
+
+        System.out.println();
+        System.out.println("=== Migration Complete ===");
+        if (dryRun) {
+            System.out.println("This was a DRY RUN — no files were modified.");
+        } else {
+            System.out.println("Review changes with: git diff");
+            System.out.println("Run verification: aem-migrate verify -r " + repositoryPath.getAbsolutePath());
+        }
+        return 0;
+    }
+
+    private boolean validateProject() {
+        if (!repositoryPath.exists() || !repositoryPath.isDirectory()) {
+            System.err.println("[FAIL] Repository path does not exist: " + repositoryPath);
+            return false;
+        }
+        if (!new File(repositoryPath, "pom.xml").exists()) {
+            System.err.println("[FAIL] No pom.xml found at: " + repositoryPath);
+            return false;
+        }
+        if (!new File(repositoryPath, ".git").exists()) {
+            System.err.println("[WARN] No .git directory — cannot track changes.");
+        }
+        System.out.println("[OK] Project structure valid.");
+        return true;
+    }
+
+    private void setCloudManagerJavaVersion() throws IOException {
+        if (dryRun) {
+            System.out.println("[DRY RUN] Would set .cloudmanager/java-version to 21");
+            return;
+        }
+        Path cmDir = repositoryPath.toPath().resolve(".cloudmanager");
+        Files.createDirectories(cmDir);
+        Files.write(cmDir.resolve("java-version"), "21\n".getBytes());
+        System.out.println("[OK] .cloudmanager/java-version set to 21.");
+    }
+
+    private void reportStepResult(String stepName, int exitCode) {
+        if (exitCode == 0) {
+            System.out.println("[OK] " + stepName + " applied.");
+        } else {
+            System.out.println("[WARN] " + stepName + " had issues (exit code: " + exitCode + ").");
+        }
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/commands/UpgradeCodeCommand.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/commands/UpgradeCodeCommand.java
@@ -1,0 +1,27 @@
+package com.adobe.aem.migration.cli.commands;
+
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "upgrade-code",
+                     description = "Upgrade Java source code from 8/11 to 21")
+public class UpgradeCodeCommand extends AbstractOpenRewriteCommand {
+
+    private static final String RECIPE_ARTIFACTS =
+        "org.openrewrite.recipe:rewrite-migrate-java:3.9.0," +
+        "com.adobe.aem:aem65lts-migration-recipes:1.0-SNAPSHOT";
+
+    @Override
+    protected String getActiveRecipes() {
+        return "aem.lts.migration.UpgradeToAEM65LTS";
+    }
+
+    @Override
+    protected String getRecipeArtifactCoordinates() {
+        return RECIPE_ARTIFACTS;
+    }
+
+    @Override
+    protected String getCommandName() {
+        return "upgrade-code";
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/commands/UpgradeDependenciesCommand.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/commands/UpgradeDependenciesCommand.java
@@ -1,0 +1,26 @@
+package com.adobe.aem.migration.cli.commands;
+
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "upgrade-dependencies",
+                     description = "Upgrade AEM-specific dependency versions")
+public class UpgradeDependenciesCommand extends AbstractOpenRewriteCommand {
+
+    private static final String RECIPE_ARTIFACTS =
+        "com.adobe.aem:aem65lts-migration-recipes:1.0-SNAPSHOT";
+
+    @Override
+    protected String getActiveRecipes() {
+        return "aem.lts.migration.UpgradeCommonLibraries";
+    }
+
+    @Override
+    protected String getRecipeArtifactCoordinates() {
+        return RECIPE_ARTIFACTS;
+    }
+
+    @Override
+    protected String getCommandName() {
+        return "upgrade-dependencies";
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/commands/UpgradePluginsCommand.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/commands/UpgradePluginsCommand.java
@@ -1,0 +1,26 @@
+package com.adobe.aem.migration.cli.commands;
+
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "upgrade-plugins",
+                     description = "Upgrade Maven build plugins for Java 21 compatibility")
+public class UpgradePluginsCommand extends AbstractOpenRewriteCommand {
+
+    private static final String RECIPE_ARTIFACTS =
+        "com.adobe.aem:aem65lts-migration-recipes:1.0-SNAPSHOT";
+
+    @Override
+    protected String getActiveRecipes() {
+        return "aem.lts.migration.UpgradePluginVersions";
+    }
+
+    @Override
+    protected String getRecipeArtifactCoordinates() {
+        return RECIPE_ARTIFACTS;
+    }
+
+    @Override
+    protected String getCommandName() {
+        return "upgrade-plugins";
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/commands/UpgradeTestsCommand.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/commands/UpgradeTestsCommand.java
@@ -1,0 +1,26 @@
+package com.adobe.aem.migration.cli.commands;
+
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "upgrade-tests",
+                     description = "Upgrade test frameworks (Mockito 1.x -> 5.x)")
+public class UpgradeTestsCommand extends AbstractOpenRewriteCommand {
+
+    private static final String RECIPE_ARTIFACTS =
+        "org.openrewrite.recipe:rewrite-testing-frameworks:3.9.0";
+
+    @Override
+    protected String getActiveRecipes() {
+        return "aem.lts.migration.UpgradeTestingFrameworks";
+    }
+
+    @Override
+    protected String getRecipeArtifactCoordinates() {
+        return RECIPE_ARTIFACTS;
+    }
+
+    @Override
+    protected String getCommandName() {
+        return "upgrade-tests";
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/commands/UpgradeUberJarCommand.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/commands/UpgradeUberJarCommand.java
@@ -1,0 +1,26 @@
+package com.adobe.aem.migration.cli.commands;
+
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "upgrade-uberjar",
+                     description = "Upgrade AEM UberJar to 6.6.0 with apis classifier")
+public class UpgradeUberJarCommand extends AbstractOpenRewriteCommand {
+
+    private static final String RECIPE_ARTIFACTS =
+        "com.adobe.aem:aem65lts-migration-recipes:1.0-SNAPSHOT";
+
+    @Override
+    protected String getActiveRecipes() {
+        return "aem.lts.migration.UpdateUberJarVersion";
+    }
+
+    @Override
+    protected String getRecipeArtifactCoordinates() {
+        return RECIPE_ARTIFACTS;
+    }
+
+    @Override
+    protected String getCommandName() {
+        return "upgrade-uberjar";
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/commands/VerifyCommand.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/commands/VerifyCommand.java
@@ -1,0 +1,232 @@
+package com.adobe.aem.migration.cli.commands;
+
+import com.adobe.aem.migration.cli.report.VerificationReport;
+import com.adobe.aem.migration.cli.report.VerificationReport.CheckResult;
+import com.adobe.aem.migration.cli.report.VerificationReport.Issue;
+import com.adobe.aem.migration.cli.report.VerificationReport.Status;
+import picocli.CommandLine;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.stream.Stream;
+
+/**
+ * Post-migration verification. Walks the project tree and runs a fixed
+ * set of checks ({@code cloudmanager-version}, {@code compiler-settings},
+ * {@code jakarta-in-aem}, {@code temp-workarounds},
+ * {@code uberjar-classifier}, {@code unsupported-packages}). Every check
+ * has a stable ID so CI consumers can match on the JSON output.
+ *
+ * <p>Default output is a human-readable summary on stdout. {@code --json}
+ * swaps that for the machine-readable contract documented on
+ * {@link VerificationReport}.
+ */
+@CommandLine.Command(name = "verify",
+                     description = "Verify migration was applied correctly")
+public class VerifyCommand implements Callable<Integer> {
+
+    @CommandLine.Option(names = {"--repository-path", "-r"},
+                        description = "Path to the AEM Maven project", required = true)
+    private File repositoryPath;
+
+    @CommandLine.Option(names = {"--json"},
+                        description = "Emit a machine-readable JSON report on stdout instead of the human summary")
+    private boolean json;
+
+    @CommandLine.Option(names = {"--skip-git"},
+                        description = "Skip the trailing git-diff summary (useful in CI containers without git)")
+    private boolean skipGit;
+
+    @Override
+    public Integer call() throws Exception {
+        VerificationReport report = new VerificationReport(repositoryPath.getAbsolutePath());
+
+        report.addResult(checkCloudManagerVersion());
+        report.addResult(checkCompilerSettings());
+        report.addResult(checkJakartaImports());
+        report.addResult(checkTempWorkarounds());
+        report.addResult(checkUberJarClassifier());
+        report.addResult(checkUnsupportedPackages());
+
+        if (json) {
+            System.out.println(report.toJson());
+        } else {
+            System.out.println(report.toHumanReadable());
+            if (!skipGit) {
+                printGitDiffStat();
+            }
+        }
+        return report.exitCode();
+    }
+
+    private CheckResult checkCloudManagerVersion() throws IOException {
+        Path cmFile = repositoryPath.toPath().resolve(".cloudmanager/java-version");
+        if (!Files.exists(cmFile)) {
+            return new CheckResult(
+                    "cloudmanager-version",
+                    ".cloudmanager/java-version = 21",
+                    Status.FAIL,
+                    one(".cloudmanager/java-version", "file is missing"));
+        }
+        String version = new String(Files.readAllBytes(cmFile)).trim();
+        if ("21".equals(version)) {
+            return passing("cloudmanager-version", ".cloudmanager/java-version = 21");
+        }
+        return new CheckResult(
+                "cloudmanager-version",
+                ".cloudmanager/java-version = 21",
+                Status.FAIL,
+                one(".cloudmanager/java-version", "found '" + version + "', expected '21'"));
+    }
+
+    private CheckResult checkCompilerSettings() throws IOException {
+        List<Issue> issues = new ArrayList<>();
+        try (Stream<Path> poms = walkPoms()) {
+            for (Path pom : (Iterable<Path>) poms::iterator) {
+                String content = new String(Files.readAllBytes(pom));
+                String rel = repositoryPath.toPath().relativize(pom).toString();
+                for (String tag : new String[]{
+                        "<source>8</source>", "<source>11</source>", "<source>1.8</source>",
+                        "<target>8</target>", "<target>11</target>", "<target>1.8</target>"}) {
+                    if (content.contains(tag)) {
+                        issues.add(new Issue(rel, "still contains " + tag));
+                    }
+                }
+            }
+        }
+        return verdict("compiler-settings", "Compiler source/target/release = 21", issues);
+    }
+
+    private CheckResult checkJakartaImports() throws IOException {
+        List<Issue> issues = new ArrayList<>();
+        String[] aemPrefixes = {"com.adobe.", "org.apache.sling.", "com.day.cq."};
+        try (Stream<Path> javaFiles = walkJava()) {
+            for (Path jf : (Iterable<Path>) javaFiles::iterator) {
+                String content = new String(Files.readAllBytes(jf));
+                boolean isAem = false;
+                for (String prefix : aemPrefixes) {
+                    if (content.contains("import " + prefix)) {
+                        isAem = true;
+                        break;
+                    }
+                }
+                if (isAem && content.contains("import jakarta.")) {
+                    issues.add(new Issue(
+                            repositoryPath.toPath().relativize(jf).toString(),
+                            "AEM source file imports jakarta.*"));
+                }
+            }
+        }
+        return verdict("jakarta-in-aem", "No accidental jakarta imports in AEM code", issues);
+    }
+
+    private CheckResult checkTempWorkarounds() throws IOException {
+        List<Issue> issues = new ArrayList<>();
+        try (Stream<Path> files = Files.walk(repositoryPath.toPath())
+                .filter(p -> !p.toString().contains("/target/"))
+                .filter(p -> !p.toString().contains("/.git/"))
+                .filter(Files::isRegularFile)) {
+            for (Path f : (Iterable<Path>) files::iterator) {
+                try {
+                    String content = new String(Files.readAllBytes(f));
+                    if (content.contains("MIGRATION_TEMP_START") || content.contains("MIGRATION_TEMP_END")) {
+                        issues.add(new Issue(
+                                repositoryPath.toPath().relativize(f).toString(),
+                                "contains MIGRATION_TEMP_* marker"));
+                    }
+                } catch (IOException ignored) {
+                    // skip binary files
+                }
+            }
+        }
+        return verdict("temp-workarounds", "No MIGRATION_TEMP markers remaining", issues);
+    }
+
+    private CheckResult checkUberJarClassifier() throws IOException {
+        List<Issue> issues = new ArrayList<>();
+        try (Stream<Path> poms = walkPoms()) {
+            for (Path pom : (Iterable<Path>) poms::iterator) {
+                String content = new String(Files.readAllBytes(pom));
+                if (content.contains("uber-jar") && !content.contains("<classifier>apis</classifier>")) {
+                    issues.add(new Issue(
+                            repositoryPath.toPath().relativize(pom).toString(),
+                            "uber-jar declared without <classifier>apis</classifier>"));
+                }
+            }
+        }
+        return verdict("uberjar-classifier", "uber-jar has 'apis' classifier", issues);
+    }
+
+    private CheckResult checkUnsupportedPackages() throws IOException {
+        List<Issue> issues = new ArrayList<>();
+        String[] badPackages = {
+                "com.adobe.cq.commerce.", "com.adobe.cq.social.",
+                "com.adobe.granite.social.", "com.adobe.cq.screens."};
+        try (Stream<Path> javaFiles = walkJava()) {
+            for (Path jf : (Iterable<Path>) javaFiles::iterator) {
+                String content = new String(Files.readAllBytes(jf));
+                for (String pkg : badPackages) {
+                    if (content.contains("import " + pkg)) {
+                        issues.add(new Issue(
+                                repositoryPath.toPath().relativize(jf).toString(),
+                                "imports unsupported package " + pkg + "*"));
+                        break;
+                    }
+                }
+            }
+        }
+        return verdict("unsupported-packages", "No unsupported package imports", issues);
+    }
+
+    private void printGitDiffStat() throws IOException, InterruptedException {
+        System.out.println();
+        System.out.println("[INFO] Git diff summary:");
+        ProcessBuilder pb = new ProcessBuilder("git", "diff", "--stat");
+        pb.directory(repositoryPath);
+        pb.redirectErrorStream(true);
+        Process proc = pb.start();
+        try (InputStream is = proc.getInputStream()) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            byte[] buf = new byte[4096];
+            int n;
+            while ((n = is.read(buf)) != -1) {
+                baos.write(buf, 0, n);
+            }
+            System.out.println(baos.toString("UTF-8"));
+        }
+        proc.waitFor();
+    }
+
+    private Stream<Path> walkPoms() throws IOException {
+        return Files.walk(repositoryPath.toPath())
+                .filter(p -> p.getFileName().toString().equals("pom.xml"))
+                .filter(p -> !p.toString().contains("/target/"));
+    }
+
+    private Stream<Path> walkJava() throws IOException {
+        return Files.walk(repositoryPath.toPath())
+                .filter(p -> p.toString().endsWith(".java"))
+                .filter(p -> !p.toString().contains("/target/"));
+    }
+
+    private static CheckResult passing(String id, String title) {
+        return new CheckResult(id, title, Status.PASS, new ArrayList<>());
+    }
+
+    private static CheckResult verdict(String id, String title, List<Issue> issues) {
+        return new CheckResult(id, title, issues.isEmpty() ? Status.PASS : Status.FAIL, issues);
+    }
+
+    private static List<Issue> one(String file, String detail) {
+        List<Issue> list = new ArrayList<>(1);
+        list.add(new Issue(file, detail));
+        return list;
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/report/AnalysisReport.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/report/AnalysisReport.java
@@ -1,0 +1,245 @@
+package com.adobe.aem.migration.cli.report;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Structured result of {@code aem-migrate analyze}.
+ *
+ * <p>The report is the contract between this CLI and any downstream
+ * consumer (CI scripts, audit dashboards, the agent's own bookkeeping).
+ * It is intentionally a flat POJO with a hand-rolled JSON serialiser so
+ * that the CLI's runtime dependency set stays minimal (picocli +
+ * maven-invoker, no Jackson/Gson).
+ *
+ * <p>JSON schema (single-line output of {@link #toJson()}):
+ *
+ * <pre>{@code
+ * {
+ *   "schemaVersion": 1,
+ *   "tool": "aem-migrate",
+ *   "command": "analyze",
+ *   "repository": "/abs/path/to/project",
+ *   "detectedJavaVersion": "8",
+ *   "hasGit": true,
+ *   "hasCloudManagerConfig": false,
+ *   "status": "BLOCKED" | "READY_WITH_WARNINGS" | "READY" | "INVALID",
+ *   "exitCode": 0 | 1 | 2,
+ *   "blockerCount": 2,
+ *   "warningCount": 0,
+ *   "findings": [
+ *     {"severity": "BLOCKER", "package": "com.adobe.cq.commerce.", "file": "core/.../Foo.java", "line": 14}
+ *   ],
+ *   "fatal": null
+ * }
+ * }</pre>
+ *
+ * <p>Stability promise: the {@code schemaVersion} field is bumped on any
+ * breaking change to keys, types, or enum values. Consumers should refuse
+ * any version they were not written against.
+ */
+public final class AnalysisReport {
+
+    public static final int SCHEMA_VERSION = 1;
+
+    public enum Severity {BLOCKER, WARNING}
+
+    public enum Status {READY, READY_WITH_WARNINGS, BLOCKED, INVALID}
+
+    public static final class Finding {
+        public final Severity severity;
+        public final String packagePrefix;
+        public final String file;
+        public final int line;
+
+        public Finding(Severity severity, String packagePrefix, String file, int line) {
+            this.severity = severity;
+            this.packagePrefix = packagePrefix;
+            this.file = file;
+            this.line = line;
+        }
+    }
+
+    private final String repository;
+    private final List<Finding> findings = new ArrayList<>();
+    private String detectedJavaVersion = "unknown";
+    private boolean hasGit;
+    private boolean hasCloudManagerConfig;
+    private String fatal;
+
+    public AnalysisReport(String repository) {
+        this.repository = repository;
+    }
+
+    public void detectedJavaVersion(String v) {
+        this.detectedJavaVersion = v;
+    }
+
+    public void hasGit(boolean v) {
+        this.hasGit = v;
+    }
+
+    public void hasCloudManagerConfig(boolean v) {
+        this.hasCloudManagerConfig = v;
+    }
+
+    public void findings(List<Finding> more) {
+        this.findings.addAll(more);
+    }
+
+    public void fatal(String message) {
+        this.fatal = message;
+    }
+
+    public int blockerCount() {
+        return (int) findings.stream().filter(f -> f.severity == Severity.BLOCKER).count();
+    }
+
+    public int warningCount() {
+        return (int) findings.stream().filter(f -> f.severity == Severity.WARNING).count();
+    }
+
+    public Status status() {
+        if (fatal != null) {
+            return Status.INVALID;
+        }
+        if (blockerCount() > 0) {
+            return Status.BLOCKED;
+        }
+        if (warningCount() > 0) {
+            return Status.READY_WITH_WARNINGS;
+        }
+        return Status.READY;
+    }
+
+    public int exitCode() {
+        switch (status()) {
+            case INVALID:
+            case BLOCKED:
+                return 2;
+            case READY_WITH_WARNINGS:
+                return 1;
+            case READY:
+            default:
+                return 0;
+        }
+    }
+
+    public String toJson() {
+        StringBuilder sb = new StringBuilder(256);
+        sb.append('{');
+        appendNumber(sb, "schemaVersion", SCHEMA_VERSION, true);
+        appendString(sb, "tool", "aem-migrate", false);
+        appendString(sb, "command", "analyze", false);
+        appendString(sb, "repository", repository, false);
+        appendString(sb, "detectedJavaVersion", detectedJavaVersion, false);
+        appendBoolean(sb, "hasGit", hasGit, false);
+        appendBoolean(sb, "hasCloudManagerConfig", hasCloudManagerConfig, false);
+        appendString(sb, "status", status().name(), false);
+        appendNumber(sb, "exitCode", exitCode(), false);
+        appendNumber(sb, "blockerCount", blockerCount(), false);
+        appendNumber(sb, "warningCount", warningCount(), false);
+        sb.append(",\"findings\":[");
+        for (int i = 0; i < findings.size(); i++) {
+            Finding f = findings.get(i);
+            if (i > 0) {
+                sb.append(',');
+            }
+            sb.append('{');
+            appendString(sb, "severity", f.severity.name(), true);
+            appendString(sb, "package", f.packagePrefix, false);
+            appendString(sb, "file", f.file, false);
+            appendNumber(sb, "line", f.line, false);
+            sb.append('}');
+        }
+        sb.append(']');
+        sb.append(",\"fatal\":");
+        if (fatal == null) {
+            sb.append("null");
+        } else {
+            sb.append('"').append(escape(fatal)).append('"');
+        }
+        sb.append('}');
+        return sb.toString();
+    }
+
+    public String toHumanReadable() {
+        StringBuilder sb = new StringBuilder(512);
+        sb.append("=== AEM 6.5 LTS Pre-Migration Analysis ===\n");
+        sb.append("Repository:           ").append(repository).append('\n');
+        sb.append("Detected Java:        ").append(detectedJavaVersion).append('\n');
+        sb.append("Git working tree:     ").append(hasGit ? "yes" : "no").append('\n');
+        sb.append("CloudManager config:  ").append(hasCloudManagerConfig ? "yes" : "no").append('\n');
+        sb.append('\n');
+        if (fatal != null) {
+            sb.append("[FATAL] ").append(fatal).append('\n');
+            return sb.toString();
+        }
+        if (findings.isEmpty()) {
+            sb.append("No blockers or warnings detected.\n");
+        } else {
+            sb.append("Findings (").append(findings.size()).append("):\n");
+            for (Finding f : findings) {
+                sb.append("  [").append(f.severity).append("] ")
+                        .append(f.file).append(':').append(f.line)
+                        .append(" imports ").append(f.packagePrefix).append("*\n");
+            }
+            sb.append('\n');
+        }
+        sb.append("Status:               ").append(status()).append('\n');
+        sb.append("Exit code:            ").append(exitCode()).append('\n');
+        return sb.toString();
+    }
+
+    private static void appendString(StringBuilder sb, String key, String value, boolean first) {
+        if (!first) {
+            sb.append(',');
+        }
+        sb.append('"').append(key).append("\":\"").append(escape(value)).append('"');
+    }
+
+    private static void appendNumber(StringBuilder sb, String key, int value, boolean first) {
+        if (!first) {
+            sb.append(',');
+        }
+        sb.append('"').append(key).append("\":").append(value);
+    }
+
+    private static void appendBoolean(StringBuilder sb, String key, boolean value, boolean first) {
+        if (!first) {
+            sb.append(',');
+        }
+        sb.append('"').append(key).append("\":").append(value);
+    }
+
+    private static String escape(String s) {
+        StringBuilder out = new StringBuilder(s.length() + 8);
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"':
+                    out.append("\\\"");
+                    break;
+                case '\\':
+                    out.append("\\\\");
+                    break;
+                case '\n':
+                    out.append("\\n");
+                    break;
+                case '\r':
+                    out.append("\\r");
+                    break;
+                case '\t':
+                    out.append("\\t");
+                    break;
+                default:
+                    if (c < 0x20) {
+                        out.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        out.append(c);
+                    }
+            }
+        }
+        return out.toString();
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/report/VerificationReport.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/cli/report/VerificationReport.java
@@ -1,0 +1,235 @@
+package com.adobe.aem.migration.cli.report;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Structured result of {@code aem-migrate verify}.
+ *
+ * <p>Mirrors {@link AnalysisReport} in shape and stability discipline.
+ * Every post-migration check the {@code verify} command runs surfaces as
+ * a {@link CheckResult} with a fixed {@code id} (greppable from CI
+ * logs) and a {@link Status} of {@code PASS}, {@code FAIL}, or
+ * {@code SKIP}. Per-finding detail (file path, observed value) is
+ * attached as a list of {@link Issue} entries under each result.
+ *
+ * <p>JSON schema (single-line output of {@link #toJson()}):
+ *
+ * <pre>{@code
+ * {
+ *   "schemaVersion": 1,
+ *   "tool": "aem-migrate",
+ *   "command": "verify",
+ *   "repository": "/abs/path/to/project",
+ *   "status": "PASS" | "FAIL",
+ *   "exitCode": 0 | 1,
+ *   "checkCount": 6,
+ *   "passCount": 5,
+ *   "failCount": 1,
+ *   "skipCount": 0,
+ *   "results": [
+ *     {
+ *       "id": "compiler-settings",
+ *       "title": "Compiler source/target/release = 21",
+ *       "status": "FAIL",
+ *       "issueCount": 1,
+ *       "issues": [{"file": "core/pom.xml", "detail": "still pinned to <source>11</source>"}]
+ *     }
+ *   ]
+ * }
+ * }</pre>
+ *
+ * <p>Stability promise: {@code schemaVersion} is incremented on any
+ * breaking change. Consumers should refuse versions they were not
+ * written against.
+ */
+public final class VerificationReport {
+
+    public static final int SCHEMA_VERSION = 1;
+
+    public enum Status {PASS, FAIL, SKIP}
+
+    public static final class Issue {
+        public final String file;
+        public final String detail;
+
+        public Issue(String file, String detail) {
+            this.file = file;
+            this.detail = detail;
+        }
+    }
+
+    public static final class CheckResult {
+        public final String id;
+        public final String title;
+        public final Status status;
+        public final List<Issue> issues;
+
+        public CheckResult(String id, String title, Status status, List<Issue> issues) {
+            this.id = id;
+            this.title = title;
+            this.status = status;
+            this.issues = issues == null ? new ArrayList<>() : issues;
+        }
+    }
+
+    private final String repository;
+    private final List<CheckResult> results = new ArrayList<>();
+
+    public VerificationReport(String repository) {
+        this.repository = repository;
+    }
+
+    public void addResult(CheckResult result) {
+        results.add(result);
+    }
+
+    public List<CheckResult> getResults() {
+        return results;
+    }
+
+    public int checkCount() {
+        return results.size();
+    }
+
+    public int passCount() {
+        return (int) results.stream().filter(r -> r.status == Status.PASS).count();
+    }
+
+    public int failCount() {
+        return (int) results.stream().filter(r -> r.status == Status.FAIL).count();
+    }
+
+    public int skipCount() {
+        return (int) results.stream().filter(r -> r.status == Status.SKIP).count();
+    }
+
+    public Status overallStatus() {
+        return failCount() > 0 ? Status.FAIL : Status.PASS;
+    }
+
+    public int exitCode() {
+        return overallStatus() == Status.PASS ? 0 : 1;
+    }
+
+    public String toJson() {
+        StringBuilder sb = new StringBuilder(512);
+        sb.append('{');
+        appendNumber(sb, "schemaVersion", SCHEMA_VERSION, true);
+        appendString(sb, "tool", "aem-migrate", false);
+        appendString(sb, "command", "verify", false);
+        appendString(sb, "repository", repository, false);
+        appendString(sb, "status", overallStatus().name(), false);
+        appendNumber(sb, "exitCode", exitCode(), false);
+        appendNumber(sb, "checkCount", checkCount(), false);
+        appendNumber(sb, "passCount", passCount(), false);
+        appendNumber(sb, "failCount", failCount(), false);
+        appendNumber(sb, "skipCount", skipCount(), false);
+        sb.append(",\"results\":[");
+        for (int i = 0; i < results.size(); i++) {
+            CheckResult r = results.get(i);
+            if (i > 0) {
+                sb.append(',');
+            }
+            sb.append('{');
+            appendString(sb, "id", r.id, true);
+            appendString(sb, "title", r.title, false);
+            appendString(sb, "status", r.status.name(), false);
+            appendNumber(sb, "issueCount", r.issues.size(), false);
+            sb.append(",\"issues\":[");
+            for (int j = 0; j < r.issues.size(); j++) {
+                Issue issue = r.issues.get(j);
+                if (j > 0) {
+                    sb.append(',');
+                }
+                sb.append('{');
+                appendString(sb, "file", issue.file, true);
+                appendString(sb, "detail", issue.detail, false);
+                sb.append('}');
+            }
+            sb.append(']');
+            sb.append('}');
+        }
+        sb.append(']');
+        sb.append('}');
+        return sb.toString();
+    }
+
+    public String toHumanReadable() {
+        StringBuilder sb = new StringBuilder(1024);
+        sb.append("=== AEM 6.5 LTS Post-Migration Verification ===\n");
+        sb.append("Repository: ").append(repository).append("\n\n");
+        for (CheckResult r : results) {
+            sb.append('[').append(pad(r.status.name(), 4)).append("] ")
+                    .append(r.id).append(" — ").append(r.title).append('\n');
+            for (Issue issue : r.issues) {
+                sb.append("         ").append(issue.file).append(": ").append(issue.detail).append('\n');
+            }
+        }
+        sb.append('\n');
+        sb.append("Checks: ").append(checkCount())
+                .append("  Pass: ").append(passCount())
+                .append("  Fail: ").append(failCount())
+                .append("  Skip: ").append(skipCount()).append('\n');
+        sb.append("Overall: ").append(overallStatus())
+                .append(" (exit ").append(exitCode()).append(")\n");
+        return sb.toString();
+    }
+
+    private static String pad(String s, int width) {
+        if (s.length() >= width) {
+            return s;
+        }
+        StringBuilder sb = new StringBuilder(width);
+        sb.append(s);
+        while (sb.length() < width) {
+            sb.append(' ');
+        }
+        return sb.toString();
+    }
+
+    private static void appendString(StringBuilder sb, String key, String value, boolean first) {
+        if (!first) {
+            sb.append(',');
+        }
+        sb.append('"').append(key).append("\":\"").append(escape(value)).append('"');
+    }
+
+    private static void appendNumber(StringBuilder sb, String key, int value, boolean first) {
+        if (!first) {
+            sb.append(',');
+        }
+        sb.append('"').append(key).append("\":").append(value);
+    }
+
+    private static String escape(String s) {
+        StringBuilder out = new StringBuilder(s.length() + 8);
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"':
+                    out.append("\\\"");
+                    break;
+                case '\\':
+                    out.append("\\\\");
+                    break;
+                case '\n':
+                    out.append("\\n");
+                    break;
+                case '\r':
+                    out.append("\\r");
+                    break;
+                case '\t':
+                    out.append("\\t");
+                    break;
+                default:
+                    if (c < 0x20) {
+                        out.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        out.append(c);
+                    }
+            }
+        }
+        return out.toString();
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/openrewrite/OpenRewriteRunner.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/java/com/adobe/aem/migration/openrewrite/OpenRewriteRunner.java
@@ -1,0 +1,130 @@
+package com.adobe.aem.migration.openrewrite;
+
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.DefaultInvoker;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.Invoker;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+public class OpenRewriteRunner {
+
+    private static final String REWRITE_PLUGIN = "org.openrewrite.maven:rewrite-maven-plugin:6.8.0";
+
+    private final File repositoryPath;
+    private final File mavenHome;
+    private final String javaHome;
+
+    public OpenRewriteRunner(File repositoryPath, String javaHome) {
+        this.repositoryPath = repositoryPath;
+        this.javaHome = javaHome;
+
+        String mavenHomePath = System.getenv("MAVEN_HOME");
+        if (mavenHomePath == null) {
+            mavenHomePath = System.getenv("M2_HOME");
+        }
+        this.mavenHome = mavenHomePath != null ? new File(mavenHomePath) : null;
+    }
+
+    public int runRecipe(String activeRecipes, String configLocation,
+                         String recipeArtifactCoordinates, boolean dryRun) throws MavenInvocationException {
+
+        InvocationRequest request = new DefaultInvocationRequest();
+        request.setPomFile(new File(repositoryPath, "pom.xml"));
+        request.setGoals(buildGoals());
+        request.setProperties(buildProperties(activeRecipes, configLocation,
+                recipeArtifactCoordinates, dryRun));
+
+        if (javaHome != null && !javaHome.isEmpty()) {
+            request.setJavaHome(new File(javaHome));
+        }
+
+        if (mavenHome != null) {
+            request.setMavenHome(mavenHome);
+        }
+
+        request.setShowErrors(true);
+        request.setBatchMode(true);
+
+        Invoker invoker = new DefaultInvoker();
+        if (mavenHome != null) {
+            invoker.setMavenHome(mavenHome);
+        }
+
+        InvocationResult result = invoker.execute(request);
+        return result.getExitCode();
+    }
+
+    public int runBuild(boolean skipTests) throws MavenInvocationException {
+        InvocationRequest request = new DefaultInvocationRequest();
+        request.setPomFile(new File(repositoryPath, "pom.xml"));
+
+        List<String> goals = new ArrayList<String>();
+        goals.add("clean");
+        goals.add("install");
+        request.setGoals(goals);
+
+        Properties props = new Properties();
+        if (skipTests) {
+            props.setProperty("skipTests", "true");
+        }
+        props.setProperty("skipFrontend", "true");
+        request.setProperties(props);
+
+        if (javaHome != null && !javaHome.isEmpty()) {
+            request.setJavaHome(new File(javaHome));
+        }
+
+        if (mavenHome != null) {
+            request.setMavenHome(mavenHome);
+        }
+
+        request.setShowErrors(true);
+        request.setBatchMode(true);
+
+        Invoker invoker = new DefaultInvoker();
+        if (mavenHome != null) {
+            invoker.setMavenHome(mavenHome);
+        }
+
+        InvocationResult result = invoker.execute(request);
+        return result.getExitCode();
+    }
+
+    private List<String> buildGoals() {
+        List<String> goals = new ArrayList<String>();
+        goals.add("clean");
+        goals.add("install");
+        goals.add(REWRITE_PLUGIN + ":run");
+        return goals;
+    }
+
+    private Properties buildProperties(String activeRecipes, String configLocation,
+                                        String recipeArtifactCoordinates, boolean dryRun) {
+        Properties props = new Properties();
+        props.setProperty("skipTests", "true");
+        props.setProperty("skipFrontend", "true");
+        props.setProperty("vault.skipValidation", "true");
+        props.setProperty("rewrite.activeRecipes", activeRecipes);
+        props.setProperty("exportDatatables", "true");
+
+        if (configLocation != null && !configLocation.isEmpty()) {
+            props.setProperty("rewrite.configLocation", configLocation);
+        }
+
+        if (recipeArtifactCoordinates != null && !recipeArtifactCoordinates.isEmpty()) {
+            props.setProperty("rewrite.recipeArtifactCoordinates", recipeArtifactCoordinates);
+        }
+
+        if (dryRun) {
+            props.setProperty("rewrite.dryRun", "true");
+        }
+
+        return props;
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/resources/META-INF/config/openrewrite/recipes/65LTSDependencyUpgrades.yaml
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/resources/META-INF/config/openrewrite/recipes/65LTSDependencyUpgrades.yaml
@@ -1,0 +1,103 @@
+---
+# 65LTSDependencyUpgrades.yaml
+#
+# Purpose: Standalone recipe for upgrading AEM-ecosystem library dependencies
+# to versions compatible with AEM 6.5 LTS and Java 21.
+#
+# NOTE: These same dependency upgrades are also included as a sub-recipe within
+# 65LTSUpgrade.yaml (as aem.lts.migration.UpgradeCommonLibraries).  This file
+# allows the dependency-only upgrade to be run independently via:
+#
+#   aem-migrate upgrade-dependencies --repository-path <path>
+#
+# Scope: runtime / compile-scope Maven dependencies consumed by AEM bundles.
+#        Maven build plugins are handled in 65LTSPluginUpgrades.yaml.
+#        UberJar migration is handled in 65LTSUpgradeUberJar.yaml.
+#
+# Version rationale:
+#   core.wcm.components 2.24.0  — last version validated for AEM 6.5 LTS GA.
+#   groovy-all 4.0.27           — Groovy 4 is the first version with full
+#     Java 21 support; 3.x line is EOL.
+#   aem-groovy-console 19.0.8   — repackaged under be.orbinson.aem groupId;
+#     the com.icfolson.aem.groovy.console coordinates are abandoned.
+
+type: specs.openrewrite.org/v1beta/recipe
+name: aem.lts.migration.UpgradeCommonLibraries
+displayName: AEM 6.5 LTS — Upgrade Common Library Dependencies (standalone)
+description: >
+  Upgrades AEM WCM Core Components, Groovy, and the AEM Groovy Console to
+  versions compatible with AEM 6.5 LTS and Java 21.  Migrates the Groovy
+  Console from the abandoned com.icfolson.aem coordinates to the actively
+  maintained be.orbinson.aem coordinates.  This recipe is also included as a
+  sub-recipe of aem.lts.migration.UpgradeToAEM65LTS.
+tags:
+  - aem
+  - dependencies
+  - migration
+recipeList:
+
+  # ── AEM WCM Core Components ───────────────────────────────────────────────
+  # Bump all four Core Components artefacts together to keep versions in sync.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: com.adobe.cq
+      artifactId: core.wcm.components.core
+      newVersion: 2.24.0
+
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: com.adobe.cq
+      artifactId: core.wcm.components.content
+      newVersion: 2.24.0
+
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: com.adobe.cq
+      artifactId: core.wcm.components.config
+      newVersion: 2.24.0
+
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: com.adobe.cq
+      artifactId: core.wcm.components.all
+      newVersion: 2.24.0
+
+  # ── Groovy runtime ────────────────────────────────────────────────────────
+  # groovy-all 4.0.27: first version with full Java 21 support; 3.x is EOL.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.apache.groovy
+      artifactId: groovy-all
+      newVersion: 4.0.27
+
+  # Also cover legacy org.codehaus.groovy groupId (pre-Groovy 4 projects)
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.codehaus.groovy
+      artifactId: groovy-all
+      newVersion: 4.0.27
+
+  # ── AEM Groovy Console ────────────────────────────────────────────────────
+  # The com.icfolson.aem.groovy.console groupId is abandoned (last release
+  # 2021).  The project was transferred to be.orbinson.aem; 19.0.8 is the
+  # current stable release.
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: com.icfolson.aem.groovy.console
+      oldArtifactId: aem-groovy-console
+      newGroupId: be.orbinson.aem
+      newArtifactId: aem-groovy-console
+      newVersion: 19.0.8
+
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: com.icfolson.aem.groovy.console
+      oldArtifactId: aem-groovy-console-bundle
+      newGroupId: be.orbinson.aem
+      newArtifactId: aem-groovy-console-bundle
+      newVersion: 19.0.8
+
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: com.icfolson.aem.groovy.console
+      oldArtifactId: aem-groovy-console-content
+      newGroupId: be.orbinson.aem
+      newArtifactId: aem-groovy-console-content
+      newVersion: 19.0.8
+
+  # For projects already on be.orbinson.aem but on an older version
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: be.orbinson.aem
+      artifactId: aem-groovy-console
+      newVersion: 19.0.8

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/resources/META-INF/config/openrewrite/recipes/65LTSPluginUpgrades.yaml
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/resources/META-INF/config/openrewrite/recipes/65LTSPluginUpgrades.yaml
@@ -1,0 +1,97 @@
+---
+# 65LTSPluginUpgrades.yaml
+#
+# Purpose: Standalone recipe for upgrading Maven build plugins to versions
+# compatible with Java 21 and AEM 6.5 LTS.
+#
+# NOTE: These same plugin upgrades are also included as a sub-recipe within
+# 65LTSUpgrade.yaml (as aem.lts.migration.UpgradePluginVersions).  This file
+# allows the plugin-only upgrade to be run independently via:
+#
+#   aem-migrate upgrade-plugins --repository-path <path>
+#
+# Plugin version rationale:
+#   maven-bundle-plugin 5.1.9   — correct 5.x target for AEM 6.5 LTS; the 6.x
+#     line is NOT required for this SDK version.
+#   bnd-maven-plugin 6.4.0      — last stable 6.x release; Java 21 compatible.
+#   maven-scr-plugin 1.26.4     — final release; ASM must be overridden to 9.7.1
+#     because the plugin ships with ASM 7 which cannot parse Java 21 bytecode.
+#   filevault-package-maven-plugin 1.3.6 — current stable with Java 21 support.
+
+type: specs.openrewrite.org/v1beta/recipe
+name: aem.lts.migration.UpgradePluginVersions
+displayName: AEM 6.5 LTS — Upgrade Maven Build Plugins (standalone)
+description: >
+  Upgrades AEM-related Maven build plugins to versions that produce and validate
+  OSGi bundles correctly when compiling with Java 21.  Uses maven-bundle-plugin
+  5.1.9 (the correct 5.x target for AEM 6.5 LTS; NOT 6.x), pins ASM 9.7.1
+  inside maven-scr-plugin for Java 21 class file parsing, and sets the compiler
+  --release flag.  This recipe is also included as a sub-recipe of
+  aem.lts.migration.UpgradeToAEM65LTS.
+tags:
+  - aem
+  - maven
+  - plugins
+  - migration
+recipeList:
+
+  # ── OSGi bundle tooling ───────────────────────────────────────────────────
+
+  # maven-bundle-plugin 5.1.9: correct 5.x release for AEM 6.5 LTS.
+  # AEM 6.5 LTS does NOT require the 6.x plugin line.
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: org.apache.felix
+      artifactId: maven-bundle-plugin
+      newVersion: 5.1.9
+
+  # bnd-maven-plugin family: 6.4.0 (last stable 6.x, Java 21 ready)
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: biz.aQute.bnd
+      artifactId: bnd-maven-plugin
+      newVersion: 6.4.0
+
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: biz.aQute.bnd
+      artifactId: bnd-indexer-maven-plugin
+      newVersion: 6.4.0
+
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: biz.aQute.bnd
+      artifactId: bnd-resolver-maven-plugin
+      newVersion: 6.4.0
+
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: biz.aQute.bnd
+      artifactId: bnd-testing-maven-plugin
+      newVersion: 6.4.0
+
+  # maven-scr-plugin 1.26.4: final release.  Ships with ASM 7 which cannot
+  # parse Java 21 class files; override with ASM 9.7.1 via plugin dependency.
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: org.apache.felix
+      artifactId: maven-scr-plugin
+      newVersion: 1.26.4
+
+  - org.openrewrite.maven.AddPluginDependency:
+      pluginGroupId: org.apache.felix
+      pluginArtifactId: maven-scr-plugin
+      groupId: org.ow2.asm
+      artifactId: asm-analysis
+      version: 9.7.1
+
+  # ── Compiler configuration ────────────────────────────────────────────────
+
+  # Set --release 21 in maven-compiler-plugin configuration.
+  - org.openrewrite.maven.ChangePluginConfiguration:
+      groupId: org.apache.maven.plugins
+      artifactId: maven-compiler-plugin
+      configuration: >
+        <release>21</release>
+
+  # ── Content package tooling ───────────────────────────────────────────────
+
+  # filevault-package-maven-plugin 1.3.6: Java 21 compatible.
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: org.apache.jackrabbit
+      artifactId: filevault-package-maven-plugin
+      newVersion: 1.3.6

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/resources/META-INF/config/openrewrite/recipes/65LTSTestLibsUpgrades.yaml
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/resources/META-INF/config/openrewrite/recipes/65LTSTestLibsUpgrades.yaml
@@ -1,0 +1,211 @@
+---
+# 65LTSTestLibsUpgrades.yaml
+#
+# Purpose: Migrate Mockito from 1.x to 5.x in progressive phases for AEM 6.5 LTS
+# projects upgrading to Java 21.
+#
+# Migration chain:
+#   Mockito 1.x → 3.x → 4.x → 5.x → Cleanup
+#
+# Phases are composed into the top-level recipe so the full chain can be
+# executed in a single rewrite:run invocation, while still being individually
+# addressable for incremental rollouts.
+#
+# Recipe artifact coordinates:
+#   org.openrewrite.recipe:rewrite-testing-frameworks:3.9.0
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Top-level orchestrator
+# ─────────────────────────────────────────────────────────────────────────────
+type: specs.openrewrite.org/v1beta/recipe
+name: aem.lts.migration.UpgradeTestingFrameworks
+displayName: AEM 6.5 LTS — Upgrade Testing Frameworks (Mockito 1.x → 5.x)
+description: >
+  Progressively migrates Mockito from 1.x through 3.x, 4.x, and finally 5.x,
+  cleaning up obsolete APIs, updating byte-buddy, and consolidating the
+  mockito-inline artefact into mockito-core.  Each phase is a sub-recipe that
+  can also be run in isolation.
+tags:
+  - aem
+  - testing
+  - mockito
+  - migration
+recipeList:
+  - aem.lts.migration.MockitoOneToThree
+  - aem.lts.migration.MockitoThreeToFour
+  - aem.lts.migration.MockitoFourToFive
+  - aem.lts.migration.MockitoCleanup
+
+---
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 1: Mockito 1.x → 3.x
+# ─────────────────────────────────────────────────────────────────────────────
+type: specs.openrewrite.org/v1beta/recipe
+name: aem.lts.migration.MockitoOneToThree
+displayName: Mockito 1.x → 3.x API migration
+description: >
+  Replaces deprecated Mockito 1.x imports, matchers, and verification helpers
+  with their Mockito 3.x equivalents.  Also migrates JUnit 4 runner to the
+  JUnit 5 extension, replaces PowerMockito usage, and switches the Maven
+  dependency from mockito-all to mockito-core.
+tags:
+  - mockito
+  - testing
+recipeList:
+
+  # Import: org.mockito.MockitoAnnotations.Mock → org.mockito.Mock
+  - org.openrewrite.java.testing.mockito.MockitoAnnotationsMockToMockitoMock
+
+  # Matcher type widening: replace typed any()/isNull()/notNull()
+  - org.openrewrite.java.testing.mockito.AnyToNullable
+
+  # Static import: org.mockito.Matchers → org.mockito.ArgumentMatchers
+  - org.openrewrite.java.testing.mockito.MockitoMatchersToArgumentMatchers
+
+  # Vararg matcher: anyVararg() was removed; use any()
+  - org.openrewrite.java.testing.mockito.MockitoVarargMatcherToAny
+
+  # Typed matchers removed in Mockito 2+; replace with untyped variants
+  - org.openrewrite.java.testing.mockito.MockitoTypedMatchersToUntypedMatchers
+
+  # ArgumentCaptor.getArgumentAt(int, Class) → getArgument(int, Class)
+  - org.openrewrite.java.testing.mockito.MockitoGetArgumentAt
+
+  # MockedStatic verify: argument order changed in 3.4+
+  - org.openrewrite.java.testing.mockito.MockitoMockedStaticVerifyArgReorder
+
+  # verifyZeroInteractions() → verifyNoMoreInteractions()
+  - org.openrewrite.java.testing.mockito.VerifyZeroToNoMoreInteractions
+
+  # Type renames between 1.x and 3.x
+  - org.openrewrite.java.testing.mockito.MockitoTypeMigration
+
+  # Remove residual org.mockito.* wildcard imports
+  - org.openrewrite.java.testing.mockito.CleanupMockitoImports
+
+  # MockUtils static helpers → inline static calls
+  - org.openrewrite.java.testing.mockito.MockitoMockUtilsToStatic
+
+  # @RunWith(MockitoJUnitRunner) → @ExtendWith(MockitoExtension)  (JUnit 5)
+  - org.openrewrite.java.testing.mockito.MockitoJUnitRunnerToMockitoExtension
+
+  # JUnit 4 @Rule MockitoJUnit.rule() → @ExtendWith(MockitoExtension)
+  - org.openrewrite.java.testing.mockito.MockitoJUnitToMockitoExtension
+
+  # Replace PowerMockito static mocking with Mockito 3.4 mockStatic()
+  - org.openrewrite.java.testing.mockito.ReplacePowerMockito
+
+  # POM: replace mockito-all (fat JAR) with mockito-core
+  - org.openrewrite.java.testing.mockito.MockitoAllToMockitoCore
+
+  # POM: bump Mockito to 3.x
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.mockito
+      artifactId: mockito-core
+      newVersion: 3.x
+
+  # POM: byte-buddy compatible with Mockito 3.x
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: net.bytebuddy
+      artifactId: byte-buddy
+      newVersion: 1.11.13
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: net.bytebuddy
+      artifactId: byte-buddy-agent
+      newVersion: 1.11.13
+
+---
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 2: Mockito 3.x → 4.x
+# ─────────────────────────────────────────────────────────────────────────────
+type: specs.openrewrite.org/v1beta/recipe
+name: aem.lts.migration.MockitoThreeToFour
+displayName: Mockito 3.x → 4.x API migration
+description: >
+  Updates Mockito from 3.x to 4.x.  Applies the MockitoWhenOnStaticToMockStatic
+  transform and bumps both mockito-core and byte-buddy to their 4.x-compatible
+  versions.
+tags:
+  - mockito
+  - testing
+recipeList:
+
+  # Mockito.when(StaticClass.method()) → try(MockedStatic) pattern
+  - org.openrewrite.java.testing.mockito.MockitoWhenOnStaticToMockStatic
+
+  # POM: bump Mockito to 4.x
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.mockito
+      artifactId: mockito-core
+      newVersion: 4.x
+
+  # POM: byte-buddy compatible with Mockito 4.x
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: net.bytebuddy
+      artifactId: byte-buddy
+      newVersion: 1.12.19
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: net.bytebuddy
+      artifactId: byte-buddy-agent
+      newVersion: 1.12.19
+
+---
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 3: Mockito 4.x → 5.x
+# ─────────────────────────────────────────────────────────────────────────────
+type: specs.openrewrite.org/v1beta/recipe
+name: aem.lts.migration.MockitoFourToFive
+displayName: Mockito 4.x → 5.x API migration
+description: >
+  Upgrades Mockito from 4.x to 5.11.0.  Removes the now-obsolete mockito-inline
+  dependency (its functionality was merged into mockito-core in 5.0), bumps
+  byte-buddy to 1.17.5, and removes duplicate dependency declarations.
+tags:
+  - mockito
+  - testing
+recipeList:
+
+  # mockito-inline merged into mockito-core in 5.x
+  - org.openrewrite.java.testing.mockito.MockitoInlineToMockitoCore
+
+  # POM: bump Mockito to 5.11.0
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.mockito
+      artifactId: mockito-core
+      newVersion: 5.11.0
+
+  # POM: byte-buddy compatible with Mockito 5.x / Java 21
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: net.bytebuddy
+      artifactId: byte-buddy
+      newVersion: 1.17.5
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: net.bytebuddy
+      artifactId: byte-buddy-agent
+      newVersion: 1.17.5
+
+  # Remove duplicate dependency entries created by the multi-phase upgrade
+  - org.openrewrite.maven.RemoveDuplicateDependencies
+
+---
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 4: Post-migration cleanup
+# ─────────────────────────────────────────────────────────────────────────────
+type: specs.openrewrite.org/v1beta/recipe
+name: aem.lts.migration.MockitoCleanup
+displayName: Mockito post-migration cleanup
+description: >
+  Final cleanup pass after the Mockito 1→5 migration chain.  Removes calls to
+  the deleted FieldSetter.setField() utility and strips unused imports left
+  behind by previous phases.
+tags:
+  - mockito
+  - testing
+recipeList:
+
+  # FieldSetter.setField() was an internal Mockito utility removed in 4.x.
+  # Replaced with a TODO comment; correct fix depends on context.
+  - org.openrewrite.java.testing.mockito.MockitoRemoveFieldSetterWithTodo
+
+  # Remove any stale/unused Mockito or test framework imports
+  - org.openrewrite.java.RemoveUnusedImports

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/resources/META-INF/config/openrewrite/recipes/65LTSUpgrade.yaml
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/resources/META-INF/config/openrewrite/recipes/65LTSUpgrade.yaml
@@ -1,0 +1,375 @@
+---
+# 65LTSUpgrade.yaml
+#
+# Purpose: Top-level composite recipe for migrating an AEM 6.5 LTS project from
+# Java 8/11 to Java 21.  Orchestrates four sub-recipes that can also be run
+# individually:
+#
+#   UpgradeToJava21                  — language + JDK API migration (no jakarta)
+#   UpgradePluginVersions            — Maven build plugin upgrades
+#   UpgradeCommonLibraries           — runtime/compile library upgrades
+#   UpgradeMavenPluginConfigurations — bnd/filevault artefact config changes
+#
+# IMPORTANT — No jakarta migration:
+#   AEM 6.5 LTS continues to use the javax.* namespace.  The OpenRewrite
+#   composite UpgradeToJava17 bundles javax→jakarta replacement that would break
+#   AEM 6.5 LTS code.  We cherry-pick only javax-neutral recipes instead.
+#
+# Recipe artifact coordinates:
+#   org.openrewrite.recipe:rewrite-migrate-java:3.9.0
+#   com.adobe.aem:aem65lts-migration-recipes:1.0-SNAPSHOT
+
+type: specs.openrewrite.org/v1beta/recipe
+name: aem.lts.migration.UpgradeToAEM65LTS
+displayName: AEM 6.5 LTS — Full Java 21 Migration
+description: >
+  Migrates an AEM 6.5 LTS Maven project from Java 8/11 to Java 21.  Runs Java
+  language modernization, Maven plugin upgrades, library dependency upgrades, and
+  FileVault/bnd configuration corrections in one pass.  Jakarta migration is
+  intentionally excluded because AEM 6.5 LTS remains on the javax namespace.
+tags:
+  - aem
+  - java21
+  - migration
+recipeList:
+  - aem.lts.migration.UpgradeToJava21
+  - aem.lts.migration.UpgradePluginVersions
+  - aem.lts.migration.UpgradeCommonLibraries
+  - aem.lts.migration.UpgradeMavenPluginConfigurations
+
+---
+# ── Sub-recipe 1: Java language + JDK API migration ─────────────────────────
+type: specs.openrewrite.org/v1beta/recipe
+name: aem.lts.migration.UpgradeToJava21
+displayName: AEM 6.5 LTS — Upgrade Java Source to Java 21
+description: >
+  Cherry-picked Java 8→11→17→21 migration recipes that are safe for AEM 6.5 LTS
+  (no javax→jakarta namespace changes).  Covers language syntax modernization,
+  removed JDK APIs, and compiler/toolchain version metadata.
+tags:
+  - aem
+  - java21
+  - migration
+recipeList:
+
+  # ── Phase 1: Java 8 → 11 ─────────────────────────────────────────────────
+  # Java8toJava11 does not include jakarta changes; safe for AEM 6.5 LTS.
+  - org.openrewrite.java.migrate.Java8toJava11
+
+  # ── Phase 2: Java 11 → 17 (cherry-picked, no jakarta) ───────────────────
+  # We do NOT invoke the UpgradeToJava17 composite because it transitively
+  # pulls in JavaxMigrationToJakarta.  Each recipe below is individually
+  # vetted to be javax-neutral.
+
+  # Tell Maven/Gradle build tooling to target Java 17
+  - org.openrewrite.java.migrate.UpgradeBuildToJava17
+
+  # Pattern-matching instanceof (JEP 394)
+  - org.openrewrite.java.migrate.InstanceOfPatternMatch
+
+  # Annotation processor compatibility
+  - org.openrewrite.java.migrate.AddSerialAnnotationToSerialVersionUID
+
+  # Removed/unsupported runtime APIs in JDK 17
+  - org.openrewrite.java.migrate.RemovedRuntimeTraceMethods
+  - org.openrewrite.java.migrate.RemovedToolProviderConstructor
+  - org.openrewrite.java.migrate.RemovedModifierAndConstantBootstrapsConstructors
+  - org.openrewrite.java.migrate.ExplicitRecordImport
+
+  # Text blocks (JEP 378) — only convert strings that already contain newlines
+  - org.openrewrite.java.migrate.UseTextBlocks:
+      convertStringsWithoutNewlines: false
+
+  # String.formatted() convenience method
+  - org.openrewrite.java.migrate.StringFormatted:
+      addParentheses: false
+
+  # Deprecated security / SSL APIs
+  - org.openrewrite.java.migrate.DeprecatedJavaxSecurityCert
+  - org.openrewrite.java.migrate.DeprecatedLogRecordThreadID
+  - org.openrewrite.java.migrate.RemovedLegacySunJSSEProviderName
+  - org.openrewrite.java.migrate.Jre17AgentMainPreMainPublic
+  - org.openrewrite.java.migrate.DeprecatedCountStackFramesMethod
+
+  # Removed ZIP / file finalization
+  - org.openrewrite.java.migrate.RemovedZipFinalizeMethods
+  - org.openrewrite.java.migrate.RemovedFileIOFinalizeMethods
+
+  # Removed SSL session method
+  - org.openrewrite.java.migrate.RemovedSSLSessionGetPeerCertificateChainMethodImpl
+
+  # Removed sun.net.ssl package
+  - org.openrewrite.java.migrate.SunNetSslPackageUnavailable
+
+  # Removed RMI constant
+  - org.openrewrite.java.migrate.RemovedRMIConnectorServerCredentialTypesConstant
+
+  # Maven plugin compatibility for Java 17
+  - org.openrewrite.java.migrate.UpgradePluginsForJava17
+
+  # ── Phase 3: Java 17 → 21 ────────────────────────────────────────────────
+
+  # Tell Maven/Gradle build tooling to target Java 21
+  - org.openrewrite.java.migrate.UpgradeBuildToJava21
+
+  # Syntax & language
+  - org.openrewrite.java.migrate.RemoveIllegalSemicolons
+
+  # Thread.stop() removed in JDK 21 (JEP — finalized deprecation)
+  - org.openrewrite.java.migrate.ThreadStopUnsupported
+
+  # URL(String) constructor deprecated; replace with URI.create().toURL()
+  - org.openrewrite.java.migrate.URLConstructorToURICreate
+
+  # Sequenced Collections (JEP 431)
+  - org.openrewrite.java.migrate.SequencedCollection
+
+  # Locale factory method
+  - org.openrewrite.java.migrate.UseLocaleOf
+
+  # Deprecated Runtime.exec() overloads
+  - org.openrewrite.java.migrate.ReplaceDeprecatedRuntimeExecMethods
+
+  # Toolchain / compiler version metadata
+  - org.openrewrite.java.migrate.SetupJavaUpgradeJavaVersion
+
+  # Maven plugin compatibility for Java 21
+  - org.openrewrite.java.migrate.UpgradePluginsForJava21
+
+  # Object.finalize() deleted in JDK 21 (JEP 421 / JEP 447)
+  - org.openrewrite.java.migrate.DeleteDeprecatedFinalize
+
+  # Removed Subject methods (JEP 411 follow-up)
+  - org.openrewrite.java.migrate.RemovedSubjectMethods
+
+  # ── Phase 4: Import cleanup ───────────────────────────────────────────────
+  - org.openrewrite.java.RemoveUnusedImports
+
+  # ── Phase 5: Library upgrades bundled with the Java 21 migration ─────────
+
+  # Google Guice: 4.x → 5.x (requires Java 11+)
+  - org.openrewrite.java.migrate.guava.UpgradeGuice_5_x
+
+  # Apache Commons Codec: upgrade to 1.17.x
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: commons-codec
+      artifactId: commons-codec
+      newVersion: 1.17.x
+
+  # SpotBugs Maven Plugin: 4.9.x (requires Java 11+)
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: com.github.spotbugs
+      artifactId: spotbugs-maven-plugin
+      newVersion: 4.9.x
+
+  # MapStruct: 1.6.x
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.mapstruct
+      artifactId: mapstruct
+      newVersion: 1.6.x
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.mapstruct
+      artifactId: mapstruct-processor
+      newVersion: 1.6.x
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: projectlombok
+      artifactId: lombok-mapstruct-binding
+      newVersion: 0.2.x
+
+  # JaCoCo: 0.8.12 (required for Java 21 bytecode instrumentation support)
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: org.jacoco
+      artifactId: jacoco-maven-plugin
+      newVersion: 0.8.12
+
+---
+# ── Sub-recipe 2: Maven plugin version upgrades ──────────────────────────────
+type: specs.openrewrite.org/v1beta/recipe
+name: aem.lts.migration.UpgradePluginVersions
+displayName: AEM 6.5 LTS — Upgrade Maven Build Plugins
+description: >
+  Upgrades AEM-related Maven build plugins to versions that produce and validate
+  OSGi bundles correctly when compiling with Java 21.  Uses maven-bundle-plugin
+  5.1.9 (the correct 5.x target for AEM 6.5 LTS; NOT 6.x), pins ASM 9.7.1
+  inside maven-scr-plugin for Java 21 class file parsing, and sets the compiler
+  --release flag.
+tags:
+  - aem
+  - maven
+  - plugins
+  - migration
+recipeList:
+
+  # ── OSGi bundle tooling ───────────────────────────────────────────────────
+
+  # maven-bundle-plugin 5.1.9: correct 5.x release for AEM 6.5 LTS.
+  # AEM 6.5 LTS does NOT require the 6.x plugin line.
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: org.apache.felix
+      artifactId: maven-bundle-plugin
+      newVersion: 5.1.9
+
+  # bnd-maven-plugin family: 6.4.0 (last stable 6.x, Java 21 ready)
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: biz.aQute.bnd
+      artifactId: bnd-maven-plugin
+      newVersion: 6.4.0
+
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: biz.aQute.bnd
+      artifactId: bnd-indexer-maven-plugin
+      newVersion: 6.4.0
+
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: biz.aQute.bnd
+      artifactId: bnd-resolver-maven-plugin
+      newVersion: 6.4.0
+
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: biz.aQute.bnd
+      artifactId: bnd-testing-maven-plugin
+      newVersion: 6.4.0
+
+  # maven-scr-plugin 1.26.4: final release.  Ships with ASM 7 which cannot
+  # parse Java 21 class files; override with ASM 9.7.1 via plugin dependency.
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: org.apache.felix
+      artifactId: maven-scr-plugin
+      newVersion: 1.26.4
+
+  - org.openrewrite.maven.AddPluginDependency:
+      pluginGroupId: org.apache.felix
+      pluginArtifactId: maven-scr-plugin
+      groupId: org.ow2.asm
+      artifactId: asm-analysis
+      version: 9.7.1
+
+  # ── Compiler configuration ────────────────────────────────────────────────
+
+  # Set --release 21 in maven-compiler-plugin configuration.
+  - org.openrewrite.maven.ChangePluginConfiguration:
+      groupId: org.apache.maven.plugins
+      artifactId: maven-compiler-plugin
+      configuration: >
+        <release>21</release>
+
+  # ── Content package tooling ───────────────────────────────────────────────
+
+  # filevault-package-maven-plugin 1.3.6: Java 21 compatible.
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: org.apache.jackrabbit
+      artifactId: filevault-package-maven-plugin
+      newVersion: 1.3.6
+
+---
+# ── Sub-recipe 3: Library dependency upgrades ────────────────────────────────
+type: specs.openrewrite.org/v1beta/recipe
+name: aem.lts.migration.UpgradeCommonLibraries
+displayName: AEM 6.5 LTS — Upgrade Common Library Dependencies
+description: >
+  Upgrades AEM WCM Core Components, Groovy, and the AEM Groovy Console to
+  versions compatible with AEM 6.5 LTS and Java 21.  Migrates the Groovy
+  Console from the abandoned com.icfolson.aem coordinates to the actively
+  maintained be.orbinson.aem coordinates.
+tags:
+  - aem
+  - dependencies
+  - migration
+recipeList:
+
+  # ── AEM WCM Core Components ───────────────────────────────────────────────
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: com.adobe.cq
+      artifactId: core.wcm.components.core
+      newVersion: 2.24.0
+
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: com.adobe.cq
+      artifactId: core.wcm.components.content
+      newVersion: 2.24.0
+
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: com.adobe.cq
+      artifactId: core.wcm.components.config
+      newVersion: 2.24.0
+
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: com.adobe.cq
+      artifactId: core.wcm.components.all
+      newVersion: 2.24.0
+
+  # ── Groovy runtime ────────────────────────────────────────────────────────
+  # Groovy 4.0.27: first version with full Java 21 support; 3.x is EOL.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.apache.groovy
+      artifactId: groovy-all
+      newVersion: 4.0.27
+
+  # Also cover legacy org.codehaus.groovy groupId
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.codehaus.groovy
+      artifactId: groovy-all
+      newVersion: 4.0.27
+
+  # ── AEM Groovy Console ────────────────────────────────────────────────────
+  # Migrate from abandoned com.icfolson.aem coordinates to be.orbinson.aem.
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: com.icfolson.aem.groovy.console
+      oldArtifactId: aem-groovy-console
+      newGroupId: be.orbinson.aem
+      newArtifactId: aem-groovy-console
+      newVersion: 19.0.8
+
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: com.icfolson.aem.groovy.console
+      oldArtifactId: aem-groovy-console-bundle
+      newGroupId: be.orbinson.aem
+      newArtifactId: aem-groovy-console-bundle
+      newVersion: 19.0.8
+
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: com.icfolson.aem.groovy.console
+      oldArtifactId: aem-groovy-console-content
+      newGroupId: be.orbinson.aem
+      newArtifactId: aem-groovy-console-content
+      newVersion: 19.0.8
+
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: be.orbinson.aem
+      artifactId: aem-groovy-console
+      newVersion: 19.0.8
+
+---
+# ── Sub-recipe 4: Maven plugin configuration corrections ─────────────────────
+type: specs.openrewrite.org/v1beta/recipe
+name: aem.lts.migration.UpgradeMavenPluginConfigurations
+displayName: AEM 6.5 LTS — Fix Maven Plugin Configurations for LTS
+description: >
+  Corrects FileVault and bnd plugin configurations that are incompatible with
+  AEM 6.5 LTS.  Migrates the Groovy Console embedded artefact from the
+  abandoned com.icfolson coordinates to the current be.orbinson coordinates
+  inside filevault-package-maven-plugin <embedded> declarations, and removes
+  the _plugin- BND instruction that is rejected by bnd 6.x.
+tags:
+  - aem
+  - maven
+  - filevault
+  - migration
+recipeList:
+
+  # Migrate Groovy Console embedded artefact inside filevault plugin config.
+  # Handles <embedded> entries in <embeddeds> within filevault-package-maven-plugin.
+  - com.adobe.aem.migration.recipes.ChangeFilevaultEmbeddedArtifact:
+      oldGroupId: "com.icfolson.aem*"
+      oldArtifactId: "aem-groovy-console*"
+      newGroupId: be.orbinson.aem
+
+  # Remove the _plugin- BND instruction header that bnd 6.x no longer accepts.
+  - com.adobe.aem.migration.recipes.RemoveBndPluginInstruction:
+      instructionPattern: SCRDescriptorBndPlugin
+
+  # Revert any accidental javax→jakarta changes in AEM source files.
+  # This is a safeguard: if any upstream recipe inadvertently migrated javax
+  # imports, this recipe restores them to the javax namespace required by
+  # AEM 6.5 LTS.
+  - com.adobe.aem.migration.recipes.RevertJakartaInAemSource

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/resources/META-INF/config/openrewrite/recipes/65LTSUpgradeUberJar.yaml
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/main/resources/META-INF/config/openrewrite/recipes/65LTSUpgradeUberJar.yaml
@@ -1,0 +1,75 @@
+---
+# 65LTSUpgradeUberJar.yaml
+#
+# Purpose: Migrate the AEM UberJar dependency to version 6.6.0 with the
+# mandatory "apis" classifier.
+#
+# Background:
+#   Starting with AEM 6.5 LTS (internally versioned as 6.6.0 in Maven), Adobe
+#   changed the UberJar packaging so that only the "apis" classifier variant
+#   contains the public API classes.  The unclassified artefact is no longer
+#   published.  Projects that previously declared the UberJar without a
+#   classifier must:
+#     1. bump the version to 6.6.0
+#     2. add <classifier>apis</classifier>
+#
+#   This recipe handles:
+#     a. <dependencies> section (direct dependency)
+#     b. <dependencyManagement> section (managed version declaration)
+#     c. Both of the above simultaneously (parent POM pattern)
+#
+# Recipe artifact coordinates:
+#   com.adobe.aem:aem65lts-migration-recipes:1.0-SNAPSHOT
+
+type: specs.openrewrite.org/v1beta/recipe
+name: aem.lts.migration.UpdateUberJarVersion
+displayName: AEM 6.5 LTS — Migrate UberJar to 6.6.0 with apis Classifier
+description: >
+  Bumps the AEM UberJar (com.adobe.aem:uber-jar) from any prior version to
+  6.6.0 and adds the required "apis" classifier.  Covers both direct
+  <dependencies> entries and <dependencyManagement> declarations, including
+  the alternate com.day.cq groupId that older projects may use.
+tags:
+  - aem
+  - uberjar
+  - migration
+recipeList:
+
+  # ── Step 1: Upgrade version to 6.6.0 ─────────────────────────────────────
+  # Handle the current canonical groupId (com.adobe.aem).
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: com.adobe.aem
+      artifactId: uber-jar
+      newVersion: 6.6.0
+
+  # Handle the legacy groupId used by pre-6.3 projects (com.day.cq).
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: com.day.cq
+      artifactId: uber-jar
+      newVersion: 6.6.0
+
+  # ── Step 2: Migrate legacy groupId to canonical groupId ──────────────────
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: com.day.cq
+      oldArtifactId: uber-jar
+      newGroupId: com.adobe.aem
+      newArtifactId: uber-jar
+      newVersion: 6.6.0
+
+  # ── Step 3: Add the "apis" classifier ────────────────────────────────────
+  - org.openrewrite.maven.AddDependencyClassifier:
+      groupId: com.adobe.aem
+      artifactId: uber-jar
+      classifier: apis
+
+  # ── Step 4: Ensure dependencyManagement is in sync ───────────────────────
+  - org.openrewrite.maven.AddManagedDependency:
+      groupId: com.adobe.aem
+      artifactId: uber-jar
+      version: 6.6.0
+      scope: provided
+      classifier: apis
+      addToRootPom: true
+
+  # ── Step 5: Remove duplicate dependency entries ───────────────────────────
+  - org.openrewrite.maven.RemoveDuplicateDependencies

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/test/java/com/adobe/aem/migration/cli/commands/MigrationCliE2ETest.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/test/java/com/adobe/aem/migration/cli/commands/MigrationCliE2ETest.java
@@ -1,0 +1,230 @@
+package com.adobe.aem.migration.cli.commands;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end coverage of the CLI's read-only commands.
+ *
+ * <p>Each test materialises a tiny Maven project under a JUnit
+ * {@code @TempDir}, drives the corresponding picocli command via
+ * {@link CommandLine#execute}, captures stdout, and asserts on both the
+ * exit code and the structured output. This is the highest-fidelity test
+ * the CLI module can run without spawning a JVM subprocess — it exercises
+ * picocli's option binding, the command's filesystem walk, and the
+ * report serialiser in one pass.
+ *
+ * <p>The destructive {@code upgrade-*} commands invoke
+ * {@code rewrite-maven-plugin} via Maven Invoker, so they need a real
+ * Maven installation on {@code PATH} and a network-reachable repository
+ * — those are deferred to a manual smoke test on a representative
+ * customer project before promoting out of beta.
+ */
+class MigrationCliE2ETest {
+
+    private static final String CLEAN_POM =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            + "<project xmlns=\"http://maven.apache.org/POM/4.0.0\">\n"
+            + "  <modelVersion>4.0.0</modelVersion>\n"
+            + "  <groupId>com.example</groupId>\n"
+            + "  <artifactId>fixture</artifactId>\n"
+            + "  <version>1.0.0</version>\n"
+            + "  <properties><maven.compiler.source>11</maven.compiler.source></properties>\n"
+            + "</project>\n";
+
+    private static final String COMMERCE_JAVA =
+            "package com.example;\n"
+            + "import com.adobe.cq.commerce.api.CommerceService;\n"
+            + "public class Bad { CommerceService s; }\n";
+
+    private static final String GUAVA_JAVA =
+            "package com.example;\n"
+            + "import com.google.common.collect.ImmutableList;\n"
+            + "public class Warn { ImmutableList<String> l; }\n";
+
+    @Test
+    @DisplayName("analyze on a clean fixture exits 0 and reports READY")
+    void analyzeCleanFixture(@TempDir Path repo) throws Exception {
+        Files.write(repo.resolve("pom.xml"), CLEAN_POM.getBytes(StandardCharsets.UTF_8));
+
+        Captured c = runAnalyze(repo, false);
+        assertEquals(0, c.exitCode, c.stdout);
+        assertTrue(c.stdout.contains("Status:               READY"), c.stdout);
+    }
+
+    @Test
+    @DisplayName("analyze --json on a clean fixture emits a single-line JSON document")
+    void analyzeCleanFixtureJson(@TempDir Path repo) throws Exception {
+        Files.write(repo.resolve("pom.xml"), CLEAN_POM.getBytes(StandardCharsets.UTF_8));
+
+        Captured c = runAnalyze(repo, true);
+        assertEquals(0, c.exitCode, c.stdout);
+        String json = c.stdout.trim();
+        assertTrue(json.startsWith("{"), json);
+        assertTrue(json.endsWith("}"), json);
+        assertEquals(0, countLines(json), "JSON output must be single-line");
+        assertTrue(json.contains("\"schemaVersion\":1"), json);
+        assertTrue(json.contains("\"status\":\"READY\""), json);
+        assertTrue(json.contains("\"exitCode\":0"), json);
+        assertTrue(json.contains("\"detectedJavaVersion\":\"11\""), json);
+    }
+
+    @Test
+    @DisplayName("analyze --json with a commerce import exits 2 and lists the file/line")
+    void analyzeWithBlocker(@TempDir Path repo) throws Exception {
+        Files.write(repo.resolve("pom.xml"), CLEAN_POM.getBytes(StandardCharsets.UTF_8));
+        Path src = repo.resolve("src/main/java/com/example");
+        Files.createDirectories(src);
+        Files.write(src.resolve("Bad.java"), COMMERCE_JAVA.getBytes(StandardCharsets.UTF_8));
+
+        Captured c = runAnalyze(repo, true);
+        assertEquals(2, c.exitCode, c.stdout);
+        String json = c.stdout.trim();
+        assertTrue(json.contains("\"status\":\"BLOCKED\""), json);
+        assertTrue(json.contains("\"exitCode\":2"), json);
+        assertTrue(json.contains("\"severity\":\"BLOCKER\""), json);
+        assertTrue(json.contains("\"package\":\"com.adobe.cq.commerce.\""), json);
+        assertTrue(json.contains("\"file\":\"src/main/java/com/example/Bad.java\""), json);
+        assertTrue(json.contains("\"line\":2"), json);
+    }
+
+    @Test
+    @DisplayName("analyze --json with only a removed-bundle import exits 1 and reports WARNING")
+    void analyzeWithWarningOnly(@TempDir Path repo) throws Exception {
+        Files.write(repo.resolve("pom.xml"), CLEAN_POM.getBytes(StandardCharsets.UTF_8));
+        Path src = repo.resolve("src/main/java/com/example");
+        Files.createDirectories(src);
+        Files.write(src.resolve("Warn.java"), GUAVA_JAVA.getBytes(StandardCharsets.UTF_8));
+
+        Captured c = runAnalyze(repo, true);
+        assertEquals(1, c.exitCode, c.stdout);
+        String json = c.stdout.trim();
+        assertTrue(json.contains("\"status\":\"READY_WITH_WARNINGS\""), json);
+        assertTrue(json.contains("\"severity\":\"WARNING\""), json);
+        assertTrue(json.contains("\"package\":\"com.google.common.\""), json);
+    }
+
+    @Test
+    @DisplayName("analyze on a directory without pom.xml exits 2 with status INVALID")
+    void analyzeWithoutPom(@TempDir Path repo) throws Exception {
+        Captured c = runAnalyze(repo, true);
+        assertEquals(2, c.exitCode, c.stdout);
+        String json = c.stdout.trim();
+        assertTrue(json.contains("\"status\":\"INVALID\""), json);
+        assertTrue(json.contains("\"fatal\":\"Invalid project"), json);
+    }
+
+    @Test
+    @DisplayName("verify --json on a fully-migrated fixture emits PASS overall")
+    void verifyFullyMigrated(@TempDir Path repo) throws Exception {
+        Files.write(repo.resolve("pom.xml"),
+                ("<?xml version=\"1.0\"?>\n"
+                + "<project xmlns=\"http://maven.apache.org/POM/4.0.0\">\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>fixture</artifactId>\n"
+                + "  <version>1.0.0</version>\n"
+                + "</project>\n").getBytes(StandardCharsets.UTF_8));
+        Files.createDirectories(repo.resolve(".cloudmanager"));
+        Files.write(repo.resolve(".cloudmanager/java-version"),
+                "21".getBytes(StandardCharsets.UTF_8));
+
+        Captured c = runVerify(repo);
+        assertEquals(0, c.exitCode, c.stdout);
+        String json = c.stdout.trim();
+        assertTrue(json.contains("\"schemaVersion\":1"), json);
+        assertTrue(json.contains("\"command\":\"verify\""), json);
+        assertTrue(json.contains("\"status\":\"PASS\""), json);
+        assertTrue(json.contains("\"id\":\"cloudmanager-version\""), json);
+        assertTrue(json.contains("\"id\":\"compiler-settings\""), json);
+    }
+
+    @Test
+    @DisplayName("verify --json catches a leftover <source>11</source> and exits 1")
+    void verifyCatchesUnmigratedCompiler(@TempDir Path repo) throws Exception {
+        Files.write(repo.resolve("pom.xml"),
+                ("<?xml version=\"1.0\"?>\n"
+                + "<project xmlns=\"http://maven.apache.org/POM/4.0.0\">\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>fixture</artifactId>\n"
+                + "  <version>1.0.0</version>\n"
+                + "  <build><plugins><plugin>\n"
+                + "    <groupId>org.apache.maven.plugins</groupId>\n"
+                + "    <artifactId>maven-compiler-plugin</artifactId>\n"
+                + "    <configuration><source>11</source><target>11</target></configuration>\n"
+                + "  </plugin></plugins></build>\n"
+                + "</project>\n").getBytes(StandardCharsets.UTF_8));
+        Files.createDirectories(repo.resolve(".cloudmanager"));
+        Files.write(repo.resolve(".cloudmanager/java-version"),
+                "21".getBytes(StandardCharsets.UTF_8));
+
+        Captured c = runVerify(repo);
+        assertEquals(1, c.exitCode, c.stdout);
+        String json = c.stdout.trim();
+        assertTrue(json.contains("\"status\":\"FAIL\""), json);
+        assertTrue(json.contains("\"id\":\"compiler-settings\""), json);
+        assertTrue(json.contains("still contains \\u003csource\\u003e11\\u003c/source\\u003e") ||
+                  json.contains("still contains <source>11</source>"), json);
+    }
+
+    private Captured runAnalyze(Path repo, boolean json) throws IOException {
+        AnalyzeCommand cmd = new AnalyzeCommand();
+        CommandLine cli = new CommandLine(cmd);
+        String[] args = json
+                ? new String[]{"-r", repo.toAbsolutePath().toString(), "--json"}
+                : new String[]{"-r", repo.toAbsolutePath().toString()};
+        return capture(cli, args);
+    }
+
+    private Captured runVerify(Path repo) throws IOException {
+        VerifyCommand cmd = new VerifyCommand();
+        CommandLine cli = new CommandLine(cmd);
+        String[] args = new String[]{"-r", repo.toAbsolutePath().toString(), "--json", "--skip-git"};
+        return capture(cli, args);
+    }
+
+    private Captured capture(CommandLine cli, String[] args) throws IOException {
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        try (PrintStream tee = new PrintStream(buf, true, "UTF-8")) {
+            System.setOut(tee);
+            int exit = cli.execute(args);
+            return new Captured(exit, buf.toString("UTF-8"));
+        } finally {
+            System.setOut(originalOut);
+        }
+    }
+
+    private int countLines(String s) {
+        int newlines = 0;
+        for (int i = 0; i < s.length(); i++) {
+            if (s.charAt(i) == '\n') {
+                newlines++;
+            }
+        }
+        return newlines;
+    }
+
+    private static final class Captured {
+        final int exitCode;
+        final String stdout;
+
+        Captured(int exitCode, String stdout) {
+            this.exitCode = exitCode;
+            this.stdout = stdout;
+        }
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/test/java/com/adobe/aem/migration/cli/report/AnalysisReportTest.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/test/java/com/adobe/aem/migration/cli/report/AnalysisReportTest.java
@@ -1,0 +1,98 @@
+package com.adobe.aem.migration.cli.report;
+
+import com.adobe.aem.migration.cli.report.AnalysisReport.Finding;
+import com.adobe.aem.migration.cli.report.AnalysisReport.Severity;
+import com.adobe.aem.migration.cli.report.AnalysisReport.Status;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link AnalysisReport}'s JSON contract.
+ *
+ * <p>JSON output is consumed by CI tools, so the schema is treated as a
+ * stability surface. The tests pin schemaVersion, status enum values,
+ * exit codes, and string escaping so a downstream consumer can rely on
+ * the shape.
+ */
+class AnalysisReportTest {
+
+    @Test
+    @DisplayName("clean project reports READY/0")
+    void cleanProjectReportsReady() {
+        AnalysisReport r = new AnalysisReport("/tmp/clean");
+        r.detectedJavaVersion("11");
+        r.hasGit(true);
+
+        assertEquals(Status.READY, r.status());
+        assertEquals(0, r.exitCode());
+        String json = r.toJson();
+        assertTrue(json.contains("\"schemaVersion\":1"), json);
+        assertTrue(json.contains("\"status\":\"READY\""), json);
+        assertTrue(json.contains("\"exitCode\":0"), json);
+        assertTrue(json.contains("\"findings\":[]"), json);
+        assertTrue(json.contains("\"fatal\":null"), json);
+    }
+
+    @Test
+    @DisplayName("removed-bundle import reports READY_WITH_WARNINGS/1")
+    void warningOnlyReportsReadyWithWarnings() {
+        AnalysisReport r = new AnalysisReport("/tmp/w");
+        r.detectedJavaVersion("8");
+        r.hasGit(true);
+        r.findings(Collections.singletonList(
+                new Finding(Severity.WARNING, "com.google.common.", "core/Cache.java", 7)));
+
+        assertEquals(Status.READY_WITH_WARNINGS, r.status());
+        assertEquals(1, r.exitCode());
+        assertEquals(0, r.blockerCount());
+        assertEquals(1, r.warningCount());
+        String json = r.toJson();
+        assertTrue(json.contains("\"severity\":\"WARNING\""), json);
+        assertTrue(json.contains("\"warningCount\":1"), json);
+    }
+
+    @Test
+    @DisplayName("commerce import reports BLOCKED/2 and lists the finding")
+    void blockerReportsBlocked() {
+        AnalysisReport r = new AnalysisReport("/tmp/b");
+        r.detectedJavaVersion("8");
+        r.findings(Arrays.asList(
+                new Finding(Severity.BLOCKER, "com.adobe.cq.commerce.", "core/Foo.java", 14),
+                new Finding(Severity.WARNING, "com.google.common.", "core/Bar.java", 5)));
+
+        assertEquals(Status.BLOCKED, r.status());
+        assertEquals(2, r.exitCode());
+        assertEquals(1, r.blockerCount());
+        assertEquals(1, r.warningCount());
+    }
+
+    @Test
+    @DisplayName("missing pom.xml reports INVALID/2")
+    void fatalReportsInvalid() {
+        AnalysisReport r = new AnalysisReport("/tmp/missing");
+        r.fatal("No pom.xml found");
+
+        assertEquals(Status.INVALID, r.status());
+        assertEquals(2, r.exitCode());
+        String json = r.toJson();
+        assertTrue(json.contains("\"fatal\":\"No pom.xml found\""), json);
+        assertTrue(json.contains("\"status\":\"INVALID\""), json);
+    }
+
+    @Test
+    @DisplayName("control characters in paths are JSON-escaped")
+    void controlCharactersAreEscaped() {
+        AnalysisReport r = new AnalysisReport("/tmp/p\"with\\quotes");
+        r.detectedJavaVersion("11");
+
+        String json = r.toJson();
+        assertTrue(json.contains("\\\"with"), json);
+        assertTrue(json.contains("\\\\quotes"), json);
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/test/java/com/adobe/aem/migration/cli/report/VerificationReportTest.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-cli/src/test/java/com/adobe/aem/migration/cli/report/VerificationReportTest.java
@@ -1,0 +1,98 @@
+package com.adobe.aem.migration.cli.report;
+
+import com.adobe.aem.migration.cli.report.VerificationReport.CheckResult;
+import com.adobe.aem.migration.cli.report.VerificationReport.Issue;
+import com.adobe.aem.migration.cli.report.VerificationReport.Status;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the JSON contract for the verify report. Downstream CI tools
+ * depend on the schema; breaking it without bumping {@code schemaVersion}
+ * is a regression.
+ */
+class VerificationReportTest {
+
+    @Test
+    @DisplayName("all-passing run reports PASS/0")
+    void allPassingReportsPass() {
+        VerificationReport r = new VerificationReport("/tmp/p");
+        r.addResult(new CheckResult("cloudmanager-version", ".cloudmanager/java-version = 21", Status.PASS, Collections.emptyList()));
+        r.addResult(new CheckResult("compiler-settings",   "Compiler source/target/release = 21", Status.PASS, Collections.emptyList()));
+
+        assertEquals(Status.PASS, r.overallStatus());
+        assertEquals(0, r.exitCode());
+        assertEquals(2, r.passCount());
+        assertEquals(0, r.failCount());
+
+        String json = r.toJson();
+        assertTrue(json.contains("\"schemaVersion\":1"), json);
+        assertTrue(json.contains("\"command\":\"verify\""), json);
+        assertTrue(json.contains("\"status\":\"PASS\""), json);
+        assertTrue(json.contains("\"exitCode\":0"), json);
+        assertTrue(json.contains("\"id\":\"cloudmanager-version\""), json);
+    }
+
+    @Test
+    @DisplayName("a single failing check makes the overall run FAIL/1")
+    void anyFailingMakesOverallFail() {
+        VerificationReport r = new VerificationReport("/tmp/f");
+        r.addResult(new CheckResult("cloudmanager-version", ".cloudmanager/java-version = 21", Status.PASS, Collections.emptyList()));
+        r.addResult(new CheckResult("compiler-settings",   "Compiler source/target/release = 21", Status.FAIL,
+                Collections.singletonList(new Issue("core/pom.xml", "still contains <source>11</source>"))));
+
+        assertEquals(Status.FAIL, r.overallStatus());
+        assertEquals(1, r.exitCode());
+        assertEquals(1, r.passCount());
+        assertEquals(1, r.failCount());
+
+        String json = r.toJson();
+        assertTrue(json.contains("\"status\":\"FAIL\""), json);
+        assertTrue(json.contains("\"file\":\"core/pom.xml\""), json);
+        assertTrue(json.contains("still contains \\u003csource\\u003e11\\u003c/source\\u003e") ||
+                  json.contains("still contains <source>11</source>"), json);
+    }
+
+    @Test
+    @DisplayName("SKIP results do not flip the overall status")
+    void skipDoesNotFail() {
+        VerificationReport r = new VerificationReport("/tmp/s");
+        r.addResult(new CheckResult("cloudmanager-version", ".cloudmanager/java-version = 21", Status.PASS, Collections.emptyList()));
+        r.addResult(new CheckResult("compiler-settings",   "Compiler source/target/release = 21", Status.SKIP, Collections.emptyList()));
+
+        assertEquals(Status.PASS, r.overallStatus());
+        assertEquals(0, r.exitCode());
+        assertEquals(1, r.skipCount());
+    }
+
+    @Test
+    @DisplayName("human-readable output prints id and title per check")
+    void humanReadableContainsIdAndTitle() {
+        VerificationReport r = new VerificationReport("/tmp/h");
+        r.addResult(new CheckResult("uberjar-classifier", "uber-jar has 'apis' classifier", Status.PASS, Collections.emptyList()));
+
+        String text = r.toHumanReadable();
+        assertTrue(text.contains("[PASS] uberjar-classifier — uber-jar has 'apis' classifier"), text);
+        assertTrue(text.contains("Overall: PASS (exit 0)"), text);
+    }
+
+    @Test
+    @DisplayName("issue count per check is preserved in JSON")
+    void issueCountIsPreserved() {
+        VerificationReport r = new VerificationReport("/tmp/i");
+        r.addResult(new CheckResult("unsupported-packages", "No unsupported package imports", Status.FAIL,
+                Arrays.asList(
+                        new Issue("core/Foo.java", "imports unsupported package com.adobe.cq.commerce.*"),
+                        new Issue("core/Bar.java", "imports unsupported package com.adobe.cq.screens.*"))));
+
+        String json = r.toJson();
+        assertTrue(json.contains("\"issueCount\":2"), json);
+        assertTrue(json.contains("\"failCount\":1"), json);
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/pom.xml
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/pom.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.adobe.aem</groupId>
+        <artifactId>aem65lts-migration-tool</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>aem65lts-migration-recipes</artifactId>
+    <name>AEM 6.5 LTS Migration Recipes</name>
+    <description>Custom OpenRewrite recipes for AEM 6.5 to AEM 6.5 LTS migration</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Force all JUnit platform artifacts to the same version to avoid engine/API mismatches -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.11.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- OpenRewrite core -->
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-core</artifactId>
+            <version>${rewrite.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-maven</artifactId>
+            <version>${rewrite.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java</artifactId>
+            <version>${rewrite.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-xml</artifactId>
+            <version>${rewrite.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.34</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-test</artifactId>
+            <version>${rewrite.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.27.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java-11</artifactId>
+            <version>${rewrite.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Classpath for RevertJakartaInAemSource tests (ChangeType needs resolved types) -->
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <version>2.0.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>2.1.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.34</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <configuration>
+                            <source>11</source>
+                            <target>11</target>
+                            <release>11</release>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/main/java/com/adobe/aem/migration/recipes/ChangeFilevaultEmbeddedArtifact.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/main/java/com/adobe/aem/migration/recipes/ChangeFilevaultEmbeddedArtifact.java
@@ -1,0 +1,122 @@
+package com.adobe.aem.migration.recipes;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.xml.ChangeTagValueVisitor;
+import org.openrewrite.xml.tree.Xml;
+
+import java.util.Optional;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ChangeFilevaultEmbeddedArtifact extends Recipe {
+
+    @Option(displayName = "Old groupId",
+            description = "The current groupId of the embedded artifact (glob pattern).",
+            example = "com.icfolson.aem*")
+    String oldGroupId;
+
+    @Option(displayName = "Old artifactId",
+            description = "The current artifactId of the embedded artifact (glob pattern).",
+            example = "aem-groovy-console*")
+    String oldArtifactId;
+
+    @Option(displayName = "New groupId",
+            description = "The new groupId to set.",
+            example = "be.orbinson.aem")
+    String newGroupId;
+
+    @Option(displayName = "New artifactId",
+            description = "The new artifactId to set. Leave empty to keep the original.",
+            example = "aem-groovy-console",
+            required = false)
+    String newArtifactId;
+
+    @Override
+    public String getDisplayName() {
+        return "Change FileVault embedded artifact coordinates";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Updates the groupId and optionally the artifactId of embedded artifacts " +
+               "in filevault-package-maven-plugin configuration.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new MavenIsoVisitor<ExecutionContext>() {
+            @Override
+            public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                Xml.Tag t = super.visitTag(tag, ctx);
+
+                if (!"embedded".equals(t.getName())) {
+                    return t;
+                }
+
+                if (!isInsideFileVaultPlugin()) {
+                    return t;
+                }
+
+                Optional<String> groupId = t.getChild("groupId")
+                        .flatMap(Xml.Tag::getValue);
+                Optional<String> artifactId = t.getChild("artifactId")
+                        .flatMap(Xml.Tag::getValue);
+
+                if (!groupId.isPresent() || !artifactId.isPresent()) {
+                    return t;
+                }
+
+                if (!matchesGlob(groupId.get().trim(), oldGroupId)) {
+                    return t;
+                }
+                if (!matchesGlob(artifactId.get().trim(), oldArtifactId)) {
+                    return t;
+                }
+
+                t.getChild("groupId").ifPresent(g ->
+                    doAfterVisit(new ChangeTagValueVisitor<>(g, newGroupId)));
+
+                if (newArtifactId != null && !newArtifactId.isEmpty()) {
+                    t.getChild("artifactId").ifPresent(a ->
+                        doAfterVisit(new ChangeTagValueVisitor<>(a, newArtifactId)));
+                }
+
+                return t;
+            }
+
+            private boolean isInsideFileVaultPlugin() {
+                Cursor parent = getCursor().getParent();
+                while (parent != null) {
+                    if (parent.getValue() instanceof Xml.Tag) {
+                        Xml.Tag parentTag = (Xml.Tag) parent.getValue();
+                        if ("plugin".equals(parentTag.getName())) {
+                            String groupId = parentTag.getChild("groupId")
+                                    .flatMap(Xml.Tag::getValue)
+                                    .map(String::trim)
+                                    .orElse("org.apache.jackrabbit");
+                            String artifactId = parentTag.getChild("artifactId")
+                                    .flatMap(Xml.Tag::getValue)
+                                    .map(String::trim)
+                                    .orElse("");
+                            return "org.apache.jackrabbit".equals(groupId)
+                                    && "filevault-package-maven-plugin".equals(artifactId);
+                        }
+                    }
+                    parent = parent.getParent();
+                }
+                return false;
+            }
+
+            private boolean matchesGlob(String value, String pattern) {
+                String regex = pattern
+                        .replace(".", "\\.")
+                        .replace("*", ".*")
+                        .replace("?", ".");
+                return value.matches(regex);
+            }
+        };
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/main/java/com/adobe/aem/migration/recipes/DetectUnsupportedPackages.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/main/java/com/adobe/aem/migration/recipes/DetectUnsupportedPackages.java
@@ -1,0 +1,73 @@
+package com.adobe.aem.migration.recipes;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class DetectUnsupportedPackages extends Recipe {
+
+    private static final List<String> UNSUPPORTED_PACKAGES = Arrays.asList(
+            "com.adobe.cq.commerce.",
+            "com.adobe.cq.social.",
+            "com.adobe.granite.social.",
+            "com.adobe.cq.screens.",
+            "com.adobe.cq.sample.we.retail.",
+            "com.day.cq.dam.pim.",
+            "com.day.cq.dam.rating.",
+            "com.adobe.cq.searchpromote.",
+            "com.adobe.cq.mcm.campaign."
+    );
+
+    private static final List<String> REMOVED_BUNDLE_PACKAGES = Arrays.asList(
+            "com.google.common.",
+            "com.github.benmanes.caffeine.",
+            "org.eclipse.jetty.",
+            "org.apache.commons.collections."
+    );
+
+    @Override
+    public String getDisplayName() {
+        return "Detect unsupported and removed bundle packages";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Scans Java source files for imports from packages that are unsupported in " +
+               "AEM 6.5 LTS or from bundles that have been removed from the runtime. " +
+               "Unsupported packages block migration; removed bundle packages require remediation.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.Import visitImport(J.Import import_, ExecutionContext ctx) {
+                String fqn = import_.getTypeName();
+
+                for (String pkg : UNSUPPORTED_PACKAGES) {
+                    if (fqn.startsWith(pkg)) {
+                        return SearchResult.found(import_,
+                                "BLOCKER: Unsupported package '" + pkg + "' — migration cannot proceed");
+                    }
+                }
+
+                for (String pkg : REMOVED_BUNDLE_PACKAGES) {
+                    if (fqn.startsWith(pkg) && !fqn.startsWith("org.apache.commons.collections4.")) {
+                        return SearchResult.found(import_,
+                                "WARNING: Removed bundle package '" + pkg + "' — requires remediation");
+                    }
+                }
+
+                return import_;
+            }
+        };
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/main/java/com/adobe/aem/migration/recipes/RemoveBndPluginInstruction.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/main/java/com/adobe/aem/migration/recipes/RemoveBndPluginInstruction.java
@@ -1,0 +1,86 @@
+package com.adobe.aem.migration.recipes;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.xml.RemoveContentVisitor;
+import org.openrewrite.xml.tree.Xml;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class RemoveBndPluginInstruction extends Recipe {
+
+    @Option(displayName = "Instruction pattern",
+            description = "Text pattern to match inside <_plugin> instructions that should be removed.",
+            example = "SCRDescriptorBndPlugin")
+    String instructionPattern;
+
+    @Override
+    public String getDisplayName() {
+        return "Remove BND plugin instruction";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Removes <_plugin> instruction elements from maven-bundle-plugin configuration " +
+               "that match the specified pattern. Used to remove SCRDescriptorBndPlugin which " +
+               "is incompatible with Java 21.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new MavenIsoVisitor<ExecutionContext>() {
+            @Override
+            public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                Xml.Tag t = super.visitTag(tag, ctx);
+
+                if (!"_plugin".equals(t.getName())) {
+                    return t;
+                }
+
+                // Check we're inside maven-bundle-plugin > configuration > instructions
+                if (!isInsideBundlePluginInstructions()) {
+                    return t;
+                }
+
+                // Check if the content matches the pattern
+                String content = t.getValue().orElse("");
+                if (content.contains(instructionPattern)) {
+                    doAfterVisit(new RemoveContentVisitor<>(t, false, false));
+                }
+
+                return t;
+            }
+
+            private boolean isInsideBundlePluginInstructions() {
+                Cursor cursor = getCursor();
+                boolean foundInstructions = false;
+                boolean foundPlugin = false;
+
+                Cursor parent = cursor.getParent();
+                while (parent != null) {
+                    if (parent.getValue() instanceof Xml.Tag) {
+                        Xml.Tag parentTag = parent.getValue();
+                        if ("instructions".equals(parentTag.getName())) {
+                            foundInstructions = true;
+                        }
+                        if ("plugin".equals(parentTag.getName())) {
+                            // Verify it's the maven-bundle-plugin
+                            boolean isBundlePlugin = parentTag.getChild("artifactId")
+                                    .flatMap(Xml.Tag::getValue)
+                                    .map(v -> v.trim().equals("maven-bundle-plugin"))
+                                    .orElse(false);
+                            if (isBundlePlugin) {
+                                foundPlugin = true;
+                            }
+                            break;
+                        }
+                    }
+                    parent = parent.getParent();
+                }
+                return foundInstructions && foundPlugin;
+            }
+        };
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/main/java/com/adobe/aem/migration/recipes/RevertJakartaInAemSource.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/main/java/com/adobe/aem/migration/recipes/RevertJakartaInAemSource.java
@@ -1,0 +1,86 @@
+package com.adobe.aem.migration.recipes;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.ChangeType;
+import org.openrewrite.java.tree.J;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class RevertJakartaInAemSource extends Recipe {
+
+    private static final List<String> AEM_PACKAGE_PREFIXES = Arrays.asList(
+            "com.adobe.", "org.apache.sling.", "com.day.cq.",
+            "org.apache.jackrabbit.", "org.apache.felix."
+    );
+
+    private static final List<String[]> JAKARTA_TO_JAVAX_MAPPINGS = Arrays.asList(
+            new String[]{"jakarta.annotation", "javax.annotation"},
+            new String[]{"jakarta.inject", "javax.inject"},
+            new String[]{"jakarta.servlet", "javax.servlet"},
+            new String[]{"jakarta.jcr", "javax.jcr"},
+            new String[]{"jakarta.json", "javax.json"}
+    );
+
+    @Override
+    public String getDisplayName() {
+        return "Revert jakarta imports to javax in AEM source files";
+    }
+
+    @Override
+    public String getDescription() {
+        return "AEM 6.5 LTS uses the javax namespace. This recipe detects Java files that " +
+               "import AEM/Sling packages and reverts any jakarta imports back to javax. " +
+               "Jakarta annotations compile but fail silently at runtime (e.g., @PostConstruct " +
+               "methods are never called).";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                // Check if this is an AEM source file (has AEM/Sling imports)
+                boolean isAemSource = cu.getImports().stream()
+                        .anyMatch(imp -> {
+                            String fqn = imp.getTypeName();
+                            return AEM_PACKAGE_PREFIXES.stream().anyMatch(fqn::startsWith);
+                        });
+
+                if (!isAemSource) {
+                    return cu;
+                }
+
+                // Check if there are any jakarta imports to revert
+                Set<String> jakartaImports = cu.getImports().stream()
+                        .map(J.Import::getTypeName)
+                        .filter(fqn -> fqn.startsWith("jakarta."))
+                        .collect(Collectors.toSet());
+
+                if (jakartaImports.isEmpty()) {
+                    return cu;
+                }
+
+                // Schedule ChangeType recipes for each jakarta->javax mapping
+                for (String jakartaImport : jakartaImports) {
+                    for (String[] mapping : JAKARTA_TO_JAVAX_MAPPINGS) {
+                        if (jakartaImport.startsWith(mapping[0])) {
+                            String javaxEquivalent = jakartaImport.replace(mapping[0], mapping[1]);
+                            doAfterVisit(new ChangeType(jakartaImport, javaxEquivalent, true).getVisitor());
+                            break;
+                        }
+                    }
+                }
+
+                return cu;
+            }
+        };
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -1,0 +1,8 @@
+# Custom recipes are auto-discovered as imperative Java recipes on the classpath.
+# This file is reserved for declarative compositions of those recipes.
+#
+# Available imperative recipes (discovered via classpath scanning):
+#   - com.adobe.aem.migration.recipes.ChangeFilevaultEmbeddedArtifact
+#   - com.adobe.aem.migration.recipes.RemoveBndPluginInstruction
+#   - com.adobe.aem.migration.recipes.RevertJakartaInAemSource
+#   - com.adobe.aem.migration.recipes.DetectUnsupportedPackages

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/test/java/com/adobe/aem/migration/recipes/ChangeFilevaultEmbeddedArtifactTest.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/test/java/com/adobe/aem/migration/recipes/ChangeFilevaultEmbeddedArtifactTest.java
@@ -1,0 +1,264 @@
+package com.adobe.aem.migration.recipes;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class ChangeFilevaultEmbeddedArtifactTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ChangeFilevaultEmbeddedArtifact(
+                "com.icfolson.aem*",
+                "aem-groovy-console*",
+                "be.orbinson.aem",
+                null
+        ));
+    }
+
+    @Test
+    void migratesGroovyConsoleEmbeddedGroupId() {
+        rewriteRun(
+                pomXml(
+                        "<project>\n"
+                        + "  <modelVersion>4.0.0</modelVersion>\n"
+                        + "  <groupId>com.example</groupId>\n"
+                        + "  <artifactId>test-content</artifactId>\n"
+                        + "  <version>1.0.0</version>\n"
+                        + "  <packaging>content-package</packaging>\n"
+                        + "  <build>\n"
+                        + "    <plugins>\n"
+                        + "      <plugin>\n"
+                        + "        <groupId>org.apache.jackrabbit</groupId>\n"
+                        + "        <artifactId>filevault-package-maven-plugin</artifactId>\n"
+                        + "        <configuration>\n"
+                        + "          <embeddeds>\n"
+                        + "            <embedded>\n"
+                        + "              <groupId>com.icfolson.aem.groovy.console</groupId>\n"
+                        + "              <artifactId>aem-groovy-console-bundle</artifactId>\n"
+                        + "              <target>/apps/install</target>\n"
+                        + "            </embedded>\n"
+                        + "          </embeddeds>\n"
+                        + "        </configuration>\n"
+                        + "      </plugin>\n"
+                        + "    </plugins>\n"
+                        + "  </build>\n"
+                        + "</project>\n",
+                        "<project>\n"
+                        + "  <modelVersion>4.0.0</modelVersion>\n"
+                        + "  <groupId>com.example</groupId>\n"
+                        + "  <artifactId>test-content</artifactId>\n"
+                        + "  <version>1.0.0</version>\n"
+                        + "  <packaging>content-package</packaging>\n"
+                        + "  <build>\n"
+                        + "    <plugins>\n"
+                        + "      <plugin>\n"
+                        + "        <groupId>org.apache.jackrabbit</groupId>\n"
+                        + "        <artifactId>filevault-package-maven-plugin</artifactId>\n"
+                        + "        <configuration>\n"
+                        + "          <embeddeds>\n"
+                        + "            <embedded>\n"
+                        + "              <groupId>be.orbinson.aem</groupId>\n"
+                        + "              <artifactId>aem-groovy-console-bundle</artifactId>\n"
+                        + "              <target>/apps/install</target>\n"
+                        + "            </embedded>\n"
+                        + "          </embeddeds>\n"
+                        + "        </configuration>\n"
+                        + "      </plugin>\n"
+                        + "    </plugins>\n"
+                        + "  </build>\n"
+                        + "</project>\n"
+                )
+        );
+    }
+
+    @Test
+    void doesNotMigrateNonMatchingArtifact() {
+        rewriteRun(
+                pomXml(
+                        "<project>\n"
+                        + "  <modelVersion>4.0.0</modelVersion>\n"
+                        + "  <groupId>com.example</groupId>\n"
+                        + "  <artifactId>test-content</artifactId>\n"
+                        + "  <version>1.0.0</version>\n"
+                        + "  <packaging>content-package</packaging>\n"
+                        + "  <build>\n"
+                        + "    <plugins>\n"
+                        + "      <plugin>\n"
+                        + "        <groupId>org.apache.jackrabbit</groupId>\n"
+                        + "        <artifactId>filevault-package-maven-plugin</artifactId>\n"
+                        + "        <configuration>\n"
+                        + "          <embeddeds>\n"
+                        + "            <embedded>\n"
+                        + "              <groupId>com.icfolson.aem.groovy.console</groupId>\n"
+                        + "              <artifactId>some-other-bundle</artifactId>\n"
+                        + "              <target>/apps/install</target>\n"
+                        + "            </embedded>\n"
+                        + "          </embeddeds>\n"
+                        + "        </configuration>\n"
+                        + "      </plugin>\n"
+                        + "    </plugins>\n"
+                        + "  </build>\n"
+                        + "</project>\n"
+                )
+        );
+    }
+
+    @Test
+    void doesNotMigrateOtherPlugins() {
+        rewriteRun(
+                pomXml(
+                        "<project>\n"
+                        + "  <modelVersion>4.0.0</modelVersion>\n"
+                        + "  <groupId>com.example</groupId>\n"
+                        + "  <artifactId>test-content</artifactId>\n"
+                        + "  <version>1.0.0</version>\n"
+                        + "  <packaging>content-package</packaging>\n"
+                        + "  <build>\n"
+                        + "    <plugins>\n"
+                        + "      <plugin>\n"
+                        + "        <groupId>org.apache.maven.plugins</groupId>\n"
+                        + "        <artifactId>maven-jar-plugin</artifactId>\n"
+                        + "        <configuration>\n"
+                        + "          <embeddeds>\n"
+                        + "            <embedded>\n"
+                        + "              <groupId>com.icfolson.aem.groovy.console</groupId>\n"
+                        + "              <artifactId>aem-groovy-console-bundle</artifactId>\n"
+                        + "              <target>/apps/install</target>\n"
+                        + "            </embedded>\n"
+                        + "          </embeddeds>\n"
+                        + "        </configuration>\n"
+                        + "      </plugin>\n"
+                        + "    </plugins>\n"
+                        + "  </build>\n"
+                        + "</project>\n"
+                )
+        );
+    }
+
+    @Test
+    void migratesOnlyMatchingEmbeddedInMixedList() {
+        rewriteRun(
+                pomXml(
+                        "<project>\n"
+                        + "  <modelVersion>4.0.0</modelVersion>\n"
+                        + "  <groupId>com.example</groupId>\n"
+                        + "  <artifactId>test-content</artifactId>\n"
+                        + "  <version>1.0.0</version>\n"
+                        + "  <packaging>content-package</packaging>\n"
+                        + "  <build>\n"
+                        + "    <plugins>\n"
+                        + "      <plugin>\n"
+                        + "        <groupId>org.apache.jackrabbit</groupId>\n"
+                        + "        <artifactId>filevault-package-maven-plugin</artifactId>\n"
+                        + "        <configuration>\n"
+                        + "          <embeddeds>\n"
+                        + "            <embedded>\n"
+                        + "              <groupId>com.icfolson.aem.groovy.console</groupId>\n"
+                        + "              <artifactId>aem-groovy-console-bundle</artifactId>\n"
+                        + "              <target>/apps/install</target>\n"
+                        + "            </embedded>\n"
+                        + "            <embedded>\n"
+                        + "              <groupId>com.example.other</groupId>\n"
+                        + "              <artifactId>other-bundle</artifactId>\n"
+                        + "              <target>/apps/install</target>\n"
+                        + "            </embedded>\n"
+                        + "          </embeddeds>\n"
+                        + "        </configuration>\n"
+                        + "      </plugin>\n"
+                        + "    </plugins>\n"
+                        + "  </build>\n"
+                        + "</project>\n",
+                        "<project>\n"
+                        + "  <modelVersion>4.0.0</modelVersion>\n"
+                        + "  <groupId>com.example</groupId>\n"
+                        + "  <artifactId>test-content</artifactId>\n"
+                        + "  <version>1.0.0</version>\n"
+                        + "  <packaging>content-package</packaging>\n"
+                        + "  <build>\n"
+                        + "    <plugins>\n"
+                        + "      <plugin>\n"
+                        + "        <groupId>org.apache.jackrabbit</groupId>\n"
+                        + "        <artifactId>filevault-package-maven-plugin</artifactId>\n"
+                        + "        <configuration>\n"
+                        + "          <embeddeds>\n"
+                        + "            <embedded>\n"
+                        + "              <groupId>be.orbinson.aem</groupId>\n"
+                        + "              <artifactId>aem-groovy-console-bundle</artifactId>\n"
+                        + "              <target>/apps/install</target>\n"
+                        + "            </embedded>\n"
+                        + "            <embedded>\n"
+                        + "              <groupId>com.example.other</groupId>\n"
+                        + "              <artifactId>other-bundle</artifactId>\n"
+                        + "              <target>/apps/install</target>\n"
+                        + "            </embedded>\n"
+                        + "          </embeddeds>\n"
+                        + "        </configuration>\n"
+                        + "      </plugin>\n"
+                        + "    </plugins>\n"
+                        + "  </build>\n"
+                        + "</project>\n"
+                )
+        );
+    }
+
+    @Test
+    void preservesOtherChildElements() {
+        rewriteRun(
+                pomXml(
+                        "<project>\n"
+                        + "  <modelVersion>4.0.0</modelVersion>\n"
+                        + "  <groupId>com.example</groupId>\n"
+                        + "  <artifactId>test-content</artifactId>\n"
+                        + "  <version>1.0.0</version>\n"
+                        + "  <packaging>content-package</packaging>\n"
+                        + "  <build>\n"
+                        + "    <plugins>\n"
+                        + "      <plugin>\n"
+                        + "        <groupId>org.apache.jackrabbit</groupId>\n"
+                        + "        <artifactId>filevault-package-maven-plugin</artifactId>\n"
+                        + "        <configuration>\n"
+                        + "          <embeddeds>\n"
+                        + "            <embedded>\n"
+                        + "              <groupId>com.icfolson.aem.groovy.console</groupId>\n"
+                        + "              <artifactId>aem-groovy-console-bundle</artifactId>\n"
+                        + "              <target>/apps/groovyconsole/install</target>\n"
+                        + "              <filter>true</filter>\n"
+                        + "            </embedded>\n"
+                        + "          </embeddeds>\n"
+                        + "        </configuration>\n"
+                        + "      </plugin>\n"
+                        + "    </plugins>\n"
+                        + "  </build>\n"
+                        + "</project>\n",
+                        "<project>\n"
+                        + "  <modelVersion>4.0.0</modelVersion>\n"
+                        + "  <groupId>com.example</groupId>\n"
+                        + "  <artifactId>test-content</artifactId>\n"
+                        + "  <version>1.0.0</version>\n"
+                        + "  <packaging>content-package</packaging>\n"
+                        + "  <build>\n"
+                        + "    <plugins>\n"
+                        + "      <plugin>\n"
+                        + "        <groupId>org.apache.jackrabbit</groupId>\n"
+                        + "        <artifactId>filevault-package-maven-plugin</artifactId>\n"
+                        + "        <configuration>\n"
+                        + "          <embeddeds>\n"
+                        + "            <embedded>\n"
+                        + "              <groupId>be.orbinson.aem</groupId>\n"
+                        + "              <artifactId>aem-groovy-console-bundle</artifactId>\n"
+                        + "              <target>/apps/groovyconsole/install</target>\n"
+                        + "              <filter>true</filter>\n"
+                        + "            </embedded>\n"
+                        + "          </embeddeds>\n"
+                        + "        </configuration>\n"
+                        + "      </plugin>\n"
+                        + "    </plugins>\n"
+                        + "  </build>\n"
+                        + "</project>\n"
+                )
+        );
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/test/java/com/adobe/aem/migration/recipes/DetectUnsupportedPackagesTest.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/test/java/com/adobe/aem/migration/recipes/DetectUnsupportedPackagesTest.java
@@ -1,0 +1,70 @@
+package com.adobe.aem.migration.recipes;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+
+class DetectUnsupportedPackagesTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new DetectUnsupportedPackages())
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    @Test
+    void detectsCommercePackage() {
+        rewriteRun(
+                java(
+                        "package com.example;\n"
+                        + "import com.adobe.cq.commerce.api.Product;\n"
+                        + "public class Foo {}\n",
+                        "package com.example;\n"
+                        + "/*~~(BLOCKER: Unsupported package 'com.adobe.cq.commerce.' — migration cannot proceed)~~>*/import com.adobe.cq.commerce.api.Product;\n"
+                        + "public class Foo {}\n"
+                )
+        );
+    }
+
+    @Test
+    void detectsGuavaPackage() {
+        rewriteRun(
+                java(
+                        "package com.example;\n"
+                        + "import com.google.common.collect.ImmutableList;\n"
+                        + "public class Foo {}\n",
+                        "package com.example;\n"
+                        + "/*~~(WARNING: Removed bundle package 'com.google.common.' — requires remediation)~~>*/import com.google.common.collect.ImmutableList;\n"
+                        + "public class Foo {}\n"
+                )
+        );
+    }
+
+    @Test
+    void doesNotMarkCollections4() {
+        // org.apache.commons.collections4 is explicitly excluded from the guard — no finding
+        rewriteRun(
+                java(
+                        "package com.example;\n"
+                        + "import org.apache.commons.collections4.CollectionUtils;\n"
+                        + "public class Foo {}\n"
+                )
+        );
+    }
+
+    @Test
+    void doesNotMarkUnrelatedImports() {
+        // slf4j imports are unrelated to any unsupported package — no finding
+        rewriteRun(
+                java(
+                        "package com.example;\n"
+                        + "import org.slf4j.Logger;\n"
+                        + "import org.slf4j.LoggerFactory;\n"
+                        + "public class Foo {}\n"
+                )
+        );
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/test/java/com/adobe/aem/migration/recipes/IdempotencyTest.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/test/java/com/adobe/aem/migration/recipes/IdempotencyTest.java
@@ -1,0 +1,208 @@
+package com.adobe.aem.migration.recipes;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+/**
+ * Idempotency contract for the four AEM 6.5 LTS custom OpenRewrite recipes.
+ *
+ * <p>For each recipe, the post-migration output is fed back as the input and the
+ * recipe is asserted to produce no further changes. This guarantees:
+ *
+ * <ul>
+ *   <li>A second {@code aem-migrate full-migrate} run against an already-migrated
+ *       project leaves the working tree clean ({@code git diff --quiet}).</li>
+ *   <li>{@code --dryRun} on a migrated project surfaces an empty diff — the
+ *       reviewer-facing contract of the CLI.</li>
+ *   <li>Visitor logic is not relying on the order in which the maven-model AST
+ *       elements are visited; running twice cannot oscillate the output.</li>
+ * </ul>
+ *
+ * <p>OpenRewrite's {@code rewriteRun} call with a single source string and no
+ * after-text asserts that the recipe produces no change for that input — exactly
+ * the idempotency invariant.
+ */
+class IdempotencyTest {
+
+    @Nested
+    @DisplayName("ChangeFilevaultEmbeddedArtifact")
+    class ChangeFilevaultEmbeddedArtifactIdempotency implements RewriteTest {
+
+        @Override
+        public void defaults(RecipeSpec spec) {
+            spec.recipe(new ChangeFilevaultEmbeddedArtifact(
+                    "com.icfolson.aem*",
+                    "aem-groovy-console*",
+                    "be.orbinson.aem",
+                    null));
+        }
+
+        @Test
+        @DisplayName("post-migration POM is left untouched on re-run")
+        void postMigrationPomIsLeftUntouched() {
+            rewriteRun(
+                    pomXml(
+                            "<project>\n"
+                            + "  <modelVersion>4.0.0</modelVersion>\n"
+                            + "  <groupId>com.example</groupId>\n"
+                            + "  <artifactId>test-content</artifactId>\n"
+                            + "  <version>1.0.0</version>\n"
+                            + "  <packaging>content-package</packaging>\n"
+                            + "  <build>\n"
+                            + "    <plugins>\n"
+                            + "      <plugin>\n"
+                            + "        <groupId>org.apache.jackrabbit</groupId>\n"
+                            + "        <artifactId>filevault-package-maven-plugin</artifactId>\n"
+                            + "        <configuration>\n"
+                            + "          <embeddeds>\n"
+                            + "            <embedded>\n"
+                            + "              <groupId>be.orbinson.aem</groupId>\n"
+                            + "              <artifactId>aem-groovy-console-bundle</artifactId>\n"
+                            + "              <target>/apps/install</target>\n"
+                            + "            </embedded>\n"
+                            + "          </embeddeds>\n"
+                            + "        </configuration>\n"
+                            + "      </plugin>\n"
+                            + "    </plugins>\n"
+                            + "  </build>\n"
+                            + "</project>\n"
+                    )
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("RemoveBndPluginInstruction")
+    class RemoveBndPluginInstructionIdempotency implements RewriteTest {
+
+        @Override
+        public void defaults(RecipeSpec spec) {
+            spec.recipe(new RemoveBndPluginInstruction("SCRDescriptorBndPlugin"));
+        }
+
+        @Test
+        @DisplayName("POM without the matching <_plugin> is left untouched")
+        void pomWithoutMatchingPluginIsLeftUntouched() {
+            rewriteRun(
+                    pomXml(
+                            "<project>\n"
+                            + "  <modelVersion>4.0.0</modelVersion>\n"
+                            + "  <groupId>com.example</groupId>\n"
+                            + "  <artifactId>test-bundle</artifactId>\n"
+                            + "  <version>1.0.0</version>\n"
+                            + "  <packaging>bundle</packaging>\n"
+                            + "  <build>\n"
+                            + "    <plugins>\n"
+                            + "      <plugin>\n"
+                            + "        <groupId>org.apache.felix</groupId>\n"
+                            + "        <artifactId>maven-bundle-plugin</artifactId>\n"
+                            + "        <configuration>\n"
+                            + "          <instructions>\n"
+                            + "            <Bundle-SymbolicName>com.example.bundle</Bundle-SymbolicName>\n"
+                            + "          </instructions>\n"
+                            + "        </configuration>\n"
+                            + "      </plugin>\n"
+                            + "    </plugins>\n"
+                            + "  </build>\n"
+                            + "</project>\n"
+                    )
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("RevertJakartaInAemSource")
+    class RevertJakartaInAemSourceIdempotency implements RewriteTest {
+
+        @Override
+        public void defaults(RecipeSpec spec) {
+            spec.recipe(new RevertJakartaInAemSource())
+                    .parser(JavaParser.fromJavaVersion()
+                            .classpath("jakarta.inject-api", "jakarta.annotation-api"))
+                    .typeValidationOptions(TypeValidation.none());
+        }
+
+        @Test
+        @DisplayName("AEM file already on javax is left untouched")
+        void aemFileAlreadyOnJavaxIsLeftUntouched() {
+            rewriteRun(
+                    java(
+                            "package com.example;\n"
+                            + "\n"
+                            + "import org.apache.sling.api.SlingHttpServletRequest;\n"
+                            + "\n"
+                            + "import javax.annotation.PostConstruct;\n"
+                            + "import javax.inject.Inject;\n"
+                            + "\n"
+                            + "public class MyModel {\n"
+                            + "    @Inject\n"
+                            + "    private SlingHttpServletRequest request;\n"
+                            + "\n"
+                            + "    @PostConstruct\n"
+                            + "    protected void activate() {\n"
+                            + "    }\n"
+                            + "}\n"
+                    )
+            );
+        }
+
+        @Test
+        @DisplayName("non-AEM file with jakarta imports is left untouched")
+        void nonAemFileWithJakartaIsLeftUntouched() {
+            rewriteRun(
+                    java(
+                            "package com.example;\n"
+                            + "\n"
+                            + "import jakarta.inject.Inject;\n"
+                            + "\n"
+                            + "public class PlainService {\n"
+                            + "    @Inject\n"
+                            + "    private String value;\n"
+                            + "}\n"
+                    )
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("DetectUnsupportedPackages")
+    class DetectUnsupportedPackagesIdempotency implements RewriteTest {
+
+        @Override
+        public void defaults(RecipeSpec spec) {
+            spec.recipe(new DetectUnsupportedPackages())
+                    .typeValidationOptions(TypeValidation.none());
+        }
+
+        @Test
+        @DisplayName("scanner leaves benign sources untouched")
+        void scannerLeavesBenignSourcesUntouched() {
+            // DetectUnsupportedPackages is a read-only scanner that attaches
+            // OpenRewrite SearchResult markers to offending imports. Markers are
+            // ephemeral by design — they surface in the analyze report and never
+            // persist to the working tree — so the meaningful idempotency
+            // contract for this recipe is that a clean source file produces no
+            // markers. Marker placement on offending sources is covered by
+            // DetectUnsupportedPackagesTest.
+            rewriteRun(
+                    java(
+                            "package com.example;\n"
+                            + "\n"
+                            + "import org.apache.sling.api.SlingHttpServletRequest;\n"
+                            + "\n"
+                            + "public class PlainConsumer {\n"
+                            + "    private SlingHttpServletRequest request;\n"
+                            + "}\n"
+                    )
+            );
+        }
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/test/java/com/adobe/aem/migration/recipes/RemoveBndPluginInstructionTest.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/test/java/com/adobe/aem/migration/recipes/RemoveBndPluginInstructionTest.java
@@ -1,0 +1,185 @@
+package com.adobe.aem.migration.recipes;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class RemoveBndPluginInstructionTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveBndPluginInstruction("SCRDescriptorBndPlugin"));
+    }
+
+    @Test
+    void removesScrDescriptorBndPluginInstruction() {
+        rewriteRun(
+                pomXml(
+                        "<project>\n"
+                        + "  <modelVersion>4.0.0</modelVersion>\n"
+                        + "  <groupId>com.example</groupId>\n"
+                        + "  <artifactId>test-bundle</artifactId>\n"
+                        + "  <version>1.0.0</version>\n"
+                        + "  <build>\n"
+                        + "    <plugins>\n"
+                        + "      <plugin>\n"
+                        + "        <groupId>org.apache.felix</groupId>\n"
+                        + "        <artifactId>maven-bundle-plugin</artifactId>\n"
+                        + "        <configuration>\n"
+                        + "          <instructions>\n"
+                        + "            <Bundle-SymbolicName>com.example.bundle</Bundle-SymbolicName>\n"
+                        + "            <_plugin>org.apache.felix.scrplugin.bnd.SCRDescriptorBndPlugin</_plugin>\n"
+                        + "          </instructions>\n"
+                        + "        </configuration>\n"
+                        + "      </plugin>\n"
+                        + "    </plugins>\n"
+                        + "  </build>\n"
+                        + "</project>\n",
+                        "<project>\n"
+                        + "  <modelVersion>4.0.0</modelVersion>\n"
+                        + "  <groupId>com.example</groupId>\n"
+                        + "  <artifactId>test-bundle</artifactId>\n"
+                        + "  <version>1.0.0</version>\n"
+                        + "  <build>\n"
+                        + "    <plugins>\n"
+                        + "      <plugin>\n"
+                        + "        <groupId>org.apache.felix</groupId>\n"
+                        + "        <artifactId>maven-bundle-plugin</artifactId>\n"
+                        + "        <configuration>\n"
+                        + "          <instructions>\n"
+                        + "            <Bundle-SymbolicName>com.example.bundle</Bundle-SymbolicName>\n"
+                        + "          </instructions>\n"
+                        + "        </configuration>\n"
+                        + "      </plugin>\n"
+                        + "    </plugins>\n"
+                        + "  </build>\n"
+                        + "</project>\n"
+                )
+        );
+    }
+
+    @Test
+    void leavesOtherInstructionsAlone() {
+        // Bundle-SymbolicName and Import-Package should survive — only _plugin matching pattern is removed
+        rewriteRun(
+                pomXml(
+                        "<project>\n"
+                        + "  <modelVersion>4.0.0</modelVersion>\n"
+                        + "  <groupId>com.example</groupId>\n"
+                        + "  <artifactId>test-bundle</artifactId>\n"
+                        + "  <version>1.0.0</version>\n"
+                        + "  <build>\n"
+                        + "    <plugins>\n"
+                        + "      <plugin>\n"
+                        + "        <groupId>org.apache.felix</groupId>\n"
+                        + "        <artifactId>maven-bundle-plugin</artifactId>\n"
+                        + "        <configuration>\n"
+                        + "          <instructions>\n"
+                        + "            <Bundle-SymbolicName>com.example.bundle</Bundle-SymbolicName>\n"
+                        + "            <Import-Package>*</Import-Package>\n"
+                        + "          </instructions>\n"
+                        + "        </configuration>\n"
+                        + "      </plugin>\n"
+                        + "    </plugins>\n"
+                        + "  </build>\n"
+                        + "</project>\n"
+                )
+        );
+    }
+
+    @Test
+    void onlyRemovesInsideMavenBundlePlugin() {
+        // Same <_plugin> content inside a different plugin must not be touched
+        rewriteRun(
+                pomXml(
+                        "<project>\n"
+                        + "  <modelVersion>4.0.0</modelVersion>\n"
+                        + "  <groupId>com.example</groupId>\n"
+                        + "  <artifactId>test-bundle</artifactId>\n"
+                        + "  <version>1.0.0</version>\n"
+                        + "  <build>\n"
+                        + "    <plugins>\n"
+                        + "      <plugin>\n"
+                        + "        <groupId>org.apache.maven.plugins</groupId>\n"
+                        + "        <artifactId>some-other-plugin</artifactId>\n"
+                        + "        <configuration>\n"
+                        + "          <instructions>\n"
+                        + "            <_plugin>org.apache.felix.scrplugin.bnd.SCRDescriptorBndPlugin</_plugin>\n"
+                        + "          </instructions>\n"
+                        + "        </configuration>\n"
+                        + "      </plugin>\n"
+                        + "    </plugins>\n"
+                        + "  </build>\n"
+                        + "</project>\n"
+                )
+        );
+    }
+
+    @Test
+    void handlesMultiplePluginsWithInstructions() {
+        // maven-bundle-plugin has the matching _plugin instruction; another plugin has a different _plugin — only the matching one is removed
+        rewriteRun(
+                pomXml(
+                        "<project>\n"
+                        + "  <modelVersion>4.0.0</modelVersion>\n"
+                        + "  <groupId>com.example</groupId>\n"
+                        + "  <artifactId>test-bundle</artifactId>\n"
+                        + "  <version>1.0.0</version>\n"
+                        + "  <build>\n"
+                        + "    <plugins>\n"
+                        + "      <plugin>\n"
+                        + "        <groupId>org.apache.felix</groupId>\n"
+                        + "        <artifactId>maven-bundle-plugin</artifactId>\n"
+                        + "        <configuration>\n"
+                        + "          <instructions>\n"
+                        + "            <Bundle-SymbolicName>com.example.bundle</Bundle-SymbolicName>\n"
+                        + "            <_plugin>org.apache.felix.scrplugin.bnd.SCRDescriptorBndPlugin</_plugin>\n"
+                        + "          </instructions>\n"
+                        + "        </configuration>\n"
+                        + "      </plugin>\n"
+                        + "      <plugin>\n"
+                        + "        <groupId>org.apache.maven.plugins</groupId>\n"
+                        + "        <artifactId>another-plugin</artifactId>\n"
+                        + "        <configuration>\n"
+                        + "          <instructions>\n"
+                        + "            <_plugin>some.other.Plugin</_plugin>\n"
+                        + "          </instructions>\n"
+                        + "        </configuration>\n"
+                        + "      </plugin>\n"
+                        + "    </plugins>\n"
+                        + "  </build>\n"
+                        + "</project>\n",
+                        "<project>\n"
+                        + "  <modelVersion>4.0.0</modelVersion>\n"
+                        + "  <groupId>com.example</groupId>\n"
+                        + "  <artifactId>test-bundle</artifactId>\n"
+                        + "  <version>1.0.0</version>\n"
+                        + "  <build>\n"
+                        + "    <plugins>\n"
+                        + "      <plugin>\n"
+                        + "        <groupId>org.apache.felix</groupId>\n"
+                        + "        <artifactId>maven-bundle-plugin</artifactId>\n"
+                        + "        <configuration>\n"
+                        + "          <instructions>\n"
+                        + "            <Bundle-SymbolicName>com.example.bundle</Bundle-SymbolicName>\n"
+                        + "          </instructions>\n"
+                        + "        </configuration>\n"
+                        + "      </plugin>\n"
+                        + "      <plugin>\n"
+                        + "        <groupId>org.apache.maven.plugins</groupId>\n"
+                        + "        <artifactId>another-plugin</artifactId>\n"
+                        + "        <configuration>\n"
+                        + "          <instructions>\n"
+                        + "            <_plugin>some.other.Plugin</_plugin>\n"
+                        + "          </instructions>\n"
+                        + "        </configuration>\n"
+                        + "      </plugin>\n"
+                        + "    </plugins>\n"
+                        + "  </build>\n"
+                        + "</project>\n"
+                )
+        );
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/test/java/com/adobe/aem/migration/recipes/RevertJakartaInAemSourceTest.java
+++ b/plugins/aem/6.5-lts/skills/java21-migration/aem65lts-migration-recipes/src/test/java/com/adobe/aem/migration/recipes/RevertJakartaInAemSourceTest.java
@@ -1,0 +1,136 @@
+package com.adobe.aem.migration.recipes;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RevertJakartaInAemSourceTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RevertJakartaInAemSource())
+                .parser(JavaParser.fromJavaVersion()
+                        .classpath("jakarta.inject-api", "jakarta.annotation-api"))
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    @Test
+    void revertsJakartaInjectInAemFile() {
+        // File has org.apache.sling import (AEM) AND jakarta.inject.Inject → must revert inject.
+        // OpenRewrite separates import groups from different packages with a blank line.
+        rewriteRun(
+                java(
+                        "package com.example;\n"
+                        + "\n"
+                        + "import org.apache.sling.api.SlingHttpServletRequest;\n"
+                        + "import jakarta.inject.Inject;\n"
+                        + "\n"
+                        + "public class MyComponent {\n"
+                        + "    @Inject\n"
+                        + "    private SlingHttpServletRequest request;\n"
+                        + "}\n",
+                        "package com.example;\n"
+                        + "\n"
+                        + "import org.apache.sling.api.SlingHttpServletRequest;\n"
+                        + "\n"
+                        + "import javax.inject.Inject;\n"
+                        + "\n"
+                        + "public class MyComponent {\n"
+                        + "    @Inject\n"
+                        + "    private SlingHttpServletRequest request;\n"
+                        + "}\n"
+                )
+        );
+    }
+
+    @Test
+    void revertsJakartaAnnotationInAemFile() {
+        // jakarta.annotation.PostConstruct → javax.annotation.PostConstruct in AEM file.
+        // OpenRewrite separates com.adobe and javax import groups with a blank line.
+        rewriteRun(
+                java(
+                        "package com.example;\n"
+                        + "\n"
+                        + "import com.adobe.cq.wcm.core.components.models.Component;\n"
+                        + "import jakarta.annotation.PostConstruct;\n"
+                        + "\n"
+                        + "public class MyModel implements Component {\n"
+                        + "    @PostConstruct\n"
+                        + "    protected void init() {\n"
+                        + "    }\n"
+                        + "}\n",
+                        "package com.example;\n"
+                        + "\n"
+                        + "import com.adobe.cq.wcm.core.components.models.Component;\n"
+                        + "\n"
+                        + "import javax.annotation.PostConstruct;\n"
+                        + "\n"
+                        + "public class MyModel implements Component {\n"
+                        + "    @PostConstruct\n"
+                        + "    protected void init() {\n"
+                        + "    }\n"
+                        + "}\n"
+                )
+        );
+    }
+
+    @Test
+    void doesNotTouchNonAemFile() {
+        // No AEM/Sling imports — recipe should leave this file alone entirely
+        rewriteRun(
+                java(
+                        "package com.example;\n"
+                        + "\n"
+                        + "import jakarta.inject.Inject;\n"
+                        + "\n"
+                        + "public class PlainService {\n"
+                        + "    @Inject\n"
+                        + "    private String value;\n"
+                        + "}\n"
+                )
+        );
+    }
+
+    @Test
+    void revertsMultipleJakartaImports() {
+        // AEM file with several jakarta imports — all should be reverted.
+        // OpenRewrite separates org.apache.sling and javax import groups with a blank line.
+        rewriteRun(
+                java(
+                        "package com.example;\n"
+                        + "\n"
+                        + "import org.apache.sling.models.annotations.Model;\n"
+                        + "import jakarta.annotation.PostConstruct;\n"
+                        + "import jakarta.inject.Inject;\n"
+                        + "\n"
+                        + "public class MyModel {\n"
+                        + "    @Inject\n"
+                        + "    private String value;\n"
+                        + "\n"
+                        + "    @PostConstruct\n"
+                        + "    protected void activate() {\n"
+                        + "    }\n"
+                        + "}\n",
+                        "package com.example;\n"
+                        + "\n"
+                        + "import org.apache.sling.models.annotations.Model;\n"
+                        + "\n"
+                        + "import javax.annotation.PostConstruct;\n"
+                        + "import javax.inject.Inject;\n"
+                        + "\n"
+                        + "public class MyModel {\n"
+                        + "    @Inject\n"
+                        + "    private String value;\n"
+                        + "\n"
+                        + "    @PostConstruct\n"
+                        + "    protected void activate() {\n"
+                        + "    }\n"
+                        + "}\n"
+                )
+        );
+    }
+}

--- a/plugins/aem/6.5-lts/skills/java21-migration/configs/maven-settings-template.xml
+++ b/plugins/aem/6.5-lts/skills/java21-migration/configs/maven-settings-template.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Maven Settings Template — AEM 6.5 LTS Java 21 Migration
+  =========================================================
+  Copy this file to ~/.m2/settings.xml if your Maven installation
+  does not already have the Adobe Public Repository configured.
+
+  Alternatively, pass it explicitly on the command line:
+    mvn -s /path/to/skills/.../configs/maven-settings-template.xml clean install
+
+  This settings file adds two repository sources:
+    1. Maven Central  — standard open-source dependencies
+    2. Adobe Public   — AEM UberJar, WCM Core Components, AEM SDK artifacts
+
+  Both are added to <repositories> (for regular dependencies) and
+  <pluginRepositories> (for Maven plugins, including OpenRewrite).
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                              https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <profiles>
+    <profile>
+      <id>adobe-public</id>
+
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+
+      <!-- ============================================================
+           Dependency Repositories
+           ============================================================ -->
+      <repositories>
+
+        <repository>
+          <id>central</id>
+          <name>Maven Central Repository</name>
+          <url>https://repo.maven.apache.org/maven2</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+            <checksumPolicy>warn</checksumPolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+
+        <repository>
+          <id>adobe-public-releases</id>
+          <name>Adobe Public Repository</name>
+          <url>https://repo.adobe.com/nexus/content/groups/public/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+            <checksumPolicy>warn</checksumPolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+
+      </repositories>
+
+      <!-- ============================================================
+           Plugin Repositories
+           OpenRewrite downloads recipe JARs at runtime via the plugin
+           repository resolution mechanism, so both repositories must
+           appear here as well as in <repositories>.
+           ============================================================ -->
+      <pluginRepositories>
+
+        <pluginRepository>
+          <id>central</id>
+          <name>Maven Central Repository</name>
+          <url>https://repo.maven.apache.org/maven2</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+
+        <pluginRepository>
+          <id>adobe-public-releases</id>
+          <name>Adobe Public Repository</name>
+          <url>https://repo.adobe.com/nexus/content/groups/public/</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+
+      </pluginRepositories>
+
+    </profile>
+  </profiles>
+
+  <!-- ================================================================
+       Active Profiles
+       The adobe-public profile is activated by default above.
+       Remove the <activeByDefault> element if you prefer to activate
+       it explicitly: mvn -Padobe-public clean install
+       ================================================================ -->
+  <activeProfiles>
+    <activeProfile>adobe-public</activeProfile>
+  </activeProfiles>
+
+  <!-- ================================================================
+       Plugin Groups
+       Allows short-form plugin invocations (e.g. 'mvn rewrite:run')
+       without specifying the full group ID on the command line.
+       ================================================================ -->
+  <pluginGroups>
+    <pluginGroup>org.apache.maven.plugins</pluginGroup>
+    <pluginGroup>org.openrewrite.maven</pluginGroup>
+  </pluginGroups>
+
+</settings>

--- a/plugins/aem/6.5-lts/skills/java21-migration/configs/settings.xml
+++ b/plugins/aem/6.5-lts/skills/java21-migration/configs/settings.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ============================================================================
+  AEM 6.5 LTS — sample Maven settings.xml
+  ============================================================================
+
+  Drop this file into ~/.m2/settings.xml (or merge into an existing one) when
+  the host environment cannot resolve com.adobe.* artefacts from Maven Central
+  alone.
+
+  The single profile (adobe-public) is activated by default and adds the Adobe
+  Public Nexus to both <repositories> and <pluginRepositories>. Release artefacts
+  are enabled; snapshots are disabled — AEM 6.5 LTS dependencies are published
+  as releases only.
+
+  This file is a template. Production environments may need additional <server>
+  blocks for private repositories, mirror configuration, or proxy settings.
+  ============================================================================
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <profiles>
+        <profile>
+            <id>adobe-public</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <!-- Component (artefact) repositories -->
+            <repositories>
+                <repository>
+                    <id>central</id>
+                    <name>Maven Central Repository</name>
+                    <url>https://repo.maven.apache.org/maven2</url>
+                    <layout>default</layout>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+                <repository>
+                    <id>adobe-public-releases</id>
+                    <name>Adobe Public Repository</name>
+                    <url>https://repo.adobe.com/nexus/content/groups/public</url>
+                    <layout>default</layout>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+
+            <!-- Plugin repositories (separate cache; same upstream URLs) -->
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>central</id>
+                    <name>Maven Central Repository</name>
+                    <url>https://repo.maven.apache.org/maven2</url>
+                    <layout>default</layout>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </pluginRepository>
+                <pluginRepository>
+                    <id>adobe-public-releases</id>
+                    <name>Adobe Public Repository</name>
+                    <url>https://repo.adobe.com/nexus/content/groups/public</url>
+                    <layout>default</layout>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+
+    <!-- Plugin shortcut groups: allow `mvn rewrite:run` etc. without full FQN -->
+    <pluginGroups>
+        <pluginGroup>org.apache.maven.plugins</pluginGroup>
+        <pluginGroup>org.openrewrite.maven</pluginGroup>
+    </pluginGroups>
+</settings>

--- a/plugins/aem/6.5-lts/skills/java21-migration/configs/toolchains.xml
+++ b/plugins/aem/6.5-lts/skills/java21-migration/configs/toolchains.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ============================================================================
+  AEM 6.5 LTS — sample Maven toolchains.xml
+  ============================================================================
+
+  Drop this file into ~/.m2/toolchains.xml when the migrated project uses
+  maven-toolchains-plugin to pick a JDK by version+vendor instead of relying
+  on $JAVA_HOME.
+
+  This template advertises three JDK toolchains — 8, 11, and 21 — under both
+  the long form (e.g. version=21) and the legacy "1.x" form (e.g. version=1.21)
+  so projects that pin maven.compiler.source=1.8 / 1.11 / 1.21 still resolve.
+
+  All vendor entries (oracle / sun / azul) point at the same installation. The
+  vendor field is left in for compatibility with toolchain selection logic that
+  filters on it; replace as needed to match the JDK actually installed on the
+  host.
+
+  Update the <jdkHome> paths to the actual install locations on the target
+  machine. Linux defaults are shown.
+  ============================================================================
+-->
+<toolchains>
+
+    <!-- ============================ JDK 8 ============================ -->
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>1.8</version>
+            <vendor>oracle</vendor>
+        </provides>
+        <configuration>
+            <jdkHome>/usr/lib/jvm/jdk-8</jdkHome>
+        </configuration>
+    </toolchain>
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>1.8</version>
+            <vendor>sun</vendor>
+        </provides>
+        <configuration>
+            <jdkHome>/usr/lib/jvm/jdk-8</jdkHome>
+        </configuration>
+    </toolchain>
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>1.8</version>
+            <vendor>azul</vendor>
+        </provides>
+        <configuration>
+            <jdkHome>/usr/lib/jvm/jdk-8</jdkHome>
+        </configuration>
+    </toolchain>
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>8</version>
+            <vendor>oracle</vendor>
+        </provides>
+        <configuration>
+            <jdkHome>/usr/lib/jvm/jdk-8</jdkHome>
+        </configuration>
+    </toolchain>
+
+    <!-- ============================ JDK 11 ============================ -->
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>11</version>
+            <vendor>oracle</vendor>
+        </provides>
+        <configuration>
+            <jdkHome>/usr/lib/jvm/jdk-11</jdkHome>
+        </configuration>
+    </toolchain>
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>11</version>
+            <vendor>azul</vendor>
+        </provides>
+        <configuration>
+            <jdkHome>/usr/lib/jvm/jdk-11</jdkHome>
+        </configuration>
+    </toolchain>
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>1.11</version>
+            <vendor>oracle</vendor>
+        </provides>
+        <configuration>
+            <jdkHome>/usr/lib/jvm/jdk-11</jdkHome>
+        </configuration>
+    </toolchain>
+
+    <!-- ============================ JDK 21 ============================ -->
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>21</version>
+            <vendor>oracle</vendor>
+        </provides>
+        <configuration>
+            <jdkHome>/usr/lib/jvm/jdk-21</jdkHome>
+        </configuration>
+    </toolchain>
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>21</version>
+            <vendor>azul</vendor>
+        </provides>
+        <configuration>
+            <jdkHome>/usr/lib/jvm/jdk-21</jdkHome>
+        </configuration>
+    </toolchain>
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>1.21</version>
+            <vendor>oracle</vendor>
+        </provides>
+        <configuration>
+            <jdkHome>/usr/lib/jvm/jdk-21</jdkHome>
+        </configuration>
+    </toolchain>
+
+</toolchains>

--- a/plugins/aem/6.5-lts/skills/java21-migration/configs/unsupported-apis.yaml
+++ b/plugins/aem/6.5-lts/skills/java21-migration/configs/unsupported-apis.yaml
@@ -1,0 +1,186 @@
+# Unsupported API Configuration
+#
+# Used by the `aem-migrate analyze` CLI command during pre-migration analysis.
+#
+# Entries under hard_stop_packages cause the migration to halt immediately.
+# The project cannot be migrated using this workflow until the dependency
+# is resolved, removed, or a dedicated migration path is available.
+#
+# Entries under warning_packages allow migration to continue but generate
+# a warning in the report. These represent dependencies that will compile
+# but may fail at AEM runtime because the bundle is not present in
+# the AEM 6.5 LTS classloader.
+#
+# Pattern matching:
+#   - Patterns use prefix matching on Java import statements and
+#     Maven dependency coordinates found in POM files.
+#   - A trailing '.*' matches any subpackage.
+#   - A pattern without '.*' matches the exact package or group ID.
+
+# -----------------------------------------------------------------------
+# HARD STOP PACKAGES
+# Migration cannot proceed while these are present in the project.
+# -----------------------------------------------------------------------
+hard_stop_packages:
+
+  - pattern: "com.adobe.cq.commerce.*"
+    reason: >
+      AEM Commerce Cloud integration — this API set requires a separate
+      Commerce-specific migration path and is not handled by this workflow.
+    remediation: >
+      Remove Commerce integration code or engage the Commerce team for
+      a coordinated migration strategy before running this workflow.
+
+  - pattern: "com.adobe.cq.social.*"
+    reason: >
+      AEM Communities — the Communities framework was deprecated in AEM 6.4
+      and its bundles are not present in AEM 6.5 LTS. Code referencing these
+      packages will not compile against the LTS UberJar.
+    remediation: >
+      Remove Communities integration. If social features are required,
+      evaluate AEM Sites social components or a third-party integration.
+
+  - pattern: "com.adobe.granite.social.*"
+    reason: >
+      Granite Social framework — deprecated and removed in AEM 6.5 LTS.
+      Code will not compile against the LTS UberJar.
+    remediation: >
+      Remove Granite Social references. Equivalent capabilities are not
+      available in AEM 6.5 LTS without a custom implementation.
+
+  - pattern: "com.adobe.cq.screens.*"
+    reason: >
+      AEM Screens — Screens requires its own migration path with specific
+      Screens SDK versions. It is not covered by this general LTS migration.
+    remediation: >
+      Separate the Screens modules from the main project and run the
+      Screens-specific migration workflow for those modules.
+
+  - pattern: "com.adobe.cq.sample.we.retail.*"
+    reason: >
+      We.Retail reference implementation — this sample content is not
+      part of a production codebase and should be removed before migration.
+    remediation: >
+      Delete We.Retail modules from the project. They are not supported
+      in production and their presence inflates the migration surface area.
+
+  - pattern: "com.day.cq.dam.pim.*"
+    reason: >
+      DAM PIM integration — deprecated in AEM 6.4 and removed in 6.5 LTS.
+      Classes are not present in the LTS UberJar.
+    remediation: >
+      Remove PIM integration code. Evaluate AEM Assets metadata schemas
+      as a replacement for product information management workflows.
+
+  - pattern: "com.day.cq.dam.rating.*"
+    reason: >
+      DAM asset rating — deprecated and removed in AEM 6.5 LTS.
+    remediation: >
+      Remove DAM rating references. Implement custom asset scoring via
+      metadata properties if rating functionality is required.
+
+  - pattern: "com.adobe.cq.searchpromote.*"
+    reason: >
+      Adobe Search and Promote integration — the Search and Promote
+      service was discontinued and its integration classes are not
+      present in AEM 6.5 LTS.
+    remediation: >
+      Remove Search and Promote integration. Migrate search functionality
+      to AEM's native search (Oak-based) or an external search platform.
+
+  - pattern: "com.day.cq.mcm.campaign.*"
+    reason: >
+      AEM Campaign integration — the legacy MCM Campaign connector was
+      removed in AEM 6.5 LTS. The replacement uses Adobe Campaign Standard
+      APIs directly.
+    remediation: >
+      Migrate to the AEM-Campaign integration via Adobe Campaign Standard
+      or Adobe Campaign Classic v7 REST APIs.
+
+# -----------------------------------------------------------------------
+# WARNING PACKAGES
+# Migration can continue, but these will cause runtime failures in AEM
+# unless the dependency is embedded in the OSGi bundle or refactored.
+# -----------------------------------------------------------------------
+warning_packages:
+
+  - pattern: "com.google.common.*"
+    reason: >
+      Google Guava — the Guava bundle (com.google.guava) is not deployed
+      in the AEM 6.5 LTS runtime. Code that imports Guava classes will
+      compile against the UberJar but throw ClassNotFoundException at runtime.
+    remediation: >
+      Refactor Guava usages to JDK equivalents where possible
+      (e.g., ImmutableList → List.of, Optional → java.util.Optional,
+      Strings → String methods). If Guava is essential, embed it in
+      the OSGi bundle using the maven-shade-plugin or bundle-plugin.
+    reference: "references/removed-bundles-remediation.md#google-guava-migration"
+    severity: "high"
+
+  - pattern: "com.github.benmanes.caffeine.*"
+    reason: >
+      Caffeine cache — the Caffeine bundle is not deployed in the
+      AEM 6.5 LTS runtime classloader. Classes will not be resolvable
+      at runtime even though compilation succeeds.
+    remediation: >
+      Embed Caffeine in the OSGi bundle or replace with a
+      ConcurrentHashMap-based cache or the Sling commons cache API.
+    reference: "references/removed-bundles-remediation.md#caffeine"
+    severity: "high"
+
+  - pattern: "org.eclipse.jetty.*"
+    reason: >
+      Eclipse Jetty — Jetty internals are not exported from the AEM 6.5
+      LTS classloader. Using Jetty APIs directly in application code is
+      not supported and will fail at runtime.
+    remediation: >
+      Replace Jetty-specific code with Servlet API abstractions
+      (javax.servlet.*) which are fully exported. If WebSocket support
+      is required, use the AEM-provided WebSocket API.
+    reference: "references/removed-bundles-remediation.md#jetty"
+    severity: "medium"
+
+  - pattern: "org.apache.commons.collections."
+    reason: >
+      Apache Commons Collections 3 — the collections 3.x bundle was
+      replaced by Collections 4 in AEM 6.5 LTS. The old package path
+      org.apache.commons.collections (without the '4' suffix) resolves
+      to an older version not present in the runtime.
+    remediation: >
+      Change import statements from org.apache.commons.collections
+      to org.apache.commons.collections4 and update the Maven dependency
+      to commons-collections4 4.4 or later.
+    reference: "references/removed-bundles-remediation.md#apache-commons-collections-3-to-4"
+    severity: "medium"
+    # Do not flag the new package as a warning
+    exclude_pattern: "org.apache.commons.collections4.*"
+
+  - pattern: "org.slf4j.impl.*"
+    reason: >
+      SLF4J implementation classes — importing SLF4J implementation
+      internals (not the API) creates a hard binding to a specific
+      logging implementation. AEM may ship a different SLF4J backend.
+    remediation: >
+      Use only the SLF4J API (org.slf4j.Logger, org.slf4j.LoggerFactory).
+      Never import from org.slf4j.impl.*.
+    severity: "low"
+
+  - pattern: "org.apache.jackrabbit.oak.spi.security.*"
+    reason: >
+      Oak SPI security internals — these are unstable APIs that may
+      change between Oak patch versions shipped with AEM 6.5 LTS service
+      packs.
+    remediation: >
+      Replace with the stable Jackrabbit API (org.apache.jackrabbit.api.*)
+      or the AEM Granite security API (com.adobe.granite.security.*).
+    severity: "low"
+
+  - pattern: "com.day.cq.wcm.mobile.*"
+    reason: >
+      CQ Mobile framework — the legacy mobile framework was deprecated
+      in AEM 6.4. While it may still be present in the LTS runtime,
+      it will not receive updates and may be removed in a future patch.
+    remediation: >
+      Migrate to responsive design using AEM Core Components and
+      AEM's built-in device detection rather than the legacy mobile framework.
+    severity: "low"

--- a/plugins/aem/6.5-lts/skills/java21-migration/pom.xml
+++ b/plugins/aem/6.5-lts/skills/java21-migration/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.adobe.aem</groupId>
+    <artifactId>aem65lts-migration-tool</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>AEM 6.5 LTS Migration Tool</name>
+    <description>Code migration tool for upgrading AEM 6.5 projects to AEM 6.5 LTS (Java 21)</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <rewrite.version>8.51.0</rewrite.version>
+    </properties>
+
+    <modules>
+        <module>aem65lts-migration-recipes</module>
+        <module>aem65lts-migration-cli</module>
+    </modules>
+</project>

--- a/plugins/aem/6.5-lts/skills/java21-migration/references/aem65lts-platform-changes.md
+++ b/plugins/aem/6.5-lts/skills/java21-migration/references/aem65lts-platform-changes.md
@@ -1,0 +1,347 @@
+# AEM 6.5 LTS Platform Changes Reference
+
+This document describes the platform-level changes introduced in AEM 6.5 LTS that
+directly affect code compilation, OSGi bundle resolution, and runtime behaviour. Use
+this as the definitive reference when diagnosing why code that compiled on a previous
+AEM 6.5 service pack fails to compile or run after migrating to the LTS baseline.
+
+---
+
+## Runtime Changes
+
+### Java 21 as Minimum Supported JDK
+
+[AEM 6.5 LTS mandates Java 21](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/release-notes/service-pack/ga) as the minimum runtime JDK. The previous long-running
+releases supported Java 8 and Java 11; those JDKs are no longer tested or supported.
+
+Key implications for application code:
+
+- Maven compiler `source` and `target` (or `release`) must be set to `21`.
+- `requireJavaVersion` in `maven-enforcer-plugin` must specify `[21,)`.
+- Java language features available: records, sealed classes, pattern matching for
+  `instanceof`, text blocks, switch expressions (all finalised).
+- Internal JDK APIs previously accessible via `--add-opens` in Java 9–17 are now
+  strongly encapsulated. Reflective access without explicit `--add-opens` flags
+  throws `InaccessibleObjectException` at runtime.
+- The reserved keyword set has expanded: `record`, `sealed`, `permits`, `yield` are
+  context-sensitive keywords in Java 17+ and become reserved identifiers in Java 21.
+  Variable or method names using these words must be renamed.
+
+### Sling Framework Upgrade
+
+AEM 6.5 LTS ships with updated Sling API and Sling Models bundles. The core Sling API
+version advances to align with current Apache Sling releases:
+
+- `org.apache.sling.api` — updated. `SlingHttpServletRequest.adaptTo()` generic
+  signatures tightened; callers with raw types may see unchecked cast warnings promoted
+  to errors under `-Werror`.
+- Sling Models — injector resolution order adjusted. `@OSGiService` takes precedence
+  over `@Inject` when both annotations target the same field type; code that relied on
+  the previous resolution order may inject an unexpected value.
+- `ResourceResolverFactory` API — `getServiceResourceResolver()` now requires an
+  explicit sub-service name in the authentication info map. Callers passing `null` will
+  receive a `LoginException` rather than an administrative session.
+- Sling Scripting (HTL / Sightly) engine updated. The Use-API adapter cache is
+  invalidated on bundle restart, which may surface lazy-initialisation bugs previously
+  hidden by cached adapters.
+
+### OSGi R8 Framework (Apache Felix 7.x)
+
+AEM 6.5 LTS moves to an OSGi R8-compliant framework based on Apache Felix 7.x. Notable
+changes affecting application bundles:
+
+- **Component property types** (OSGi R7+) are now the preferred configuration API.
+  Annotation-based component property interfaces replace the legacy
+  `PropertiesUtil.toStringArray()` / `PropertiesUtil.toLong()` pattern.
+- **Declarative Services 1.4** features are active: `@Activate` / `@Modified` methods
+  may accept a `ComponentContext`, `BundleContext`, `Map<String, Object>`, or a
+  component property type directly.
+- **Bundle symbolic names** must be globally unique. Duplicate symbolic names that
+  previously resolved by load order now cause one bundle to remain unresolved.
+- **`ServiceObjects`** API is available for prototype-scope services. Bundles that
+  previously obtained a new service instance on each `getService()` call (relying on
+  undocumented behaviour) must be updated to use `ServiceObjects.getService()`.
+
+### Oak 1.68+ with Segment-Tar Improvements
+
+The underlying JCR repository is built on Apache Jackrabbit Oak 1.68+.
+
+- **Index definition validation** is stricter. `oak:index` nodes with malformed or
+  unsupported properties that were silently ignored in earlier versions now log
+  `WARNING` or fail to activate.
+- **Segment store format** version updated. Repositories created on earlier Oak versions
+  are migrated on first startup; this migration is one-way and cannot be rolled back.
+- **Query engine**: `QueryBuilder.createQuery()` with deprecated `XPATH` queries logs
+  deprecation warnings. The `JCR-SQL2` dialect is the supported path.
+- **EventListener registration**: synchronous observation listeners block the commit
+  thread more aggressively under heavy write load. Listeners that perform repository
+  writes should be converted to asynchronous listeners.
+
+### Jackrabbit 2.22+
+
+The Jackrabbit compatibility layer (used for legacy JCR 2.0 API calls) is updated to
+2.22+. Binary-compatible with 2.20 for most API surfaces. Note:
+`JackrabbitSession.impersonate()` requires an explicit privilege grant in the
+repository access control list; silent impersonation through configuration is removed.
+
+---
+
+## Removed Bundles
+
+### Google Guava
+
+Guava was previously exported from an AEM internal system bundle, making classes such
+as `ImmutableList`, `CacheBuilder`, `Joiner`, and `Preconditions` available to all
+application bundles without a compile-time dependency.
+
+**In AEM 6.5 LTS, [Guava is no longer exported](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/upgrading-code-and-customizations).** The bundle may still be present in
+the OSGi container for internal Adobe use, but it is not exported to the application
+classloader. Any `Import-Package: com.google.common.*` in an application bundle will
+fail to resolve.
+
+Affected API areas:
+
+| Area | Guava Classes |
+|------|--------------|
+| Immutable collections | `ImmutableList`, `ImmutableMap`, `ImmutableSet`, `ImmutableSortedMap` |
+| Caching | `CacheBuilder`, `LoadingCache`, `CacheLoader`, `CacheStats` |
+| String utilities | `Joiner`, `Splitter`, `Strings`, `CharMatcher` |
+| I/O utilities | `Files` (Guava), `ByteStreams`, `CharStreams` |
+| Functional | `Function`, `Predicate`, `FluentIterable`, `Optional` (Guava) |
+| Preconditions | `Preconditions`, `Verify` |
+| Concurrency | `ListenableFuture`, `Futures`, `MoreExecutors` |
+
+See `removed-bundles-remediation.md` for a complete mapping to JDK and alternative
+implementations.
+
+### Apache Commons Collections 3
+
+`org.apache.commons.collections` (version 3.x) is no longer on the runtime classpath.
+This library contained known serialisation vulnerabilities (CVE-2015-7501 and
+subsequent) and was removed from the AEM runtime.
+
+The replacement is **Apache Commons Collections 4** (`org.apache.commons.collections4`).
+The top-level package name changes; most class names are preserved. Generics are
+enforced in version 4, so raw-type usages must be parameterised.
+
+### Caffeine Cache Library
+
+`com.github.benmanes.caffeine` is not deployed to the AEM 6.5 LTS OSGi runtime. Code
+that uses `Caffeine.newBuilder()` or `LoadingCache` from Caffeine (as opposed to Guava)
+will fail at runtime with `ClassNotFoundException`.
+
+Remediation: embed Caffeine as a private OSGi package within the application bundle, or
+replace simple caches with `ConcurrentHashMap.computeIfAbsent()`.
+
+---
+
+## Namespace: javax Stays in AEM 6.5 LTS
+
+[AEM 6.5 LTS does **not** adopt the Jakarta EE namespace](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/release-notes/faq). Every javax package that was
+present in previous AEM 6.5 service packs remains under the `javax.*` namespace:
+
+| Package | Status |
+|---------|--------|
+| `javax.servlet.*` | Unchanged — use this |
+| `javax.servlet.http.*` | Unchanged — use this |
+| `javax.annotation.PostConstruct` | Unchanged — use this |
+| `javax.annotation.PreDestroy` | Unchanged — use this |
+| `javax.inject.Inject` | Unchanged — use this |
+| `javax.inject.Named` | Unchanged — use this |
+| `jakarta.servlet.*` | NOT present in runtime |
+| `jakarta.annotation.*` | NOT present in runtime |
+| `jakarta.inject.*` | NOT present in runtime |
+
+**Why this matters:** Jakarta EE artifacts are widely published on Maven Central and
+compile without error. A developer who accepts an IDE suggestion to import
+`jakarta.annotation.PostConstruct` instead of `javax.annotation.PostConstruct` will
+produce a bundle that:
+
+1. Compiles successfully.
+2. Passes unit tests (most unit tests mock injection rather than exercising the OSGi
+   container).
+3. Deploys to AEM without error.
+4. Silently fails at runtime — `@PostConstruct` methods are never called, `@Inject`
+   fields remain null.
+
+OpenRewrite's standard Jakarta migration recipe (`org.openrewrite.java.migrate.jakarta.*`)
+MUST be excluded from the recipe list when running on AEM codebases.
+
+---
+
+## Build Plugin Compatibility
+
+Plugins that parse or generate Java bytecode must support Java 21 class file format
+(major version 65). Older plugin versions will fail with
+`Unsupported class file major version 65` or produce incorrect Bundle-ClassPath entries.
+See the [upgrading code and customizations guide](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/upgrading-code-and-customizations) for the full list of supported plugin versions.
+
+### maven-bundle-plugin
+
+Minimum version: **5.1.9**
+
+Versions before 5.1.9 use an embedded bnd library that cannot parse Java 21 class
+files. The symptom is `Unsupported class file major version 65` during the `package`
+phase.
+
+```xml
+<plugin>
+  <groupId>org.apache.felix</groupId>
+  <artifactId>maven-bundle-plugin</artifactId>
+  <version>5.1.9</version>
+  <extensions>true</extensions>
+</plugin>
+```
+
+### bnd-maven-plugin
+
+Minimum version: **6.4.0** (bnd 6.4.0 supports Java 21 bytecode analysis).
+
+### maven-scr-plugin
+
+Minimum version: **1.26.4** with **ASM 9.7.1**.
+
+The maven-scr-plugin uses the ASM bytecode library to parse `@SlingServlet` and related
+annotations. ASM versions below 9.x cannot parse Java 21 class files. Version 1.26.4
+ships with ASM 9.7.1.
+
+Note: The maven-scr-plugin is considered legacy. New code should use OSGi DS
+annotations (`@Component`, `@Service`) rather than Sling-specific SCR annotations.
+If the project uses only DS annotations, this plugin can be removed from the build.
+
+### maven-compiler-plugin
+
+Minimum version: **3.11.0** for Java 21 support.
+
+Use `<release>21</release>` rather than `<source>21</source>` + `<target>21</target>`.
+The `release` parameter additionally sets the bootstrap classpath to the Java 21
+platform API, preventing accidental use of JDK-internal classes:
+
+```xml
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-compiler-plugin</artifactId>
+  <version>3.11.0</version>
+  <configuration>
+    <release>21</release>
+  </configuration>
+</plugin>
+```
+
+---
+
+## Dependency Version Requirements
+
+### AEM UberJar
+
+The [AEM 6.5 LTS uber-jar](https://mvnrepository.com/artifact/com.adobe.aem/uber-jar) coordinate changes:
+
+| Item | Previous (6.5.x SP) | AEM 6.5 LTS |
+|------|--------------------|--------------------|
+| Version | `6.5.x` (e.g. `6.5.21`) | `6.6.0` |
+| Classifier | none or `uber-jar` | `apis` |
+| Scope | `provided` | `provided` |
+
+```xml
+<dependency>
+  <groupId>com.adobe.aem</groupId>
+  <artifactId>uber-jar</artifactId>
+  <version>6.6.0</version>
+  <classifier>apis</classifier>
+  <scope>provided</scope>
+</dependency>
+```
+
+Using the old uber-jar without the `apis` classifier against AEM 6.5 LTS will result in
+missing classes for newer Sling API methods added in the LTS release.
+
+### AEM Core WCM Components
+
+Minimum version: **2.24.0**. Recommended: **2.30.4** or later.
+
+Versions before 2.24.0 were not tested against Java 21 and may produce compilation
+warnings or fail OSGi resolution due to transitive Guava dependencies.
+
+```xml
+<dependency>
+  <groupId>com.adobe.cq</groupId>
+  <artifactId>core.wcm.components.core</artifactId>
+  <version>2.30.4</version>
+  <scope>provided</scope>
+</dependency>
+```
+
+### AEM Groovy Console
+
+The Groovy Console artifact has been transferred to a new Maven group:
+
+| Item | Previous | Current |
+|------|----------|---------|
+| GroupId | `be.orbinson.aem` | `be.orbinson.aem` |
+| ArtifactId | `aem-groovy-console-bundle` | `aem-groovy-console-bundle` |
+| Version | `<19.0.0` | `19.0.8` |
+
+Version 19.0.8 is compiled against Java 21 and OSGi R8. Earlier versions will not
+resolve on AEM 6.5 LTS.
+
+---
+
+## Deprecated APIs
+
+The following APIs are present in AEM 6.5 LTS for backwards compatibility but should
+not be used in migrated code. They may be removed in a future LTS release.
+
+### `org.apache.sling.commons.osgi.PropertiesUtil`
+
+All `PropertiesUtil.to*()` methods are deprecated. Replace with OSGi R7 component
+property types — define an `@interface` annotated with `@ObjectClassDefinition` and
+inject it as the `@Activate` parameter.
+
+```java
+// Deprecated pattern
+@Activate
+protected void activate(Map<String, Object> config) {
+    String value = PropertiesUtil.toString(config.get("myProp"), "default");
+}
+
+// Preferred pattern (OSGi R7 component property type)
+@interface Config {
+    String myProp() default "default";
+}
+
+@Activate
+protected void activate(Config config) {
+    String value = config.myProp();
+}
+```
+
+### Foundation Components (`/libs/foundation/*`)
+
+Foundation page components, form components, and parsys implementations under
+`/libs/foundation/` are deprecated. Migrated projects should reference Core WCM
+Components from `core.wcm.components.*`. Foundation components will not receive
+bug fixes against AEM 6.5 LTS.
+
+### Classic UI (ExtJS) Widgets
+
+All Classic UI JavaScript widgets (`CQ.Ext.*`, `CQ.form.*`) are in maintenance-only
+mode. They are not supported in the LTS release for new development. Touch UI (Coral UI
+/ Granite UI) is the supported authoring interface.
+
+### `JcrPropertyPredicateEvaluator` Direct Instantiation
+
+Direct instantiation of `com.day.cq.search.eval.JcrPropertyPredicateEvaluator` is
+deprecated. Use the `property` predicate string key through `QueryBuilder.createQuery()`
+instead of referencing the evaluator class directly. This decouples code from the
+internal evaluator implementation, which may be replaced in a future LTS release.
+
+---
+
+## References
+
+- [AEM 6.5 LTS GA release notes](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/release-notes/service-pack/ga)
+- [AEM 6.5 LTS SP2 release notes](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/release-notes/release-notes)
+- [Upgrading code and customizations](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/upgrading-code-and-customizations)
+- [AEM 6.5 LTS FAQ](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/release-notes/faq)
+- [AEM 6.5 LTS Analyzer Tool](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/aem-analyzer)
+- [AEM UberJar on Maven Central](https://mvnrepository.com/artifact/com.adobe.aem/uber-jar)

--- a/plugins/aem/6.5-lts/skills/java21-migration/references/build-fix-constraints.md
+++ b/plugins/aem/6.5-lts/skills/java21-migration/references/build-fix-constraints.md
@@ -1,0 +1,249 @@
+# Build Fix Constraints
+
+Rules the agent MUST follow when fixing a build error that surfaces during a
+migration phase. The rules are layered by severity. Higher tiers are
+absolute; lower tiers are practices the fix is expected to respect.
+
+The tiers are explicit so reviewers can reason about an agent fix at a
+glance: a Tier 0 violation is unrecoverable, a Tier 1 violation is a bug, a
+Tier 2 violation is a style regression. The same content is greppable —
+`grep -n "^### T" references/build-fix-constraints.md` lists every rule.
+
+---
+
+## Tier 0 — STOP
+
+A Tier 0 hit means the migration cannot complete and the agent must
+terminate with a clear report. Do not attempt workarounds, alternatives,
+or partial fixes.
+
+### T0.1  Unsupported AEM packages
+
+If any error references one of the following packages, terminate immediately.
+These products are not part of the AEM 6.5 LTS surface area and there is no
+in-scope remediation.
+
+| Package prefix | Product |
+|---|---|
+| `com.adobe.cq.commerce.*` | AEM Commerce |
+| `com.adobe.cq.social.*` | AEM Communities |
+| `com.adobe.granite.social.*` | Granite Social |
+| `com.adobe.cq.screens.*` | AEM Screens |
+| `com.adobe.cq.sample.we.retail.*` | We.Retail samples |
+| `com.day.cq.dam.pim.*` | DAM PIM |
+| `com.day.cq.dam.rating.*` | DAM Rating |
+| `com.adobe.cq.searchpromote.*` | Search & Promote |
+| `com.adobe.cq.mcm.campaign.*` | MCM Campaign |
+
+Termination report template (verbatim, to make downstream parsing reliable):
+
+```
+TERMINATE: project depends on unsupported AEM package <pkg> in <file>:<line>.
+Migration cannot proceed.
+```
+
+Do not add these packages to `pom.xml`. Do not search for replacement
+artefacts. Do not comment out the importing class.
+
+### T0.2  Customer-specific dependency cannot be resolved (initial build only)
+
+If the initial build (source JDK, before any recipe runs) fails because a
+non-public artefact (private groupId, internal Nexus) cannot be resolved,
+terminate. Manual settings.xml triage is out of scope for the agent.
+
+```
+TERMINATE: initial build cannot resolve customer-specific artefact <coords>.
+Resolve Maven settings before retrying.
+```
+
+### T0.3  Public dependency auth failure (initial build only)
+
+`401`/`403` from Maven Central while the requested artefact actually exists
+indicates a credential or proxy problem on the host. Terminate.
+
+### T0.4  Infrastructure failure
+
+`Connection refused`, `Unknown host`, or any I/O error that does not name a
+specific artefact. Terminate — the agent has no signal to act on.
+
+---
+
+## Tier 1 — Invariants
+
+A Tier 1 hit means the agent's proposed fix would break the migration
+contract. The fix is rejected and a new fix is attempted on the next
+iteration. Tier 1 violations are bugs in the agent's reasoning, not
+acceptable trade-offs.
+
+### T1.1  `javax` stays `javax`
+
+AEM 6.5 LTS exports the `javax.*` namespace. Swapping to `jakarta.*`
+compiles successfully but produces a silent runtime no-op — for example, a
+`@PostConstruct` callback on a `jakarta.annotation.PostConstruct` method is
+never invoked because AEM's Sling Models processor only recognises the
+`javax.annotation.PostConstruct` variant.
+
+Forbidden transformations:
+
+- `import javax.*` → `import jakarta.*` in any Java source.
+- `<groupId>javax.*</groupId>` → `<groupId>jakarta.*</groupId>` in any POM.
+- Replacing `javax.*` annotation processor coordinates in `bnd` or
+  `maven-bundle-plugin` configuration.
+
+Affected packages include but are not limited to: `javax.xml.bind`,
+`javax.annotation`, `javax.inject`, `javax.servlet`, `javax.ws.rs`,
+`javax.persistence`, `javax.mail`, `javax.activation`.
+
+When an upstream OpenRewrite recipe inadvertently introduces a
+`jakarta.*` import, the bundled `RevertJakartaInAemSource` custom recipe
+will revert it on the next phase. If a manual fix must be applied first,
+add the correct `javax.*` dependency to the POM rather than touching the
+import.
+
+### T1.2  Enforcer `requireJavaVersion` floor monotonicity
+
+The Maven Enforcer `requireJavaVersion` rule is a build-time gate, not a
+runtime constraint. The floor must increase monotonically along the path
+`1.8 → 11 → 21`. Lowering the floor is never the correct fix.
+
+| Symptom | Correct fix |
+|---|---|
+| Build fails on `requireJavaVersion=11` while running JDK 8 | Re-run that phase with `--javaHome $JAVA11_HOME`. |
+| Build fails on `requireJavaVersion=21` while running JDK 11 | Re-run that phase with `--javaHome $JAVA21_HOME`. |
+| `requireJavaVersion=8` in a migrated module | Raise to `11` or `21`. Do not leave at `8`. |
+
+Also rewrite the rule's `<message>` text to match the new floor — leaving a
+`Java 8 required` message attached to a `version=11` rule is a Tier 2
+violation.
+
+### T1.3  Removed and non-exported bundles
+
+The packages below are NOT exported by the AEM 6.5 LTS OSGi runtime.
+Adding them with `<scope>provided</scope>` (or expecting them from
+`uber-jar`) produces a deploy-time resolution failure:
+
+```
+osgi.wiring.package; ... Cannot be resolved
+```
+
+| Package | Status | Remediation |
+|---|---|---|
+| `com.google.common.*` (Guava) | Bundle removed | Refactor to JDK collections or embed Guava 33.x |
+| `com.github.benmanes.caffeine.*` | Not deployed | Embed Caffeine 2.9.3 (NOT 3.x — needs Java 11 JDK module path) |
+| `org.eclipse.jetty.*` | Private inside `org.apache.felix.http.jetty` | Embed `org.apache.felix.http.jetty` 5.1.26 |
+| `org.apache.commons.collections.*` (3.x) | Removed | Migrate to `commons-collections4` |
+
+For "embed" remediation, the bundle manifest must explicitly exclude the
+embedded package from `Import-Package`:
+
+```xml
+<Embed-Dependency>caffeine;inline=true</Embed-Dependency>
+<Embed-Transitive>true</Embed-Transitive>
+<Import-Package>!com.github.benmanes.caffeine.*,*</Import-Package>
+```
+
+Detailed recipes live in `references/removed-bundles-remediation.md`.
+
+### T1.4  POM formatting must be preserved by construction
+
+Every POM transformation in this skill runs through an OpenRewrite recipe.
+Text-substitution edits to POMs by the agent are a Tier 1 violation
+because they break formatting in ways that subsequent recipe runs cannot
+re-normalise — the diff becomes unreviewable.
+
+If the agent reaches a point where no OpenRewrite recipe applies and a POM
+edit is mandatory, prefer adding a `<!-- aem-lts-migration: ai-fix -->`
+marker on a fresh well-indented block over modifying an existing one.
+
+---
+
+## Tier 2 — Practices
+
+Tier 2 rules describe the shape a correct fix should take. A Tier 2
+violation is not rejected automatically but the resulting commit will
+look messy in review and the fix counts as low quality.
+
+### T2.1  POM indentation matches surrounding context
+
+When inserting or replacing XML in a POM, count the leading whitespace
+of the surrounding context and reuse it exactly. Default 2-space
+indentation is the wrong choice for files that use 4-space indentation,
+even if it compiles.
+
+### T2.2  JDK selection is a runtime override only
+
+If a phase fails because the wrong JDK is selected, re-invoke the CLI
+with `--javaHome` pointing at the correct JDK. Never modify
+`<source>`, `<release>`, `<requireJavaVersion>`, or `.cloudmanager/java-version`
+to bypass the failure. The selection is per-process and must not be
+persisted to the project.
+
+### T2.3  Temporary workarounds are tagged
+
+If a fix is intentionally temporary (for example, a Maven Central
+fallback added to make an intermediate build pass while a private
+artefact is missing), wrap the change in:
+
+```xml
+<!-- MIGRATION_TEMP_START -->
+<!-- aem-lts-migration: ai-fix -->
+<!-- ... -->
+<!-- MIGRATION_TEMP_END -->
+```
+
+The `verify` command counts and reports `MIGRATION_TEMP_*` markers. A
+non-zero count blocks promotion past the verify step until the
+workaround is removed or made permanent.
+
+### T2.4  Change attribution marker is mandatory
+
+Every agent-authored fix carries `// aem-lts-migration: ai-fix` (or the
+`<!-- ... -->` variant for XML, `# ...` for shell/YAML). The marker is
+deliberately a single kebab-cased token so a `grep -rn
+"aem-lts-migration: ai-fix"` over the working tree is a complete audit
+trail. The `verify` command counts these and includes the count in its
+final report; a non-zero count signals manual intervention occurred.
+
+---
+
+## Tier 3 — Iteration Rules
+
+### T3.1  What the agent CAN fix
+
+- Compilation errors caused by Java API changes between 8/11 and 21.
+- Missing imports for relocated JDK classes.
+- Replacement of removed JDK APIs with current equivalents.
+- Adding a missing dependency to a POM, with `// aem-lts-migration: ai-fix`.
+- Tightening type inference where the Java 21 compiler refuses inferred types
+  the older compiler accepted.
+
+### T3.2  What the agent MUST NOT modify
+
+- `README.md`, `LICENSE`, `NOTICE`.
+- `.gitignore`, `Dockerfile`, `docker-compose.yml`, CI workflow files.
+- `settings.xml`, `toolchains.xml` outside of `MIGRATION_TEMP_*` markers.
+- Build/deploy shell scripts, infrastructure-as-code.
+- Test data files.
+- Application business logic.
+- Component/template files under `ui.apps` or `ui.content`.
+- Sling/OSGi configuration files unless directly required for compilation.
+
+### T3.3  Iteration budget
+
+Each build phase has a budget of 3 fix-and-rerun attempts. The exact
+cycle:
+
+1. Run the build command.
+2. If exit code = 0 → phase complete; advance.
+3. Otherwise, parse the compiler/Maven output.
+4. Check Tier 0 conditions — terminate if any hit.
+5. Identify the first failing module; resolve its root cause first.
+6. Apply the minimal fix that compiles the failing file.
+7. Re-run the build.
+8. Repeat from step 2, up to 3 total attempts.
+9. If still failing after the third attempt, write a phase-failure
+   report and stop.
+
+The retry budget is per-phase, not per-error. Three fixes in one phase
+that each shift the failure point are still three attempts; the budget
+does not regenerate.

--- a/plugins/aem/6.5-lts/skills/java21-migration/references/build-troubleshooting.md
+++ b/plugins/aem/6.5-lts/skills/java21-migration/references/build-troubleshooting.md
@@ -1,0 +1,503 @@
+# Build Troubleshooting Guide
+
+This guide covers the compilation and build errors most commonly encountered when
+migrating an AEM 6.5 project to Java 21. Each entry includes the exact error message
+pattern, root cause, and the minimal fix required.
+
+---
+
+## Java 21 Compilation Errors
+
+### 1. `source release 8 is not supported`
+
+**Full error:**
+```
+[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:...
+[ERROR] Fatal error compiling: error: Source release 8 is not supported.
+[ERROR] Use --release 21 or higher.
+```
+
+**Root cause:** The `maven-compiler-plugin` is configured with `<source>8</source>` and
+`<target>8</target>` (or `<source>1.8</source>`), but is being invoked with JDK 21.
+JDK 21 dropped support for cross-compilation to Java 8 target via `--source 8`.
+
+**Fix:** Update `maven-compiler-plugin` configuration to target Java 21:
+
+```xml
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-compiler-plugin</artifactId>
+  <version>3.11.0</version>
+  <configuration>
+    <!-- Remove <source> and <target>, use <release> instead -->
+    <release>21</release>
+  </configuration>
+</plugin>
+```
+
+Also update the `maven-enforcer-plugin` `requireJavaVersion` to `[21,)`.
+
+---
+
+### 2. `has been removed` / `deprecated and marked for removal`
+
+**Full error examples:**
+```
+[ERROR] error: sun.misc.BASE64Encoder has been removed
+[ERROR] error: com.sun.org.apache.xml.internal.serialize.XMLSerializer has been removed
+[ERROR] warning: [removal] Integer(int) in Integer has been deprecated and marked for removal
+```
+
+**Root cause:** The code uses an internal JDK API (`sun.*`, `com.sun.*`) or a JDK class
+that was deprecated for removal prior to Java 9 and removed in Java 17 or Java 21.
+See [AEM deprecated and removed features](https://experienceleague.adobe.com/en/docs/experience-manager-65/content/release-notes/deprecated-removed-features) for the AEM-specific removal list.
+
+**Common removals and replacements:**
+
+| Removed API | Replacement |
+|-------------|------------|
+| `sun.misc.BASE64Encoder` | `java.util.Base64.getEncoder()` |
+| `sun.misc.BASE64Decoder` | `java.util.Base64.getDecoder()` |
+| `com.sun.image.codec.jpeg.*` | `javax.imageio.ImageIO` |
+| `Integer(int)` constructor | `Integer.valueOf(int)` |
+| `Double(double)` constructor | `Double.valueOf(double)` |
+| `Long(long)` constructor | `Long.valueOf(long)` |
+| `Boolean(boolean)` constructor | `Boolean.valueOf(boolean)` |
+| `Character(char)` constructor | `Character.valueOf(char)` |
+
+**Fix:** Replace with the listed API. If the removed API is in a transitive dependency
+(not your own code), update the dependency to a version that has already migrated.
+
+---
+
+### 3. `module java.base does not export ... to unnamed module`
+
+**Full error:**
+```
+[ERROR] error: package sun.reflect is not visible
+[ERROR]   (package sun.reflect is declared in module java.base, which does not export it)
+```
+
+**Root cause:** The code accesses JDK-internal packages that are encapsulated since
+Java 9. Under Java 21, strong encapsulation is fully enforced; the `--illegal-access`
+flag that permitted this in Java 11–16 is removed.
+
+**Fix options (in preference order):**
+
+1. **Refactor to the public API.** This is always the correct long-term fix.
+   - `sun.reflect.*` → `java.lang.reflect.*`
+   - `sun.misc.Unsafe` → context-dependent; often eliminates the need with modern APIs
+
+2. **Add `--add-opens` to the build if the access is in test code only:**
+
+   ```xml
+   <plugin>
+     <groupId>org.apache.maven.plugins</groupId>
+     <artifactId>maven-surefire-plugin</artifactId>
+     <configuration>
+       <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+     </configuration>
+   </plugin>
+   ```
+
+   Never add `--add-opens` for production code paths. It is a test-only workaround.
+
+---
+
+### 4. `incompatible types: java.lang.Object cannot be converted to X`
+
+**Full error:**
+```
+[ERROR] error: incompatible types: Object cannot be converted to String
+[ERROR]   String value = map.get("key");
+```
+
+**Root cause:** Raw-type collections (`Map map` instead of `Map<String, String> map`)
+produce `Object` return types. Java 21's stricter type inference (combined with
+`-Xlint:unchecked` promoted to error by some enforcer configurations) flags these.
+
+**Fix:** Parameterise the collection type:
+
+```java
+// Before
+Map map = new HashMap();
+String value = (String) map.get("key");
+
+// After
+Map<String, String> map = new HashMap<>();
+String value = map.get("key");
+```
+
+---
+
+### 5. `sealed`, `permits`, `record`, `yield` as Identifiers
+
+**Full error:**
+```
+[ERROR] error: as of release 16, 'record' is a restricted type name and cannot be used
+[ERROR] error: as of release 14, 'yield' is a restricted identifier
+```
+
+**Root cause:** These words became context-sensitive keywords in Java 14–17 and are
+reserved in Java 21. Variable names, method names, or class names using these words
+cause compilation failure.
+
+**Common patterns requiring rename:**
+
+| Identifier | Suggested Replacement |
+|-----------|----------------------|
+| `record` (variable) | `jcrRecord`, `dataRecord`, `entry` |
+| `yield` (variable) | `yieldValue`, `returnValue`, `result` |
+| `sealed` (variable) | `isSealed`, `sealedFlag` |
+| `permits` (variable) | `permitsCount`, `allowedCount` |
+
+**Fix:** Rename the identifier. If the identifier is in a public API (method name in
+an interface), the interface contract must be updated and all callers updated as well.
+
+---
+
+## Maven Plugin Errors
+
+### 1. `Unsupported class file major version 65`
+
+**Full error:**
+```
+[ERROR] Failed to execute goal org.apache.felix:maven-bundle-plugin:...
+[ERROR] Unsupported class file major version 65
+```
+
+**Root cause:** Class file major version 65 = Java 21. The `maven-bundle-plugin` version
+in use embeds an old bnd library that cannot parse Java 21 class files.
+See [upgrading code and customizations](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/upgrading-code-and-customizations) for the minimum plugin versions required by AEM 6.5 LTS.
+
+**Fix:** Upgrade `maven-bundle-plugin` to 5.1.9 or later:
+
+```xml
+<plugin>
+  <groupId>org.apache.felix</groupId>
+  <artifactId>maven-bundle-plugin</artifactId>
+  <version>5.1.9</version>
+  <extensions>true</extensions>
+</plugin>
+```
+
+If the project uses `bnd-maven-plugin` directly, upgrade to 6.4.0+.
+
+---
+
+### 2. `SCRDescriptorBndPlugin not found` / `SCRDescriptor: Error processing`
+
+**Full error:**
+```
+[ERROR] Failed to execute goal org.apache.felix:maven-scr-plugin:...
+[ERROR] SCRDescriptorBndPlugin not found in the bnd plugins
+```
+
+**Root cause:** The `maven-scr-plugin` is incompatible with the version of bnd used by
+a newer `maven-bundle-plugin`. The SCR plugin injects itself as a bnd plugin; the API
+it uses has changed.
+
+**Fix:**
+
+*Option A* (preferred) — Remove the `maven-scr-plugin` entirely if the project uses
+OSGi DS annotations (`@Component`, `@Reference` from `org.osgi.service.component.*`).
+The `maven-bundle-plugin` 5.x processes DS annotations natively via bnd.
+
+*Option B* — If the project uses Sling-specific SCR annotations, upgrade
+`maven-scr-plugin` to 1.26.4:
+
+```xml
+<plugin>
+  <groupId>org.apache.felix</groupId>
+  <artifactId>maven-scr-plugin</artifactId>
+  <version>1.26.4</version>
+</plugin>
+```
+
+---
+
+### 3. `Unable to parse class ... ClassNotFoundException: org.objectweb.asm.ClassVisitor`
+
+**Full error:**
+```
+[ERROR] Unable to parse class file MyComponent.class
+[ERROR] Caused by: java.lang.ClassNotFoundException: org.objectweb.asm.ClassVisitor
+```
+
+or:
+
+```
+[ERROR] ASM ClassReader failed to parse class file - probably due to a new Java class file version
+```
+
+**Root cause:** The ASM bytecode library bundled with the Maven plugin is too old to
+parse Java 21 class files (ASM supports a specific maximum class file major version per
+release; ASM 9.7+ is required for Java 21).
+
+**Fix:** Upgrade the plugin to a version that ships with ASM 9.7.1. For
+`maven-scr-plugin`, this is 1.26.4. For custom Mojo plugins, add an explicit ASM
+dependency override:
+
+```xml
+<plugin>
+  <groupId>org.apache.felix</groupId>
+  <artifactId>maven-scr-plugin</artifactId>
+  <version>1.26.4</version>
+  <dependencies>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>9.7.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+      <version>9.7.1</version>
+    </dependency>
+  </dependencies>
+</plugin>
+```
+
+---
+
+## OSGi / Sling Runtime Errors
+
+### 1. `Cannot resolve bundle ... com.google.common is missing`
+
+**Full log:**
+```
+org.osgi.framework.BundleException: Unresolved constraint in bundle [com.example.myapp 1.0.0]:
+  Unable to resolve 1.0.0: missing requirement [1.0.0] osgi.wiring.package;
+  (&(osgi.wiring.package=com.google.common.collect)(version>=30.0))
+```
+
+**Root cause:** The bundle declares `Import-Package: com.google.common.collect` but
+Guava is not exported by the AEM 6.5 LTS framework. The bundle cannot be resolved.
+See the [Apache Sling OSGi bundle documentation](https://sling.apache.org/documentation/) for guidance on OSGi bundle resolution.
+
+**Fix:** Apply the Guava remediation from `removed-bundles-remediation.md`:
+- Refactor to JDK equivalents, or
+- Embed Guava as `<Private-Package>` with `<Import-Package>!com.google.common.*,*</Import-Package>`
+
+---
+
+### 2. `@PostConstruct method not called` / `@Inject field is null`
+
+**Symptom:** An OSGi component activates without error, but:
+- A method annotated `@PostConstruct` is never invoked.
+- A field annotated `@Inject` or `@OSGiService` remains `null` at runtime.
+
+**Root cause:** The import statement uses the Jakarta namespace:
+
+```java
+// WRONG — compiles, but silently ignored at runtime on AEM 6.5 LTS
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+
+// CORRECT
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+```
+
+**Diagnosis:** Search for jakarta imports in the codebase:
+
+```bash
+grep -r "import jakarta\." src/main/java --include="*.java"
+```
+
+**Fix:** Replace all `import jakarta.` with `import javax.` in AEM application code.
+Then recheck that the `javax.*` artifacts are available on the compile classpath (they
+are provided by the AEM uber-jar).
+
+---
+
+### 3. `Service not registered` / Component remains in `Unsatisfied` state
+
+**Full log ([Felix web console](https://sling.apache.org/documentation/)):**
+```
+State: Unsatisfied Reference
+  com.example.MyService -> com.example.DependencyService (0:0:0)
+  [unsatisfied] required
+```
+
+**Root cause possibilities:**
+
+1. The `@Component(service = ...)` attribute was changed during migration and no longer
+   matches the interface under which the service is registered.
+2. An `@Reference` targets an interface that is no longer exported (e.g., a removed AEM
+   API).
+3. The component property type annotation was incorrectly modified during migration,
+   causing the component to fail `@Activate` with a `ComponentException`.
+
+**Diagnosis:**
+
+- Check Felix console at `/system/console/components` for the component's state.
+- Click the component name — the "References" section lists which references are
+  satisfied and which are not.
+- Check `/system/console/bundles` to confirm the bundle containing the referenced
+  service is `Active`.
+
+**Fix:** Restore the original `@Component(service = ...)` value and verify that the
+referenced interface is present in the AEM 6.5 LTS uber-jar APIs.
+
+---
+
+## Mockito / Test Framework Errors
+
+### 1. `MockitoAnnotations.initMocks deprecated` / Test class initialisation warning
+
+**Warning:**
+```
+org.mockito.exceptions.misusing.UnnecessaryStubbingException:
+```
+or deprecation warning about `MockitoAnnotations.initMocks(this)`.
+
+**Root cause:** [Mockito 5.x](https://javadoc.io/doc/org.mockito/mockito-core/latest/) deprecates `MockitoAnnotations.initMocks()` in favour of
+the JUnit 5 extension.
+
+**Fix:** Replace the `@Before` setup method with the JUnit 5 `@ExtendWith` annotation:
+
+```java
+// Before (Mockito 4.x / JUnit 4 style)
+@RunWith(MockitoJUnitRunner.class)
+public class MyServiceTest {
+    @Mock
+    private ResourceResolver resolver;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+}
+
+// After (Mockito 5.x / JUnit 5 style)
+@ExtendWith(MockitoExtension.class)
+class MyServiceTest {
+    @Mock
+    private ResourceResolver resolver;
+    // No @BeforeEach init needed
+}
+```
+
+---
+
+### 2. `PowerMockito is not compatible with Java 21`
+
+**Error:**
+```
+java.lang.reflect.InaccessibleObjectException: Unable to make ... accessible:
+  module java.base does not "opens java.lang" to unnamed module
+```
+
+or:
+```
+java.lang.UnsupportedOperationException: Cannot define class using reflection
+```
+
+**Root cause:** PowerMock relies on `sun.misc.Unsafe` and reflective class definition
+mechanisms (`java.lang.reflect.Proxy`, `sun.reflect.ConstructorAccessor`) that are
+strongly encapsulated in Java 21. PowerMock has not released a version compatible
+with Java 17+.
+
+**Fix:** Remove PowerMock and replace static method mocking with Mockito 5.x
+`mockStatic()` (available in `mockito-inline`, now merged into `mockito-core`):
+
+```java
+// Before (PowerMock)
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(StaticUtil.class)
+public class MyTest {
+    @Test
+    public void testSomething() {
+        PowerMockito.mockStatic(StaticUtil.class);
+        when(StaticUtil.compute()).thenReturn("mocked");
+        // ...
+    }
+}
+
+// After (Mockito 5.x)
+@ExtendWith(MockitoExtension.class)
+class MyTest {
+    @Test
+    void testSomething() {
+        try (MockedStatic<StaticUtil> mocked = Mockito.mockStatic(StaticUtil.class)) {
+            mocked.when(StaticUtil::compute).thenReturn("mocked");
+            // ... assertions
+        }
+    }
+}
+```
+
+Update the dependency:
+
+```xml
+<!-- Remove PowerMock -->
+<!-- <dependency>
+  <groupId>org.powermock</groupId>
+  <artifactId>powermock-module-junit4</artifactId>
+</dependency> -->
+
+<!-- Ensure Mockito 5.x is used -->
+<dependency>
+  <groupId>org.mockito</groupId>
+  <artifactId>mockito-core</artifactId>
+  <version>5.11.0</version>
+  <scope>test</scope>
+</dependency>
+```
+
+---
+
+### 3. `byte-buddy version conflict` / `ClassFormatError` in Mockito
+
+**Error:**
+```
+net.bytebuddy.agent.builder.AgentBuilder$Listener$StreamWriting - FAIL com.example.MyClass
+java.lang.ClassFormatError: Illegal field modifiers in class com/example/MyClass
+```
+
+or:
+```
+java.lang.VerifyError: Bad type on operand stack
+```
+
+**Root cause:** Mockito uses Byte Buddy to generate proxy classes. An older Byte Buddy
+version (below 1.14.x) cannot generate valid Java 21 class files, producing bytecode
+that the JVM verifier rejects.
+
+**Fix:** Align Byte Buddy version with Mockito. Mockito 5.x declares a compatible
+Byte Buddy version as a managed dependency; the conflict arises when a parent POM or
+another dependency overrides the Byte Buddy version.
+
+Add an explicit Byte Buddy version to the `<dependencyManagement>` section:
+
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
+      <version>1.14.15</version>
+    </dependency>
+    <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy-agent</artifactId>
+      <version>1.14.15</version>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+```
+
+Verify with `mvn dependency:tree -Dincludes=net.bytebuddy` that no other version of
+Byte Buddy is being pulled in. If there is a conflict, add an explicit `<exclusion>`
+at the point where the older version is introduced.
+
+---
+
+## References
+
+- [AEM 6.5 LTS GA release notes](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/release-notes/service-pack/ga)
+- [Upgrading code and customizations](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/upgrading-code-and-customizations)
+- [Java deprecated and removed features](https://experienceleague.adobe.com/en/docs/experience-manager-65/content/release-notes/deprecated-removed-features)
+- [Apache Sling documentation](https://sling.apache.org/documentation/)
+- [Mockito Core API documentation](https://javadoc.io/doc/org.mockito/mockito-core/latest/)

--- a/plugins/aem/6.5-lts/skills/java21-migration/references/migration-guardrails.md
+++ b/plugins/aem/6.5-lts/skills/java21-migration/references/migration-guardrails.md
@@ -1,0 +1,285 @@
+# Migration Safety Guardrails
+
+These rules govern AI agent behavior during AEM 6.5 LTS / Java 21 migration. They are
+non-negotiable: the agent MUST enforce each rule unconditionally during every phase.
+
+---
+
+## Hard Stops — Migration Terminates
+
+If any of the following conditions is detected the agent MUST stop, report the blocking
+condition with full context, and wait for explicit human approval before proceeding. The
+migration is NOT automatically resumable.
+
+### 1. Unsupported Package Patterns
+
+The following package namespaces indicate a dependency on an AEM add-on or deprecated
+product line that is outside the scope of a base-platform migration. Migrating these
+modules without the corresponding add-on artifacts available at build time will produce
+a broken build that cannot be automatically repaired. See the [upgrading code and customizations guide](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/upgrading-code-and-customizations) for the full list of deprecated and removed features.
+
+| Pattern | Product / Reason |
+|---------|-----------------|
+| `com.adobe.cq.commerce.*` | AEM Commerce (CIF) — requires separate Commerce add-on |
+| `com.adobe.cq.social.*` | AEM Communities — deprecated, no LTS path |
+| `com.adobe.granite.social.*` | Granite Social layer — deprecated alongside Communities |
+| `com.adobe.cq.screens.*` | AEM Screens — separate release cadence, not included in LTS base |
+| `com.day.cq.wcm.weretail.*` / `we.retail` | We.Retail reference site — not production code, should not be migrated |
+| `com.adobe.cq.dam.pim.*` | DAM Product Information Management — removed in LTS |
+| `com.adobe.cq.dam.rating.*` | DAM Rating service — removed in LTS |
+| `com.adobe.searchpromote.*` | Search&Promote — product end-of-life, no replacement bundle |
+
+**Why this is a hard stop:** These packages are absent from the AEM 6.5 LTS uber-jar
+and from the OSGi runtime. Automated fixes (e.g., removing imports or stubbing classes)
+would silently break business functionality. A human architect must decide whether to
+remove the feature, obtain the add-on, or exclude the module from the migration.
+
+### 2. Customer-Specific / Private Dependency Resolution Failures
+
+If Maven cannot resolve a `groupId` that does not match any well-known public artifact
+(e.g., `com.acme.*`, a corporate groupId, or any artifact requiring credentials to a
+private Nexus/Artifactory), the agent must not attempt to guess versions, substitute
+similar artifacts, or add repository entries pointing to unknown hosts.
+
+**Why this is a hard stop:** Private artifact resolution requires credentials and
+organisational knowledge the agent does not possess. Guessing version bumps can
+introduce API incompatibilities or security vulnerabilities in proprietary libraries.
+
+### 3. Network / Infrastructure Issues (HTTP 401 / 403 on Public Repositories)
+
+If Maven dependency resolution returns HTTP 401 (Unauthorized) or HTTP 403 (Forbidden)
+against a publicly known repository (Maven Central, Adobe public repo, repo.adobe.com),
+the agent must stop rather than retry indefinitely.
+
+**Why this is a hard stop:** A 401/403 against a public repo indicates a local
+settings.xml mirror override, corporate proxy interception, or a repository that
+requires authentication that has not been provided. Continuing will produce a
+misleadingly partial migration. The environment must be fixed first.
+
+---
+
+## Forbidden Actions
+
+The agent MUST NEVER perform any of the following actions under any circumstances,
+regardless of whether it believes they would help:
+
+### javax.* Namespace — Never Migrate to jakarta.*
+
+```
+FORBIDDEN: replacing javax.annotation.PostConstruct with jakarta.annotation.PostConstruct
+FORBIDDEN: replacing javax.inject.Inject with jakarta.inject.Inject
+FORBIDDEN: replacing javax.servlet.* with jakarta.servlet.*
+```
+
+[AEM 6.5 LTS runs on OSGi / Apache Felix with the **javax** namespace](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/release-notes/faq). The runtime
+classloader resolves `javax.annotation.PostConstruct`, `javax.inject.Inject`, and the
+entire `javax.servlet.*` tree. Jakarta EE namespace classes (`jakarta.*`) are absent
+from the OSGi framework and **will not trigger a compilation error** — the Jakarta
+artifacts are available on Maven Central and will compile cleanly. However, at runtime
+the OSGi SCR and Sling injection framework will silently skip methods and fields
+annotated with jakarta types. Symptoms: `@PostConstruct` lifecycle callbacks never
+fire; `@Inject` / `@OSGiService` fields remain null; HTTP servlets registered via
+`jakarta.servlet.Servlet` are never activated.
+
+This failure mode is particularly dangerous because:
+- The build passes green.
+- Unit tests (which usually mock injection) also pass.
+- The defect surfaces only at runtime on an AEM instance.
+
+### maven-enforcer-plugin requireJavaVersion — Never Lower the Floor
+
+The `requireJavaVersion` rule in `maven-enforcer-plugin` must only move forward (per the [AEM 6.5 LTS GA release notes](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/release-notes/service-pack/ga)):
+
+```
+Allowed:   1.8  →  11  →  21
+Forbidden: 21   →  11  (downgrade)
+Forbidden: 21   →  8   (downgrade)
+Forbidden: removing the requireJavaVersion rule entirely
+```
+
+Lowering the floor permits compilation on an older JDK that may miss binary
+incompatibilities with Java 21 class files, and defeats the purpose of the migration.
+
+### Files the Agent Must Not Modify
+
+The following file types and paths are out of scope. The agent must treat them as
+read-only regardless of whether modifying them would fix a build error:
+
+| Category | Examples |
+|----------|----------|
+| Documentation | `README.md`, `CHANGELOG.md`, `*.adoc`, `*.rst` |
+| Repository metadata | `.gitignore`, `.gitattributes` |
+| Container definitions | `Dockerfile`, `docker-compose.yml`, `*.dockerfile` |
+| Build infrastructure scripts | `Makefile`, shell scripts in `scripts/`, `bin/`, CI pipeline YAML |
+| Test data fixtures | `src/test/resources/**`, `*.json` fixture files, `*.xml` fixture files |
+| Business logic (non-migration changes) | Any `.java` change not required to compile against Java 21 |
+| AEM component dialog XML | `_cq_dialog/.content.xml`, `dialog/.content.xml` |
+| AEM content XML | `jcr_root/**/.content.xml`, `*.page.xml` |
+
+### New Dependencies — Never Add Without Approval
+
+The agent must not add a `<dependency>` block that was not already present in any
+`pom.xml` unless:
+1. It is a direct replacement for a removed bundle listed in this document, AND
+2. The replacement is specified in the migration recipes.
+
+Even then, the agent records the addition in the migration report and does not silently
+add transitive dependencies.
+
+### OSGi Component Annotation Semantics — Never Change
+
+The agent may update annotation class names (e.g., to correct an import path) or add
+missing imports, but must not change annotation attribute values such as:
+- `@Component(service = ...)` — the registered service interface
+- `@Component(immediate = ...)` — startup timing
+- `@Reference(cardinality = ...)` — service dependency cardinality
+- `@Reference(policy = ...)` — static vs dynamic binding policy
+
+---
+
+## Required Practices
+
+### POM Whitespace and Indentation Preservation
+
+POM files are often under version control and reviewed by developers. Unnecessary
+formatting changes produce noisy diffs that obscure the actual migration changes.
+
+The agent MUST:
+1. Parse POM files with a proper XML library (not regex) to identify the elements to
+   change.
+2. Apply changes using text-level replacement that preserves surrounding whitespace,
+   indentation style (spaces vs tabs), and line endings.
+3. Never pretty-print or reformat an entire POM.
+
+### AI-Assisted Fix Attribution
+
+Every line or block of code added or materially rewritten by the agent to resolve a
+build error must be followed by an inline comment:
+
+```java
+// aem-lts-migration: ai-fix
+```
+
+This comment serves two purposes:
+1. It marks code that should receive human review before production deployment.
+2. It enables automated post-migration audits (`grep -r "aem-lts-migration: ai-fix"`)
+   to find every AI-generated change.
+
+The comment must be placed on the line immediately following the added code, or on
+the same line if it is a one-liner, consistent with the file's commenting style.
+
+### Temporary Workaround Markers
+
+Workarounds that are required to unblock a later phase but must be removed before
+the migration is finalised must be wrapped in markers:
+
+```java
+// MIGRATION_TEMP_START: <reason>
+<temporary code>
+// MIGRATION_TEMP_END
+```
+
+For XML/POM files:
+
+```xml
+<!-- MIGRATION_TEMP_START: <reason> -->
+<temporary element/>
+<!-- MIGRATION_TEMP_END -->
+```
+
+The final cleanup step in the migration workflow searches for these markers and
+fails if any remain. This ensures no temporary workaround is inadvertently shipped.
+
+### Build-Fix Retry Limit
+
+For each migration phase, the agent is permitted a maximum of **3 consecutive
+build-fix retry attempts**. If the build has not succeeded after 3 attempts:
+
+1. Record the full Maven output of the final failed attempt.
+2. Record every change made across all 3 attempts.
+3. Escalate to human review.
+4. Do not attempt a 4th fix.
+
+This prevents infinite loops where the agent oscillates between two broken states.
+
+### JDK Version Selection
+
+The correct JDK must be used at each phase of the migration. Using the wrong JDK
+produces misleading errors (e.g., Java 21 bytecode errors during an OpenRewrite run
+that should target Java 11).
+
+| Phase | JDK to Use | Reason |
+|-------|-----------|--------|
+| Initial baseline build | Detected source JDK (8 or 11) | Reproduce the original build environment |
+| OpenRewrite Java migration recipes | JDK 11 | OpenRewrite 8.x can parse both Java 8 and Java 11 source; running under JDK 21 may trigger parser edge cases with legacy syntax |
+| All builds after Java 21 source/target is set | JDK 21 | Verify actual target bytecode compatibility |
+| Mockito / test framework migration | JDK 21 | Byte-buddy (used by Mockito 5.x) requires JDK 17+ to instrument Java 21 class files |
+
+Always select the **lowest JDK version that satisfies the enforcer floor** for each
+phase. Do not use JDK 21 where JDK 11 is sufficient, to keep build output
+representative of the phase's requirements.
+
+---
+
+## Removed and Non-Exported Bundles in AEM 6.5 LTS
+
+The following libraries are no longer available as exported OSGi packages in the
+AEM 6.5 LTS runtime. Code that imports these packages will compile if the
+corresponding Maven artifact is on the compile classpath, but will fail at runtime
+with `ClassNotFoundException` or `NoClassDefFoundError`.
+
+### Google Guava (`com.google.common.*`)
+
+[Guava was previously exported by an AEM system bundle. In AEM 6.5 LTS it is no
+longer exported from the container classloader.](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/upgrading-code-and-customizations)
+
+**Options:**
+
+**(a) Refactor to JDK equivalents** — preferred for light usage. See
+`removed-bundles-remediation.md` for the full mapping table.
+
+**(b) Embed as private OSGi package** — required for heavy usage where refactoring
+is impractical. Add `Embed-Dependency` and `Private-Package` instructions to the
+bundle plugin configuration. The Guava classes will be classloader-isolated to that
+bundle and will not conflict with other bundles.
+
+### Caffeine (`com.github.benmanes.caffeine.*`)
+
+[Caffeine is not deployed to the AEM 6.5 LTS OSGi runtime.](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/upgrading-code-and-customizations) Code using
+`Caffeine.newBuilder()` or any `com.github.benmanes.caffeine.*` class will fail at
+runtime.
+
+Same options as Guava: refactor to `ConcurrentHashMap.computeIfAbsent()` for
+simple caching, or embed Caffeine as a private package for complex cache policies.
+
+### Jetty (`org.eclipse.jetty.*`)
+
+[Jetty is the embedded servlet container in AEM but its packages are not exported
+from the system classloader into application bundles.](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/upgrading-code-and-customizations) Direct use of Jetty APIs
+(e.g., `org.eclipse.jetty.server.*`, `org.eclipse.jetty.client.*`) is unsupported
+in application code.
+
+Replace with Servlet API abstractions (`javax.servlet.*`) for inbound request
+handling, and use the OSGi `HttpService` or Sling `SlingHttpServletRequest` /
+`SlingHttpServletResponse` wrappers.
+
+### Apache Commons Collections 3 (`org.apache.commons.collections`)
+
+Version 3.x of Commons Collections is no longer on the AEM runtime classpath.
+Migrate all usages to Commons Collections 4 (`org.apache.commons.collections4`).
+
+The top-level package name changes from `org.apache.commons.collections` to
+`org.apache.commons.collections4`. Most class names are identical; the migration
+is primarily an import update. Verify generics — Collections4 enforces proper
+generic type parameters that Collections3 often omitted.
+
+---
+
+## References
+
+- [AEM 6.5 LTS GA release notes](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/release-notes/service-pack/ga)
+- [AEM 6.5 LTS SP2 release notes](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/release-notes/release-notes)
+- [Upgrading code and customizations](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/upgrading-code-and-customizations)
+- [AEM 6.5 LTS FAQ](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/release-notes/faq)
+- [AEM 6.5 LTS Analyzer Tool](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/aem-analyzer)
+- [Java deprecated and removed features](https://experienceleague.adobe.com/en/docs/experience-manager-65/content/release-notes/deprecated-removed-features)

--- a/plugins/aem/6.5-lts/skills/java21-migration/references/openrewrite-commands.md
+++ b/plugins/aem/6.5-lts/skills/java21-migration/references/openrewrite-commands.md
@@ -1,0 +1,147 @@
+# OpenRewrite Commands
+
+The `aem-migrate` CLI is the only supported entry point. It packages a fixed pair
+of recipe artefact coordinates (`rewrite-migrate-java`, `rewrite-testing-frameworks`)
+plus the in-tree `aem65lts-migration-recipes` JAR, and resolves the active recipe
+names from the bundled `META-INF/config/openrewrite/recipes/*.yaml` declarative
+recipes via OpenRewrite classpath discovery.
+
+There is intentionally **one** invocation path. Hand-crafted `mvn rewrite:run`
+invocations are not supported because the recipe-artefact / recipe-name pairing
+is brittle and a single mismatched coordinate (for example
+`rewrite-migrate-java:3.9.0` vs `:3.18.0`) silently changes the set of resolvable
+recipes. Pinning both ends in code is what makes the pipeline reproducible.
+
+For the upstream OpenRewrite recipe catalog and Maven plugin reference, see the
+[OpenRewrite documentation](https://docs.openrewrite.org/).
+
+## CLI Invocations
+
+```bash
+MIGRATE_JAR="$SKILL_DIR/aem65lts-migration-cli/target/aem65lts-migration-cli-1.0-SNAPSHOT.jar"
+
+# Full automated migration (8-step pipeline — see workflows/migrate.md)
+java -jar "$MIGRATE_JAR" full-migrate \
+    -r "$AEM_PROJECT_PATH" \
+    --sourceJavaHome "$JAVA8_HOME" \
+    --java11Home    "$JAVA11_HOME" \
+    --javaHome      "$JAVA21_HOME"
+
+# Individual phases (each can be re-run in isolation)
+java -jar "$MIGRATE_JAR" analyze              -r "$AEM_PROJECT_PATH"
+java -jar "$MIGRATE_JAR" upgrade-code         -r "$AEM_PROJECT_PATH" -j "$JAVA11_HOME"
+java -jar "$MIGRATE_JAR" upgrade-plugins      -r "$AEM_PROJECT_PATH" -j "$JAVA11_HOME"
+java -jar "$MIGRATE_JAR" upgrade-dependencies -r "$AEM_PROJECT_PATH" -j "$JAVA11_HOME"
+java -jar "$MIGRATE_JAR" upgrade-uberjar      -r "$AEM_PROJECT_PATH" -j "$JAVA11_HOME"
+java -jar "$MIGRATE_JAR" upgrade-tests        -r "$AEM_PROJECT_PATH" -j "$JAVA21_HOME"
+java -jar "$MIGRATE_JAR" verify               -r "$AEM_PROJECT_PATH"
+```
+
+Every command supports `--dryRun` / `-d` to surface the diff without writing it
+back to the working tree, and exits non-zero if the underlying `rewrite-maven-plugin`
+run fails.
+
+## JDK Selection per Phase
+
+| Phase | Required JDK | Why |
+|---|---|---|
+| `analyze` | any | Read-only AST scan of `*.java` and `pom.xml` — no compilation. |
+| `upgrade-code`, `upgrade-plugins`, `upgrade-dependencies`, `upgrade-uberjar` | **JDK 11** | The `rewrite-maven-plugin` parser must accept both the pre-migration source level (8 or 11) and the post-migration target (21). JDK 11 is the lowest common denominator that parses Java 8 source correctly while still being supported by `rewrite-maven-plugin`. |
+| `upgrade-tests` | **JDK 21** | At this point the project has already been moved to Java 21 source and Mockito 5.x needs the matching bytecode level. |
+| `verify` | any | Reads POMs and Java sources for static checks; never compiles. |
+
+If the source project is Java 8 and `upgrade-code` fails to parse a file under
+JDK 11 (rare, caused by legacy toolchain configuration), re-run that single phase
+with `-j "$JAVA8_HOME"`. The CLI never modifies the project's enforced JDK
+floor; JDK selection is a runtime concern only.
+
+## Active Recipe Wiring
+
+The phase boundaries match the active recipe name passed by each CLI command.
+Active recipes live in
+`aem65lts-migration-cli/src/main/resources/META-INF/config/openrewrite/recipes/`
+and are loaded automatically via OpenRewrite classpath discovery — there is no
+filesystem `configLocation` to manage.
+
+| Active recipe | Loaded from | Phase |
+|---|---|---|
+| `aem.lts.migration.UpgradeToAEM65LTS` | `65LTSUpgrade.yaml` | `upgrade-code` and `full-migrate` |
+| `aem.lts.migration.UpgradePluginVersions` | `65LTSPluginUpgrades.yaml` | `upgrade-plugins` |
+| `aem.lts.migration.UpgradeCommonLibraries` | `65LTSDependencyUpgrades.yaml` | `upgrade-dependencies` |
+| `aem.lts.migration.UpdateUberJarVersion` | `65LTSUpgradeUberJar.yaml` | `upgrade-uberjar` |
+| `aem.lts.migration.UpgradeTestingFrameworks` | `65LTSTestLibsUpgrades.yaml` | `upgrade-tests` |
+
+### `aem.lts.migration.UpgradeToAEM65LTS`
+
+Composes the upstream `org.openrewrite.recipe:rewrite-migrate-java` Java 8 →
+11 → 17 → 21 chain with the four custom AEM-specific recipes
+(`ChangeFilevaultEmbeddedArtifact`, `RemoveBndPluginInstruction`,
+`RevertJakartaInAemSource`, `DetectUnsupportedPackages`).
+
+It explicitly **excludes** the upstream `javax → jakarta` migration: AEM 6.5
+LTS exports `javax.*`. An accidental swap compiles but produces a runtime
+no-op (e.g. `@PostConstruct` callbacks never fire). The
+`RevertJakartaInAemSource` safeguard reverts any stray jakarta imports
+re-introduced by a transitive composite.
+
+### `aem.lts.migration.UpgradeTestingFrameworks`
+
+Mockito makes hard-cut API changes between every major version. The recipe
+runs four staged sub-chains in order: `MockitoOneToThree` →
+`MockitoThreeToFour` → `MockitoFourToFive` → `MockitoCleanup`. Skipping a
+stage causes compilation chaos because intermediate API renames (for
+example `Matchers` → `ArgumentMatchers`) only exist in the intermediate
+versions.
+
+## Determinism Guarantees
+
+The custom recipes ship with idempotency tests
+(`*IdempotencyTest` in `aem65lts-migration-recipes/src/test/`) that run each
+recipe twice over its expected post-migration output and assert that the
+second run produces zero changes. This catches accidental visitor reruns,
+oscillating edits, and order-dependent transforms before they reach a
+customer codebase. The bundled declarative composites are exercised by the
+same harness via their constituent custom recipes.
+
+`--dryRun` on every CLI command exposes the diff without writing it back —
+running the same command twice with `--dryRun` against a freshly migrated
+project must produce an empty diff. This is the contract any new recipe in
+this skill is expected to uphold.
+
+## Maven Build Command (manual phase verification)
+
+The CLI does not invoke `mvn install` on the target project — that remains a
+separate concern. Use the following invocation for the three intermediate
+verification builds (initial baseline, pre-Mockito, final):
+
+```bash
+cd "$AEM_PROJECT_PATH" && \
+env JAVA_HOME="$JAVA_HOME_FOR_THIS_PHASE" PATH="$JAVA_HOME_FOR_THIS_PHASE/bin:$PATH" \
+mvn clean install \
+    -Dmaven.clean.failOnError=false \
+    -DskipTests \
+    -DskipFrontend=true \
+    -Dassembly.skipAssembly=true \
+    -Dcheckstyle.skip=true \
+    -Dvault.skipValidation=true \
+    -Dsling.install.skip=true \
+    -Dexec.skip=true \
+    -Dpackage.skip=true \
+    -Dosgi.bundle.status.skip=true
+```
+
+| Phase | JDK | Purpose |
+|---|---|---|
+| Initial build | source (8 or 11) | Verify project compiles before migration. |
+| Pre-Mockito build | 21 | Verify Java 21 migration succeeded before touching tests. |
+| Final build | 21 | Verify Mockito migration succeeded. |
+
+---
+
+## References
+
+- [OpenRewrite documentation](https://docs.openrewrite.org/)
+- [rewrite-migrate-java recipes](https://docs.openrewrite.org/recipes/java/migrate)
+- [rewrite-testing-frameworks Mockito recipes](https://docs.openrewrite.org/recipes/java/testing/mockito)
+- [AEM 6.5 LTS GA release notes](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/release-notes/service-pack/ga)
+- [Upgrading code and customizations (AEM 6.5 LTS)](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/upgrading-code-and-customizations)

--- a/plugins/aem/6.5-lts/skills/java21-migration/references/pom-manipulation-rules.md
+++ b/plugins/aem/6.5-lts/skills/java21-migration/references/pom-manipulation-rules.md
@@ -1,0 +1,125 @@
+# POM Manipulation Rules
+
+The migration tool applies targeted POM transformations that stock OpenRewrite
+recipes do not cover. All transformations are implemented as **AST-based
+[OpenRewrite](https://docs.openrewrite.org/) recipes**, not text-substitution scripts. This means:
+
+- Original POM formatting, comments, and indentation are preserved by construction
+- Transformations are idempotent (re-running produces the same result)
+- Edits are deterministic (no LLM, no regex fragility)
+
+Custom recipes are defined in the `aem65lts-migration-recipes` Maven module and
+invoked from the composite recipe `aem.lts.migration.UpgradeMavenPluginConfigurations`
+inside `65LTSUpgrade.yaml`.
+
+## Custom Recipes
+
+### `ChangeFilevaultEmbeddedArtifact`
+
+Updates `<embedded>` artefact coordinates inside the
+`filevault-package-maven-plugin` configuration. Targets the Groovy Console
+artefact whose project moved to the `be.orbinson.aem` groupId.
+
+| Option | Required | Example | Purpose |
+|--------|----------|---------|---------|
+| `oldGroupId` | yes | `com.icfolson.aem*` | Glob pattern matching the current groupId |
+| `oldArtifactId` | yes | `aem-groovy-console*` | Glob pattern matching the current artifactId |
+| `newGroupId` | yes | `be.orbinson.aem` | Replacement groupId |
+| `newArtifactId` | no | `aem-groovy-console` | Replacement artifactId (omit to keep original) |
+
+The visitor walks each `<plugin>` element, verifies its `<artifactId>` is
+`filevault-package-maven-plugin`, then navigates `configuration > embeddeds >
+embedded` and applies `ChangeTagValueVisitor` for each matched child tag.
+
+### `RemoveBndPluginInstruction`
+
+Removes `<_plugin>` instruction elements from `maven-bundle-plugin`
+configuration that match a text pattern. Used to remove `SCRDescriptorBndPlugin`
+which is incompatible with Java 21 and BND 6.x.
+
+| Option | Required | Example |
+|--------|----------|---------|
+| `instructionPattern` | yes | `SCRDescriptorBndPlugin` |
+
+The visitor walks each `<_plugin>` tag, verifies it sits inside a
+`maven-bundle-plugin > configuration > instructions` ancestor chain, then
+schedules `RemoveContentVisitor` if the tag content matches the pattern.
+
+### `RevertJakartaInAemSource`
+
+Java source-code safeguard. AEM 6.5 LTS uses the `javax` namespace; `jakarta`
+annotations compile but fail silently at runtime (e.g. `@PostConstruct` methods
+are never called). If any upstream recipe inadvertently introduces a jakarta
+import, this recipe restores the javax equivalent.
+
+Detection rule: a file is treated as AEM source if it imports any of
+`com.adobe.*`, `org.apache.sling.*`, `com.day.cq.*`, `org.apache.jackrabbit.*`,
+or `org.apache.felix.*`.
+
+Reverted mappings:
+
+| Jakarta import | Javax replacement |
+|----------------|-------------------|
+| `jakarta.annotation.*` | `javax.annotation.*` |
+| `jakarta.inject.*` | `javax.inject.*` |
+| `jakarta.servlet.*` | `javax.servlet.*` |
+| `jakarta.jcr.*` | `javax.jcr.*` |
+| `jakarta.json.*` | `javax.json.*` |
+
+This recipe is included in `UpgradeMavenPluginConfigurations` as a safeguard
+and is also enforced by the `aem-migrate verify` command.
+
+### `DetectUnsupportedPackages`
+
+Read-only scanning recipe used by `aem-migrate analyze`. Marks each import
+finding with an OpenRewrite `SearchResult` so the analyser can report blockers
+and warnings without modifying source code.
+
+**BLOCKER patterns** (migration cannot proceed):
+
+| Pattern | Reason |
+|---------|--------|
+| `com.adobe.cq.commerce.*` | AEM Commerce — requires separate migration |
+| `com.adobe.cq.social.*` | AEM Communities — removed |
+| `com.adobe.granite.social.*` | Granite Social framework — removed |
+| `com.adobe.cq.screens.*` | AEM Screens — separate migration path |
+| `com.adobe.cq.sample.we.retail.*` | Sample code — should be removed before migration |
+| `com.day.cq.dam.pim.*` | DAM PIM — deprecated |
+| `com.day.cq.dam.rating.*` | DAM rating — deprecated |
+| `com.adobe.cq.searchpromote.*` | Search & Promote — discontinued |
+| `com.adobe.cq.mcm.campaign.*` | MCM Campaign — discontinued |
+
+**WARNING patterns** (migration can proceed but remediation needed):
+
+| Pattern | Reason | Remediation |
+|---------|--------|-------------|
+| `com.google.common.*` | Guava removed from AEM 6.5 LTS runtime | See `removed-bundles-remediation.md` |
+| `com.github.benmanes.caffeine.*` | Caffeine not deployed | Embed or refactor |
+| `org.eclipse.jetty.*` | Jetty not exported | Use Servlet API abstractions |
+| `org.apache.commons.collections.*` (not `.collections4.*`) | Commons Collections 3 deprecated | Migrate to Collections 4 |
+
+## Why Custom Recipes Instead of Text Manipulation?
+
+Earlier prototypes used text-substitution scripts to manipulate POM files.
+That approach has well-known failure modes. See [Maven plugin development documentation](https://maven.apache.org/plugin-developers/index.html) and [OpenRewrite visitor API docs](https://docs.openrewrite.org/concepts-explanations/visitors) for background on the AST approach:
+
+- **Formatting drift**: text substitution must guess at whitespace
+- **Ordering assumptions**: `<groupId>` may appear before or after `<artifactId>`
+- **Property indirection**: a `<version>` may be a literal or `${prop.name}`
+- **Profile scoping**: the same plugin may appear in multiple `<profile>` blocks
+- **Comments and CDATA**: regex matches inside comments cause false positives
+- **Re-run safety**: text substitution is not idempotent in the general case
+
+OpenRewrite recipes solve all of these by operating on the parsed XML LST
+(Lossless Semantic Tree), so transformations are structurally aware while
+formatting is preserved.
+
+---
+
+## References
+
+- [OpenRewrite documentation](https://docs.openrewrite.org/)
+- [OpenRewrite visitor API](https://docs.openrewrite.org/concepts-explanations/visitors)
+- [rewrite-migrate-java recipes](https://docs.openrewrite.org/recipes/java/migrate)
+- [Maven plugin development guide](https://maven.apache.org/plugin-developers/index.html)
+- [Upgrading code and customizations](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/upgrading-code-and-customizations)

--- a/plugins/aem/6.5-lts/skills/java21-migration/references/post-migration-checklist.md
+++ b/plugins/aem/6.5-lts/skills/java21-migration/references/post-migration-checklist.md
@@ -1,0 +1,277 @@
+# Post-Migration Verification Checklist
+
+This checklist must be completed in full before a migrated codebase is considered
+ready for deployment to any non-local environment. Work through sections in order —
+each section depends on the previous one passing cleanly.
+
+---
+
+## Section 1: Automated Checks
+
+Run the migration verification script against the repository root. All checks must
+pass before proceeding to Section 2.
+
+### POM Compiler Settings
+
+- [ ] Every `pom.xml` that contains a `maven-compiler-plugin` configuration has
+      `<release>21</release>` (or `<source>21</source>` + `<target>21</target>`).
+      No module should still compile to an earlier release.
+
+- [ ] No `pom.xml` contains `<source>8</source>`, `<source>1.8</source>`,
+      `<source>11</source>`, or `<target>` values below 21.
+
+- [ ] The `maven-enforcer-plugin` `requireJavaVersion` rule is set to `[21,)` in
+      every module that declares it. No module lowers the floor.
+
+### Namespace Integrity
+
+- [ ] Zero occurrences of `import jakarta.annotation.` in `src/main/java`.
+- [ ] Zero occurrences of `import jakarta.inject.` in `src/main/java`.
+- [ ] Zero occurrences of `import jakarta.servlet.` in `src/main/java`.
+- [ ] All `@PostConstruct` and `@PreDestroy` imports resolve to `javax.annotation`.
+- [ ] All `@Inject` imports resolve to `javax.inject.Inject`.
+
+  Verification command:
+  ```bash
+  grep -rn "import jakarta\." src/main/java --include="*.java"
+  # Expected: no output
+  ```
+
+### Temporary Workaround Markers
+
+- [ ] Zero `MIGRATION_TEMP_START` markers remain in any source file.
+- [ ] Zero `MIGRATION_TEMP_END` markers remain in any source file.
+
+  Verification command:
+  ```bash
+  grep -rn "MIGRATION_TEMP_START\|MIGRATION_TEMP_END" src/ pom.xml **/pom.xml
+  # Expected: no output
+  ```
+
+### Cloud Manager Java Version File
+
+- [ ] The file `.cloudmanager/java-version` exists at the repository root.
+- [ ] Its content is exactly `21` (no trailing spaces, single newline).
+
+  Verification command:
+  ```bash
+  cat .cloudmanager/java-version
+  # Expected output: 21
+  ```
+
+### AEM UberJar
+
+- [ ] The uber-jar `<version>` is `6.6.0` (or the version specified in the migration
+      target config).
+- [ ] The uber-jar `<classifier>` is `apis`.
+- [ ] No module references the old uber-jar without the `apis` classifier.
+
+  Verification command:
+  ```bash
+  grep -rn "uber-jar" pom.xml **/pom.xml | grep -v "apis"
+  # Expected: no output (all uber-jar references include classifier=apis)
+  ```
+
+### Duplicate Dependencies
+
+- [ ] Running `mvn dependency:analyze` produces no `WARN  Duplicate artifact` lines.
+- [ ] No module declares both `commons-collections` (v3) and
+      `commons-collections4` (v4) — only the v4 artifact should be present.
+
+### Unsupported Package Imports
+
+- [ ] Zero `import com.google.common.` in `src/main/java` unless the module embeds
+      Guava as a private OSGi package (confirmed in plugin config).
+- [ ] Zero `import org.eclipse.jetty.` in `src/main/java`.
+- [ ] Zero `import org.apache.commons.collections.` (v3) — only
+      `org.apache.commons.collections4.` is permitted.
+- [ ] Zero `import com.github.benmanes.caffeine.` in `src/main/java` unless the module
+      embeds Caffeine as a private OSGi package.
+
+### Build Passes with JDK 21
+
+- [ ] A clean build (`mvn clean install -DskipTests`) completes with `BUILD SUCCESS`
+      when executed with JDK 21.
+- [ ] No `[WARNING]` lines related to unchecked casts, deprecated APIs, or
+      serialisation issues that were not present before migration (new warnings
+      introduced by the migration must be resolved, not suppressed).
+
+---
+
+## Section 2: Manual Code Review
+
+A human reviewer must inspect every file touched by the migration before this section
+is marked complete.
+
+### AI-Assisted Fix Annotations
+
+- [ ] Every block of code added or materially rewritten by the automated migration
+      carries an `// aem-lts-migration: ai-fix` comment.
+- [ ] The annotated code is reviewed line-by-line for correctness. Automated fixes
+      are not inherently correct; they must be verified by a developer with knowledge
+      of the component's intended behaviour.
+- [ ] The complete list of AI-assisted fixes is recorded in the migration report.
+
+### Business Logic Integrity
+
+- [ ] No `if`, `for`, `while`, `switch`, or `return` statement in production code was
+      changed except where strictly required to compile against Java 21.
+- [ ] No algorithm or data processing logic was rewritten or restructured during
+      migration (only import changes, type parameter additions, and API substitutions
+      are permitted).
+- [ ] All public method signatures (name, parameter types, return type) are unchanged
+      unless a removed API forced a signature change. Any signature change must be
+      documented in the migration report.
+
+### Test Assertion Integrity
+
+- [ ] No `assertEquals`, `assertThat`, `assertTrue`, `verify`, or similar assertion
+      was removed or weakened (e.g., replaced with `assertNotNull` where a specific
+      value was previously asserted).
+- [ ] No test was disabled (via `@Disabled`, `@Ignore`, or commenting out) to work
+      around a migration issue.
+- [ ] Tests that previously tested the behaviour of a removed API (e.g., Guava
+      `LoadingCache`) now test the equivalent replacement behaviour.
+
+### POM Formatting
+
+- [ ] The diff of each `pom.xml` contains only the lines that were intentionally
+      changed (dependency versions, plugin versions, compiler settings). No
+      reformatting, indentation changes, or XML attribute reordering is present.
+- [ ] This can be verified by reviewing the `git diff` for each `pom.xml` and
+      confirming every changed line maps to a documented migration action.
+
+---
+
+## Section 3: Runtime Verification
+
+These checks require access to a running AEM 6.5 LTS instance with the migrated
+bundles deployed. They cannot be substituted with build-time checks.
+
+### Bundle Resolution (Felix Console)
+
+See [Apache Sling OSGi bundle documentation](https://sling.apache.org/documentation/) for Felix web console guidance.
+
+- [ ] Navigate to `/system/console/bundles`.
+- [ ] Every application bundle is in `Active` state.
+- [ ] Zero bundles are in `Installed`, `Resolved` (without being `Active`), or
+      `Failure` state.
+- [ ] The bundle count in `Active` state matches the count from the pre-migration
+      baseline (no bundles were accidentally dropped from the deployment).
+
+### Sling Models Registration
+
+See [Apache Sling Models documentation](https://sling.apache.org/documentation/bundles/models.html) for registration and injection details.
+
+- [ ] Navigate to `/system/console/status-slingmodels`.
+- [ ] Every Sling Model class present before migration is listed.
+- [ ] No model shows a registration error or `Unresolvable` status.
+- [ ] Models that use `@Inject` fields are spot-checked: inject a known resource or
+      OSGi service and confirm the field is non-null at runtime.
+
+### OSGi Service Activation
+
+- [ ] Navigate to `/system/console/components`.
+- [ ] Every `@Component`-annotated class is in `Active` state.
+- [ ] Zero components are in `Unsatisfied` or `Failure` state.
+- [ ] For components with `@Reference` fields, confirm each reference shows as
+      `satisfied` in the component detail view.
+
+### Lifecycle Callback Verification
+
+- [ ] Add a log statement at `INFO` level to at least one `@PostConstruct` method in
+      each migrated bundle (or confirm existing log statements are present).
+- [ ] Deploy the bundle and verify the log message appears in `error.log` or
+      `stdout` within 30 seconds of bundle activation.
+- [ ] Remove test log statements before promotion to higher environments.
+
+**Why this check is critical:** Jakarta annotation imports compile and deploy without
+error but produce no log output. This check is the only reliable way to confirm
+`@PostConstruct` is actually executing.
+
+### ClassNotFoundException / NoClassDefFoundError
+
+- [ ] Monitor `error.log` for 5 minutes after bundle deployment. Zero
+      `ClassNotFoundException` or `NoClassDefFoundError` entries are acceptable.
+- [ ] If errors appear, identify the offending class and check whether its containing
+      package is in the removed-bundle list (`migration-guardrails.md`).
+
+### Dispatcher Cache Rules
+
+- [ ] Send requests for at least 3 different page types through the Dispatcher.
+- [ ] Confirm that cache headers (`Cache-Control`, `Dispatcher-TTL`) are present and
+      match pre-migration values.
+- [ ] Confirm that the Dispatcher cache is being populated (check cache directory for
+      newly created `.html` files after a cache flush).
+- [ ] Invalidation requests from AEM author still propagate to the Dispatcher
+      correctly (publish a page, observe the corresponding cache file is deleted).
+
+### Content Rendering
+
+- [ ] Render 5 representative pages of each major template type (landing page,
+      article, product detail, etc.) and visually compare with the pre-migration
+      baseline screenshots.
+- [ ] No `WCMMode.DISABLED` rendering errors appear in page source (`class="parbase
+      error"`).
+- [ ] HTL / Sightly expressions that use Sling Models render expected values.
+- [ ] Forms (if present) still submit and process correctly.
+
+---
+
+## Section 4: Performance Validation
+
+### Page Load Times
+
+- [ ] Run a load test against at least 3 representative pages using the same tool and
+      configuration as the pre-migration performance baseline.
+- [ ] P50 response time is within 10% of the pre-migration baseline.
+- [ ] P95 response time is within 15% of the pre-migration baseline.
+- [ ] No new timeouts (HTTP 504) were observed that were not present in the baseline.
+
+### Memory and GC Behaviour
+
+Refer to the [Java 21 GC tuning documentation](https://docs.oracle.com/en/java/javase/21/gctuning/) when evaluating GC behaviour after migration.
+
+- [ ] Monitor the JVM heap for 30 minutes under representative load.
+- [ ] No `java.lang.OutOfMemoryError: Java heap space` events.
+- [ ] GC pause times (observable via JVM flags `-Xlog:gc*` or via JMX) are not
+      materially higher than the pre-migration baseline.
+- [ ] If the JVM is configured to use ZGC (`-XX:+UseZGC`), confirm pause times are
+      consistently below 1 ms under normal load (ZGC is the recommended collector for
+      Java 21 with AEM 6.5 LTS).
+- [ ] If using G1GC, confirm no `To-space exhausted` events appear in GC logs.
+
+### Thread Usage
+
+- [ ] Thread count under load is not materially higher than the pre-migration baseline
+      (check via `/system/console/status-threads` or JMX `java.lang:type=Threading`).
+- [ ] No thread deadlocks (`java.lang.management.ThreadMXBean.findDeadlockedThreads()`
+      returns null).
+
+---
+
+## Completion Sign-Off
+
+All four sections must pass before marking the migration complete:
+
+| Section | Pass / Fail | Reviewer | Date |
+|---------|------------|----------|------|
+| 1 — Automated Checks | | | |
+| 2 — Manual Code Review | | | |
+| 3 — Runtime Verification | | | |
+| 4 — Performance Validation | | | |
+
+The migration is complete when all four rows show **Pass** and are signed by a
+reviewer with commit access to the repository.
+
+---
+
+## References
+
+- [AEM 6.5 LTS GA release notes](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/release-notes/service-pack/ga)
+- [AEM 6.5 LTS SP2 release notes](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/release-notes/release-notes)
+- [Upgrading code and customizations](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/upgrading-code-and-customizations)
+- [AEM 6.5 LTS FAQ](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/release-notes/faq)
+- [Apache Sling documentation](https://sling.apache.org/documentation/)
+- [Apache Sling Models documentation](https://sling.apache.org/documentation/bundles/models.html)
+- [Java 21 GC tuning guide](https://docs.oracle.com/en/java/javase/21/gctuning/)

--- a/plugins/aem/6.5-lts/skills/java21-migration/references/prerequisites.md
+++ b/plugins/aem/6.5-lts/skills/java21-migration/references/prerequisites.md
@@ -1,0 +1,83 @@
+# Prerequisites
+
+The skill is invoked as a CLI process and assumes the host machine has the
+toolchain available before the agent runs anything. Every prerequisite is
+checked at the top of the workflow (`workflows/migrate.md` step 1) and the
+migration terminates with a clear error if any item is missing.
+
+## Tool Matrix
+
+| Tool | Min version | Why it is needed | How to verify |
+|---|---|---|---|
+| JDK 8 | `1.8.0_311+` | Compiles a baseline build of projects that were originally authored against Java 8; some Maven Toolchains setups also pin Java 8 for `rewrite-maven-plugin` invocations on legacy modules. | `"$JAVA8_HOME/bin/java" -version` reports `1.8.x` |
+| JDK 11 | `11.0.20+` | Default JDK for `upgrade-code`, `upgrade-plugins`, `upgrade-dependencies`, `upgrade-uberjar`. JDK 11 is the lowest common denominator that parses Java 8 sources while remaining supported by `rewrite-maven-plugin`. | `"$JAVA11_HOME/bin/java" -version` reports `11.x` |
+| JDK 21 | `21.0.0+` | Runs the post-migration build phases and `upgrade-tests`, which needs Mockito 5.x at matching bytecode level. Also the runtime target of the migrated project. | `"$JAVA21_HOME/bin/java" -version` reports `21.x` |
+| Maven | `3.9.x` | Drives `rewrite-maven-plugin` from the CLI's Maven Invoker; older 3.6/3.8 lines have known issues with the plugin's classpath isolation. | `mvn --version` reports `3.9.x` |
+| Git | `2.30+` | The migration commits to a fresh branch, so `git` must be available and the project working tree must be clean. | `git --version` |
+
+The skill does **not** require Python, Node.js, or Docker on the host — every
+transformation runs through the bundled CLI JAR using the local Maven
+installation.
+
+## Environment Variables
+
+Three JDK locations are read from the environment. The `--javaHome`
+arguments on individual CLI commands override these per-phase, so the
+environment defaults only matter when the agent invokes `full-migrate`
+without per-phase overrides.
+
+| Variable | Required? | Read by | Notes |
+|---|---|---|---|
+| `JAVA8_HOME` | When source project is Java 8 | `full-migrate --sourceJavaHome` | Skip if the source project is Java 11. |
+| `JAVA11_HOME` | Always | `full-migrate --java11Home`, `upgrade-code`, `upgrade-plugins`, `upgrade-dependencies`, `upgrade-uberjar` | The default OpenRewrite JDK. |
+| `JAVA21_HOME` | Always | `full-migrate --javaHome`, `upgrade-tests`, post-migration builds | The migration target. |
+| `AEM_PROJECT_PATH` | Always | All CLI commands via `-r/--repository-path` | Absolute path to the project root containing `pom.xml`. |
+| `MAVEN_HOME` / `PATH` | Always | Maven Invoker discovers `mvn` from `PATH` first, falls back to `MAVEN_HOME`. | Either works. |
+
+A sample shell-profile snippet:
+
+```bash
+export JAVA8_HOME=/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home
+export JAVA11_HOME=/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home
+export JAVA21_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
+```
+
+## Project State
+
+The target project must be in a state that allows a clean migration commit:
+
+- A `pom.xml` exists at `$AEM_PROJECT_PATH`.
+- `$AEM_PROJECT_PATH/.git` is a Git working tree.
+- `git status --porcelain` produces no output (clean working tree).
+- All required JDKs above resolve at the paths in their `*_HOME` variables.
+- Maven can reach Maven Central or the configured internal mirror.
+
+The `analyze` subcommand checks the first four items, plus the
+unsupported-package scan, and exits non-zero if any fails. Run it before
+`full-migrate`:
+
+```bash
+java -jar "$MIGRATE_JAR" analyze -r "$AEM_PROJECT_PATH"
+```
+
+## Build the CLI Once Per Checkout
+
+The CLI is built from this skill's own Maven reactor:
+
+```bash
+cd "$SKILL_DIR"
+mvn clean install -DskipTests
+```
+
+The shaded executable JAR lands at
+`aem65lts-migration-cli/target/aem65lts-migration-cli-1.0-SNAPSHOT.jar`.
+The `aem65lts-migration-recipes` module is also installed into the local
+Maven repository so the CLI's own `rewrite-maven-plugin` invocations can
+resolve it as a recipe artefact.
+
+## References
+
+- [AEM 6.5 LTS GA release notes](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/release-notes/service-pack/ga)
+- [Apache Maven 3.9 release notes](https://maven.apache.org/docs/3.9.0/release-notes.html)
+- [Eclipse Temurin JDK 21 downloads](https://adoptium.net/temurin/releases/?version=21)
+- [AEM UberJar on Maven Central](https://mvnrepository.com/artifact/com.adobe.aem/uber-jar)

--- a/plugins/aem/6.5-lts/skills/java21-migration/references/removed-bundles-remediation.md
+++ b/plugins/aem/6.5-lts/skills/java21-migration/references/removed-bundles-remediation.md
@@ -1,0 +1,329 @@
+# Removed Bundle Remediation Guide
+
+This document provides concrete, step-by-step remediation for every library that is
+no longer available on the AEM 6.5 LTS runtime classpath. For each library, two
+strategies are offered: (a) refactor to a JDK or alternative API (preferred when
+usage is light), and (b) embed the library as a private OSGi package (required when
+the effort of refactoring is disproportionate to the risk).
+
+---
+
+## Google Guava (`com.google.common.*`)
+
+Guava is [no longer exported from the AEM 6.5 LTS runtime](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/upgrading-code-and-customizations). See also [deprecated and removed features](https://experienceleague.adobe.com/en/docs/experience-manager-65/content/release-notes/deprecated-removed-features) for the full scope of removals.
+
+### Assessment: Light vs. Heavy Usage
+
+Count usages before choosing a strategy:
+
+```bash
+grep -r "com.google.common" src/main/java --include="*.java" | wc -l
+```
+
+- **Fewer than 20 usages across the module:** refactor to JDK equivalents.
+- **20 or more usages, or usage of `LoadingCache` / `ListenableFuture`:** embed Guava
+  as a private OSGi package.
+
+### Strategy A — Refactor to JDK Equivalents
+
+The following table maps every commonly used Guava class or method to its JDK
+replacement. All JDK equivalents listed are available in [Java 11+](https://docs.oracle.com/en/java/javase/21/docs/api/).
+
+| Guava | JDK Equivalent | Notes |
+|-------|---------------|-------|
+| `ImmutableList.of(...)` | `List.of(...)` | Null-hostile (throws NPE), unmodifiable |
+| `ImmutableList.copyOf(collection)` | `List.copyOf(collection)` | Same null-hostile semantics |
+| `ImmutableMap.of(k,v,...)` | `Map.of(k,v,...)` | Max 10 entries; use `Map.ofEntries()` beyond that |
+| `ImmutableMap.copyOf(map)` | `Map.copyOf(map)` | |
+| `ImmutableSet.of(...)` | `Set.of(...)` | |
+| `ImmutableSet.copyOf(collection)` | `Set.copyOf(collection)` | |
+| `ImmutableSortedMap` | `Collections.unmodifiableSortedMap(new TreeMap<>(...))` | No direct replacement |
+| `com.google.common.base.Optional` | `java.util.Optional` | API nearly identical |
+| `Optional.fromNullable(x)` | `Optional.ofNullable(x)` | |
+| `Optional.absent()` | `Optional.empty()` | |
+| `optional.or(default)` | `optional.orElse(default)` | |
+| `Preconditions.checkNotNull(x)` | `Objects.requireNonNull(x)` | |
+| `Preconditions.checkNotNull(x, msg)` | `Objects.requireNonNull(x, msg)` | |
+| `Preconditions.checkArgument(cond, msg)` | `if (!cond) throw new IllegalArgumentException(msg)` | No single-call replacement |
+| `Preconditions.checkState(cond, msg)` | `if (!cond) throw new IllegalStateException(msg)` | |
+| `Strings.isNullOrEmpty(s)` | `s == null \|\| s.isEmpty()` | |
+| `Strings.nullToEmpty(s)` | `s == null ? "" : s` | |
+| `Strings.emptyToNull(s)` | `(s == null \|\| s.isEmpty()) ? null : s` | |
+| `Joiner.on(sep).join(list)` | `String.join(sep, list)` | |
+| `Joiner.on(sep).join(a, b, c)` | `String.join(sep, a, b, c)` | |
+| `Joiner.on(sep).skipNulls().join(...)` | `stream.filter(Objects::nonNull).collect(Collectors.joining(sep))` | |
+| `Splitter.on(sep).split(s)` | `Arrays.stream(s.split(sep))` | Returns `Stream<String>` |
+| `Splitter.on(sep).trimResults().split(s)` | `Arrays.stream(s.split(sep)).map(String::trim)` | |
+| `Files.toString(file, charset)` | `Files.readString(file.toPath(), charset)` | Java 11+ |
+| `Files.toByteArray(file)` | `Files.readAllBytes(file.toPath())` | |
+| `Files.write(bytes, file)` | `Files.write(file.toPath(), bytes)` | |
+| `CharStreams.toString(reader)` | `reader.lines().collect(Collectors.joining("\n"))` | Or use `BufferedReader.readLine()` loop |
+| `ByteStreams.toByteArray(stream)` | `stream.readAllBytes()` | Java 11+ |
+| `ByteStreams.copy(in, out)` | `in.transferTo(out)` | Java 9+ |
+| `Lists.newArrayList()` | `new ArrayList<>()` | |
+| `Lists.newArrayList(elements...)` | `new ArrayList<>(Arrays.asList(elements...))` | |
+| `Lists.newArrayList(iterable)` | `StreamSupport.stream(iterable.spliterator(), false).collect(Collectors.toList())` | |
+| `Lists.partition(list, size)` | No direct JDK equivalent — keep Guava or implement manually | |
+| `Maps.newHashMap()` | `new HashMap<>()` | |
+| `Maps.newLinkedHashMap()` | `new LinkedHashMap<>()` | |
+| `Maps.newConcurrentMap()` | `new ConcurrentHashMap<>()` | |
+| `Maps.transformValues(map, fn)` | `map.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> fn.apply(e.getValue())))` | |
+| `Sets.newHashSet()` | `new HashSet<>()` | |
+| `Sets.union(a, b)` | `Stream.concat(a.stream(), b.stream()).collect(Collectors.toSet())` | |
+| `Sets.intersection(a, b)` | `a.stream().filter(b::contains).collect(Collectors.toSet())` | |
+| `Sets.difference(a, b)` | `a.stream().filter(e -> !b.contains(e)).collect(Collectors.toSet())` | |
+| `FluentIterable.from(col)` | `col.stream()` | |
+| `FluentIterable.from(col).filter(pred)` | `col.stream().filter(pred)` | |
+| `FluentIterable.from(col).transform(fn)` | `col.stream().map(fn)` | |
+| `FluentIterable.from(col).toList()` | `col.stream().collect(Collectors.toList())` | |
+| `Iterables.transform(col, fn)` | `col.stream().map(fn).collect(Collectors.toList())` | |
+| `Iterables.filter(col, pred)` | `col.stream().filter(pred).collect(Collectors.toList())` | |
+| `Iterables.getFirst(col, default)` | `col.stream().findFirst().orElse(default)` | |
+| `Iterables.isEmpty(col)` | `!col.iterator().hasNext()` or `col instanceof Collection c && c.isEmpty()` | |
+| `Collections2.transform(col, fn)` | `col.stream().map(fn).collect(Collectors.toList())` | |
+| `Collections2.filter(col, pred)` | `col.stream().filter(pred).collect(Collectors.toList())` | |
+
+#### Caching: `CacheBuilder` / `LoadingCache` Replacement
+
+For simple time-based eviction caches, replace with a `ConcurrentHashMap` plus
+scheduled cleanup:
+
+```java
+// Before (Guava)
+private final LoadingCache<String, MyObject> cache = CacheBuilder.newBuilder()
+    .expireAfterWrite(10, TimeUnit.MINUTES)
+    .maximumSize(1000)
+    .build(CacheLoader.from(key -> loadValue(key)));
+
+// After (JDK — suitable for moderate-traffic caches without strict eviction)
+private final ConcurrentHashMap<String, MyObject> cache = new ConcurrentHashMap<>();
+
+public MyObject get(String key) {
+    return cache.computeIfAbsent(key, this::loadValue); // aem-lts-migration: ai-fix
+}
+```
+
+For production caches that require LRU eviction, TTL, or statistics, see
+Strategy B (embed Caffeine).
+
+### Strategy B — Embed as Private OSGi Package
+
+When Guava usage is pervasive (20+ usages) or uses `LoadingCache`, `ListenableFuture`,
+or other features without clean JDK replacements, embed Guava inside the OSGi bundle
+as a private (non-exported) package.
+
+**Step 1** — Add Guava as a `compile`-scoped Maven dependency (it is already a
+transitive dependency in most AEM projects; make it explicit):
+
+```xml
+<dependency>
+  <groupId>com.google.guava</groupId>
+  <artifactId>guava</artifactId>
+  <version>32.1.3-jre</version>
+  <scope>compile</scope>
+</dependency>
+```
+
+**Step 2** — Configure `maven-bundle-plugin` to embed and privatise the package:
+
+```xml
+<plugin>
+  <groupId>org.apache.felix</groupId>
+  <artifactId>maven-bundle-plugin</artifactId>
+  <version>5.1.9</version>
+  <extensions>true</extensions>
+  <configuration>
+    <instructions>
+      <Embed-Dependency>guava;scope=compile</Embed-Dependency>
+      <Embed-Transitive>false</Embed-Transitive>
+      <Private-Package>com.google.common.*</Private-Package>
+      <!-- Ensure these do not appear in Import-Package -->
+      <Import-Package>!com.google.common.*,*</Import-Package>
+    </instructions>
+  </configuration>
+</plugin>
+```
+
+**Step 3** — Verify that `Import-Package` in the generated MANIFEST.MF does not
+include `com.google.common.*`:
+
+```bash
+mvn package -pl <module>
+unzip -p target/<bundle>.jar META-INF/MANIFEST.MF | grep "Import-Package" | grep -v "com.google.common"
+```
+
+**Isolation note:** Because Guava is embedded as a private package, it is classloader-
+isolated to this bundle. Other bundles cannot share the same instance. This is
+intentional and correct — it prevents version conflicts.
+
+---
+
+## Apache Commons Collections 3 → 4
+
+See the [Apache Commons Collections 4 migration guide](https://commons.apache.org/proper/commons-collections/upgradeto4_0.html) for detailed upgrade instructions.
+
+### Package Rename
+
+The top-level package changes from `org.apache.commons.collections` (v3) to
+`org.apache.commons.collections4` (v4).
+
+```java
+// Before (v3)
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections.Transformer;
+import org.apache.commons.collections.Predicate;
+
+// After (v4)
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.collections4.Transformer;
+import org.apache.commons.collections4.Predicate;
+```
+
+### Maven Dependency
+
+```xml
+<!-- Remove v3 -->
+<!-- <dependency>
+  <groupId>commons-collections</groupId>
+  <artifactId>commons-collections</artifactId>
+  <version>3.2.2</version>
+</dependency> -->
+
+<!-- Add v4 -->
+<dependency>
+  <groupId>org.apache.commons</groupId>
+  <artifactId>commons-collections4</artifactId>
+  <version>4.4</version>
+  <scope>provided</scope>  <!-- provided: AEM 6.5 LTS exports this package -->
+</dependency>
+```
+
+### Generics Enforcement
+
+Collections4 enforces proper generic type parameters. Raw-type usages will produce
+compiler warnings or errors under `-Xlint:unchecked`:
+
+```java
+// Before (v3 — raw type accepted)
+List result = CollectionUtils.select(inputList, predicate);
+
+// After (v4 — generics required)
+List<String> result = (List<String>) CollectionUtils.select(inputList, predicate);
+// Or preferably:
+Collection<String> result = CollectionUtils.select(inputList, (Predicate<String>) predicate);
+```
+
+---
+
+## Caffeine Cache Library
+
+[Caffeine is not deployed to the AEM 6.5 LTS OSGi runtime.](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/upgrading-code-and-customizations)
+
+### Strategy A — Replace with JDK ConcurrentHashMap (Simple Caches)
+
+```java
+// Before (Caffeine)
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+private Cache<String, Resource> resourceCache = Caffeine.newBuilder()
+    .maximumSize(500)
+    .expireAfterWrite(5, TimeUnit.MINUTES)
+    .build();
+
+// After (ConcurrentHashMap — no TTL, bounded by maximumSize approximation)
+private final ConcurrentHashMap<String, Resource> resourceCache = new ConcurrentHashMap<>(); // aem-lts-migration: ai-fix
+
+public Resource getResource(String key) {
+    return resourceCache.computeIfAbsent(key, this::loadResource); // aem-lts-migration: ai-fix
+}
+```
+
+Note: `ConcurrentHashMap.computeIfAbsent()` has no built-in eviction. For caches
+where stale entries are a concern, implement a periodic cleanup via a
+`ScheduledExecutorService`, or use Strategy B.
+
+### Strategy B — Embed Caffeine as Private OSGi Package
+
+```xml
+<dependency>
+  <groupId>com.github.ben-manes.caffeine</groupId>
+  <artifactId>caffeine</artifactId>
+  <version>3.1.8</version>
+  <scope>compile</scope>
+</dependency>
+```
+
+```xml
+<plugin>
+  <groupId>org.apache.felix</groupId>
+  <artifactId>maven-bundle-plugin</artifactId>
+  <version>5.1.9</version>
+  <configuration>
+    <instructions>
+      <Embed-Dependency>caffeine;scope=compile</Embed-Dependency>
+      <Private-Package>com.github.benmanes.caffeine.*</Private-Package>
+      <Import-Package>!com.github.benmanes.caffeine.*,*</Import-Package>
+    </instructions>
+  </configuration>
+</plugin>
+```
+
+---
+
+## Jetty (`org.eclipse.jetty.*`)
+
+[Direct Jetty API usage in application code is unsupported.](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/upgrading-code-and-customizations) The Jetty packages are not
+exported from the OSGi system bundle to application classloaders.
+
+### Inbound Request Handling
+
+Replace Jetty-specific request/response types with Sling or Servlet API types:
+
+```java
+// Before (incorrect — Jetty-specific)
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+
+// After (correct — Servlet API, available as javax.servlet.*)
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+```
+
+For Sling servlets, extend `SlingSafeMethodsServlet` or `SlingAllMethodsServlet` and
+use `SlingHttpServletRequest` / `SlingHttpServletResponse`.
+
+### HTTP Client Usage
+
+If the codebase uses Jetty's `HttpClient` for outbound requests:
+
+```java
+// Before (Jetty HttpClient — not available)
+import org.eclipse.jetty.client.HttpClient;
+
+// After (Apache HttpComponents — available via AEM platform)
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+```
+
+Or use the OSGi `HttpClientBuilderFactory` service provided by the Sling
+HTTP client bundle for a container-managed client instance.
+
+### WebSocket Usage
+
+If Jetty WebSocket APIs are used (`org.eclipse.jetty.websocket.*`), this is not
+supported in AEM application bundles and must be removed. The AEM Dispatcher or an
+external reverse proxy should handle WebSocket upgrade for client-facing use cases.
+
+---
+
+## References
+
+- [Upgrading code and customizations](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/implementing/deploying/upgrading/upgrading-code-and-customizations)
+- [Java deprecated and removed features](https://experienceleague.adobe.com/en/docs/experience-manager-65/content/release-notes/deprecated-removed-features)
+- [Java 21 API documentation](https://docs.oracle.com/en/java/javase/21/docs/api/)
+- [Apache Commons Collections 4 migration guide](https://commons.apache.org/proper/commons-collections/upgradeto4_0.html)
+- [AEM 6.5 LTS FAQ](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/release-notes/faq)

--- a/plugins/aem/6.5-lts/skills/java21-migration/references/validation-report.md
+++ b/plugins/aem/6.5-lts/skills/java21-migration/references/validation-report.md
@@ -1,0 +1,87 @@
+# Validation Report — java21-migration
+
+> Skill version: 1.0 (beta). Last updated: 2026-06-03.
+
+## Migration Pipeline Coverage
+
+The skill's workflow covers the full Java 8/11 → 21 migration path for AEM 6.5 LTS projects.
+
+### Steps and Tooling
+
+| Step | Action | Tool | Automated |
+|------|--------|------|-----------|
+| 1 | Validate project structure | `aem-migrate analyze` (CLI) | Yes |
+| 2 | Detect source Java version | `.cloudmanager/java-version` or `maven-compiler-plugin` | Yes |
+| 3 | Initial build (source Java) | Maven + JDK 8/11 | Yes |
+| 4 | OpenRewrite Java migration | `aem-migrate upgrade-code` → `rewrite-maven-plugin` + custom recipes | Yes |
+| 5 | Build plugin upgrades | `aem-migrate upgrade-plugins` → custom OpenRewrite recipes | Yes |
+| 6 | Dependency + UberJar upgrades | `aem-migrate upgrade-dependencies` + `upgrade-uberjar` | Yes |
+| 7 | CloudManager Java version | `aem-migrate full-migrate` writes `21` to `.cloudmanager/java-version` | Yes |
+| 8 | Pre-Mockito build (Java 21) | Maven + JDK 21 | Yes |
+| 9 | OpenRewrite Mockito migration | `aem-migrate upgrade-tests` | Yes |
+| 10 | Final build (Java 21) | Maven + JDK 21 | Yes |
+| 11 | Post-migration verification | `aem-migrate verify` | Yes |
+| 12 | Review diff and commit | Git | Agent-assisted |
+
+### OpenRewrite Recipe Coverage
+
+**65LTSUpgrade.yaml** — top-level composite (`aem.lts.migration.UpgradeToAEM65LTS`) chaining
+four sub-recipes:
+
+| Sub-Recipe | Recipes | What They Do |
+|------------|---------|-------------|
+| `UpgradeToJava21` | Java 8→11→17→21 | Cherry-picked migration recipes; **excludes** javax→jakarta |
+| `UpgradePluginVersions` | 5+ | `maven-bundle-plugin` → 5.1.9, `maven-scr-plugin` → 1.26.4 + ASM 9.7.1, `bnd-maven-plugin` → 6.4.0, `maven-compiler-plugin` release=21, `filevault-package-maven-plugin` → 1.3.6 |
+| `UpgradeCommonLibraries` | 6+ | WCM Core Components → 2.24.0, Groovy 4.0.27, Groovy Console → `be.orbinson.aem` 19.0.8 |
+| `UpgradeMavenPluginConfigurations` | 3 custom | FileVault embedded artefact migration, BND `_plugin` instruction removal, javax safeguard |
+
+**65LTSTestLibsUpgrades.yaml** — Mockito 1.x → 5.x progressive chain:
+
+| Phase | Recipes | What They Do |
+|-------|---------|-------------|
+| 1.x → 3.x | 20+ | `Matchers` → `ArgumentMatchers`, method renames, type changes, PowerMockito replacement |
+| 3.x → 4.x | 4 | `MockitoWhenOnStaticToMockStatic`, `byte-buddy` → 1.12.19 |
+| 4.x → 5.x | 4 | `mockito-inline` → `mockito-core`, `byte-buddy` → 1.17.5 |
+| Cleanup | 2 | Remove `FieldSetter.setField()`, remove unused imports |
+
+**65LTSUpgradeUberJar.yaml** — UberJar coordinate migration:
+
+| Operation | Detail |
+|-----------|--------|
+| Version bump | `com.adobe.aem:uber-jar` → 6.6.0 |
+| Classifier addition | adds `apis` classifier (required for 6.6.0) |
+| Legacy groupId | migrates `com.day.cq:uber-jar` → `com.adobe.aem:uber-jar` |
+| Managed deps | syncs `dependencyManagement` declarations |
+| Dedup | removes duplicate uber-jar declarations |
+
+### Custom Java Recipes
+
+Defined in `aem65lts-migration-recipes/` and used by the composite recipes above:
+
+| Class | Operation | Used By |
+|-------|-----------|---------|
+| `ChangeFilevaultEmbeddedArtifact` | Updates `<embedded>` `groupId`/`artifactId` inside `filevault-package-maven-plugin` configuration | `UpgradeMavenPluginConfigurations` |
+| `RemoveBndPluginInstruction` | Removes `<_plugin>` instruction elements from `maven-bundle-plugin` configuration that match a pattern (e.g., `SCRDescriptorBndPlugin`) | `UpgradeMavenPluginConfigurations` |
+| `RevertJakartaInAemSource` | Safeguard: detects AEM/Sling Java source files and reverts any `jakarta.*` imports back to `javax.*` | `UpgradeMavenPluginConfigurations` |
+| `DetectUnsupportedPackages` | Scans source files for imports from unsupported AEM packages or removed runtime bundles; marks each finding as BLOCKER or WARNING | `aem-migrate analyze` |
+
+### Guardrail Coverage
+
+| Guardrail | Enforced In | How |
+|-----------|------------|-----|
+| javax not jakarta | `migration-guardrails.md`, `RevertJakartaInAemSource` recipe, `verify` command | Triple defense: agent rule + AST recipe + post-migration check |
+| Unsupported packages (8 patterns) | `migration-guardrails.md`, `analyze` command, `DetectUnsupportedPackages` recipe | HARD STOP on detection |
+| Enforcer version monotonicity | `migration-guardrails.md` | Only raise, never lower |
+| POM formatting preservation | OpenRewrite is AST-based | Recipes preserve formatting by construction |
+| Removed bundles (Guava, Caffeine, Jetty) | `removed-bundles-remediation.md`, `analyze` command | Detection + detailed remediation guide with JDK equivalents |
+| Change attribution | `migration-guardrails.md` | `// aem-lts-migration: ai-fix` comment for agent edits |
+| Temp workaround cleanup | `verify` command | `MIGRATION_TEMP` marker detection |
+| Build retry limit | `migrate.md` workflow | Max 3 attempts per build phase |
+
+## Known Limitations
+
+1. **Frontend builds skipped**: All Maven commands use `-DskipFrontend=true`. Frontend migration (Node.js version, webpack/vite upgrades) is out of scope.
+2. **Tests skipped during build**: Build phases use `-DskipTests`. Test execution is deferred to CI after migration. The `upgrade-tests` command does upgrade Mockito source code, but does not run the tests.
+3. **No runtime validation**: The skill verifies compilation only. OSGi bundle resolution, Sling Model registration, and runtime behaviour require deployment to an AEM instance.
+4. **Mockito migration is non-fatal**: If the project does not use Mockito or the recipe fails, migration continues. The `upgrade-tests` command logs a warning rather than failing.
+5. **Customer-specific dependencies**: Private/internal dependencies that fail Maven resolution cause a HARD STOP requiring manual intervention.

--- a/plugins/aem/6.5-lts/skills/java21-migration/workflows/migrate.md
+++ b/plugins/aem/6.5-lts/skills/java21-migration/workflows/migrate.md
@@ -1,0 +1,826 @@
+# AEM 6.5 LTS — Java 21 Migration Workflow
+
+This document is the authoritative step-by-step guide the agent follows during migration. Read it in full before starting. Each step specifies exact commands, expected outcomes, error thresholds, and hard-stop conditions.
+
+---
+
+## Pre-flight Checklist
+
+Complete all items before executing Step 1. Do not proceed if any item cannot be satisfied.
+
+### Build the Migration Tool
+
+The CLI tool must be built before any migration commands can run:
+
+```bash
+cd $SKILL_DIR
+mvn clean install -DskipTests
+```
+
+Expected output ends with:
+```
+[INFO] BUILD SUCCESS
+```
+
+Set the JAR path for use in all subsequent commands:
+
+```bash
+MIGRATE_JAR="$SKILL_DIR/aem65lts-migration-cli/target/aem65lts-migration-cli-1.0-SNAPSHOT.jar"
+```
+
+Verify the JAR exists:
+
+```bash
+test -f "$MIGRATE_JAR" && echo "OK: migration JAR found" || echo "FAIL: JAR not found — build failed"
+```
+
+If the build fails, check that both `aem65lts-migration-recipes` and `aem65lts-migration-cli` modules compiled successfully. The CLI depends on the recipes JAR being installed to the local Maven repository (`~/.m2`).
+
+### Environment Variables
+
+Verify the following variables are set and point to valid paths:
+
+```bash
+# Required for Java 8 source projects; skip if project is already on Java 11
+echo $JAVA8_HOME   # e.g. /Library/Java/JavaVirtualMachines/jdk1.8.0_392.jdk/Contents/Home
+
+# Required — OpenRewrite must run under JDK 11 or later
+echo $JAVA11_HOME  # e.g. /Library/Java/JavaVirtualMachines/jdk-11.0.22.jdk/Contents/Home
+
+# Required — intermediate and final builds
+echo $JAVA21_HOME  # e.g. /Library/Java/JavaVirtualMachines/jdk-21.0.3.jdk/Contents/Home
+
+# Required — root of the Maven project to migrate
+echo $PROJECT_DIR  # e.g. /Users/dev/projects/my-aem-project
+
+# Required — absolute path to this skill directory
+echo $SKILL_DIR    # e.g. /path/to/skills/plugins/aem/6.5-lts/skills/java21-migration
+```
+
+Verify each JDK binary exists:
+
+```bash
+$JAVA8_HOME/bin/java  -version   2>&1 | head -1
+$JAVA11_HOME/bin/java -version   2>&1 | head -1
+$JAVA21_HOME/bin/java -version   2>&1 | head -1
+```
+
+Expected pattern: `openjdk version "X[...]"` where X matches the major version. If any JDK is missing, resolve before continuing.
+
+### Maven
+
+```bash
+mvn --version
+```
+
+Expected: `Apache Maven 3.9.x` or later. If Maven is not on `PATH`, set `MAVEN_HOME` and add `$MAVEN_HOME/bin` to `PATH`.
+
+### Git
+
+```bash
+cd $PROJECT_DIR && git status
+```
+
+Expected: `nothing to commit, working tree clean`. If there are uncommitted changes, stash or commit them before proceeding.
+
+### Maven Settings
+
+If the project requires the Adobe Public Repository and it is not in `~/.m2/settings.xml`, copy the template:
+
+```bash
+cp $SKILL_DIR/configs/maven-settings-template.xml ~/.m2/settings.xml
+```
+
+Or pass it explicitly via `--mavenSettings $SKILL_DIR/configs/maven-settings-template.xml` on all CLI invocations below.
+
+---
+
+## Step 1: Pre-Migration Analysis
+
+**Purpose:** Scan the project for blockers that would prevent a successful migration before any changes are made. No files are modified in this step.
+
+### Command
+
+```bash
+java -jar $MIGRATE_JAR analyze -r $PROJECT_DIR \
+  2>&1 | tee $PROJECT_DIR/analysis.log
+```
+
+### Expected Output
+
+```
+Pre-migration analysis complete.
+  Hard blockers : 0
+  Warnings      : 3
+  Modules scanned: 12
+```
+
+The command exits with:
+- **0** — project is ready to migrate
+- **1** — warnings present, migration can proceed with caution
+- **2** — hard blockers found, migration must not proceed
+
+### Decision Logic
+
+**If exit code 2 (hard blockers) → HARD STOP**
+
+Read the analysis output. Each blocker entry contains:
+- The matched import or dependency pattern
+- Why migration cannot proceed
+- The source files affected
+
+Report all blockers to the user. Do not proceed until blockers are resolved. Hard-stop packages are defined in `configs/unsupported-apis.yaml` under `hard_stop_packages`.
+
+**If exit code 1 (warnings) → log and continue**
+
+Warnings indicate dependencies that were removed from the AEM 6.5 LTS runtime (Guava, Caffeine, Jetty, Commons Collections 3). The project will compile but may fail at runtime. Record warnings in the final report. Remediation guidance is in `references/removed-bundles-remediation.md`.
+
+**If the command itself fails (non-zero, not 1 or 2) → HARD STOP**
+
+Fix the invocation before continuing. Common causes: wrong `$PROJECT_DIR`, missing `pom.xml` at project root, JAR not built.
+
+---
+
+## Step 2: Validate Project Structure
+
+**Purpose:** Confirm the Maven project layout is compatible with the migration tool.
+
+### Checks
+
+```bash
+# 1. Root pom.xml exists
+test -f $PROJECT_DIR/pom.xml && echo "OK: pom.xml found" || echo "FAIL: no pom.xml"
+
+# 2. Git repository exists
+test -d $PROJECT_DIR/.git && echo "OK: git repo found" || echo "FAIL: not a git repo"
+
+# 3. Count Maven modules
+grep -r '<module>' $PROJECT_DIR/pom.xml | wc -l
+```
+
+### Decision Logic
+
+**If pom.xml missing → HARD STOP.** The `$PROJECT_DIR` is not a Maven project root.
+
+**If .git missing → HARD STOP.** The migration requires git for change attribution and rollback.
+
+**If module count is 0**, the project is a single-module build. This is valid; the workflow proceeds identically.
+
+### Detect Source Java Version
+
+Inspect the root POM for the compiler source version:
+
+```bash
+# Read maven.compiler.source, maven.compiler.release, or maven-compiler-plugin <source>
+SOURCE_JAVA_VERSION=$(grep -m1 'maven\.compiler\.source\|maven\.compiler\.release' \
+  $PROJECT_DIR/pom.xml | grep -oP '\d+' | head -1)
+
+echo "Detected source Java version: $SOURCE_JAVA_VERSION"
+
+if [ "$SOURCE_JAVA_VERSION" = "8" ] || [ "$SOURCE_JAVA_VERSION" = "1.8" ]; then
+  SOURCE_JDK_HOME=$JAVA8_HOME
+  SOURCE_JAVA_VERSION=8
+elif [ "$SOURCE_JAVA_VERSION" = "11" ]; then
+  SOURCE_JDK_HOME=$JAVA11_HOME
+else
+  echo "ERROR: Unexpected or undetected source version: $SOURCE_JAVA_VERSION"
+  # HARD STOP if version is 17 or 21 — project already migrated
+  # Ask user to confirm $SOURCE_JDK_HOME manually if detection is ambiguous
+fi
+
+echo "Source JDK home: $SOURCE_JDK_HOME"
+```
+
+**If source version is 17 or 21 → HARD STOP.** The project is already at or past Java 17. This workflow is not intended for that case.
+
+**If source version is ambiguous (not clearly 8 or 11)** → warn the user and ask for confirmation before proceeding.
+
+### Create Migration Branch
+
+```bash
+MIGRATION_BRANCH="java21-migration/$(date +%Y%m%d-%H%M%S)"
+cd $PROJECT_DIR && git checkout -b $MIGRATION_BRANCH
+echo "Migration branch: $MIGRATION_BRANCH"
+```
+
+All subsequent changes will be committed to this branch.
+
+---
+
+## Step 3: Baseline Build
+
+**Purpose:** Confirm the project compiles successfully at its current Java version before any changes are applied. This establishes a known-good baseline.
+
+### Command
+
+```bash
+JAVA_HOME=$SOURCE_JDK_HOME mvn clean install \
+  -DskipTests \
+  -DskipFrontend=true \
+  -T1C \
+  -f $PROJECT_DIR/pom.xml \
+  2>&1 | tee $PROJECT_DIR/build-baseline.log
+```
+
+### Expected Output
+
+```
+[INFO] BUILD SUCCESS
+```
+
+Build time varies. A 12-module project typically takes 3–8 minutes.
+
+### Decision Logic
+
+**If BUILD SUCCESS → continue to Step 4.**
+
+**If BUILD FAILURE:**
+
+1. Read `build-baseline.log`. Find the first `[ERROR]` line containing `COMPILATION ERROR` or `BUILD FAILURE`.
+2. Attempt AI-assisted fix. The fix must be minimal — do not change APIs, only resolve the compile error.
+3. Re-run the build command.
+4. Repeat up to 3 attempts total.
+
+**After 3 failed attempts → HARD STOP.**
+
+Report the last compiler error verbatim. The project has pre-existing build issues that must be resolved manually before migration can begin.
+
+---
+
+## Step 4: Java Code Modernization
+
+**Purpose:** Apply AST-based custom recipes that handle Java API modernization, BND plugin cleanup, FileVault artifact updates, and jakarta→javax reversion.
+
+### Command
+
+```bash
+java -jar $MIGRATE_JAR upgrade-code \
+  -r $PROJECT_DIR \
+  -j $JAVA11_HOME \
+  2>&1 | tee $PROJECT_DIR/upgrade-code.log
+```
+
+OpenRewrite requires JDK 11+ to parse and transform Java source files. The `-j $JAVA11_HOME` flag sets the JDK used for the Maven Invoker subprocess; it does not change the project's source/target version.
+
+### Expected Output
+
+```
+[upgrade-code] Running OpenRewrite recipes on $PROJECT_DIR
+[upgrade-code] Recipes applied:
+  - RevertJakartaInAemSource
+  - RemoveBndScrDescriptorPlugin
+  - MigrateFileVaultEmbeddedArtifacts
+  - DetectUnsupportedPackages
+  - ModernizeJavaCode (stock + custom)
+[upgrade-code] SUCCESS — X files modified
+```
+
+### What the Recipes Do
+
+| Recipe | Effect |
+|---|---|
+| `RevertJakartaInAemSource` | Converts any `jakarta.*` imports back to `javax.*` (AEM 6.5 LTS is javax-only) |
+| `RemoveBndScrDescriptorPlugin` | Removes `SCRDescriptorBndPlugin` from BND configurations (incompatible with Java 21) |
+| `MigrateFileVaultEmbeddedArtifacts` | Updates Groovy Console group ID to `be.orbinson.aem`, version `19.0.8` |
+| `DetectUnsupportedPackages` | Flags commerce, social, screens, and other unsupported API usages |
+| `ModernizeJavaCode` (stock OpenRewrite) | Java 8/11 → 17/21 API and language updates |
+
+### Decision Logic
+
+**If exit code 0 → commit and continue to Step 5.**
+
+**If command fails with "Could not resolve plugin":**
+- Verify Maven settings include the Adobe Public Repository
+- Re-run with `--mavenSettings $SKILL_DIR/configs/maven-settings-template.xml`
+
+**If command fails with a recipe execution error:**
+- Try running on a single module first: add `-pl core` to isolate the issue
+- If that succeeds, run remaining modules: `-pl !core`
+
+**If `DetectUnsupportedPackages` reports blockers:**
+- Treat as a HARD STOP — same as Step 1 exit code 2
+- Do not commit; resolve the unsupported API usage first
+
+### Commit After Step 4
+
+```bash
+cd $PROJECT_DIR && git add -A && git commit -m "chore(migration): apply Java code modernization recipes
+
+- RevertJakartaInAemSource: ensured javax namespace throughout
+- RemoveBndScrDescriptorPlugin: removed SCRDescriptorBndPlugin from BND configs
+- MigrateFileVaultEmbeddedArtifacts: Groovy Console → be.orbinson.aem 19.0.8
+- ModernizeJavaCode: Java 8/11 → 21 API and language updates
+
+[java21-migration step-4]"
+```
+
+---
+
+## Step 5: Upgrade Maven Build Plugins
+
+**Purpose:** Update Maven build plugin versions to versions compatible with Java 21.
+
+### Command
+
+```bash
+java -jar $MIGRATE_JAR upgrade-plugins \
+  -r $PROJECT_DIR \
+  -j $JAVA11_HOME \
+  2>&1 | tee $PROJECT_DIR/upgrade-plugins.log
+```
+
+### Expected Output
+
+```
+[upgrade-plugins] SUCCESS — X plugin versions updated
+  maven-bundle-plugin: → 5.1.9
+  bnd-maven-plugin: → 6.4.0
+  maven-compiler-plugin: source/target/release → 21
+```
+
+### What This Step Does
+
+- Sets `maven-bundle-plugin` to version 5.1.9 or later
+- Sets `bnd-maven-plugin` to version 6.4.0 or later
+- Sets `maven.compiler.source`, `maven.compiler.target`, and `maven.compiler.release` to `21` in root POM properties
+- Sets `<source>21</source>`, `<target>21</target>`, `<release>21</release>` inside `maven-compiler-plugin` configuration blocks
+
+### Decision Logic
+
+**If exit code 0 → commit and continue to Step 6.**
+
+**If the step fails:**
+- This step is considered soft-failure. Log the failure with the error from `upgrade-plugins.log`.
+- Attempt the plugin upgrades manually by editing the POM files directly.
+- Do not continue to Step 6 until `maven-compiler-plugin` has been set to target Java 21 — this is required for the intermediate build.
+
+### Commit After Step 5
+
+```bash
+cd $PROJECT_DIR && git add -A && git commit -m "chore(migration): upgrade Maven build plugin versions
+
+- maven-bundle-plugin: → 5.1.9
+- bnd-maven-plugin: → 6.4.0
+- maven-compiler-plugin: source/target/release set to 21
+
+[java21-migration step-5]"
+```
+
+---
+
+## Step 6: Upgrade Dependencies and UberJar
+
+**Purpose:** Update AEM dependency versions and inject the `apis` classifier into all UberJar references.
+
+### Commands
+
+Run dependency upgrade and UberJar migration in sequence:
+
+```bash
+java -jar $MIGRATE_JAR upgrade-dependencies \
+  -r $PROJECT_DIR \
+  -j $JAVA11_HOME \
+  2>&1 | tee $PROJECT_DIR/upgrade-dependencies.log
+
+java -jar $MIGRATE_JAR upgrade-uberjar \
+  -r $PROJECT_DIR \
+  -j $JAVA11_HOME \
+  2>&1 | tee $PROJECT_DIR/upgrade-uberjar.log
+```
+
+### Expected Output
+
+```
+[upgrade-dependencies] SUCCESS — X dependency versions updated
+  com.adobe.aem:uber-jar: → 6.6.0
+  com.adobe.cq:core.wcm.components.all: → 2.24.0
+  be.orbinson.aem:aem-groovy-console-bundle: → 19.0.8
+
+[upgrade-uberjar] SUCCESS — apis classifier injected
+  uber-jar dependencies updated: X occurrences
+```
+
+### What These Steps Do
+
+**upgrade-dependencies:**
+- Updates `com.adobe.aem:uber-jar` to version `6.6.0`
+- Updates WCM Core Components to `2.24.0` or later
+- Updates Groovy Console group and version (if not already handled by Step 4 recipes)
+
+**upgrade-uberjar:**
+- Ensures all `com.adobe.aem:uber-jar` dependencies have `<classifier>apis</classifier>`
+- This is required for UberJar 6.6.0 — without it the dependency resolves but annotation processors are missing
+
+### Decision Logic
+
+**If both commands exit 0 → commit and continue to Step 7.**
+
+**If `upgrade-dependencies` fails:**
+- Log the failure. Attempt manual POM edits for the dependency versions listed above.
+- Do not block on this — the intermediate build in Step 7 will reveal missing version updates.
+
+**If `upgrade-uberjar` fails:**
+- This is more critical. Inject the classifier manually:
+  ```xml
+  <!-- In every pom.xml that declares uber-jar -->
+  <dependency>
+    <groupId>com.adobe.aem</groupId>
+    <artifactId>uber-jar</artifactId>
+    <version>6.6.0</version>
+    <classifier>apis</classifier>
+    <scope>provided</scope>
+  </dependency>
+  ```
+- Do not proceed to Step 7 without the classifier — the build will fail with missing annotation processor JARs.
+
+### Commit After Step 6
+
+```bash
+cd $PROJECT_DIR && git add -A && git commit -m "chore(migration): upgrade AEM dependencies and UberJar
+
+- uber-jar: → 6.6.0 with apis classifier
+- core.wcm.components.all: → 2.24.0
+- upgrade-dependencies: updated remaining dependency versions
+
+[java21-migration step-6]"
+```
+
+---
+
+## Step 7: Set CloudManager Java Version
+
+**Purpose:** Signal to Cloud Manager that this project requires JDK 21 for pipeline builds.
+
+### Command
+
+The `full-migrate` command sets this automatically. When running steps individually:
+
+```bash
+mkdir -p $PROJECT_DIR/.cloudmanager
+printf '21' > $PROJECT_DIR/.cloudmanager/java-version
+echo "OK: .cloudmanager/java-version set to 21"
+```
+
+Verify:
+
+```bash
+cat $PROJECT_DIR/.cloudmanager/java-version
+# Expected: 21
+```
+
+The file must contain exactly `21` with no trailing newline. Cloud Manager reads this value literally.
+
+### Decision Logic
+
+**If the file exists and contains `21` → continue.**
+
+**If the file is missing or contains a different value:** Create or overwrite it with the command above. This is not optional — without it, Cloud Manager will build with the default JDK (8 or 11) and the build will fail.
+
+### Commit After Step 7
+
+```bash
+cd $PROJECT_DIR && git add $PROJECT_DIR/.cloudmanager/java-version
+cd $PROJECT_DIR && git commit -m "chore(migration): set CloudManager Java version to 21
+
+- .cloudmanager/java-version: 21
+
+[java21-migration step-7]"
+```
+
+---
+
+## Step 8: Intermediate Build (JDK 21)
+
+**Purpose:** Verify the project compiles with JDK 21 after the automated transforms. This is the critical checkpoint — failures here are expected and handled by the AI-assisted fix loop.
+
+### Command
+
+```bash
+JAVA_HOME=$JAVA21_HOME mvn clean install \
+  -DskipTests \
+  -DskipFrontend=true \
+  -T1C \
+  -f $PROJECT_DIR/pom.xml \
+  2>&1 | tee $PROJECT_DIR/build-intermediate.log
+```
+
+### Decision Logic
+
+**If BUILD SUCCESS → continue to Step 9.**
+
+**If BUILD FAILURE — AI-assisted fix loop (up to 3 attempts):**
+
+For each attempt:
+
+1. Parse `build-intermediate.log` to extract compilation errors. Focus on the first `COMPILATION ERROR` block.
+
+2. Identify the root cause category:
+
+   | Error Pattern | Root Cause | Fix |
+   |---|---|---|
+   | `package jakarta.* does not exist` | OpenRewrite introduced jakarta imports | Revert to javax namespace |
+   | `package javax.* does not exist` | Missing dependency scope | Check provided/compile scope on uber-jar |
+   | `cannot find symbol ... class Foo` | Removed AEM API | Check `references/removed-bundles-remediation.md` |
+   | `error: module X not found` | Split package issue | Add `--add-opens` JVM arg or remove split package |
+   | `method X in class Y cannot be applied` | Signature change | Update call site to new signature |
+   | `unchecked or unsafe operations` | Raw type warning promoted to error | Add `@SuppressWarnings` or parameterize type |
+
+3. Apply the minimal fix that resolves the root cause.
+
+   **Critical guardrail for this step:** If any javax import was changed to jakarta, revert it. AEM 6.5 LTS runs on the javax namespace. Search for accidental jakarta imports:
+
+   ```bash
+   grep -rn "import jakarta\." $PROJECT_DIR --include="*.java"
+   ```
+
+   For each hit, revert to the javax equivalent:
+   ```bash
+   find $PROJECT_DIR -name "*.java" \
+     -exec sed -i '' 's/import jakarta\.servlet\./import javax.servlet./g' {} + \
+     -exec sed -i '' 's/import jakarta\.annotation\./import javax.annotation./g' {} +
+   ```
+
+4. Re-run the build command.
+
+5. If BUILD SUCCESS → commit fixes and continue to Step 9.
+
+**After 3 failed attempts → HARD STOP.**
+
+Record:
+- The final compiler error (full block from the log)
+- Which files were modified in each attempt
+- Which error category was identified
+- Why the fix did not resolve it
+
+The user must manually fix these modules. Once fixed, the workflow can resume at Step 8.
+
+### Commit After Step 8 (if fixes were applied)
+
+```bash
+cd $PROJECT_DIR && git add -A && git commit -m "fix(migration): resolve Java 21 compilation errors (intermediate build)
+
+[list each fix applied and the file it targeted]
+
+[java21-migration step-8]"
+```
+
+---
+
+## Step 9: Test Framework Migration
+
+**Purpose:** Migrate test dependencies, primarily Mockito, from 1.x/2.x to 5.x. This runs after the intermediate build succeeds to avoid compounding failures.
+
+### Command
+
+```bash
+java -jar $MIGRATE_JAR upgrade-tests \
+  -r $PROJECT_DIR \
+  -j $JAVA21_HOME \
+  2>&1 | tee $PROJECT_DIR/upgrade-tests.log
+```
+
+Note: `upgrade-tests` uses JDK 21 (not JDK 11) because the test source code must be parsed against the JDK 21 classpath, which is now set in the project's compiler configuration.
+
+### Expected Output
+
+```
+[upgrade-tests] Running Mockito migration recipes on $PROJECT_DIR
+[upgrade-tests] SUCCESS — X test files modified
+  Mockito: 1.x/2.x → 5.11.0
+  Updated import paths and mock creation APIs
+```
+
+### Decision Logic
+
+**This step is NON-FATAL.**
+
+**If the command succeeds → commit and continue.**
+
+**If the command fails:**
+- Log the failure with the error from `upgrade-tests.log`.
+- Add a warning entry to the migration report: "Mockito migration was not applied automatically. Manual migration required."
+- Continue to Step 10 without committing Step 9 changes.
+
+Do not retry this step more than once. Test migration failures do not block the Java 21 compilation goal.
+
+### Commit After Step 9 (only if successful)
+
+```bash
+cd $PROJECT_DIR && git add -A && git commit -m "chore(migration): apply test framework migration
+
+- Mockito: 1.x/2.x → 5.11.0
+- Updated import paths and mock creation APIs
+- PowerMock references flagged for manual review (not auto-migrated)
+
+[java21-migration step-9]"
+```
+
+---
+
+## Step 10: Final Build (JDK 21)
+
+**Purpose:** Run the complete build including tests with JDK 21. This is the definitive pass/fail gate for the migration.
+
+### Command
+
+```bash
+JAVA_HOME=$JAVA21_HOME mvn clean install \
+  -DskipFrontend=true \
+  -T1C \
+  -f $PROJECT_DIR/pom.xml \
+  2>&1 | tee $PROJECT_DIR/build-final.log
+```
+
+Note: `-DskipTests` is NOT set. Tests run in this step.
+
+### Decision Logic
+
+**If BUILD SUCCESS → continue to Step 11.**
+
+**If BUILD FAILURE — AI-assisted fix loop (up to 3 attempts, 45 minutes maximum per attempt):**
+
+Follow the same process as Step 8, but now also handle test failures:
+
+| Failure Type | Action |
+|---|---|
+| Compilation error | Fix root cause in production code |
+| Test compilation error | Fix test code to match new APIs |
+| Test runtime failure: `StrictStubbing` | Mockito 5 is stricter — remove unused stubs |
+| Test runtime failure: `NullPointerException` | Check for APIs removed from mocked AEM objects |
+| Test runtime failure: assertion mismatch | Verify the logic change was intentional |
+
+**Per-attempt time limit:** If a single fix attempt takes more than 45 minutes of elapsed time, stop that attempt and count it. This prevents infinite loops on deeply nested build failures.
+
+**After 3 failed attempts → HARD STOP.**
+
+At this point the project compiles (as verified by Step 8) but tests fail. Report:
+- Module(s) with failing tests
+- Test names and failure messages
+- Whether failures appear to be pre-existing or introduced by the migration
+
+The user may choose to merge the migration branch with `-DskipTests` for now and address test failures separately.
+
+### Commit After Step 10 (if fixes were applied)
+
+```bash
+cd $PROJECT_DIR && git add -A && git commit -m "fix(migration): resolve Java 21 build and test failures (final build)
+
+[list each fix applied and the file it targeted]
+
+[java21-migration step-10]"
+```
+
+---
+
+## Step 11: Verify and Cleanup
+
+**Purpose:** Clean up any migration artifacts, run post-migration verification, and generate the migration report.
+
+### 11a. Cleanup
+
+Verify no accidental jakarta imports remain:
+
+```bash
+JAKARTA_COUNT=$(grep -rn "import jakarta\." $PROJECT_DIR --include="*.java" | wc -l | tr -d ' ')
+echo "Accidental jakarta imports: $JAKARTA_COUNT"
+if [ "$JAKARTA_COUNT" -gt "0" ]; then
+  grep -rn "import jakarta\." $PROJECT_DIR --include="*.java"
+  # HARD STOP — do not proceed until these are resolved
+fi
+```
+
+If any jakarta imports are found, apply the `RevertJakartaInAemSource` recipe again:
+
+```bash
+java -jar $MIGRATE_JAR upgrade-code \
+  -r $PROJECT_DIR \
+  -j $JAVA11_HOME \
+  --recipe RevertJakartaInAemSource
+```
+
+### 11b. Post-Migration Verification
+
+```bash
+java -jar $MIGRATE_JAR verify -r $PROJECT_DIR \
+  2>&1 | tee $PROJECT_DIR/verification.log
+```
+
+The `verify` command checks:
+- `maven.compiler.source` / `maven.compiler.release` set to `21` in root POM
+- No module POM sets compiler source to less than 21
+- `com.adobe.aem:uber-jar` version is `6.6.0` and classifier is `apis`
+- `maven-bundle-plugin` version is `5.1.9` or later
+- `.cloudmanager/java-version` contains `21`
+- No `jakarta.*` imports in Java source files
+- No `SCRDescriptorBndPlugin` references in any POM
+
+Expected output:
+
+```
+[verify] Verification complete.
+  Checks passed : 8
+  Checks failed : 0
+  Warnings      : 1
+```
+
+**If any check fails → do not proceed.** Resolve the failure and re-run verify.
+
+**If warnings only → continue.** Record warnings in the final report.
+
+### 11c. Review Git Diff
+
+Display the full diff for human review:
+
+```bash
+cd $PROJECT_DIR && git diff main..HEAD --stat
+```
+
+This shows the total scope of changes. Review for:
+- Unexpected file modifications
+- Files that should not have changed (content packages, frontend assets)
+- Modules that appear unchanged when they should have been updated
+
+### 11d. Final Commit
+
+```bash
+cd $PROJECT_DIR && git add -A && git commit -m "chore(migration): post-migration verification and cleanup
+
+- No accidental jakarta imports found
+- All verification checks passed
+- .cloudmanager/java-version confirmed as 21
+
+[java21-migration step-11]"
+```
+
+### 11e. Summary to User
+
+Present the following to the user:
+
+1. Migration branch name: `$MIGRATION_BRANCH`
+2. Verification result: pass / pass-with-warnings / fail
+3. Any warnings that require manual follow-up
+4. Recommended next steps:
+   - Review the git diff: `git diff main..HEAD`
+   - Run full test suite in CI
+   - Test on a local AEM SDK 6.5 LTS instance before merging
+
+---
+
+## One-Command Migration
+
+If you want to run the complete pipeline in a single invocation:
+
+```bash
+java -jar $MIGRATE_JAR full-migrate \
+  -r $PROJECT_DIR \
+  --javaHome $JAVA21_HOME \
+  --java11Home $JAVA11_HOME \
+  --sourceJavaHome $SOURCE_JDK_HOME \
+  2>&1 | tee $PROJECT_DIR/full-migrate.log
+```
+
+The `full-migrate` command sequences all steps (analyze → validate → baseline build → upgrade-code → upgrade-plugins → upgrade-dependencies → upgrade-uberjar → set CloudManager version → intermediate build → upgrade-tests → final build → verify) in order, applying the same decision logic and hard-stop conditions as the manual steps above.
+
+Use the manual step-by-step approach when:
+- A previous full-migrate run failed partway through and you are resuming
+- You want to run only specific steps
+- You need to inspect outputs between steps
+
+---
+
+## Reference: Exit Codes and Hard Stops
+
+| Condition | Action |
+|---|---|
+| Unsupported API package detected (Step 1) | HARD STOP — report blockers |
+| No pom.xml at project root (Step 2) | HARD STOP — wrong directory |
+| No .git directory (Step 2) | HARD STOP — git required |
+| Source Java version > 11 (Step 2) | HARD STOP — wrong workflow |
+| Baseline build fails after 3 attempts (Step 3) | HARD STOP — pre-existing issue |
+| `upgrade-uberjar` fails and classifier not injected manually | HARD STOP — intermediate build will fail |
+| Intermediate build fails after 3 attempts (Step 8) | HARD STOP — manual fix required |
+| Final build fails after 3 attempts (Step 10) | HARD STOP — manual fix required |
+| Jakarta imports found after cleanup (Step 11) | HARD STOP — AEM 6.5 LTS is javax only |
+| OpenRewrite recipe fails in upgrade-code (Step 4) | Soft failure if on single module — log and continue |
+| upgrade-plugins fails (Step 5) | Attempt manual correction, then continue |
+| upgrade-tests fails (Step 9) | NON-FATAL — log warning and continue |
+
+---
+
+## Reference: AI Fix Guardrails
+
+When applying AI-assisted fixes in Steps 3, 8, and 10, the following rules are absolute:
+
+1. **Never change `javax.*` to `jakarta.*`.** AEM 6.5 LTS runs on a Servlet 4 / JavaEE 8 runtime. Jakarta namespace is not available.
+
+2. **Never remove `provided` scope from `uber-jar`.** The UberJar must be `<scope>provided</scope>` — including it in compile scope causes classpath pollution.
+
+3. **Never lower a version number.** If a recipe set a plugin to version 5.1.9, do not revert it to 4.x to fix a compilation error. Fix the compilation error at the call site instead.
+
+4. **Never modify generated files.** Files under `target/`, `node_modules/`, or `.generated/` must not be touched.
+
+5. **One module at a time.** When fixing compilation errors, fix the failing module's source files only. Do not preemptively change other modules.
+
+6. **Attribute all changes.** Every change must be traceable to the error it resolved. Include the error message as a comment in the commit message body.
+
+7. **No javax→jakarta reversions that break compilation.** If reverting a jakarta import causes a new compilation error, the dependency scope or version is wrong — fix the dependency, not the import.


### PR DESCRIPTION
## Summary

Adds a new `java21-migration` skill (beta) to the `aem-6-5-lts` plugin that automates upgrading AEM 6.5 Maven projects to AEM 6.5 LTS on Java 21.

The skill is designed around **determinism** — every code/POM transformation is implemented as an AST-based [OpenRewrite](https://docs.openrewrite.org/) recipe (Java visitor or declarative YAML), not text substitution. This minimises LLM hallucination during agent-driven migrations and gives reviewers a predictable, replayable diff.

## What's inside

Two Maven modules under `plugins/aem/6.5-lts/skills/java21-migration/`:

- **`aem65lts-migration-recipes/`** — Four custom OpenRewrite recipes implemented as Java visitors with full unit-test coverage (17 tests, all passing).
- **`aem65lts-migration-cli/`** — A picocli CLI (`aem-migrate`) that wraps `rewrite-maven-plugin` invocations into a single `full-migrate` pipeline plus discrete `upgrade-*` subcommands.

Bundled declarative YAML recipes compose the custom recipes with the official `rewrite-migrate-java` and `rewrite-testing-frameworks` recipe modules.

## Custom recipes

| Recipe | Purpose |
|--------|---------|
| `ChangeFilevaultEmbeddedArtifact` | Updates embedded artefact coordinates inside `filevault-package-maven-plugin` (handles Groovy Console groupId migration) |
| `RemoveBndPluginInstruction` | Removes `SCRDescriptorBndPlugin` and similar legacy BND instructions incompatible with bnd 6.x / Java 21 |
| `RevertJakartaInAemSource` | Safeguard recipe — reverts accidental `jakarta.*` imports back to `javax.*` in AEM source files (jakarta annotations compile but fail silently at runtime on AEM 6.5 LTS) |
| `DetectUnsupportedPackages` | Read-only scanner that marks BLOCKER and WARNING imports for the `analyze` command |

## CLI commands

| Command | What it does |
|---------|-------------|
| `analyze` | Pre-migration scan for blockers and warnings; exit codes 0=ready, 1=warnings, 2=blockers |
| `upgrade-code` | Java 8/11 → 21 source migration. Cherry-picks recipes from `rewrite-migrate-java` and **explicitly excludes** `javax`→`jakarta` migration |
| `upgrade-tests` | Mockito 1.x → 5.x progressive migration via `rewrite-testing-frameworks` |
| `upgrade-uberjar` | UberJar bump to 6.6.0 with `apis` classifier |
| `upgrade-plugins` | `maven-bundle-plugin` 5.1.9, `bnd-maven-plugin` 6.4.0, `maven-scr-plugin` 1.26.4 + ASM 9.7.1, `maven-compiler-plugin` `release=21`, `filevault-package-maven-plugin` 1.3.6 |
| `upgrade-dependencies` | Core WCM Components, Groovy 4, Groovy Console coordinate updates |
| `full-migrate` | Orchestrated 8-step pipeline (validate → baseline build → code → plugins → deps + uberjar → CloudManager version → intermediate build → tests) |
| `verify` | Post-migration checks: compiler settings (= 21), jakarta-in-AEM detection, `MIGRATION_TEMP` markers, uber-jar `apis` classifier across all POMs, unsupported package imports, `.cloudmanager/java-version`, `git diff` summary |

## Critical guardrails

- **`javax`, not `jakarta`** — AEM 6.5 LTS uses the `javax` namespace. The Java migration excludes jakarta recipes; a custom revert recipe and a `verify` check guard against silent regressions.
- **Unsupported packages → hard stop** — Commerce, Communities, Granite Social, Screens, We.Retail, DAM PIM/rating, Search & Promote, MCM Campaign.
- **Removed bundles** — Guava, Caffeine, Jetty, Commons Collections 3 produce WARNINGs with class-level remediation guidance.
- **Enforcer version floor** — monotonically increasing (1.8 → 11 → 21), never lowered.

## Documentation

All reference documents include links to public [Adobe Experience League](https://experienceleague.adobe.com/en/docs/experience-manager-65-lts/content/release-notes/release-notes), [OpenRewrite](https://docs.openrewrite.org/), Apache Maven, and Sling documentation so every claim is verifiable.

## Test plan

- [x] `mvn clean install` from the skill root → BUILD SUCCESS for all three reactor modules
- [x] `mvn test -pl aem65lts-migration-recipes` → 17 tests pass across 4 recipe test classes
- [x] Java 8 source compatibility for the custom recipes (so the tool can run on the broadest JDK range)
- [x] CLI `--help` renders for all 8 subcommands
- [x] `analyze` correctly returns exit code 2 on a project containing an unsupported-package import
- [x] `verify` walks all POMs (not just the root) when checking the uber-jar `apis` classifier
- [x] `npx skills-ref validate` passes locally
- [ ] End-to-end smoke test on a representative AEM 6.5 Maven project (recommended before promoting out of beta)

## Beta status

The skill is marked beta. The `[BETA]` prefix in the description and a blockquote in the SKILL.md body signal beta status to the LLM during skill selection and execution. Validate all migrations against the post-migration checklist before promoting changes to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)