### PR TITLE
feat(best-practices,migration): wire orchestrators to expert skill subdirectories

### DIFF
--- a/plugins/aem/cloud-service/skills/best-practices/README.md
+++ b/plugins/aem/cloud-service/skills/best-practices/README.md
@@ -2,12 +2,12 @@
 
 Source: `skills/aem/cloud-service/skills/best-practices/`. **`SKILL.md`** routes to:
 
-- **Expert skill subdirectories** (each a self-contained skill with migration, greenfield, review, troubleshooting, pitfalls, modern alternatives): `scheduler/`, `resource-change-listener/`, `replication/`, `event-migration/`, `asset-manager/`
-- **Reference modules** under `references/` (cross-cutting concerns): Java baseline (`scr-to-osgi-ds.md`, `resource-resolver-logging.md`, prerequisites hub), HTL lint (`data-sly-test-redundant-constant.md` and proactive `rg` discovery in `SKILL.md`)
+- **Pattern guides** (each covering migration, greenfield, review, troubleshooting, common pitfalls, modern alternatives for one pattern): `scheduler/`, `resource-change-listener/`, `replication/`, `event-migration/`, `asset-manager/`
+- **Shared references** under `references/` (topics used across patterns): Java baseline (`scr-to-osgi-ds.md`, `resource-resolver-logging.md`, prerequisites hub), HTL lint (`data-sly-test-redundant-constant.md` and proactive `rg` discovery in `SKILL.md`)
 
 These files ship with the **AEM as a Cloud Service** plugin (`aem-cloud-service` in the marketplace). Install that umbrella package once; the agent selects this skill when the task matches.
 
-For **BPA- or CAM-driven bulk migration**, use the **`migration`** skill under the same plugin (`skills/aem/cloud-service/skills/migration/`); it supplies targets and orchestration, while this folder supplies transformation modules.
+For **BPA- or CAM-driven bulk migration**, use the **`migration`** skill under the same plugin (`skills/aem/cloud-service/skills/migration/`); it discovers the migration targets and runs the workflow, while this folder supplies the transformation steps.
 
 ## Installation
 

--- a/plugins/aem/cloud-service/skills/best-practices/README.md
+++ b/plugins/aem/cloud-service/skills/best-practices/README.md
@@ -1,6 +1,9 @@
 # AEM as a Cloud Service — Best practices
 
-Source: `skills/aem/cloud-service/skills/best-practices/`. **`SKILL.md`** and **`references/`** (patterns: scheduler, replication, events, assets; Java baseline: `scr-to-osgi-ds.md`, `resource-resolver-logging.md`, prerequisites hub; **HTL:** `data-sly-test-redundant-constant.md` and proactive `rg` discovery in `SKILL.md`).
+Source: `skills/aem/cloud-service/skills/best-practices/`. **`SKILL.md`** routes to:
+
+- **Expert skill subdirectories** (each a self-contained skill with migration, greenfield, review, troubleshooting, pitfalls, modern alternatives): `scheduler/`, `resource-change-listener/`, `replication/`, `event-migration/`, `asset-manager/`
+- **Reference modules** under `references/` (cross-cutting concerns): Java baseline (`scr-to-osgi-ds.md`, `resource-resolver-logging.md`, prerequisites hub), HTL lint (`data-sly-test-redundant-constant.md` and proactive `rg` discovery in `SKILL.md`)
 
 These files ship with the **AEM as a Cloud Service** plugin (`aem-cloud-service` in the marketplace). Install that umbrella package once; the agent selects this skill when the task matches.
 

--- a/plugins/aem/cloud-service/skills/best-practices/SKILL.md
+++ b/plugins/aem/cloud-service/skills/best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: best-practices
-description: AEM as a Cloud Service Java/OSGi best practices, guardrails, and legacy-to-cloud pattern transformations. Routes to dedicated expert skills for the five major patterns (scheduler, resource-change-listener, replication, event-migration, asset-manager) and reference modules for cross-cutting concerns (SCR→DS, ResourceResolver/SLF4J, HTL data-sly-test lint, prerequisites). Use for Cloud Service–correct bundles, deprecated APIs, schedulers, ResourceChangeListener, replication, Replicator, JCR observation (javax.jcr.observation.EventListener), OSGi Event Admin (org.osgi.service.event.EventHandler), DAM AssetManager, BPA-style fixes, or HTL (Sightly) Cloud SDK lint warnings (data-sly-test redundant constant value comparison).
+description: AEM as a Cloud Service Java/OSGi best practices, guardrails, and legacy-to-cloud pattern transformations. Includes pattern-specific guides for the five major migration patterns (scheduler, resource-change-listener, replication, event-migration, asset-manager) plus shared guides for SCR→DS, ResourceResolver/SLF4J, HTL data-sly-test lint, and prerequisites. Use for Cloud Service–correct bundles, deprecated APIs, schedulers, ResourceChangeListener, replication, Replicator, JCR observation (javax.jcr.observation.EventListener), OSGi Event Admin (org.osgi.service.event.EventHandler), DAM AssetManager, BPA-style fixes, or HTL (Sightly) Cloud SDK lint warnings (data-sly-test redundant constant value comparison).
 license: Apache-2.0
 ---
 
@@ -8,44 +8,44 @@ license: Apache-2.0
 
 Platform guidance for **AEM as a Cloud Service**: **Java/OSGi** (what to use, what to avoid, how to refactor legacy patterns) and **HTL** (component `.html` templates, Cloud SDK HTL lint).
 
-This skill is a **router**: each major migration pattern lives in its own **expert skill subdirectory** (`scheduler/`, `resource-change-listener/`, `replication/`, `event-migration/`, `asset-manager/`) — each one is a self-contained expert skill covering migration, greenfield, review, troubleshooting, common pitfalls, and modern alternatives. Smaller cross-cutting reference modules (SCR→DS, resolver/logging, HTL lint, prerequisites hub) still live under `references/`.
+Each major migration pattern has its own **pattern guide** (`scheduler/`, `resource-change-listener/`, `replication/`, `event-migration/`, `asset-manager/`) covering migration, greenfield, review, troubleshooting, common pitfalls, and modern alternatives. Shared topics used across patterns (SCR→DS, resolver/logging, HTL lint, prerequisites hub) live as references under `references/`.
 
-The skill ships with the **`aem-cloud-service`** plugin. Use it **without** the **migration** skill for greenfield or maintenance work that only needs the pattern guidance. Use **migration** when you need BPA/CAM orchestration on top.
+The skill ships with the **`aem-cloud-service`** plugin. Use it **without** the **migration** skill for greenfield or maintenance work that only needs the pattern guidance. Use **migration** when you also need BPA/CAM-driven discovery and a one-pattern-per-session workflow on top.
 
-**Quick pick:** Open the **Pattern Reference Modules** table below → jump to the matching skill (`<pattern>/SKILL.md`) or reference (`references/<file>.md`) → read it fully before editing. For Java baseline concerns (Felix SCR, resolvers, logging), check the **Java / OSGi baseline** links first when those appear in the same change set.
+**Quick pick:** Open the **Pattern Guides** table below → jump to the matching pattern guide (`<pattern>/SKILL.md`) or reference (`references/<file>.md`) → read it fully before editing. For Java baseline concerns (Felix SCR, resolvers, logging), check the **Java / OSGi baseline** links first when those appear in the same change set.
 
 ## When to Use This Skill
 
 Use this skill when you need to:
 
 - Apply **AEM as a Cloud Service** constraints to **Java/OSGi** code (new or existing)
-- Refactor **legacy Java patterns** into supported APIs (same expert skills and reference modules migration uses)
+- Refactor **legacy Java patterns** into supported APIs (same pattern guides and references the migration skill uses)
 - Follow **consistent rules** across schedulers, replication, **JCR observation listeners** (`eventListener`), **OSGi event handlers** (`eventHandler`), and DAM assets
 - Fix **HTL (Sightly)** issues from the **AEM Cloud SDK build**, especially `data-sly-test: redundant constant value comparison`
 - Read **step-by-step transformation** and validation checklists for a specific pattern
 
-For **BPA/CAM orchestration** (collections, CSV, MCP project selection), use the **`migration`** skill (`skills/aem/cloud-service/skills/migration/`).
+For **BPA/CAM-driven discovery** (collections, CSV, MCP project selection), use the **`migration`** skill (`skills/aem/cloud-service/skills/migration/`).
 
-## Pattern Reference Modules
+## Pattern Guides
 
-The five major patterns have **dedicated expert skill subdirectories** with end-to-end coverage (migration, greenfield, review checklist, troubleshooting, common pitfalls, modern alternatives, expert guidance). Smaller cross-cutting concerns are reference modules under `references/`.
+The five major patterns each have a **dedicated pattern guide** with end-to-end coverage (migration, greenfield, review checklist, troubleshooting, common pitfalls, modern alternatives, and AEMaaCS-specific guidance). Shared topics used across patterns are references under `references/`.
 
-| Pattern / topic | BPA Pattern ID | Skill / module | Status |
-|-----------------|----------------|----------------|--------|
-| Scheduler | `scheduler` | [`scheduler/SKILL.md`](scheduler/SKILL.md) | Expert skill |
-| Resource Change Listener | `resourceChangeListener` | [`resource-change-listener/SKILL.md`](resource-change-listener/SKILL.md) | Expert skill |
-| Replication | `replication` | [`replication/SKILL.md`](replication/SKILL.md) | Expert skill |
-| Event listener (JCR observation) | `eventListener` | [`event-migration/SKILL.md`](event-migration/SKILL.md) | Expert skill |
-| Event handler (OSGi Event Admin) | `eventHandler` | [`event-migration/SKILL.md`](event-migration/SKILL.md) | Expert skill |
-| Asset Manager | `assetApi` | [`asset-manager/SKILL.md`](asset-manager/SKILL.md) | Expert skill |
-| Felix SCR → OSGi DS | — | [`references/scr-to-osgi-ds.md`](references/scr-to-osgi-ds.md) | Reference module |
-| ResourceResolver + SLF4J | — | [`references/resource-resolver-logging.md`](references/resource-resolver-logging.md) | Reference module |
-| HTL: `data-sly-test` redundant constant | — (HTL lint) | [`references/data-sly-test-redundant-constant.md`](references/data-sly-test-redundant-constant.md) | Reference module |
-| *(Prerequisites hub)* | — | [`references/aem-cloud-service-pattern-prerequisites.md`](references/aem-cloud-service-pattern-prerequisites.md) | Reference module |
+| Pattern / topic | BPA Pattern ID | Guide | Kind |
+|-----------------|----------------|-------|------|
+| Scheduler | `scheduler` | [`scheduler/SKILL.md`](scheduler/SKILL.md) | Pattern guide |
+| Resource Change Listener | `resourceChangeListener` | [`resource-change-listener/SKILL.md`](resource-change-listener/SKILL.md) | Pattern guide |
+| Replication | `replication` | [`replication/SKILL.md`](replication/SKILL.md) | Pattern guide |
+| Event listener (JCR observation) | `eventListener` | [`event-migration/SKILL.md`](event-migration/SKILL.md) | Pattern guide |
+| Event handler (OSGi Event Admin) | `eventHandler` | [`event-migration/SKILL.md`](event-migration/SKILL.md) | Pattern guide |
+| Asset Manager | `assetApi` | [`asset-manager/SKILL.md`](asset-manager/SKILL.md) | Pattern guide |
+| Felix SCR → OSGi DS | — | [`references/scr-to-osgi-ds.md`](references/scr-to-osgi-ds.md) | Reference |
+| ResourceResolver + SLF4J | — | [`references/resource-resolver-logging.md`](references/resource-resolver-logging.md) | Reference |
+| HTL: `data-sly-test` redundant constant | — (HTL lint) | [`references/data-sly-test-redundant-constant.md`](references/data-sly-test-redundant-constant.md) | Reference |
+| *(Prerequisites hub)* | — | [`references/aem-cloud-service-pattern-prerequisites.md`](references/aem-cloud-service-pattern-prerequisites.md) | Reference |
 
-**Event listener vs event handler (not the same):** **`eventListener`** is **JCR observation** — the JCR API for repository change callbacks (`javax.jcr.observation.EventListener`, `onEvent`). **`eventHandler`** is **OSGi Event Admin** — whiteboard-style OSGi events (`org.osgi.service.event.EventHandler`, `handleEvent`). Both migrate via the [`event-migration/SKILL.md`](event-migration/SKILL.md) expert skill (covers JCR `EventListener` migration as Path A and OSGi `EventHandler` migration as Path B). **`resourceChangeListener`** is separate: Sling **`ResourceChangeListener`**, expert skill at [`resource-change-listener/SKILL.md`](resource-change-listener/SKILL.md).
+**Event listener vs event handler (not the same):** **`eventListener`** is **JCR observation** — the JCR API for repository change callbacks (`javax.jcr.observation.EventListener`, `onEvent`). **`eventHandler`** is **OSGi Event Admin** — whiteboard-style OSGi events (`org.osgi.service.event.EventHandler`, `handleEvent`). Both migrate via the [`event-migration/SKILL.md`](event-migration/SKILL.md) pattern guide (covers JCR `EventListener` migration as Path A and OSGi `EventHandler` migration as Path B). **`resourceChangeListener`** is separate: Sling **`ResourceChangeListener`**, guide at [`resource-change-listener/SKILL.md`](resource-change-listener/SKILL.md).
 
-**Before changing code for a pattern:** read the expert skill (or reference module) for that pattern in full. Each expert skill contains classification criteria, complete before/after examples, ordered transformation steps, greenfield templates, composition examples with other expert skills, review checklists, troubleshooting fingerprints, common pitfalls, modern alternatives, and expert guidance on AEMaaCS-specific concerns.
+**Before changing code for a pattern:** read the relevant pattern guide (or shared reference) in full. Each pattern guide contains classification criteria, complete before/after examples, ordered transformation steps, greenfield templates, composition examples with other patterns, review checklists, troubleshooting fingerprints, common pitfalls, modern alternatives, and guidance on AEMaaCS-specific concerns.
 
 ## Java / OSGi baseline (same skill; no separate installables)
 
@@ -56,20 +56,20 @@ SCR→DS and `ResourceResolver`/logging are **reference modules** under `referen
 
 ## Critical Rules (All Patterns)
 
-**These rules apply to every pattern — expert skill or reference module. Violation means incorrect migration or unsafe Cloud Service code.**
+**These rules apply to every pattern guide and reference. Violation means incorrect migration or unsafe Cloud Service code.**
 
-- **READ THE PATTERN'S EXPERT SKILL OR REFERENCE MODULE FIRST** — never transform code without reading the relevant file in full
-- **READ** [`scr-to-osgi-ds.md`](references/scr-to-osgi-ds.md) and [`resource-resolver-logging.md`](references/resource-resolver-logging.md) when SCR, `ResourceResolver`, or logging are in scope (expert skills and reference modules link via the [prerequisites hub](references/aem-cloud-service-pattern-prerequisites.md); do not duplicate long guides inline)
+- **READ THE RELEVANT PATTERN GUIDE OR REFERENCE FIRST** — never transform code without reading the relevant file in full
+- **READ** [`scr-to-osgi-ds.md`](references/scr-to-osgi-ds.md) and [`resource-resolver-logging.md`](references/resource-resolver-logging.md) when SCR, `ResourceResolver`, or logging are in scope (pattern guides and references link via the [prerequisites hub](references/aem-cloud-service-pattern-prerequisites.md); do not duplicate long guides inline)
 - **DO** preserve environment-specific guards (e.g. `isAuthor()` run mode checks)
-- **DO NOT** change business logic inside methods (Java) or **logical show/hide intent** (HTL) unless the expert skill or reference module explicitly allows it
-- **DO NOT** rename classes unless the expert skill or reference module explicitly says to
+- **DO NOT** change business logic inside methods (Java) or **logical show/hide intent** (HTL) unless the pattern guide or reference explicitly allows it
+- **DO NOT** rename classes unless the pattern guide or reference explicitly says to
 - **DO NOT** invent values — extract from existing code
 - **DO NOT** edit files outside the scope agreed with the user (e.g. only BPA targets or paths they named)
 - **DO** keep **searches, discovery, and edits** for the customer's AEM sources inside the **IDE workspace root(s)** currently open; **DO NOT** grep or walk directories outside that boundary to find Java unless the user explicitly points there
 
 ## Manual Pattern Hints (Classification)
 
-When no BPA list exists, scan imports and types to pick the expert skill or reference module:
+When no BPA list exists, scan imports and types to pick the pattern guide or reference:
 
 | Look for | Pattern → Expert skill / Reference module |
 |----------|-------------------------------------------|
@@ -87,4 +87,4 @@ If multiple patterns match, ask which to fix first.
 
 ## Relationship to Migration
 
-The **`migration`** skill defines **one-pattern-per-session** workflow, BPA/CAM/MCP flows, and user messaging. It **delegates** all detailed transformation steps to this skill's expert skill subdirectories (`<pattern>/SKILL.md`) and reference modules (`references/<file>.md`). It uses a **`{best-practices}`** repo-root path alias to this folder (see its `SKILL.md`). Keep platform truth here; keep orchestration there.
+The **`migration`** skill drives the **one-pattern-per-session** workflow, BPA/CAM/MCP discovery, and user messaging. It **points to** this skill's pattern guides (`<pattern>/SKILL.md`) and references (`references/<file>.md`) for all detailed transformation steps. It uses a **`{best-practices}`** repo-root path alias to this folder (see its `SKILL.md`). Keep platform truth here; keep the workflow there.

--- a/plugins/aem/cloud-service/skills/best-practices/SKILL.md
+++ b/plugins/aem/cloud-service/skills/best-practices/SKILL.md
@@ -49,7 +49,7 @@ The five major patterns each have a **dedicated pattern guide** with end-to-end 
 
 ## Java / OSGi baseline (same skill; no separate installables)
 
-SCR→DS and `ResourceResolver`/logging are **reference modules** under `references/` — not separate skills. Read them when relevant **instead of** re-embedding the same steps inside each pattern file.
+SCR→DS and `ResourceResolver`/logging are **shared references** under `references/` — not separate skills. Read them when relevant **instead of** re-embedding the same steps inside each pattern file.
 
 - **Hub:** [`references/aem-cloud-service-pattern-prerequisites.md`](references/aem-cloud-service-pattern-prerequisites.md)
 - **Modules:** [`references/scr-to-osgi-ds.md`](references/scr-to-osgi-ds.md), [`references/resource-resolver-logging.md`](references/resource-resolver-logging.md)
@@ -71,8 +71,8 @@ SCR→DS and `ResourceResolver`/logging are **reference modules** under `referen
 
 When no BPA list exists, scan imports and types to pick the pattern guide or reference:
 
-| Look for | Pattern → Expert skill / Reference module |
-|----------|-------------------------------------------|
+| Look for | Pattern → Guide |
+|----------|-----------------|
 | `org.apache.sling.commons.scheduler.Scheduler` or `scheduler.schedule(` with `Runnable` | `scheduler` → [`scheduler/SKILL.md`](scheduler/SKILL.md) |
 | `implements ResourceChangeListener` | `resourceChangeListener` → [`resource-change-listener/SKILL.md`](resource-change-listener/SKILL.md) |
 | `com.day.cq.replication.Replicator` or `org.apache.sling.replication.*` | `replication` → [`replication/SKILL.md`](replication/SKILL.md) |

--- a/plugins/aem/cloud-service/skills/best-practices/SKILL.md
+++ b/plugins/aem/cloud-service/skills/best-practices/SKILL.md
@@ -8,9 +8,11 @@ license: Apache-2.0
 
 Platform guidance for **AEM as a Cloud Service**: **Java/OSGi** (what to use, what to avoid, how to refactor legacy patterns) and **HTL** (component `.html` templates, Cloud SDK HTL lint).
 
-This skill holds the **pattern transformation modules** (`references/*.md`). They ship with the **`aem-cloud-service`** plugin; use this skill **without** the **migration** skill for greenfield or maintenance work that only needs these references. Use **migration** when you need BPA/CAM orchestration on top.
+This skill is a **router**: each major migration pattern lives in its own **expert skill subdirectory** (`scheduler/`, `resource-change-listener/`, `replication/`, `event-migration/`, `asset-manager/`) — each one is a self-contained expert skill covering migration, greenfield, review, troubleshooting, common pitfalls, and modern alternatives. Smaller cross-cutting reference modules (SCR→DS, resolver/logging, HTL lint, prerequisites hub) still live under `references/`.
 
-**Quick pick:** Open the **Pattern Reference Modules** table below → jump to the matching `references/<file>.md` → read it fully before editing. For Java: Felix SCR, resolvers, or logging, use **Java / OSGi baseline** links first when those appear in the same change set.
+The skill ships with the **`aem-cloud-service`** plugin. Use it **without** the **migration** skill for greenfield or maintenance work that only needs the pattern guidance. Use **migration** when you need BPA/CAM orchestration on top.
+
+**Quick pick:** Open the **Pattern Reference Modules** table below → jump to the matching skill (`<pattern>/SKILL.md`) or reference (`references/<file>.md`) → read it fully before editing. For Java baseline concerns (Felix SCR, resolvers, logging), check the **Java / OSGi baseline** links first when those appear in the same change set.
 
 ## When to Use This Skill
 
@@ -26,24 +28,24 @@ For **BPA/CAM orchestration** (collections, CSV, MCP project selection), use the
 
 ## Pattern Reference Modules
 
-Each supported pattern has a dedicated module under `references/` relative to this `SKILL.md`.
+The five major patterns have **dedicated expert skill subdirectories** with end-to-end coverage (migration, greenfield, review checklist, troubleshooting, common pitfalls, modern alternatives, expert guidance). Smaller cross-cutting concerns are reference modules under `references/`.
 
-| Pattern / topic | BPA Pattern ID | Module file | Status |
-|-----------------|----------------|-------------|--------|
-| Scheduler | `scheduler` | `references/scheduler.md` | Ready |
-| Resource Change Listener | `resourceChangeListener` | `references/resource-change-listener.md` | Ready |
-| Replication | `replication` | `references/replication.md` | Ready |
-| Event listener (JCR observation) | `eventListener` | `references/event-migration.md` | Ready |
-| Event handler (OSGi Event Admin) | `eventHandler` | `references/event-migration.md` | Ready |
-| Asset Manager | `assetApi` | `references/asset-manager.md` | Ready |
-| Felix SCR → OSGi DS | — | `references/scr-to-osgi-ds.md` | Ready |
-| ResourceResolver + SLF4J | — | `references/resource-resolver-logging.md` | Ready |
-| HTL: `data-sly-test` redundant constant | — (HTL lint) | `references/data-sly-test-redundant-constant.md` | Ready |
-| *(Prerequisites hub)* | — | `references/aem-cloud-service-pattern-prerequisites.md` | — |
+| Pattern / topic | BPA Pattern ID | Skill / module | Status |
+|-----------------|----------------|----------------|--------|
+| Scheduler | `scheduler` | [`scheduler/SKILL.md`](scheduler/SKILL.md) | Expert skill |
+| Resource Change Listener | `resourceChangeListener` | [`resource-change-listener/SKILL.md`](resource-change-listener/SKILL.md) | Expert skill |
+| Replication | `replication` | [`replication/SKILL.md`](replication/SKILL.md) | Expert skill |
+| Event listener (JCR observation) | `eventListener` | [`event-migration/SKILL.md`](event-migration/SKILL.md) | Expert skill |
+| Event handler (OSGi Event Admin) | `eventHandler` | [`event-migration/SKILL.md`](event-migration/SKILL.md) | Expert skill |
+| Asset Manager | `assetApi` | [`asset-manager/SKILL.md`](asset-manager/SKILL.md) | Expert skill |
+| Felix SCR → OSGi DS | — | [`references/scr-to-osgi-ds.md`](references/scr-to-osgi-ds.md) | Reference module |
+| ResourceResolver + SLF4J | — | [`references/resource-resolver-logging.md`](references/resource-resolver-logging.md) | Reference module |
+| HTL: `data-sly-test` redundant constant | — (HTL lint) | [`references/data-sly-test-redundant-constant.md`](references/data-sly-test-redundant-constant.md) | Reference module |
+| *(Prerequisites hub)* | — | [`references/aem-cloud-service-pattern-prerequisites.md`](references/aem-cloud-service-pattern-prerequisites.md) | Reference module |
 
-**Event listener vs event handler (not the same):** **`eventListener`** is **JCR observation** — the JCR API for repository change callbacks (`javax.jcr.observation.EventListener`, `onEvent`). **`eventHandler`** is **OSGi Event Admin** — whiteboard-style OSGi events (`org.osgi.service.event.EventHandler`, `handleEvent`). Both migrate via **`references/event-migration.md`** (Path A vs Path B). **`resourceChangeListener`** is separate: Sling **`ResourceChangeListener`**, module **`references/resource-change-listener.md`**.
+**Event listener vs event handler (not the same):** **`eventListener`** is **JCR observation** — the JCR API for repository change callbacks (`javax.jcr.observation.EventListener`, `onEvent`). **`eventHandler`** is **OSGi Event Admin** — whiteboard-style OSGi events (`org.osgi.service.event.EventHandler`, `handleEvent`). Both migrate via the [`event-migration/SKILL.md`](event-migration/SKILL.md) expert skill (covers JCR `EventListener` migration as Path A and OSGi `EventHandler` migration as Path B). **`resourceChangeListener`** is separate: Sling **`ResourceChangeListener`**, expert skill at [`resource-change-listener/SKILL.md`](resource-change-listener/SKILL.md).
 
-**Before changing code for a pattern:** read the module for that pattern in full. Modules include classification criteria, ordered transformation steps, and validation checklists.
+**Before changing code for a pattern:** read the expert skill (or reference module) for that pattern in full. Each expert skill contains classification criteria, complete before/after examples, ordered transformation steps, greenfield templates, composition examples with other expert skills, review checklists, troubleshooting fingerprints, common pitfalls, modern alternatives, and expert guidance on AEMaaCS-specific concerns.
 
 ## Java / OSGi baseline (same skill; no separate installables)
 
@@ -83,6 +85,8 @@ When no BPA list exists, scan imports and types to pick a module:
 
 If multiple patterns match, ask which to fix first.
 
-## Relationship to Migration
+## Relationship to Migration and Code-Assessment
 
-The **`migration`** skill defines **one-pattern-per-session** workflow, BPA/CAM/MCP flows, and user messaging. It **delegates** all detailed transformation steps to this skill's `references/` modules. It uses a **`{best-practices}`** repo-root path alias to this folder (see its `SKILL.md`). Keep platform truth here; keep orchestration there.
+The **`migration`** skill defines **one-pattern-per-session** workflow, BPA/CAM/MCP flows, and user messaging. It **delegates** all detailed transformation steps to this skill's expert skill subdirectories (`<pattern>/SKILL.md`) and reference modules (`references/<file>.md`). It uses a **`{best-practices}`** repo-root path alias to this folder (see its `SKILL.md`). Keep platform truth here; keep orchestration there.
+
+The **`code-assessment`** skill (when present) is the second orchestrator entry point: it tries Health Assessment (HA) findings via MCP first, and falls back to this skill's expert subdirectories when HA has no detector coverage for a named pattern. Both orchestrators invoke the same expert skills — the difference is the discovery path (BPA/CAM for `migration`, HA/MCP for `code-assessment`).

--- a/plugins/aem/cloud-service/skills/best-practices/SKILL.md
+++ b/plugins/aem/cloud-service/skills/best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: best-practices
-description: AEM as a Cloud Service Java/OSGi best practices, guardrails, and legacy-to-cloud pattern transformations. Use for Cloud Service–correct bundles, deprecated APIs, schedulers, ResourceChangeListener, replication, Replicator, JCR observation (javax.jcr.observation.EventListener), OSGi Event Admin (org.osgi.service.event.EventHandler), DAM AssetManager, BPA-style fixes, HTL (Sightly) Cloud SDK lint warnings (data-sly-test redundant constant value comparison), or any time you need the detailed pattern reference modules under this skill.
+description: AEM as a Cloud Service Java/OSGi best practices, guardrails, and legacy-to-cloud pattern transformations. Routes to dedicated expert skills for the five major patterns (scheduler, resource-change-listener, replication, event-migration, asset-manager) and reference modules for cross-cutting concerns (SCR→DS, ResourceResolver/SLF4J, HTL data-sly-test lint, prerequisites). Use for Cloud Service–correct bundles, deprecated APIs, schedulers, ResourceChangeListener, replication, Replicator, JCR observation (javax.jcr.observation.EventListener), OSGi Event Admin (org.osgi.service.event.EventHandler), DAM AssetManager, BPA-style fixes, or HTL (Sightly) Cloud SDK lint warnings (data-sly-test redundant constant value comparison).
 license: Apache-2.0
 ---
 
@@ -19,7 +19,7 @@ The skill ships with the **`aem-cloud-service`** plugin. Use it **without** the 
 Use this skill when you need to:
 
 - Apply **AEM as a Cloud Service** constraints to **Java/OSGi** code (new or existing)
-- Refactor **legacy Java patterns** into supported APIs (same modules migration uses)
+- Refactor **legacy Java patterns** into supported APIs (same expert skills and reference modules migration uses)
 - Follow **consistent rules** across schedulers, replication, **JCR observation listeners** (`eventListener`), **OSGi event handlers** (`eventHandler`), and DAM assets
 - Fix **HTL (Sightly)** issues from the **AEM Cloud SDK build**, especially `data-sly-test: redundant constant value comparison`
 - Read **step-by-step transformation** and validation checklists for a specific pattern
@@ -56,37 +56,35 @@ SCR→DS and `ResourceResolver`/logging are **reference modules** under `referen
 
 ## Critical Rules (All Patterns)
 
-**These rules apply to every pattern module. Violation means incorrect migration or unsafe Cloud Service code.**
+**These rules apply to every pattern — expert skill or reference module. Violation means incorrect migration or unsafe Cloud Service code.**
 
-- **READ THE PATTERN MODULE FIRST** — never transform code without reading the module
-- **READ** [`scr-to-osgi-ds.md`](references/scr-to-osgi-ds.md) and [`resource-resolver-logging.md`](references/resource-resolver-logging.md) when SCR, `ResourceResolver`, or logging are in scope (pattern modules link via the [prerequisites hub](references/aem-cloud-service-pattern-prerequisites.md); do not duplicate long guides inline)
+- **READ THE PATTERN'S EXPERT SKILL OR REFERENCE MODULE FIRST** — never transform code without reading the relevant file in full
+- **READ** [`scr-to-osgi-ds.md`](references/scr-to-osgi-ds.md) and [`resource-resolver-logging.md`](references/resource-resolver-logging.md) when SCR, `ResourceResolver`, or logging are in scope (expert skills and reference modules link via the [prerequisites hub](references/aem-cloud-service-pattern-prerequisites.md); do not duplicate long guides inline)
 - **DO** preserve environment-specific guards (e.g. `isAuthor()` run mode checks)
-- **DO NOT** change business logic inside methods (Java) or **logical show/hide intent** (HTL) unless the module explicitly allows it
-- **DO NOT** rename classes unless the pattern module explicitly says to
+- **DO NOT** change business logic inside methods (Java) or **logical show/hide intent** (HTL) unless the expert skill or reference module explicitly allows it
+- **DO NOT** rename classes unless the expert skill or reference module explicitly says to
 - **DO NOT** invent values — extract from existing code
 - **DO NOT** edit files outside the scope agreed with the user (e.g. only BPA targets or paths they named)
 - **DO** keep **searches, discovery, and edits** for the customer's AEM sources inside the **IDE workspace root(s)** currently open; **DO NOT** grep or walk directories outside that boundary to find Java unless the user explicitly points there
 
 ## Manual Pattern Hints (Classification)
 
-When no BPA list exists, scan imports and types to pick a module:
+When no BPA list exists, scan imports and types to pick the expert skill or reference module:
 
-| Look for | Pattern |
-|----------|---------|
-| `org.apache.sling.commons.scheduler.Scheduler` or `scheduler.schedule(` with `Runnable` | `scheduler` |
-| `implements ResourceChangeListener` | `resourceChangeListener` |
-| `com.day.cq.replication.Replicator` or `org.apache.sling.replication.*` | `replication` |
-| **JCR observation:** `javax.jcr.observation.EventListener`, `onEvent(EventIterator)`, `javax.jcr.observation.*` | `eventListener` |
-| **OSGi Event Admin:** `org.osgi.service.event.EventHandler`, substantive `handleEvent` (resolver/session/node work) | `eventHandler` |
-| `com.day.cq.dam.api.AssetManager` create/remove asset APIs | `assetApi` |
-| `org.apache.felix.scr.annotations` | read `references/scr-to-osgi-ds.md` (often combined with a BPA pattern) |
-| `getAdministrativeResourceResolver`, `System.out` / `printStackTrace` | read `references/resource-resolver-logging.md` |
-| **HTL:** build warning `data-sly-test: redundant constant value comparison`, or `.html` under `ui.apps` / `jcr_root` with bad `data-sly-test` | read `references/data-sly-test-redundant-constant.md` |
+| Look for | Pattern → Expert skill / Reference module |
+|----------|-------------------------------------------|
+| `org.apache.sling.commons.scheduler.Scheduler` or `scheduler.schedule(` with `Runnable` | `scheduler` → [`scheduler/SKILL.md`](scheduler/SKILL.md) |
+| `implements ResourceChangeListener` | `resourceChangeListener` → [`resource-change-listener/SKILL.md`](resource-change-listener/SKILL.md) |
+| `com.day.cq.replication.Replicator` or `org.apache.sling.replication.*` | `replication` → [`replication/SKILL.md`](replication/SKILL.md) |
+| **JCR observation:** `javax.jcr.observation.EventListener`, `onEvent(EventIterator)`, `javax.jcr.observation.*` | `eventListener` → [`event-migration/SKILL.md`](event-migration/SKILL.md) |
+| **OSGi Event Admin:** `org.osgi.service.event.EventHandler`, substantive `handleEvent` (resolver/session/node work) | `eventHandler` → [`event-migration/SKILL.md`](event-migration/SKILL.md) |
+| `com.day.cq.dam.api.AssetManager` create/remove asset APIs | `assetApi` → [`asset-manager/SKILL.md`](asset-manager/SKILL.md) |
+| `org.apache.felix.scr.annotations` | [`references/scr-to-osgi-ds.md`](references/scr-to-osgi-ds.md) (often combined with one of the patterns above) |
+| `getAdministrativeResourceResolver`, `System.out` / `printStackTrace` | [`references/resource-resolver-logging.md`](references/resource-resolver-logging.md) |
+| **HTL:** build warning `data-sly-test: redundant constant value comparison`, or `.html` under `ui.apps` / `jcr_root` with bad `data-sly-test` | [`references/data-sly-test-redundant-constant.md`](references/data-sly-test-redundant-constant.md) |
 
 If multiple patterns match, ask which to fix first.
 
-## Relationship to Migration and Code-Assessment
+## Relationship to Migration
 
 The **`migration`** skill defines **one-pattern-per-session** workflow, BPA/CAM/MCP flows, and user messaging. It **delegates** all detailed transformation steps to this skill's expert skill subdirectories (`<pattern>/SKILL.md`) and reference modules (`references/<file>.md`). It uses a **`{best-practices}`** repo-root path alias to this folder (see its `SKILL.md`). Keep platform truth here; keep orchestration there.
-
-The **`code-assessment`** skill (when present) is the second orchestrator entry point: it tries Health Assessment (HA) findings via MCP first, and falls back to this skill's expert subdirectories when HA has no detector coverage for a named pattern. Both orchestrators invoke the same expert skills — the difference is the discovery path (BPA/CAM for `migration`, HA/MCP for `code-assessment`).

--- a/plugins/aem/cloud-service/skills/migration/README.md
+++ b/plugins/aem/cloud-service/skills/migration/README.md
@@ -17,7 +17,7 @@ This skill drives migration **from legacy AEM (6.x, AMS, or on-prem) to AEM as a
 
 - BPA collection, CSV, and CAM/MCP flows (CAM tool schemas and retries: `references/cam-mcp.md`)
 - Manual flow and pattern auto-detection
-- Delegates detailed transformations to **`best-practices`**
+- Points to **`best-practices`** for all detailed transformation steps
 
 **First run:** In chat, name **one BPA pattern** (e.g. scheduler) and either a **CSV path**, **CAM/MCP**, or **concrete Java files**. See **Quick start** in `SKILL.md` for copy-paste prompts and the CAM happy path in `references/cam-mcp.md`.
 

--- a/plugins/aem/cloud-service/skills/migration/README.md
+++ b/plugins/aem/cloud-service/skills/migration/README.md
@@ -6,7 +6,7 @@ This skill orchestrates migration **from legacy AEM (6.x, AMS, or on-prem) to AE
 
 ## Requires `best-practices`
 
-**This skill is not standalone.** It orchestrates BPA/CAM and target discovery; **step-by-step refactors and pattern modules live only in the [`best-practices`](../best-practices/) skill** (`SKILL.md` and `references/*.md`). For any code change, the agent must read that material—**migration does not copy those procedures** here.
+**This skill is not standalone.** It orchestrates BPA/CAM and target discovery; **step-by-step refactors live only in the [`best-practices`](../best-practices/) skill**. Five major patterns are dedicated **expert skill subdirectories** (`scheduler/`, `resource-change-listener/`, `replication/`, `event-migration/`, `asset-manager/`); cross-cutting concerns (SCR→DS, ResourceResolver/SLF4J, HTL lint, prerequisites hub) are **reference modules** under `references/`. For any code change, the agent must read the relevant expert skill or reference module — **migration does not copy those procedures** here.
 
 - **You need both:** use **migration** for workflow and targets; use **best-practices** for how to edit Java/OSGi and apply each pattern.
 - **Install once, get both:** the umbrella **`aem-cloud-service`** plugin (path `skills/aem/cloud-service`) includes `migration/` and `best-practices/` together. Do not rely on migration alone unless the same `best-practices` files are already on disk (for example full `adobe/skills` checkout with working `{best-practices}` links).

--- a/plugins/aem/cloud-service/skills/migration/README.md
+++ b/plugins/aem/cloud-service/skills/migration/README.md
@@ -1,12 +1,12 @@
 # AEM as a Cloud Service — Code Migration
 
-This skill orchestrates migration **from legacy AEM (6.x, AMS, or on-prem) to AEM as a Cloud Service**: Best Practices Analyzer (BPA) data, Cloud Acceleration Manager (CAM) via MCP when available, and a one-pattern-per-session workflow.
+This skill drives migration **from legacy AEM (6.x, AMS, or on-prem) to AEM as a Cloud Service**: Best Practices Analyzer (BPA) data, Cloud Acceleration Manager (CAM) via MCP when available, and a one-pattern-per-session workflow.
 
 **Target platform** is always **AEM as a Cloud Service**. Source is legacy AEM; ambiguous top-level “migration” is avoided by scoping this under `skills/aem/cloud-service/skills/migration/`.
 
 ## Requires `best-practices`
 
-**This skill is not standalone.** It orchestrates BPA/CAM and target discovery; **step-by-step refactors live only in the [`best-practices`](../best-practices/) skill**. Five major patterns are dedicated **expert skill subdirectories** (`scheduler/`, `resource-change-listener/`, `replication/`, `event-migration/`, `asset-manager/`); cross-cutting concerns (SCR→DS, ResourceResolver/SLF4J, HTL lint, prerequisites hub) are **reference modules** under `references/`. For any code change, the agent must read the relevant expert skill or reference module — **migration does not copy those procedures** here.
+**This skill is not standalone.** It drives BPA/CAM and target discovery; **step-by-step refactors live only in the [`best-practices`](../best-practices/) skill**. Five major patterns each have a **pattern guide** (`scheduler/`, `resource-change-listener/`, `replication/`, `event-migration/`, `asset-manager/`); shared topics (SCR→DS, ResourceResolver/SLF4J, HTL lint, prerequisites hub) live as **references** under `references/`. For any code change, the agent must read the relevant pattern guide or reference — **migration does not copy those procedures** here.
 
 - **You need both:** use **migration** for workflow and targets; use **best-practices** for how to edit Java/OSGi and apply each pattern.
 - **Install once, get both:** the umbrella **`aem-cloud-service`** plugin (path `skills/aem/cloud-service`) includes `migration/` and `best-practices/` together. Do not rely on migration alone unless the same `best-practices` files are already on disk (for example full `adobe/skills` checkout with working `{best-practices}` links).

--- a/plugins/aem/cloud-service/skills/migration/SKILL.md
+++ b/plugins/aem/cloud-service/skills/migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: migration
-description: Orchestrates legacy AEM (6.x, AMS, on-prem) to AEM as a Cloud Service migration using BPA CSV or cache, CAM/MCP target discovery, and one-pattern-per-session workflow. Use for BPA/CAM findings, Cloud Service blockers, or fixes for scheduler, ResourceChangeListener, replication, EventListener, OSGi EventHandler, DAM AssetManager, HTL data-sly-test lint. OSGi configs → Cloud Manager — scan ui.config, .cfg.json, secrets, $[secret:]/$[env:] — agent follows references/osgi-cfg-json-cloud-manager.md when prompted. Transformation steps live in the best-practices skill: five major patterns are dedicated expert skills (scheduler/, resource-change-listener/, replication/, event-migration/, asset-manager/); cross-cutting concerns are reference modules under references/. Read the right one before editing code.
+description: Migrates legacy AEM (6.x, AMS, on-prem) to AEM as a Cloud Service using BPA CSV or cache, CAM/MCP target discovery, and a one-pattern-per-session workflow. Use for BPA/CAM findings, Cloud Service blockers, or fixes for scheduler, ResourceChangeListener, replication, EventListener, OSGi EventHandler, DAM AssetManager, HTL data-sly-test lint. OSGi configs → Cloud Manager — scan ui.config, .cfg.json, secrets, $[secret:]/$[env:] — agent follows references/osgi-cfg-json-cloud-manager.md when prompted. Transformation steps live in the best-practices skill: five major patterns each have a pattern guide (scheduler/, resource-change-listener/, replication/, event-migration/, asset-manager/); shared topics live as references under references/. Read the right one before editing code.
 license: Apache-2.0
 ---
 
@@ -8,7 +8,7 @@ license: Apache-2.0
 
 **Source → target:** Legacy **AEM 6.x / AMS / on-prem** → **AEM as a Cloud Service**. Scoped under `skills/aem/cloud-service/skills/migration/` so this is not confused with Edge Delivery or 6.5 LTS.
 
-This skill is **orchestration**: BPA data, CAM/MCP, **one pattern per session**, and target discovery. **Transformation rules and steps** live in the **`best-practices`** skill — read that skill and the right **expert skill subdirectory** (`<pattern>/SKILL.md`) or reference module (`references/<file>.md`) before editing code.
+This skill drives the **migration workflow**: BPA data, CAM/MCP, **one pattern per session**, and target discovery. **Transformation rules and steps** live in the **`best-practices`** skill — read that skill and the right **pattern guide** (`<pattern>/SKILL.md`) or reference (`references/<file>.md`) before editing code.
 
 **Setup:** Use the **`aem-cloud-service`** install (see repository root **README**) so both **migration** and **best-practices** paths are available. If you already have the monorepo open with resolvable `{best-practices}` paths, no separate install step is required.
 
@@ -59,16 +59,16 @@ Applies to **finding and editing the user's AEM project** (Java, bundles, config
 **Branch B — Java / HTL / BPA pattern migration:**
 
 1. Read **`{best-practices}/SKILL.md`** — critical rules, Java baseline links, **Pattern Reference Modules** table, **Manual Pattern Hints**.
-2. Read the **expert skill** (or reference module) for the **single** active pattern. Routing:
-   - `scheduler` → **`{best-practices}/scheduler/SKILL.md`** *(expert skill)*
-   - `resourceChangeListener` → **`{best-practices}/resource-change-listener/SKILL.md`** *(expert skill)*
-   - `replication` → **`{best-practices}/replication/SKILL.md`** *(expert skill)*
-   - `eventListener` / `eventHandler` → **`{best-practices}/event-migration/SKILL.md`** *(expert skill — both JCR and OSGi Event Admin paths)*
-   - `assetApi` → **`{best-practices}/asset-manager/SKILL.md`** *(expert skill)*
-   - `htlLint` → **`{best-practices}/references/data-sly-test-redundant-constant.md`** *(reference module by design — HTL lint stays a reference module, not an expert skill subdirectory)*
+2. Read the **pattern guide** (or reference) for the **single** active pattern:
+   - `scheduler` → **`{best-practices}/scheduler/SKILL.md`** *(pattern guide)*
+   - `resourceChangeListener` → **`{best-practices}/resource-change-listener/SKILL.md`** *(pattern guide)*
+   - `replication` → **`{best-practices}/replication/SKILL.md`** *(pattern guide)*
+   - `eventListener` / `eventHandler` → **`{best-practices}/event-migration/SKILL.md`** *(pattern guide — both JCR and OSGi Event Admin paths)*
+   - `assetApi` → **`{best-practices}/asset-manager/SKILL.md`** *(pattern guide)*
+   - `htlLint` → **`{best-practices}/references/data-sly-test-redundant-constant.md`** *(reference — HTL lint is a single shared reference, not a dedicated pattern guide)*
 3. When code uses SCR, `ResourceResolver`, or console logging, read **`{best-practices}/references/scr-to-osgi-ds.md`** and **`{best-practices}/references/resource-resolver-logging.md`** (or the hub **`{best-practices}/references/aem-cloud-service-pattern-prerequisites.md`**).
 
-Do not transform **Java or HTL** until the pattern's expert skill (or reference module) is read (branch B). Branch A does not require `{best-practices}` pattern guidance.
+Do not transform **Java or HTL** until the pattern guide (or reference) is read (branch B). Branch A does not require `{best-practices}` pattern guidance.
 
 ## When to Use This Skill
 
@@ -198,7 +198,7 @@ For retries, error categories, and when user-directed CSV/manual paths are allow
 
 ## Pattern modules
 
-Do **not** duplicate the pattern table here. Use **`{best-practices}/SKILL.md` → Pattern Reference Modules** — five patterns route to expert skill subdirectories (`{best-practices}/<pattern>/SKILL.md`); cross-cutting concerns (SCR→DS, ResourceResolver/SLF4J, HTL lint, prerequisites hub) stay as reference modules (`{best-practices}/references/<file>.md`). See **Branch B step 2** above for the per-pattern routing table.
+Do **not** duplicate the pattern table here. Use **`{best-practices}/SKILL.md` → Pattern Guides** — five patterns each have a pattern guide (`{best-practices}/<pattern>/SKILL.md`); shared topics (SCR→DS, ResourceResolver/SLF4J, HTL lint, prerequisites hub) stay as references (`{best-practices}/references/<file>.md`). See **Branch B step 2** above for the per-pattern routing table.
 
 ## Workflow
 
@@ -228,7 +228,7 @@ the user says to continue. See **Batched processing (batch size 5)** below.
 
 ### Step 4: Read before edits
 
-**STOP.** Read **`{best-practices}/SKILL.md`** and the expert skill (or reference module) for the active pattern — see **Branch B step 2** above for the pattern → file routing table.
+**STOP.** Read **`{best-practices}/SKILL.md`** and the pattern guide (or reference) for the active pattern — see **Branch B step 2** above for the pattern → file routing table.
 
 ### Step 5: Process the batch
 
@@ -256,7 +256,7 @@ requests it, and pass `offset: paging.nextOffset` unchanged.
 
 ### Manual flow (no BPA)
 
-User-named files → classify (best-practices hints or ask) → confirm the expert skill or reference module exists → read **`{best-practices}/SKILL.md`** + the expert skill (or reference module) — see Branch B step 2 routing — → transform → report.
+User-named files → classify (best-practices hints or ask) → confirm the pattern guide or reference exists → read **`{best-practices}/SKILL.md`** + the pattern guide (or reference) — see Branch B step 2 routing — → transform → report.
 
 ### OSGi → Cloud Manager flow
 
@@ -266,7 +266,7 @@ Does **not** use BPA CSV, CAM/MCP, or best-practices pattern modules for collect
 
 `htlLint` does not use BPA CSV or CAM/MCP. Instead:
 
-1. **Read** [`{best-practices}/references/data-sly-test-redundant-constant.md`](../best-practices/references/data-sly-test-redundant-constant.md) — it contains the **Workflow**, **Proactive Discovery** `rg` patterns, and all 4 fix patterns. (HTL lint stays as a reference module — not an expert skill subdirectory.)
+1. **Read** [`{best-practices}/references/data-sly-test-redundant-constant.md`](../best-practices/references/data-sly-test-redundant-constant.md) — it contains the **Workflow**, **Proactive Discovery** `rg` patterns, and all 4 fix patterns. (HTL lint lives as a shared reference, not a dedicated pattern guide.)
 2. **Discover** targets using the `rg` commands from the module's **Proactive Discovery** table (scope: `ui.apps/**/jcr_root/**/*.html` or the user's content package paths).
 3. **Group** hits by file, classify each by pattern (boolean literal, raw string, numeric, split expression).
 4. **Fix** each hit per the matching pattern section in the module.

--- a/plugins/aem/cloud-service/skills/migration/SKILL.md
+++ b/plugins/aem/cloud-service/skills/migration/SKILL.md
@@ -8,7 +8,7 @@ license: Apache-2.0
 
 **Source → target:** Legacy **AEM 6.x / AMS / on-prem** → **AEM as a Cloud Service**. Scoped under `skills/aem/cloud-service/skills/migration/` so this is not confused with Edge Delivery or 6.5 LTS.
 
-This skill is **orchestration**: BPA data, CAM/MCP, **one pattern per session**, and target discovery. **Transformation rules and steps** live in the **`best-practices`** skill — read that skill and the right `references/*.md` before editing code.
+This skill is **orchestration**: BPA data, CAM/MCP, **one pattern per session**, and target discovery. **Transformation rules and steps** live in the **`best-practices`** skill — read that skill and the right **expert skill subdirectory** (`<pattern>/SKILL.md`) or reference module (`references/<file>.md`) before editing code.
 
 **Setup:** Use the **`aem-cloud-service`** install (see repository root **README**) so both **migration** and **best-practices** paths are available. If you already have the monorepo open with resolvable `{best-practices}` paths, no separate install step is required.
 
@@ -41,7 +41,7 @@ From the **repository root** (parent of the `skills/` directory):
 |--------|------|
 | **`{best-practices}`** | `skills/aem/cloud-service/skills/best-practices/` |
 
-Examples: `{best-practices}/SKILL.md`, `{best-practices}/references/scheduler.md`.
+Examples: `{best-practices}/SKILL.md`, `{best-practices}/scheduler/SKILL.md`, `{best-practices}/references/scr-to-osgi-ds.md`.
 
 ## Workspace scope (IDE) — user code only
 
@@ -59,10 +59,16 @@ Applies to **finding and editing the user's AEM project** (Java, bundles, config
 **Branch B — Java / HTL / BPA pattern migration:**
 
 1. Read **`{best-practices}/SKILL.md`** — critical rules, Java baseline links, **Pattern Reference Modules** table, **Manual Pattern Hints**.
-2. Read **`{best-practices}/references/<module>.md`** for the **single** active pattern (see table in that `SKILL.md`).
+2. Read the **expert skill** (or reference module) for the **single** active pattern. Routing:
+   - `scheduler` → **`{best-practices}/scheduler/SKILL.md`**
+   - `resourceChangeListener` → **`{best-practices}/resource-change-listener/SKILL.md`**
+   - `replication` → **`{best-practices}/replication/SKILL.md`**
+   - `eventListener` / `eventHandler` → **`{best-practices}/event-migration/SKILL.md`**
+   - `assetApi` → **`{best-practices}/asset-manager/SKILL.md`**
+   - `htlLint` → **`{best-practices}/references/data-sly-test-redundant-constant.md`**
 3. When code uses SCR, `ResourceResolver`, or console logging, read **`{best-practices}/references/scr-to-osgi-ds.md`** and **`{best-practices}/references/resource-resolver-logging.md`** (or the hub **`{best-practices}/references/aem-cloud-service-pattern-prerequisites.md`**).
 
-Do not transform **Java or HTL** until the pattern module is read (branch B). Branch A does not require `{best-practices}` pattern modules.
+Do not transform **Java or HTL** until the pattern's expert skill (or reference module) is read (branch B). Branch A does not require `{best-practices}` pattern guidance.
 
 ## When to Use This Skill
 
@@ -222,7 +228,7 @@ the user says to continue. See **Batched processing (batch size 5)** below.
 
 ### Step 4: Read before edits
 
-**STOP.** Read **`{best-practices}/SKILL.md`** and **`{best-practices}/references/<module>.md`** for the active pattern.
+**STOP.** Read **`{best-practices}/SKILL.md`** and the expert skill (or reference module) for the active pattern — see **Branch B step 2** above for the pattern → file routing table.
 
 ### Step 5: Process the batch
 
@@ -250,7 +256,7 @@ requests it, and pass `offset: paging.nextOffset` unchanged.
 
 ### Manual flow (no BPA)
 
-User-named files → classify (best-practices hints or ask) → confirm module exists → read **`{best-practices}/SKILL.md`** + module → transform → report.
+User-named files → classify (best-practices hints or ask) → confirm the expert skill or reference module exists → read **`{best-practices}/SKILL.md`** + the expert skill (or reference module) — see Branch B step 2 routing — → transform → report.
 
 ### OSGi → Cloud Manager flow
 
@@ -260,7 +266,7 @@ Does **not** use BPA CSV, CAM/MCP, or best-practices pattern modules for collect
 
 `htlLint` does not use BPA CSV or CAM/MCP. Instead:
 
-1. **Read** `{best-practices}/references/data-sly-test-redundant-constant.md` — it contains the **Workflow**, **Proactive Discovery** `rg` patterns, and all 4 fix patterns.
+1. **Read** [`{best-practices}/references/data-sly-test-redundant-constant.md`](../best-practices/references/data-sly-test-redundant-constant.md) — it contains the **Workflow**, **Proactive Discovery** `rg` patterns, and all 4 fix patterns. (HTL lint stays as a reference module — not an expert skill subdirectory.)
 2. **Discover** targets using the `rg` commands from the module's **Proactive Discovery** table (scope: `ui.apps/**/jcr_root/**/*.html` or the user's content package paths).
 3. **Group** hits by file, classify each by pattern (boolean literal, raw string, numeric, split expression).
 4. **Fix** each hit per the matching pattern section in the module.

--- a/plugins/aem/cloud-service/skills/migration/SKILL.md
+++ b/plugins/aem/cloud-service/skills/migration/SKILL.md
@@ -22,11 +22,11 @@ This skill drives the **migration workflow**: BPA data, CAM/MCP, **one pattern p
 | **CAM + MCP** only | *"Get **scheduler** findings from CAM; I'll pick the project when you list them."* | Agent lists projects → you confirm → MCP fetch ([cam-mcp.md](references/cam-mcp.md)) |
 | **Just a few files** | *"Migrate **scheduler** in `core/.../MyJob.java`"* | Manual flow: no BPA required |
 | **OSGi → Cloud Manager** | *"**Scan my config files and create Cloud Manager environment secrets or variables.**"* | Agent **auto-reads** [references/osgi-cfg-json-cloud-manager.md](references/osgi-cfg-json-cloud-manager.md) (full Adobe-aligned rules inlined there); no BPA pattern id |
-| **HTL lint warnings** | *"Fix **htlLint** issues in `ui.apps`"* | Proactive discovery via `rg` → fix per reference module |
+| **HTL lint warnings** | *"Fix **htlLint** issues in `ui.apps`"* | Proactive discovery via `rg` → fix per the HTL lint reference |
 
 **Starter prompts (copy-paste):**
 
-- *"Use the migration skill: **scheduler** only, BPA CSV at `./reports/bpa.csv`, then apply best-practices reference modules before editing."*
+- *"Use the migration skill: **scheduler** only, BPA CSV at `./reports/bpa.csv`, then apply the best-practices pattern guide before editing."*
 - *"**Replication** only from CAM; list projects first, I'll pick one."*
 - *"**Manual:** **event listener** migration for `.../Listener.java` — read best-practices module first."*
 - *"Scan my config files and create Cloud Manager environment secrets or variables."*
@@ -58,7 +58,7 @@ Applies to **finding and editing the user's AEM project** (Java, bundles, config
 
 **Branch B — Java / HTL / BPA pattern migration:**
 
-1. Read **`{best-practices}/SKILL.md`** — critical rules, Java baseline links, **Pattern Reference Modules** table, **Manual Pattern Hints**.
+1. Read **`{best-practices}/SKILL.md`** — critical rules, Java baseline links, **Pattern Guides** table, **Manual Pattern Hints**.
 2. Read the **pattern guide** (or reference) for the **single** active pattern:
    - `scheduler` → **`{best-practices}/scheduler/SKILL.md`** *(pattern guide)*
    - `resourceChangeListener` → **`{best-practices}/resource-change-listener/SKILL.md`** *(pattern guide)*
@@ -196,7 +196,7 @@ For retries, error categories, and when user-directed CSV/manual paths are allow
 
 **Optional prompt after stop (user must reply):** *"Reply with the CAM project to use (id or name from the list), a path to your BPA CSV, or the Java files for a manual migration."*
 
-## Pattern modules
+## Pattern guides
 
 Do **not** duplicate the pattern table here. Use **`{best-practices}/SKILL.md` → Pattern Guides** — five patterns each have a pattern guide (`{best-practices}/<pattern>/SKILL.md`); shared topics (SCR→DS, ResourceResolver/SLF4J, HTL lint, prerequisites hub) stay as references (`{best-practices}/references/<file>.md`). See **Branch B step 2** above for the per-pattern routing table.
 
@@ -260,7 +260,7 @@ User-named files → classify (best-practices hints or ask) → confirm the patt
 
 ### OSGi → Cloud Manager flow
 
-Does **not** use BPA CSV, CAM/MCP, or best-practices pattern modules for collection. Follow **Branch A** in **Required delegation** and the **One-prompt workflow** in [references/osgi-cfg-json-cloud-manager.md](references/osgi-cfg-json-cloud-manager.md).
+Does **not** use BPA CSV, CAM/MCP, or best-practices pattern guides for collection. Follow **Branch A** in **Required delegation** and the **One-prompt workflow** in [references/osgi-cfg-json-cloud-manager.md](references/osgi-cfg-json-cloud-manager.md).
 
 ### htlLint flow
 

--- a/plugins/aem/cloud-service/skills/migration/SKILL.md
+++ b/plugins/aem/cloud-service/skills/migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: migration
-description: Orchestrates legacy AEM (6.x, AMS, on-prem) to AEM as a Cloud Service migration using BPA CSV or cache, CAM/MCP target discovery, and one-pattern-per-session workflow. Use for BPA/CAM findings, Cloud Service blockers, or fixes for scheduler, ResourceChangeListener, replication, EventListener, OSGi EventHandler, DAM AssetManager, HTL data-sly-test lint. OSGi configs → Cloud Manager — scan ui.config, .cfg.json, secrets, $[secret:]/$[env:] — agent follows references/osgi-cfg-json-cloud-manager.md when prompted. Transformation steps live in the best-practices skill—read it and the right references/ modules before editing code.
+description: Orchestrates legacy AEM (6.x, AMS, on-prem) to AEM as a Cloud Service migration using BPA CSV or cache, CAM/MCP target discovery, and one-pattern-per-session workflow. Use for BPA/CAM findings, Cloud Service blockers, or fixes for scheduler, ResourceChangeListener, replication, EventListener, OSGi EventHandler, DAM AssetManager, HTL data-sly-test lint. OSGi configs → Cloud Manager — scan ui.config, .cfg.json, secrets, $[secret:]/$[env:] — agent follows references/osgi-cfg-json-cloud-manager.md when prompted. Transformation steps live in the best-practices skill: five major patterns are dedicated expert skills (scheduler/, resource-change-listener/, replication/, event-migration/, asset-manager/); cross-cutting concerns are reference modules under references/. Read the right one before editing code.
 license: Apache-2.0
 ---
 
@@ -60,12 +60,12 @@ Applies to **finding and editing the user's AEM project** (Java, bundles, config
 
 1. Read **`{best-practices}/SKILL.md`** — critical rules, Java baseline links, **Pattern Reference Modules** table, **Manual Pattern Hints**.
 2. Read the **expert skill** (or reference module) for the **single** active pattern. Routing:
-   - `scheduler` → **`{best-practices}/scheduler/SKILL.md`**
-   - `resourceChangeListener` → **`{best-practices}/resource-change-listener/SKILL.md`**
-   - `replication` → **`{best-practices}/replication/SKILL.md`**
-   - `eventListener` / `eventHandler` → **`{best-practices}/event-migration/SKILL.md`**
-   - `assetApi` → **`{best-practices}/asset-manager/SKILL.md`**
-   - `htlLint` → **`{best-practices}/references/data-sly-test-redundant-constant.md`**
+   - `scheduler` → **`{best-practices}/scheduler/SKILL.md`** *(expert skill)*
+   - `resourceChangeListener` → **`{best-practices}/resource-change-listener/SKILL.md`** *(expert skill)*
+   - `replication` → **`{best-practices}/replication/SKILL.md`** *(expert skill)*
+   - `eventListener` / `eventHandler` → **`{best-practices}/event-migration/SKILL.md`** *(expert skill — both JCR and OSGi Event Admin paths)*
+   - `assetApi` → **`{best-practices}/asset-manager/SKILL.md`** *(expert skill)*
+   - `htlLint` → **`{best-practices}/references/data-sly-test-redundant-constant.md`** *(reference module by design — HTL lint stays a reference module, not an expert skill subdirectory)*
 3. When code uses SCR, `ResourceResolver`, or console logging, read **`{best-practices}/references/scr-to-osgi-ds.md`** and **`{best-practices}/references/resource-resolver-logging.md`** (or the hub **`{best-practices}/references/aem-cloud-service-pattern-prerequisites.md`**).
 
 Do not transform **Java or HTL** until the pattern's expert skill (or reference module) is read (branch B). Branch A does not require `{best-practices}` pattern guidance.
@@ -198,7 +198,7 @@ For retries, error categories, and when user-directed CSV/manual paths are allow
 
 ## Pattern modules
 
-Do **not** duplicate the pattern table here. Use **`{best-practices}/SKILL.md` → Pattern Reference Modules** (`references/<file>.md`).
+Do **not** duplicate the pattern table here. Use **`{best-practices}/SKILL.md` → Pattern Reference Modules** — five patterns route to expert skill subdirectories (`{best-practices}/<pattern>/SKILL.md`); cross-cutting concerns (SCR→DS, ResourceResolver/SLF4J, HTL lint, prerequisites hub) stay as reference modules (`{best-practices}/references/<file>.md`). See **Branch B step 2** above for the per-pattern routing table.
 
 ## Workflow
 

--- a/plugins/aem/cloud-service/skills/migration/SKILL.md
+++ b/plugins/aem/cloud-service/skills/migration/SKILL.md
@@ -28,7 +28,7 @@ This skill drives the **migration workflow**: BPA data, CAM/MCP, **one pattern p
 
 - *"Use the migration skill: **scheduler** only, BPA CSV at `./reports/bpa.csv`, then apply the best-practices pattern guide before editing."*
 - *"**Replication** only from CAM; list projects first, I'll pick one."*
-- *"**Manual:** **event listener** migration for `.../Listener.java` — read best-practices module first."*
+- *"**Manual:** **event listener** migration for `.../Listener.java` — read the best-practices pattern guide first."*
 - *"Scan my config files and create Cloud Manager environment secrets or variables."*
 - *"Fix **htlLint** in `ui.apps` — scan for `data-sly-test` redundant constant warnings and fix them."*
 
@@ -235,7 +235,7 @@ the user says to continue. See **Batched processing (batch size 5)** below.
 For **each finding in the returned batch only** (up to 5):
 
 1. Resolve the target **inside the IDE workspace** (see **Workspace scope (IDE)**).
-2. Read source → classify with the module → apply steps **in order** → check lints → next file.
+2. Read source → classify with the pattern guide (or reference) → apply steps **in order** → check lints → next file.
 
 Do **not** request the next batch mid-processing. Never hold more than one batch of findings in working memory at a time.
 
@@ -267,9 +267,9 @@ Does **not** use BPA CSV, CAM/MCP, or best-practices pattern guides for collecti
 `htlLint` does not use BPA CSV or CAM/MCP. Instead:
 
 1. **Read** [`{best-practices}/references/data-sly-test-redundant-constant.md`](../best-practices/references/data-sly-test-redundant-constant.md) — it contains the **Workflow**, **Proactive Discovery** `rg` patterns, and all 4 fix patterns. (HTL lint lives as a shared reference, not a dedicated pattern guide.)
-2. **Discover** targets using the `rg` commands from the module's **Proactive Discovery** table (scope: `ui.apps/**/jcr_root/**/*.html` or the user's content package paths).
+2. **Discover** targets using the `rg` commands from the reference's **Proactive Discovery** table (scope: `ui.apps/**/jcr_root/**/*.html` or the user's content package paths).
 3. **Group** hits by file, classify each by pattern (boolean literal, raw string, numeric, split expression).
-4. **Fix** each hit per the matching pattern section in the module.
+4. **Fix** each hit per the matching pattern section in the reference.
 5. **Report** and recommend the user run `mvn clean install` or HTL validate to confirm no warnings remain.
 
 ## Batched processing (batch size 5)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Wires the two orchestrator skills (best-practices/SKILL.md and migration/SKILL.md) to route to the new expert skill subdirectories that landed in the feat/best-practices-expert-skills base branch.

## Related Issue

Prerequisite PRs (already merged into the base branch):

#165 — scheduler expert skill
#167 — resource-change-listener expert skill
#175 — replication expert skill
event-migration expert skill (committed on feat/best-practices-expert-skills)
asset-manager expert skill (committed on feat/best-practices-expert-skills)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

- Verified all link targets resolve on the base branch (feat/best-practices-expert-skills): all five expert skill SKILL.md files exist and all four cross-cutting references/*.md files exist
- Confirmed no {best-practices} placeholder syntax remains (uses relative paths)
- Cross-checked that BPA pattern IDs in the routing table match the IDs already used in getBpaFindings / CAM MCP flows

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
