### PR TITLE
feat(snowflake): mechanical asset normalization for Claude Design pages

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/snowflake/knowledge/methodology.md
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/knowledge/methodology.md
@@ -93,9 +93,14 @@ assigns a per-asset strategy based on reachability and type:
 
 | Asset reachability | Asset type | Strategy | Destination |
 |---|---|---|---|
-| Stable public URL (any CDN or publicly reachable host) | any | `absolute` — leave URL as-is | no download |
-| Local / unreachable | font | `vendor` — git repo (Code Bus) | `input/fonts/` → `/fonts/` |
-| Local / unreachable | image, video | `da-media` — DA Media Bus | `input/images/` or `input/videos/` → upload in Phase 5 |
+| Stable CDN (fonts.gstatic.com, cdn.jsdelivr.net, etc.) | any | `absolute` — leave URL as-is | no download |
+| Ephemeral host (claudeusercontent.com, etc.) | font | `vendor` — always download | `input/fonts/` → `/fonts/` |
+| Ephemeral host | image, video | `da-media` — always download | `input/images/` or `input/videos/` |
+| Reachable public host + public base URL | any | `absolute` — leave URL as-is | no download |
+| Reachable public host + local base URL (snapshot) | font | `vendor` — download | `input/fonts/` → `/fonts/` |
+| Reachable public host + local base URL (snapshot) | image, video | `da-media` — download | `input/images/` or `input/videos/` |
+| Local / private IP | font | `vendor` — download | `input/fonts/` → `/fonts/` |
+| Local / private IP | image, video | `da-media` — download | `input/images/` or `input/videos/` |
 
 **Never vendor images or videos into the git repo.** Binary content
 assets belong in DA Media Bus, not Code Bus. Only code assets (fonts,

--- a/plugins/aem/edge-delivery-services/skills/snowflake/knowledge/methodology.md
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/knowledge/methodology.md
@@ -86,46 +86,44 @@ output/
 └── da/<page-slug>.html                        ← DA-source body fragment
 ```
 
-**Rewrite relative asset paths.** When a source uses relative paths
-like `assets/photos/foo.jpg`, `url(./images/bar.png)`,
-`<link href="assets/css/site.css">`, they resolve against our serving
-host (`localhost:3000/drafts/...` or
-`<branch>--<repo>--<owner>.aem.page/<da-root>/...`) — where they 404.
-They need rewriting to one of three target forms, depending on
-**asset strategy** (recorded in `decisions.json["assetStrategy"]`):
+**Asset handling is per-asset, decided mechanically.** The
+`asset-collect.mjs` script (run in Phase 1) scans `index.html` for
+in-scope asset references — raster images, videos, and fonts — and
+assigns a per-asset strategy based on reachability and type:
 
-1. **`absolute`** (default for publicly hosted sources):
-   `https://<source-host>/path/to/assets/...`. Source host serves the
-   binaries directly; EDS preview sideloads any `<img src>` URL into
-   Media Bus on first preview (see da-content `media.md` §2).
-2. **`vendor`** (local-only source, accepted repo size impact):
-   Copy the asset tree into `./assets/` in the repo. Template /
-   fragment / page-CSS refs become root-relative `/assets/...`. DA
-   cell refs use absolute branch URLs
-   (`https://<branch>--<repo>--<owner>.aem.page/assets/...`).
-3. **`da-media`** (cleanest long-term):
-   Upload binaries to DA `/media/<scope>/<file>` via the bundled
-   `<SKILL_DIR>/scripts/da-media-upload.mjs` script. Template /
-   fragment / page-CSS / DA cell refs all use
-   `https://content.da.live/<org>/<repo>/media/<scope>/<file>`. The
-   uploader emits a `media-mapping.json` of local-path →
-   content.da.live URL that Generate consumes for the rewrites.
+| Asset reachability | Asset type | Strategy | Destination |
+|---|---|---|---|
+| Stable public URL (any CDN or publicly reachable host) | any | `absolute` — leave URL as-is | no download |
+| Local / unreachable | font | `vendor` — git repo (Code Bus) | `input/fonts/` → `/fonts/` |
+| Local / unreachable | image, video | `da-media` — DA Media Bus | `input/images/` or `input/videos/` → upload in Phase 5 |
 
-| Aspect                    | absolute    | vendor       | da-media     |
-|---------------------------|-------------|--------------|--------------|
-| Repo size                 | unchanged   | +N MB        | unchanged    |
-| Branch-independent assets | N/A         | No           | **Yes**      |
-| Local-only source         | No          | Yes          | Yes          |
-| Initial-run effort        | none        | curl+sed     | uploader     |
-| Tooling required          | none        | none         | bundled `.mjs` |
-| Reusable across runs      | N/A         | per-run      | **Yes**      |
-| DA-cell image URL form    | source host | branch URL   | content.da.live |
-| Delivered image URL       | `./media_<hash>` (sideload) | `./media_<hash>` | `./media_<hash>` |
+**Never vendor images or videos into the git repo.** Binary content
+assets belong in DA Media Bus, not Code Bus. Only code assets (fonts,
+SVGs under 40KB, scripts, stylesheets) go in the git repo.
 
-For fonts specifically, even under `da-media`, place font files in Code
-Bus `/fonts/<file>.woff2` (or `.otf`) per da-content `media.md`
-§13.2 decision tree. Fonts upload would be a DA media-bus mismatch
-(SVG/PNG/JPG/MP4 are Media Bus; fonts are Content Bus).
+The script downloads assets, normalizes filenames, and rewrites
+references in `index.html` to relative paths (`fonts/foo.woff2`,
+`images/hero.jpg`). Phase 3 transforms these to root-relative
+(`/fonts/foo.woff2`) for template/fragment/CSS, and to absolute branch
+URLs for DA cells:
+
+- **Template / fragment / CSS**: root-relative paths (`/fonts/...`,
+  `/assets/images/...`). Browser resolves against code-bus host.
+- **DA cell image refs**: absolute branch URLs
+  (`https://<branch>--<repo>--<owner>.aem.page/assets/images/...`).
+  Media Bus resolves against `content.da.live`, not code-bus — root-
+  relative paths produce `about:error` there.
+
+The `da-media-upload.mjs` script (Phase 5) uploads `da-media` assets
+to DA and emits final `content.da.live` URLs; DA cells should be
+updated to those final URLs after upload.
+
+| Aspect | absolute | vendor | da-media |
+|---|---|---|---|
+| Asset types | any | fonts only | images, videos |
+| Repo size | unchanged | +font files (small) | unchanged |
+| DA-cell URL form | source host (leave as-is) | branch URL | content.da.live (after upload) |
+| Delivered image URL | `./media_<hash>` (sideload) | `./media_<hash>` | `./media_<hash>` |
 
 This applies to template HTML, fragment HTML, DA cell values
 referencing images, and any CSS `url()` references.

--- a/plugins/aem/edge-delivery-services/skills/snowflake/knowledge/methodology.md
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/knowledge/methodology.md
@@ -103,16 +103,14 @@ SVGs under 40KB, scripts, stylesheets) go in the git repo.
 
 The script downloads assets, normalizes filenames, and rewrites
 references in `index.html` to relative paths (`fonts/foo.woff2`,
-`images/hero.jpg`). Phase 3 transforms these to root-relative
-(`/fonts/foo.woff2`) for template/fragment/CSS, and to absolute branch
-URLs for DA cells:
+`images/hero.jpg`). Phase 3 transforms these depending on context:
 
 - **Template / fragment / CSS**: root-relative paths (`/fonts/...`,
-  `/assets/images/...`). Browser resolves against code-bus host.
-- **DA cell image refs**: absolute branch URLs
-  (`https://<branch>--<repo>--<owner>.aem.page/assets/images/...`).
-  Media Bus resolves against `content.da.live`, not code-bus — root-
-  relative paths produce `about:error` there.
+  `/images/...`). Browser resolves against code-bus host.
+- **DA cell image refs**: relative paths (`images/hero.jpg`). The
+  calling pipeline's `rewriteImageRefs` rewrites these to DA Media
+  Bus URLs before pushing to DA. Do NOT use absolute branch URLs —
+  they break the pipeline's pattern matching.
 
 The `da-media-upload.mjs` script (Phase 5) uploads `da-media` assets
 to DA and emits final `content.da.live` URLs; DA cells should be
@@ -122,7 +120,7 @@ updated to those final URLs after upload.
 |---|---|---|---|
 | Asset types | any | fonts only | images, videos |
 | Repo size | unchanged | +font files (small) | unchanged |
-| DA-cell URL form | source host (leave as-is) | branch URL | content.da.live (after upload) |
+| DA-cell URL form | source host (leave as-is) | N/A (fonts are in CSS, not DA cells) | relative (`images/...`) → pipeline rewrites |
 | Delivered image URL | `./media_<hash>` (sideload) | `./media_<hash>` | `./media_<hash>` |
 
 This applies to template HTML, fragment HTML, DA cell values
@@ -201,15 +199,15 @@ or consequences that aren't in `da-content`:
    page styling hooks to CSS-on-structure (`:has()`, sibling
    selectors) or swap to a preserved semantic element before emitting.
 
-3. **`<img>` URLs in DA cells are stricter than template/fragment
-   HTML.** DA cells require absolute URLs (`da-content` §9).
-   Template and fragment HTML can use root-relative `/assets/...`
-   because the browser resolves those against the rendered page host
-   (= code-bus host). The DA pipeline is what's stricter, not the
-   browser. Acceptable absolute forms in Snowflake DA cells:
-   - Public source page: `https://<source-host>/<path>/image.png`
-   - Vendored same-branch assets: `https://<branch>--<repo>--<owner>.aem.page/assets/...`
-   - DA media: `https://content.da.live/<org>/<repo>/media_<sha>...`
+3. **`<img>` URLs in DA cells must be relative, not absolute.**
+   Phase 3 writes relative paths (`images/hero.jpg`) in DA cell
+   image refs. The calling pipeline's `rewriteImageRefs` matches
+   these patterns and rewrites them to DA Media Bus URLs before
+   the DA push. Absolute branch URLs
+   (`https://<branch>--...aem.page/images/...`) break the
+   pipeline's pattern matching. Template and fragment HTML use
+   root-relative paths (`/images/...`) instead — the browser
+   resolves those against the code-bus host.
 
 ### Slot rules in the template
 
@@ -333,19 +331,16 @@ animations to settle, then capture. Save each as
 cannot reach the source's assets. Three options, in order of
 preference:
 
-1. **Vendor the referenced assets under `/assets/` in the repo.**
-   Same paths work locally and on production via code-bus. Same-origin
-   so no CORS issues for fonts. Trade-off is repo size. Mechanical
-   steps:
-   - `cp -R <source-assets-dir> ./assets/`
-   - Remove `.DS_Store`s and unreferenced files
-   - Rename any directory containing spaces (AEM CLI 404s on
-     URL-encoded `%20`)
-   - In template/fragments/CSS: rewrite localhost URLs to
-     root-relative `/assets/...`
-   - In DA doc cells: rewrite localhost URLs to ABSOLUTE branch URLs
-     (`https://<branch>--<repo>--<owner>.aem.page/assets/...`) — Media
-     Bus requires absolute (see Generate phase rule #4).
+1. **Deploy assets to the repo** (`fonts/`, `images/`, `videos/`).
+   `asset-collect.mjs` handles this automatically — it downloads,
+   normalizes, and rewrites refs in Phase 1. Wire (Phase 4) copies
+   them to repo root. Same paths work locally and on production via
+   code-bus. Same-origin so no CORS issues for fonts. Mechanical
+   rules:
+   - In template/fragments/CSS: root-relative `/fonts/...`,
+     `/images/...`
+   - In DA doc cells: relative paths (`images/...`) — the pipeline
+     rewrites these to DA Media Bus URLs before the DA push.
 2. **Migrate assets to DA `/media/`.** Cleaner long-term; requires
    tooling not yet in scope.
 3. **Skip production round-trip.** Lowest effort; ask the user first

--- a/plugins/aem/edge-delivery-services/skills/snowflake/phases/1-capture.md
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/phases/1-capture.md
@@ -117,9 +117,12 @@ node "<SKILL_DIR>/scripts/asset-collect.mjs" \
 The script handles:
 - HTML tags (`<img src>`, `<img srcset>`, `<picture>`, `<video>`, inline `style` url())
 - CSS `url()` inside inline `<style>` blocks (including `@font-face src`)
-- Per-asset strategy: local fonts → `vendor` (saved to `input/fonts/`),
-  local images/videos → `da-media` (saved to `input/images/` or `input/videos/`),
-  public stable URLs → `absolute` (left as-is)
+- Per-asset strategy: local/ephemeral fonts → `vendor` (saved to `input/fonts/`),
+  local/ephemeral images/videos → `da-media` (saved to `input/images/` or `input/videos/`),
+  stable CDN URLs → `absolute` (left as-is).
+  Ephemeral hosts (e.g. claudeusercontent.com) are always downloaded.
+  When base URL is localhost (snapshot mode), all non-CDN external assets
+  are downloaded too.
 - Hash-named font files: renamed to human-readable names from `@font-face` context
 - References in `index.html` rewritten to normalized relative paths
 

--- a/plugins/aem/edge-delivery-services/skills/snowflake/phases/1-capture.md
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/phases/1-capture.md
@@ -101,44 +101,32 @@ curl -fsS "$SOURCE_URL" -o "${PROJ}/input/index.html"
 Validate: file size > 0, response was HTML (look for `<!doctype html`
 or `<html` in the first 200 bytes).
 
-## Identify and fetch external assets
+## Collect and normalize assets
 
-Look for these patterns in the saved HTML:
-
-- `<link rel="stylesheet" href="...">` — external CSS
-- `<script src="...">` — external JS
-- For each match, if the href is relative or points to the same host
-  as the source, fetch it into `input/` (preserve filename).
-
-Skip CDN resources (Google Fonts, jsdelivr, etc.) that are publicly
-available; they'll be referenced directly in the converted artifacts.
-Local/same-host external assets are saved so the project is self-
-contained.
+Run the asset-collect script to discover in-scope asset references
+(raster images, videos, fonts), download local/unreachable ones,
+normalize filenames, rewrite references in `index.html`, and emit
+`asset-manifest.json`. Always runs — no-op when already collected.
 
 ```bash
-INPUT="${PROJ}/input"
-# Extract candidate external assets
-grep -oE '<(link|script)[^>]*(href|src)="[^"]+"' "$INPUT/index.html" \
-  | grep -oE '(href|src)="[^"]+"' \
-  | sed -E 's/^(href|src)="//;s/"$//' \
-  | sort -u \
-  | while IFS= read -r ref; do
-      case "$ref" in
-        http://*|https://*)
-          host=$(echo "$ref" | sed -E 's|^https?://([^/]+)/.*|\1|')
-          src_host=$(echo "$SOURCE_URL" | sed -E 's|^https?://([^/]+)/.*|\1|')
-          if [ "$host" != "$src_host" ]; then continue; fi
-          ;;
-      esac
-      url=$(node -e "
-        const base = process.argv[1];
-        const ref = process.argv[2];
-        process.stdout.write(new URL(ref, base).toString());
-      " "$SOURCE_URL" "$ref")
-      filename=$(basename "$url" | sed 's/?.*$//')
-      [ -n "$filename" ] && curl -fsS "$url" -o "$INPUT/$filename" || true
-    done
+node "<SKILL_DIR>/scripts/asset-collect.mjs" \
+  --input "${PROJ}/input" \
+  --base-url "$SOURCE_URL"
 ```
+
+The script handles:
+- HTML tags (`<img src>`, `<img srcset>`, `<picture>`, `<video>`, inline `style` url())
+- CSS `url()` inside inline `<style>` blocks (including `@font-face src`)
+- Per-asset strategy: local fonts → `vendor` (saved to `input/fonts/`),
+  local images/videos → `da-media` (saved to `input/images/` or `input/videos/`),
+  public stable URLs → `absolute` (left as-is)
+- Hash-named font files: renamed to human-readable names from `@font-face` context
+- References in `index.html` rewritten to normalized relative paths
+
+Validate the manifest: check `asset-manifest.json` was written, review
+any `warnings` entries (especially cross-origin font CORS risks).
+
+Read `asset-manifest.json` to note asset stats for the init summary.
 
 ## Write a stub README.md for the project
 
@@ -155,6 +143,8 @@ Status: capturing
 ## Update state and finish
 
 Set `state.phase = "capture"` and `state.phaseStatus = "complete"`,
-append `state.captureCompletedAt = "<timestamp>"`. Save state.json.
+append `state.captureCompletedAt = "<timestamp>"` and
+`state.assetStats` from `input/asset-manifest.json`'s `stats` block.
+Save state.json.
 
 Continue to Phase 2 (Analyze).

--- a/plugins/aem/edge-delivery-services/skills/snowflake/phases/2-analyze.md
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/phases/2-analyze.md
@@ -100,11 +100,11 @@ For the HTML at `<projectsDir>/<NNN>-<slug>/input/index.html`:
     item. Record the manifest path in `decisions.json` under
     `assetManifest`.
 
-    **Reminder on DA cell image URLs**: images vendored locally still
-    need absolute branch URLs in DA cells (Media Bus resolves against
-    `content.da.live`, not the code-bus host). See `knowledge/learnings.md`
-    2026-05-19 Media Bus entry. This is a Generate-phase concern — note
-    it here so Generate doesn't miss it.
+    **Reminder on DA cell image URLs**: DA cell image refs must use
+    relative paths (`images/filename.jpg`), not absolute branch URLs.
+    The calling pipeline's `rewriteImageRefs` rewrites these to DA
+    Media Bus URLs before the DA push. This is a Generate-phase
+    concern — note it here so Generate doesn't miss it.
 
 ## Produce `notes.md`
 

--- a/plugins/aem/edge-delivery-services/skills/snowflake/phases/2-analyze.md
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/phases/2-analyze.md
@@ -89,19 +89,22 @@ For the HTML at `<projectsDir>/<NNN>-<slug>/input/index.html`:
    - Reference a public CDN
    - Concatenate into the per-template animations file
 
-10. **Asset references** — count all relative paths
-    (`assets/...`, `./images/...`, etc.) and absolute paths to
-    external hosts. Decide the asset strategy:
-    - **Public source host**: rewrite to absolute URLs pointing at
-      that host
-    - **Local-only source host** (`localhost`, `127.0.0.1`): two
-      paths — vendor to `/assets/` in the repo (proven; ~38 MB
-      acceptable for one-off bespoke), or migrate to DA `/media/`
-      (out of scope unless asked). Default: vendor.
-    - **NOTE**: image URLs INSIDE DA cells must be absolute even
-      when template/fragment refs are root-relative (Media Bus
-      requires absolute). See `knowledge/learnings.md` 2026-05-19
-      Media Bus entry.
+10. **Asset manifest** — read `input/asset-manifest.json` produced by
+    `asset-collect.mjs` in Phase 1. The script has already classified
+    every in-scope asset (raster images, videos, fonts), decided its
+    per-asset strategy, downloaded local/unreachable ones, and rewritten
+    references in `index.html`. No manual asset classification is needed.
+
+    Record the manifest's `stats` summary and any `warnings` in
+    `notes.md`. Surface CORS warnings for cross-origin fonts as a risk
+    item. Record the manifest path in `decisions.json` under
+    `assetManifest`.
+
+    **Reminder on DA cell image URLs**: images vendored locally still
+    need absolute branch URLs in DA cells (Media Bus resolves against
+    `content.da.live`, not the code-bus host). See `knowledge/learnings.md`
+    2026-05-19 Media Bus entry. This is a Generate-phase concern — note
+    it here so Generate doesn't miss it.
 
 ## Produce `notes.md`
 
@@ -267,9 +270,13 @@ this directly. Suggested shape:
   "externalLibs": [
     { "name": "lenis", "css": "assets/lenis.min.css", "js": "assets/lenis.min.js", "strategy": "vendor" }
   ],
-  "assetStrategy": "vendor",
-  "assetBase": "http://127.0.0.1:8080/path/to/page/",
-  "vendorAssetsTo": "assets/"
+  "assetManifest": "input/asset-manifest.json",
+  "assetStats": {
+    "total": 4,
+    "byStrategy": { "absolute": 2, "vendor": 2, "da-media": 0 },
+    "byType": { "font": 2, "image": 2, "video": 0 }
+  },
+  "assetWarnings": []
 }
 ```
 

--- a/plugins/aem/edge-delivery-services/skills/snowflake/phases/3-generate.md
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/phases/3-generate.md
@@ -63,7 +63,7 @@ da/<page-slug>.html                    ← DA-source body fragment
 
 Plus any vendored external libs (`scripts/<template>-<libname>.js`,
 `styles/<template>-<libname>.css`) and any vendored static assets
-(`assets/...`) per the asset strategy in `decisions.json`.
+(`images/...`, `fonts/...`) per the asset strategy in `decisions.json`.
 
 ## Step-by-step
 
@@ -191,10 +191,11 @@ apply this context-dependent transformation:
   browser resolves these against the code-bus host where these files
   will be deployed.
 
-- **DA doc image/video cells** (`da-media` assets): use absolute
-  branch URLs. Media Bus resolves against `content.da.live`, not
-  code-bus — root-relative paths produce `about:error`.
-  Form: `https://<branch>--<repo>--<owner>.aem.page/images/hero.jpg`
+- **DA doc image/video cells** (`da-media` assets): use relative
+  paths (`images/hero.jpg`, not absolute branch URLs). The calling
+  pipeline's upload step rewrites these to DA Media Bus URLs before
+  pushing to DA. Absolute branch URLs break the pipeline's
+  `rewriteImageRefs` pattern matching.
 
 - **Fonts** (vendored to `input/fonts/`): deploy to `/fonts/` in the
   repo. Emit `@font-face` in `styles/<template>.css` with
@@ -246,10 +247,9 @@ Snowflake-specific reminders (universal rules are in `da-content`):
   bails → standard EDS decoration 404s on every block).
 - Never write `<span class="…">` into cells — class is lost on
   normalization, breaking any CSS hook the source page relied on.
-- For vendored assets, DA cells use the absolute branch URL form:
-  `https://<branch>--<repo>--<owner>.aem.page/assets/...` (DA cells
-  don't accept root-relative paths even though template/fragment
-  HTML does).
+- For collected images/videos, DA cells use relative paths
+  (`images/filename.jpg`) — the pipeline rewrites these to DA
+  Media Bus URLs before the DA push.
 
 ### 3.9 — Self-checks before declaring Generate done
 
@@ -267,7 +267,7 @@ node -e '
 '
 
 # 2) No bare relative asset refs in template/fragments/CSS
-# (paths must be root-relative /fonts/... /assets/... not bare fonts/... assets/...)
+# (paths must be root-relative /fonts/... /images/... not bare fonts/... images/...)
 grep -REn "=\"fonts/\|=\"images/\|=\"videos/" "$PROJ/output/templates" "$PROJ/output/fragments" "$PROJ/output/styles" && echo "FAIL: missing leading slash on asset ref" || echo "OK"
 
 # 3) No nested [data-slot] inside another [data-slot]
@@ -282,9 +282,10 @@ grep -cE "<table|<span class" "$PROJ/output/da/"*.html
 # 4a) WARN: <br> is position-dependent (da-content §3.9).
 grep -nE "<br>" "$PROJ/output/da/"*.html && echo "WARN: <br> found — verify position" || echo "OK"
 
-# 5) DA cell <img> URLs are absolute
+# 5) DA cell <img> URLs are bare relative (pipeline rewrites to Media Bus)
+#    Catch both absolute (https://...) and root-relative (/images/...) — both break pipeline
 grep -oE "<img[^>]*src=\"[^\"]+\"" "$PROJ/output/da/"*.html \
-  | grep -vE "src=\"https?://" && echo "FAIL: non-absolute DA img" || echo "OK"
+  | grep -E "src=\"(https?://|/)" && echo "FAIL: DA img must be bare relative (images/...)" || echo "OK"
 
 # 6) No section first-class collides with a CSS layout rule
 #    This is the most common post-conversion layout bug — inner CSS class
@@ -353,7 +354,8 @@ fragments/<brand>/footer.html         ← static footer fragment
 blocks/header/header.{js,css}         ← fragment loader + header styles
 blocks/footer/footer.{js,css}         ← fragment loader + footer styles
 blocks/<name>/<name>.{js,css}         ← one pair per content section
-assets/                               ← vendored images/logo
+images/                               ← extracted images
+videos/                               ← extracted videos
 drafts/<page-slug>.html               ← local test page
 output/da/<page-slug>.html            ← DA body fragment (for upload)
 ```
@@ -395,13 +397,13 @@ cp -R "${PROJ}/input/fonts" ./fonts/ 2>/dev/null || true
 
 # Content assets (images/videos) → local staging for dev server;
 # Phase 5 uploads to DA Media Bus via da-media-upload.mjs
-cp -R "${PROJ}/input/images" ./assets/images/ 2>/dev/null || true
-cp -R "${PROJ}/input/videos" ./assets/videos/ 2>/dev/null || true
+cp -R "${PROJ}/input/images" ./images/ 2>/dev/null || true
+cp -R "${PROJ}/input/videos" ./videos/ 2>/dev/null || true
 ```
 
 Use root-relative paths in template/fragment/CSS (`/fonts/...`,
-`/assets/images/...`). Use absolute branch URLs in DA cells
-(`https://<branch>--<repo>--<owner>.aem.page/assets/images/...`).
+`/images/...`). Use relative paths in DA cells
+(`images/filename.jpg`) — the pipeline rewrites to Media Bus URLs.
 
 ### B.4 — Create header/footer fragments
 
@@ -493,7 +495,8 @@ No `template` metadata key — block-level pages don't use the
 overlay engine. No slot-keyed rows — standard EDS positional
 block tables.
 
-DA cell image URLs must be absolute (same rule as page-level).
+DA cell image URLs must be relative (`images/filename.jpg`) —
+same rule as page-level. The pipeline rewrites to Media Bus URLs.
 
 ### B.9 — Self-checks (block-level)
 
@@ -505,16 +508,17 @@ for dir in blocks/*/; do
     || echo "MISSING: $dir"
 done
 
-# 2) No relative "assets/" in block CSS or fragments
-grep -rn '"assets/' blocks/ fragments/ && echo "FAIL" || echo "OK"
+# 2) No bare relative asset refs in block CSS or fragments
+grep -rEn '"fonts/|"images/|"videos/' blocks/ fragments/ && echo "FAIL: missing leading slash" || echo "OK"
 
 # 3) Lint passes
 npm run lint
 
-# 4) DA cell <img> URLs are absolute
+# 4) DA cell <img> URLs are bare relative (pipeline rewrites to Media Bus)
+#    Catch both absolute (https://...) and root-relative (/images/...) — both break pipeline
 grep -oE '<img[^>]*src="[^"]+"' output/da/*.html \
-  | grep -vE 'src="https?://' \
-  && echo "FAIL: non-absolute DA img" || echo "OK"
+  | grep -E 'src="(https?://|/)' \
+  && echo "FAIL: DA img must be bare relative (images/...)" || echo "OK"
 ```
 
 Then start the dev server and verify:

--- a/plugins/aem/edge-delivery-services/skills/snowflake/phases/3-generate.md
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/phases/3-generate.md
@@ -259,6 +259,19 @@ the check.
 ```bash
 PROJ="${PROJECTS_DIR}/${NNN}-${SLUG}"
 
+# 0) All required artifacts exist — hard fail if any missing
+for f in \
+  "templates/${TEMPLATE_NAME}.html" \
+  "fragments/${TEMPLATE_NAME}/header.html" \
+  "fragments/${TEMPLATE_NAME}/footer.html" \
+  "styles/${TEMPLATE_NAME}.css" \
+  "da/${PAGE_SLUG}.html"; do
+  if [ ! -f "${PROJ}/output/$f" ]; then
+    echo "FAIL: missing required artifact: output/$f — Phase 3 did not complete"
+    exit 1
+  fi
+done
+
 # 1) Template has <main> and all sections have unique first-classes
 node -e '
   const fs = require("fs");
@@ -501,6 +514,12 @@ same rule as page-level. The pipeline rewrites to Media Bus URLs.
 ### B.9 — Self-checks (block-level)
 
 ```bash
+# 0) DA doc exists — hard fail if missing
+if [ ! -f "output/da/${PAGE_SLUG}.html" ]; then
+  echo "FAIL: missing required artifact: output/da/${PAGE_SLUG}.html — Phase 3 did not complete"
+  exit 1
+fi
+
 # 1) Each block has both .js and .css
 for dir in blocks/*/; do
   name=$(basename "$dir")

--- a/plugins/aem/edge-delivery-services/skills/snowflake/phases/3-generate.md
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/phases/3-generate.md
@@ -177,33 +177,36 @@ Lenis), inject a small loader prelude that:
 For any inline `onclick="someFunc()"` references in the template,
 expose `someFunc` on `window` from inside `main()`.
 
-### 3.7 — Asset path rewriting
+### 3.7 — Asset paths (already normalized by asset-collect.mjs)
 
-Per `decisions.json["assetStrategy"]`:
+`asset-collect.mjs` ran in Phase 1 and already:
+- Downloaded local/unreachable assets into `input/fonts/`, `input/images/`, `input/videos/`
+- Rewrote references in `input/index.html` to normalized relative paths
 
-- **`"absolute"`** (public source host): rewrite every relative
-  `assets/...` reference to `${assetBase}assets/...` (absolute URL
-  pointing at the source host).
+When copying content from `input/index.html` into output artifacts,
+apply this context-dependent transformation:
 
-- **`"vendor"`** (local-only source host, or user-requested vendor):
-  - Copy the referenced asset files from source into the target
-    repo's `assets/` directory (preserving subfolder structure).
-    Use `curl` if source is HTTP, `cp -R` if filesystem path is
-    available.
-  - Remove `.DS_Store`s and any unreferenced files in the copied
-    tree.
-  - Rename any directory containing spaces (AEM CLI 404s on
-    URL-encoded `%20`).
-  - In template, fragments, and CSS: rewrite source URLs to
-    root-relative `/assets/...`.
-  - **In the DA doc (next step): rewrite to ABSOLUTE branch URLs**
-    (`https://<branch>--<repo>--<owner>.aem.page/assets/...`). Media
-    Bus only resolves absolute URLs. The branch name comes from
-    decisions.json or is asked of the user.
+- **Template / fragment / CSS** refs to vendored assets: prepend `/`
+  to make root-relative (`fonts/foo.otf` → `/fonts/foo.otf`). The
+  browser resolves these against the code-bus host where these files
+  will be deployed.
 
-The asymmetry is critical and worth a sanity check: search the
-output for any `src="assets/"` (missing leading slash, non-absolute,
-not vendored-absolute) — should find none.
+- **DA doc image/video cells** (`da-media` assets): use absolute
+  branch URLs. Media Bus resolves against `content.da.live`, not
+  code-bus — root-relative paths produce `about:error`.
+  Form: `https://<branch>--<repo>--<owner>.aem.page/images/hero.jpg`
+
+- **Fonts** (vendored to `input/fonts/`): deploy to `/fonts/` in the
+  repo. Emit `@font-face` in `styles/<template>.css` with
+  `src: url('/fonts/<file>')`.
+
+Read `input/asset-manifest.json` to find the `normalizedPath` for
+each asset entry. Assets with `strategy: "absolute"` need no action —
+their URLs were left as-is in `index.html`.
+
+Sanity check: search output artifacts for any `src="fonts/"` or
+`src="images/"` without a leading `/` in template/fragment/CSS files
+— should find none.
 
 ### 3.8 — DA-source body fragment
 
@@ -263,8 +266,9 @@ node -e '
   // ... or use regex-based check if jsdom not available
 '
 
-# 2) No relative "assets/" refs in template/fragments/CSS
-grep -REn "=\"assets/" "$PROJ/output/templates" "$PROJ/output/fragments" "$PROJ/output/styles" && echo "FAIL: relative assets/" || echo "OK"
+# 2) No bare relative asset refs in template/fragments/CSS
+# (paths must be root-relative /fonts/... /assets/... not bare fonts/... assets/...)
+grep -REn "=\"fonts/\|=\"images/\|=\"videos/" "$PROJ/output/templates" "$PROJ/output/fragments" "$PROJ/output/styles" && echo "FAIL: missing leading slash on asset ref" || echo "OK"
 
 # 3) No nested [data-slot] inside another [data-slot]
 # (would need a DOM parse — skip for now if jsdom not available;
@@ -379,14 +383,25 @@ Write `styles/fonts.css` as empty (fonts loaded via CDN).
 Append font preconnects and the CDN stylesheet link to `head.html`,
 placed after the viewport meta but before the `aem.js` script tag.
 
-### B.3 — Vendor assets
+### B.3 — Deploy collected assets
 
-Per `decisions.json["assetStrategy"]` (usually `vendor` for
-local-only sources):
-1. Copy referenced images and logo to `assets/`
-2. Remove `.DS_Store`s, rename dirs with spaces
-3. All template/fragment/CSS refs use root-relative `/assets/...`
-4. DA cell image refs use absolute branch URLs
+`asset-collect.mjs` already downloaded assets into `input/fonts/`,
+`input/images/`, `input/videos/` and rewrote refs in `index.html`.
+Deploy to the repo:
+
+```bash
+# Code assets (fonts) → Code Bus
+cp -R "${PROJ}/input/fonts" ./fonts/ 2>/dev/null || true
+
+# Content assets (images/videos) → local staging for dev server;
+# Phase 5 uploads to DA Media Bus via da-media-upload.mjs
+cp -R "${PROJ}/input/images" ./assets/images/ 2>/dev/null || true
+cp -R "${PROJ}/input/videos" ./assets/videos/ 2>/dev/null || true
+```
+
+Use root-relative paths in template/fragment/CSS (`/fonts/...`,
+`/assets/images/...`). Use absolute branch URLs in DA cells
+(`https://<branch>--<repo>--<owner>.aem.page/assets/images/...`).
 
 ### B.4 — Create header/footer fragments
 

--- a/plugins/aem/edge-delivery-services/skills/snowflake/phases/4-wire.md
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/phases/4-wire.md
@@ -39,6 +39,10 @@ ls "${PROJ}/output/styles/" 2>/dev/null \
 [ -d "${PROJ}/input/videos" ] && mkdir -p videos && cp -R "${PROJ}/input/videos/." videos/
 
 # 2) Build the local-test drafts file from the DA doc
+if [ ! -f "${PROJ}/output/da/${PAGE_SLUG}.html" ]; then
+  echo "FAIL: DA doc missing at output/da/${PAGE_SLUG}.html — Phase 3 did not complete. Re-run Generate."
+  exit 1
+fi
 node "<SKILL_DIR>/scripts/transform-da-to-eds.mjs" \
   "${PROJ}/output/da/${PAGE_SLUG}.html" \
   "drafts/${TEMPLATE_NAME}-${PAGE_SLUG}.html"

--- a/plugins/aem/edge-delivery-services/skills/snowflake/phases/4-wire.md
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/phases/4-wire.md
@@ -32,19 +32,25 @@ ls "${PROJ}/output/styles/" 2>/dev/null \
   | grep -v -- "^${TEMPLATE_NAME}\.css$" \
   | while IFS= read -r f; do cp "${PROJ}/output/styles/$f" "styles/$f"; done
 
+# 1b) Deploy collected assets from input/ to repo root
+#     asset-collect.mjs downloaded these in Phase 1; Wire deploys them.
+[ -d "${PROJ}/input/fonts" ] && mkdir -p fonts && cp -R "${PROJ}/input/fonts/." fonts/
+[ -d "${PROJ}/input/images" ] && mkdir -p images && cp -R "${PROJ}/input/images/." images/
+[ -d "${PROJ}/input/videos" ] && mkdir -p videos && cp -R "${PROJ}/input/videos/." videos/
+
 # 2) Build the local-test drafts file from the DA doc
 node "<SKILL_DIR>/scripts/transform-da-to-eds.mjs" \
   "${PROJ}/output/da/${PAGE_SLUG}.html" \
   "drafts/${TEMPLATE_NAME}-${PAGE_SLUG}.html"
 
-# 3) Vendored assets (if asset strategy is "vendor"):
-#    Assets were copied during Generate phase. Confirm they're in
-#    place under assets/.
-if [ "$ASSET_STRATEGY" = "vendor" ]; then
-  if [ ! -d assets ]; then
-    echo "FAIL: assetStrategy=vendor but ./assets/ does not exist"
-    exit 1
-  fi
+# 3) Verify collected assets are in place (deployed by step 1b above)
+if [ -d "${PROJ}/input/fonts" ] && [ ! -d fonts ]; then
+  echo "FAIL: input/fonts exists but ./fonts/ does not"
+  exit 1
+fi
+if [ -d "${PROJ}/input/images" ] && [ ! -d images ]; then
+  echo "FAIL: input/images exists but ./images/ does not"
+  exit 1
 fi
 
 # 4) Lint

--- a/plugins/aem/edge-delivery-services/skills/snowflake/phases/5-roundtrip.md
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/phases/5-roundtrip.md
@@ -208,8 +208,8 @@ git add \
   drafts/${TEMPLATE_NAME}-${PAGE_SLUG}.html \
   ${PROJECTS_DIR}/${NNN}-${SLUG}/
 
-# If asset strategy was vendor:
-[ "$ASSET_STRATEGY" = "vendor" ] && git add assets/
+# Collected assets (deployed by Wire step 1b)
+git add fonts/ images/ videos/ 2>/dev/null || true
 
 git commit -m "snowflake #${NNN} — ${SLUG} overlay"
 git push -u origin "$BRANCH"
@@ -360,9 +360,10 @@ Evaluate this JavaScript in the browser and report the result:
 Apply the **same health gate** (checks 1–5) as the local run. Production
 notes specific to check 5:
 - Any background-image slot src must have been rewritten by Media Bus to
-  `./media_<sha>.png?width=...` form — confirms DA cells used absolute
-  URLs. If they didn't, `brokenImages` will list `about:error` entries;
-  the fix is in the Generate self-check 3.9.
+  `./media_<sha>.png?width=...` form — confirms the pipeline rewrote
+  DA cell image refs to Media Bus URLs. If they weren't rewritten,
+  `brokenImages` will list `about:error` entries; check that the
+  pipeline's `rewriteImageRefs` ran before the DA push.
 
 The page must clear all five checks on production, not just locally — a
 page that passes locally but fails here is still a gate failure.
@@ -396,8 +397,10 @@ source.
 
 Diagnose, not workaround. Common patterns:
 
-- **`about:error` in background-image** → DA cells used root-relative
-  URLs; Media Bus requires absolute. Fix the DA doc and re-PUT.
+- **`about:error` in background-image** → DA cell image refs were not
+  rewritten to Media Bus URLs. Check that the pipeline's image upload
+  and `rewriteImageRefs` ran before the DA push. Phase 3 writes
+  relative refs (`images/...`) that the pipeline rewrites.
 - **Half-empty cards** → wrapping `<a>` was slotted while its
   children were ALSO slotted; the slot writer wiped children. Drop
   the wrap slot in template + DA, keep child slots.

--- a/plugins/aem/edge-delivery-services/skills/snowflake/scripts/asset-collect.mjs
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/scripts/asset-collect.mjs
@@ -25,8 +25,12 @@
  *
  * Asset strategies (per-asset, not per-run):
  *   absolute  — stable public URL; leave as-is
- *   vendor    — local/unreachable font; download to fonts/
- *   da-media  — local/unreachable image or video; download to images/ or videos/
+ *   vendor    — local/ephemeral/unreachable font; download to fonts/
+ *   da-media  — local/ephemeral/unreachable image or video; download to images/ or videos/
+ *
+ * Ephemeral hosts (e.g. claudeusercontent.com) are always downloaded regardless
+ * of reachability. When --base-url is localhost, all non-stable-CDN external
+ * assets are also downloaded (snapshot mode).
  *
  * Usage:
  *   node <SKILL_DIR>/scripts/asset-collect.mjs \
@@ -75,6 +79,10 @@ const STABLE_CDN_HOSTS = new Set([
   'unpkg.com',
 ]);
 
+const EPHEMERAL_HOST_PATTERNS = [
+  /claudeusercontent\.com$/,
+];
+
 const PRIVATE_IP_RE = /^(localhost|127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)/;
 
 const log = (msg) => console.log(`[asset-collect] ${msg}`);
@@ -119,23 +127,26 @@ function assetType(url) {
 
 /**
  * @param {string} resolvedUrl
- * @returns {'local'|'stable-cdn'|'reachable'}
+ * @returns {'local'|'stable-cdn'|'ephemeral'|'reachable'}
  */
 function reachability(resolvedUrl) {
   let host;
   try { host = new URL(resolvedUrl).hostname; } catch { return 'local'; }
   if (PRIVATE_IP_RE.test(host)) return 'local';
   if (STABLE_CDN_HOSTS.has(host)) return 'stable-cdn';
+  if (EPHEMERAL_HOST_PATTERNS.some((re) => re.test(host))) return 'ephemeral';
   return 'reachable';
 }
 
 /**
- * @param {'local'|'stable-cdn'|'reachable'} reach
+ * @param {'local'|'stable-cdn'|'ephemeral'|'reachable'} reach
  * @param {'image'|'video'|'font'} type
+ * @param {boolean} baseIsLocal
  * @returns {'absolute'|'vendor'|'da-media'}
  */
-function strategy(reach, type) {
-  if (reach !== 'local') return 'absolute';
+function strategy(reach, type, baseIsLocal) {
+  if (reach === 'stable-cdn') return 'absolute';
+  if (reach === 'reachable' && !baseIsLocal) return 'absolute';
   if (type === 'font') return 'vendor';
   return 'da-media';
 }
@@ -324,6 +335,9 @@ async function alreadyCollected(inputDir) {
 // ---------------------------------------------------------------------------
 
 const { inputDir, baseUrl, dryRun } = parseArgs();
+const baseIsLocal = PRIVATE_IP_RE.test(
+  (() => { try { return new URL(baseUrl).hostname; } catch { return 'localhost'; } })(),
+);
 
 const indexPath = join(inputDir, 'index.html');
 try { await access(indexPath); } catch { die(`index.html not found in ${inputDir}`, 1); }
@@ -385,7 +399,7 @@ for (const originalUrl of rawUrls) {
   if (!type) continue;
 
   const reach = reachability(resolvedUrl);
-  const strat = strategy(reach, type);
+  const strat = strategy(reach, type, baseIsLocal);
 
   const asset = { originalUrl, resolvedUrl, normalizedPath: null, type, reachability: reach, strategy: strat };
 

--- a/plugins/aem/edge-delivery-services/skills/snowflake/scripts/asset-collect.mjs
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/scripts/asset-collect.mjs
@@ -1,0 +1,403 @@
+#!/usr/bin/env node
+/* eslint-disable no-await-in-loop, no-console, no-restricted-syntax, no-continue --
+   CLI batch tool: sequential async downloads are intentional (avoid hammering
+   the source server); console is the output channel; for-of loops are clearer
+   for ordered side effects; continue is clearer than nested ternaries for
+   skip paths. */
+/**
+ * asset-collect.mjs
+ *
+ * Mechanical asset normalization for snowflake Phase 1 (Capture).
+ * Scans index.html for in-scope asset references (raster images, videos,
+ * fonts), classifies each by reachability, downloads local/unreachable
+ * assets into normalized subdirectories, rewrites references in index.html,
+ * and emits asset-manifest.json.
+ *
+ * In-scope types:
+ *   images : .png .jpg .jpeg .webp .avif .gif
+ *   videos : .mp4 .webm
+ *   fonts  : .otf .woff .woff2 .ttf .eot
+ *
+ * Asset strategies (per-asset, not per-run):
+ *   absolute  — stable public URL; leave as-is
+ *   vendor    — local/unreachable font; download to fonts/
+ *   da-media  — local/unreachable image or video; download to images/ or videos/
+ *
+ * Usage:
+ *   node <SKILL_DIR>/scripts/asset-collect.mjs \
+ *     --input  <path-to-input-dir> \
+ *     --base-url <source-url>      \
+ *     [--dry-run]
+ *
+ * Flags:
+ *   --input     Directory containing index.html (required)
+ *   --base-url  Original page URL for resolving relative refs (required)
+ *   --dry-run   Classify without downloading or rewriting; print manifest to stdout
+ *
+ * Exit codes:
+ *   0  Success (collected, no-op, or dry-run completed cleanly)
+ *   1  Input error (missing flags, missing index.html)
+ *   2  Fetch failure (hard stop, not recoverable)
+ *   3  Filesystem error
+ */
+
+import { readFile, writeFile, mkdir, copyFile, access, stat } from 'node:fs/promises';
+import { join, basename, extname, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.avif', '.gif']);
+const VIDEO_EXTS = new Set(['.mp4', '.webm']);
+const FONT_EXTS = new Set(['.otf', '.woff', '.woff2', '.ttf', '.eot']);
+
+const STABLE_CDN_HOSTS = new Set([
+  'fonts.googleapis.com',
+  'fonts.gstatic.com',
+  'cdn.jsdelivr.net',
+  'cdnjs.cloudflare.com',
+  'unpkg.com',
+]);
+
+const PRIVATE_IP_RE = /^(localhost|127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)/;
+
+const log = (msg) => console.log(`[asset-collect] ${msg}`);
+const warn = (msg) => console.warn(`[asset-collect] WARN: ${msg}`);
+const die = (msg, code = 1) => { console.error(`[asset-collect] ERROR: ${msg}`); process.exit(code); };
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+
+/** @returns {{ inputDir: string, baseUrl: string, dryRun: boolean }} */
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let inputDir = '';
+  let baseUrl = '';
+  let dryRun = false;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--input') inputDir = args[++i] ?? '';
+    else if (args[i] === '--base-url') baseUrl = args[++i] ?? '';
+    else if (args[i] === '--dry-run') dryRun = true;
+  }
+  if (!inputDir) die('--input is required');
+  if (!baseUrl) die('--base-url is required');
+  return { inputDir, baseUrl, dryRun };
+}
+
+// ---------------------------------------------------------------------------
+// Type helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} url
+ * @returns {'image'|'video'|'font'|null}
+ */
+function assetType(url) {
+  const ext = extname(new URL(url, 'http://x').pathname).toLowerCase();
+  if (IMAGE_EXTS.has(ext)) return 'image';
+  if (VIDEO_EXTS.has(ext)) return 'video';
+  if (FONT_EXTS.has(ext)) return 'font';
+  return null;
+}
+
+/**
+ * @param {string} resolvedUrl
+ * @returns {'local'|'stable-cdn'|'reachable'}
+ */
+function reachability(resolvedUrl) {
+  let host;
+  try { host = new URL(resolvedUrl).hostname; } catch { return 'local'; }
+  if (PRIVATE_IP_RE.test(host)) return 'local';
+  if (STABLE_CDN_HOSTS.has(host)) return 'stable-cdn';
+  return 'reachable';
+}
+
+/**
+ * @param {'local'|'stable-cdn'|'reachable'} reach
+ * @param {'image'|'video'|'font'} type
+ * @returns {'absolute'|'vendor'|'da-media'}
+ */
+function strategy(reach, type) {
+  if (reach !== 'local') return 'absolute';
+  if (type === 'font') return 'vendor';
+  return 'da-media';
+}
+
+/**
+ * @param {'image'|'video'|'font'} type
+ * @returns {string}
+ */
+function typeDir(type) {
+  if (type === 'font') return 'fonts';
+  if (type === 'video') return 'videos';
+  return 'images';
+}
+
+// ---------------------------------------------------------------------------
+// Filename normalization
+// ---------------------------------------------------------------------------
+
+const HASH_RE = /^[0-9a-f]{8,}$/i;
+
+/**
+ * Build a normalized filename for a downloaded asset.
+ * For hash-named fonts, derive from @font-face context.
+ *
+ * @param {string} originalUrl - the raw URL as found in HTML
+ * @param {'image'|'video'|'font'} type
+ * @param {Map<string, {family: string, style: string}>} fontContext - basename → font metadata
+ * @param {Set<string>} usedNames - already-claimed normalized names (collision guard)
+ * @returns {string} e.g. "adobe-clean-spectrum-vf.woff2"
+ */
+function normalizeFilename(originalUrl, type, fontContext, usedNames) {
+  const urlPath = (() => {
+    try { return new URL(originalUrl).pathname; } catch { return originalUrl; }
+  })();
+  const base = basename(urlPath);
+  const ext = extname(base).toLowerCase();
+  const stem = base.slice(0, base.length - ext.length);
+  const cleanStem = stem.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+
+  let candidate;
+  if (type === 'font' && HASH_RE.test(cleanStem)) {
+    const ctx = fontContext.get(base);
+    if (ctx) {
+      const familySlug = ctx.family.toLowerCase().replace(/["']/g, '').trim()
+        .replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+      const italicSuffix = ctx.style === 'italic' ? '-italic' : '';
+      candidate = `${familySlug}${italicSuffix}${ext}`;
+    }
+  }
+  if (!candidate) candidate = `${cleanStem || 'asset'}${ext}`;
+
+  // Collision guard
+  if (!usedNames.has(candidate)) { usedNames.add(candidate); return candidate; }
+  for (let n = 2; n < 1000; n++) {
+    const alt = `${candidate.slice(0, candidate.length - ext.length)}-${n}${ext}`;
+    if (!usedNames.has(alt)) { usedNames.add(alt); return alt; }
+  }
+  die(`Cannot resolve filename collision for ${candidate}`, 3);
+}
+
+// ---------------------------------------------------------------------------
+// HTML/CSS scanning
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract @font-face context: basename → { family, style }.
+ * Used for hash-named font renaming.
+ *
+ * @param {string} html
+ * @returns {Map<string, {family: string, style: string}>}
+ */
+function extractFontContext(html) {
+  const map = new Map();
+  const faceRE = /@font-face\s*\{([^}]+)\}/gi;
+  let m;
+  while ((m = faceRE.exec(html)) !== null) {
+    const block = m[1];
+    const familyM = block.match(/font-family\s*:\s*(['"]?)([^;'"]+)\1/i);
+    const styleM = block.match(/font-style\s*:\s*(\w+)/i);
+    const srcM = block.match(/url\(['"]?([^'")\s]+)['"]?\)/g);
+    if (!familyM || !srcM) continue;
+    const family = familyM[2].trim();
+    const style = styleM ? styleM[1].toLowerCase() : 'normal';
+    for (const srcEntry of srcM) {
+      const urlM = srcEntry.match(/url\(['"]?([^'")\s]+)['"]?\)/);
+      if (urlM) map.set(basename(urlM[1]), { family, style });
+    }
+  }
+  return map;
+}
+
+/**
+ * Extract all in-scope asset URLs from HTML text.
+ * Returns raw URL strings as they appear in the HTML (not resolved).
+ *
+ * @param {string} html
+ * @returns {string[]}
+ */
+function scanHtml(html) {
+  const found = new Set();
+
+  const addIfInScope = (rawUrl) => {
+    if (!rawUrl || rawUrl.startsWith('data:')) return;
+    const ext = extname(new URL(rawUrl, 'http://x').pathname).toLowerCase();
+    if (IMAGE_EXTS.has(ext) || VIDEO_EXTS.has(ext) || FONT_EXTS.has(ext)) found.add(rawUrl);
+  };
+
+  // img src
+  for (const m of html.matchAll(/<img[^>]+src=['"]([^'"]+)['"]/gi)) addIfInScope(m[1]);
+  // img srcset / picture source srcset — "url [descriptor], url [descriptor]"
+  for (const m of html.matchAll(/srcset=['"]([^'"]+)['"]/gi)) {
+    for (const part of m[1].split(',')) {
+      const url = part.trim().split(/\s+/)[0];
+      if (url) addIfInScope(url);
+    }
+  }
+  // video source src, video poster
+  for (const m of html.matchAll(/<(?:source|video)[^>]+src=['"]([^'"]+)['"]/gi)) addIfInScope(m[1]);
+  for (const m of html.matchAll(/poster=['"]([^'"]+)['"]/gi)) addIfInScope(m[1]);
+  // inline style: background-image / content url()
+  for (const m of html.matchAll(/style=['"][^'"]*url\((['"]?)([^'")\s]+)\1\)[^'"]*['"]/gi)) {
+    addIfInScope(m[2]);
+  }
+  // CSS url() inside <style> blocks
+  for (const m of html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/gi)) {
+    for (const u of m[1].matchAll(/url\((['"]?)([^'")\s]+)\1\)/g)) addIfInScope(u[2]);
+  }
+
+  return [...found];
+}
+
+// ---------------------------------------------------------------------------
+// Download
+// ---------------------------------------------------------------------------
+
+/**
+ * Download or copy a single asset to dest path.
+ *
+ * @param {string} resolvedUrl
+ * @param {string} inputDir - base for resolving file:// or relative paths
+ * @param {string} destPath
+ * @returns {Promise<number>} file size in bytes
+ */
+async function downloadAsset(resolvedUrl, inputDir, destPath) {
+  await mkdir(dirname(destPath), { recursive: true });
+
+  if (resolvedUrl.startsWith('file://')) {
+    const src = fileURLToPath(resolvedUrl);
+    await copyFile(src, destPath);
+    return (await stat(destPath)).size;
+  }
+
+  const res = await fetch(resolvedUrl);
+  if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  await writeFile(destPath, buf);
+  return buf.length;
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency check
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} inputDir
+ * @returns {Promise<boolean>} true if already collected and all files present
+ */
+async function alreadyCollected(inputDir) {
+  const manifestPath = join(inputDir, 'asset-manifest.json');
+  try { await access(manifestPath); } catch { return false; }
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  for (const asset of manifest.assets ?? []) {
+    if (asset.strategy === 'absolute' || !asset.normalizedPath) continue;
+    try { await access(join(inputDir, asset.normalizedPath)); } catch { return false; }
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const { inputDir, baseUrl, dryRun } = parseArgs();
+
+const indexPath = join(inputDir, 'index.html');
+try { await access(indexPath); } catch { die(`index.html not found in ${inputDir}`, 1); }
+
+if (!dryRun && await alreadyCollected(inputDir)) {
+  log('already collected — skipping');
+  process.exit(0);
+}
+
+const html = await readFile(indexPath, 'utf8');
+const fontContext = extractFontContext(html);
+const rawUrls = scanHtml(html);
+
+log(`scanned ${rawUrls.length} in-scope asset reference(s)`);
+
+const assets = [];
+const warnings = [];
+const usedNames = new Set();
+const rewrites = new Map(); // originalUrl → normalizedPath
+
+for (const originalUrl of rawUrls) {
+  let resolvedUrl;
+  try { resolvedUrl = new URL(originalUrl, baseUrl).toString(); } catch {
+    warnings.push(`Cannot resolve URL '${originalUrl}' against base '${baseUrl}' — skipped`);
+    continue;
+  }
+
+  const type = assetType(resolvedUrl);
+  if (!type) continue;
+
+  const reach = reachability(resolvedUrl);
+  const strat = strategy(reach, type);
+
+  const asset = { originalUrl, resolvedUrl, normalizedPath: null, type, reachability: reach, strategy: strat };
+
+  if (strat === 'absolute') {
+    if (type === 'font' && reach === 'reachable') {
+      warnings.push(`Font '${originalUrl}' is cross-origin — may hit CORS issues in EDS`);
+    }
+    assets.push(asset);
+    continue;
+  }
+
+  const filename = normalizeFilename(originalUrl, type, fontContext, usedNames);
+  const normalizedPath = `${typeDir(type)}/${filename}`;
+  const destPath = join(inputDir, normalizedPath);
+  asset.normalizedPath = normalizedPath;
+
+  if (!dryRun) {
+    try {
+      const size = await downloadAsset(resolvedUrl, inputDir, destPath);
+      asset.size = size;
+      log(`${strat === 'vendor' ? 'vendored' : 'downloaded'} ${originalUrl} → ${normalizedPath}`);
+    } catch (err) {
+      warnings.push(`Failed to fetch '${originalUrl}': ${err.message}`);
+      asset.fetchFailed = true;
+    }
+  }
+
+  rewrites.set(originalUrl, normalizedPath);
+  assets.push(asset);
+}
+
+// Rewrite index.html in-place
+if (!dryRun && rewrites.size > 0) {
+  let rewritten = html;
+  for (const [original, normalized] of rewrites) {
+    rewritten = rewritten.replaceAll(original, normalized);
+  }
+  await writeFile(indexPath, rewritten, 'utf8');
+  log(`rewrote ${rewrites.size} reference(s) in index.html`);
+}
+
+// Build manifest
+const byStrategy = { absolute: 0, vendor: 0, 'da-media': 0 };
+const byType = { font: 0, image: 0, video: 0 };
+for (const a of assets) {
+  byStrategy[a.strategy] = (byStrategy[a.strategy] ?? 0) + 1;
+  byType[a.type] = (byType[a.type] ?? 0) + 1;
+}
+
+const manifest = {
+  version: 1,
+  sourceUrl: baseUrl,
+  scannedAt: new Date().toISOString(),
+  stats: { total: assets.length, byStrategy, byType },
+  assets,
+  warnings,
+};
+
+if (dryRun) {
+  console.log(JSON.stringify(manifest, null, 2));
+} else {
+  await writeFile(join(inputDir, 'asset-manifest.json'), JSON.stringify(manifest, null, 2), 'utf8');
+  log(`wrote asset-manifest.json (${assets.length} asset(s), ${warnings.length} warning(s))`);
+}

--- a/plugins/aem/edge-delivery-services/skills/snowflake/scripts/asset-collect.mjs
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/scripts/asset-collect.mjs
@@ -14,9 +14,14 @@
  * and emits asset-manifest.json.
  *
  * In-scope types:
- *   images : .png .jpg .jpeg .webp .avif .gif
+ *   images : .png .jpg .jpeg .webp .avif .gif  (+ data URI base64 images)
  *   videos : .mp4 .webm
  *   fonts  : .otf .woff .woff2 .ttf .eot
+ *
+ * Data URI images (data:image/...;base64,...) are always extracted — they are
+ * the primary source of DA document bloat on Claude Design pages. Each unique
+ * data URI is decoded, written to images/<sha256-12>.ext, and the data: ref
+ * is rewritten in index.html. Duplicates resolve to the same hash → one file.
  *
  * Asset strategies (per-asset, not per-run):
  *   absolute  — stable public URL; leave as-is
@@ -44,6 +49,7 @@
 import { readFile, writeFile, mkdir, copyFile, access, stat } from 'node:fs/promises';
 import { join, basename, extname, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -52,6 +58,14 @@ import { fileURLToPath } from 'node:url';
 const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.avif', '.gif']);
 const VIDEO_EXTS = new Set(['.mp4', '.webm']);
 const FONT_EXTS = new Set(['.otf', '.woff', '.woff2', '.ttf', '.eot']);
+
+const MIME_TO_EXT = {
+  'image/png': '.png',
+  'image/jpeg': '.jpg',
+  'image/webp': '.webp',
+  'image/gif': '.gif',
+  'image/avif': '.avif',
+};
 
 const STABLE_CDN_HOSTS = new Set([
   'fonts.googleapis.com',
@@ -224,7 +238,12 @@ function scanHtml(html) {
   const found = new Set();
 
   const addIfInScope = (rawUrl) => {
-    if (!rawUrl || rawUrl.startsWith('data:')) return;
+    if (!rawUrl) return;
+    if (rawUrl.startsWith('data:')) {
+      const mimeMatch = rawUrl.match(/^data:(image\/[a-z+]+);base64,/);
+      if (mimeMatch && MIME_TO_EXT[mimeMatch[1]]) found.add(rawUrl);
+      return;
+    }
     const ext = extname(new URL(rawUrl, 'http://x').pathname).toLowerCase();
     if (IMAGE_EXTS.has(ext) || VIDEO_EXTS.has(ext) || FONT_EXTS.has(ext)) found.add(rawUrl);
   };
@@ -326,6 +345,36 @@ const usedNames = new Set();
 const rewrites = new Map(); // originalUrl → normalizedPath
 
 for (const originalUrl of rawUrls) {
+  // Data URI: extract to file instead of fetching
+  if (originalUrl.startsWith('data:')) {
+    const mimeMatch = originalUrl.match(/^data:(image\/[a-z+]+);base64,(.+)$/s);
+    if (!mimeMatch) continue;
+    const [, mime, b64] = mimeMatch;
+    const ext = MIME_TO_EXT[mime] ?? '.bin';
+    const buf = Buffer.from(b64, 'base64');
+    const hash = createHash('sha256').update(buf).digest('hex').slice(0, 12);
+    const normalizedPath = `images/${hash}${ext}`;
+    usedNames.add(`${hash}${ext}`);
+    const asset = {
+      originalUrl: `${originalUrl.slice(0, 64)}…`,
+      resolvedUrl: null,
+      normalizedPath,
+      type: 'image',
+      reachability: 'local',
+      strategy: 'da-media',
+      size: buf.length,
+      dataUri: true,
+    };
+    if (!dryRun) {
+      await mkdir(join(inputDir, 'images'), { recursive: true });
+      await writeFile(join(inputDir, normalizedPath), buf);
+      log(`extracted data URI → ${normalizedPath} (${buf.length} bytes)`);
+    }
+    rewrites.set(originalUrl, normalizedPath);
+    assets.push(asset);
+    continue;
+  }
+
   let resolvedUrl;
   try { resolvedUrl = new URL(originalUrl, baseUrl).toString(); } catch {
     warnings.push(`Cannot resolve URL '${originalUrl}' against base '${baseUrl}' — skipped`);

--- a/plugins/aem/edge-delivery-services/skills/snowflake/scripts/asset-collect.test.mjs
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/scripts/asset-collect.test.mjs
@@ -283,7 +283,7 @@ test('stable CDN assets are left as absolute — no download', async () => {
   }
 });
 
-test('cross-origin font warning generated for reachable non-CDN font', async () => {
+test('cross-origin font warning generated for reachable non-CDN font (public base)', async () => {
   const dir = makeInput({
     'index.html': `<html><head>
       <style>
@@ -294,14 +294,16 @@ test('cross-origin font warning generated for reachable non-CDN font', async () 
       </style>
     </head><body></body></html>`,
   });
-  serverRoot = dir;
   try {
-    const r = await run(dir, `http://127.0.0.1:${serverPort}/index.html`);
+    // Public base URL → reachable font stays absolute → CORS warning
+    const r = await run(dir, 'https://example.com/page.html', ['--dry-run']);
     assert.equal(r.code, 0, r.stderr);
-    const m = readManifest(dir);
+    const jsonStart = r.stdout.indexOf('{');
+    const manifest = JSON.parse(r.stdout.slice(jsonStart));
+    assert.equal(manifest.assets[0].strategy, 'absolute');
     assert.ok(
-      m.warnings.some((w) => w.includes('cross-origin')),
-      `Expected cross-origin warning, got: ${JSON.stringify(m.warnings)}`,
+      manifest.warnings.some((w) => w.includes('cross-origin')),
+      `Expected cross-origin warning, got: ${JSON.stringify(manifest.warnings)}`,
     );
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -444,6 +446,62 @@ test('duplicate data URIs — same file written once, both refs rewritten', asyn
     // Both img tags now reference the extracted file
     const occurrences = (rewritten.match(new RegExp(m.assets[0].normalizedPath, 'g')) || []).length;
     assert.equal(occurrences, 2, 'expected both img srcs to be rewritten');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('ephemeral host — claudeusercontent.com font always extracted', async () => {
+  const dir = makeInput({
+    'index.html': `<html><head><style>
+      @font-face {
+        font-family: "Design Font";
+        src: url("https://abc123.claudeusercontent.com/v1/blobs/font.woff2") format("woff2");
+      }
+    </style></head><body></body></html>`,
+  });
+  try {
+    // Even with a public base URL, ephemeral hosts are always downloaded
+    const r = await run(dir, 'https://example.com/page.html', ['--dry-run']);
+    assert.equal(r.code, 0, r.stderr);
+    const jsonStart = r.stdout.indexOf('{');
+    const manifest = JSON.parse(r.stdout.slice(jsonStart));
+    assert.equal(manifest.assets[0].reachability, 'ephemeral');
+    assert.equal(manifest.assets[0].strategy, 'vendor');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('base-is-local — non-CDN external image downloaded in snapshot mode', async () => {
+  const dir = makeInput({
+    'index.html': `<html><body>
+      <img src="https://random-host.com/photo.jpg" alt="">
+    </body></html>`,
+  });
+  try {
+    const r = await run(dir, `http://127.0.0.1:${serverPort}/index.html`, ['--dry-run']);
+    assert.equal(r.code, 0, r.stderr);
+    const jsonStart = r.stdout.indexOf('{');
+    const manifest = JSON.parse(r.stdout.slice(jsonStart));
+    assert.equal(manifest.assets[0].strategy, 'da-media', 'should download in snapshot mode');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('public base URL — reachable external image left as absolute', async () => {
+  const dir = makeInput({
+    'index.html': `<html><body>
+      <img src="https://random-host.com/photo.jpg" alt="">
+    </body></html>`,
+  });
+  try {
+    const r = await run(dir, 'https://example.com/page.html', ['--dry-run']);
+    assert.equal(r.code, 0, r.stderr);
+    const jsonStart = r.stdout.indexOf('{');
+    const manifest = JSON.parse(r.stdout.slice(jsonStart));
+    assert.equal(manifest.assets[0].strategy, 'absolute');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/plugins/aem/edge-delivery-services/skills/snowflake/scripts/asset-collect.test.mjs
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/scripts/asset-collect.test.mjs
@@ -1,0 +1,423 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFile, execFileSync } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createServer } from 'node:http';
+
+const execFileAsync = promisify(execFile);
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(HERE, 'asset-collect.mjs');
+
+// ---------------------------------------------------------------------------
+// Local HTTP server — serves files from a configurable root
+// ---------------------------------------------------------------------------
+
+let serverRoot = '';
+let serverPort = 0;
+let server;
+
+before(async () => {
+  server = createServer((req, res) => {
+    const fp = join(serverRoot, decodeURIComponent(req.url.split('?')[0]));
+    try {
+      const data = readFileSync(fp);
+      res.writeHead(200);
+      res.end(data);
+    } catch {
+      res.writeHead(404);
+      res.end('not found');
+    }
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  serverPort = server.address().port;
+});
+
+after(() => server?.close());
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeInput(files = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'ac-test-'));
+  for (const [rel, content] of Object.entries(files)) {
+    mkdirSync(join(dir, dirname(rel)), { recursive: true });
+    writeFileSync(join(dir, rel), typeof content === 'string' ? content : content);
+  }
+  return dir;
+}
+
+// Use async execFile so the HTTP server's event loop stays unblocked
+// while the subprocess does fetch() calls back to it.
+async function run(inputDir, baseUrl, extra = []) {
+  try {
+    const { stdout } = await execFileAsync(
+      'node', [SCRIPT, '--input', inputDir, '--base-url', baseUrl, ...extra],
+      { encoding: 'utf8' },
+    );
+    return { code: 0, stdout };
+  } catch (e) {
+    return { code: e.status ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' };
+  }
+}
+
+function readManifest(dir) {
+  return JSON.parse(readFileSync(join(dir, 'asset-manifest.json'), 'utf8'));
+}
+
+const TINY_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  'base64',
+);
+const TINY_WOFF2 = Buffer.from('d09GMgABAAAAAAA', 'base64');
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test('missing --input exits with code 1', () => {
+  try {
+    execFileSync('node', [SCRIPT, '--base-url', 'http://example.com'], { encoding: 'utf8' });
+    assert.fail('should have thrown');
+  } catch (e) {
+    assert.equal(e.status, 1);
+    assert.match(e.stderr, /--input is required/);
+  }
+});
+
+test('missing --base-url exits with code 1', () => {
+  try {
+    execFileSync('node', [SCRIPT, '--input', '/tmp'], { encoding: 'utf8' });
+    assert.fail('should have thrown');
+  } catch (e) {
+    assert.equal(e.status, 1);
+    assert.match(e.stderr, /--base-url is required/);
+  }
+});
+
+test('missing index.html exits with code 1', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'ac-test-'));
+  try {
+    const r = await run(dir, 'http://localhost/');
+    assert.equal(r.code, 1);
+    assert.match(r.stderr, /index\.html not found/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('img src — discovers and downloads local image', async () => {
+  const dir = makeInput({
+    'index.html': `<html><body><img src="hero.png" alt=""></body></html>`,
+    'hero.png': TINY_PNG,
+  });
+  serverRoot = dir;
+  try {
+    const r = await run(dir, `http://127.0.0.1:${serverPort}/index.html`);
+    assert.equal(r.code, 0, r.stderr);
+    const m = readManifest(dir);
+    assert.equal(m.stats.total, 1);
+    assert.equal(m.assets[0].type, 'image');
+    assert.equal(m.assets[0].strategy, 'da-media');
+    assert.equal(m.assets[0].normalizedPath, 'images/hero.png');
+    assert.ok(existsSync(join(dir, 'images/hero.png')));
+    assert.match(readFileSync(join(dir, 'index.html'), 'utf8'), /images\/hero\.png/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('img srcset — discovers both descriptors', async () => {
+  const dir = makeInput({
+    'index.html': `<html><body>
+      <img srcset="thumb-400.webp 400w, thumb-800.webp 800w" src="thumb.webp">
+    </body></html>`,
+    'thumb.webp': TINY_PNG,
+    'thumb-400.webp': TINY_PNG,
+    'thumb-800.webp': TINY_PNG,
+  });
+  serverRoot = dir;
+  try {
+    const r = await run(dir, `http://127.0.0.1:${serverPort}/index.html`);
+    assert.equal(r.code, 0, r.stderr);
+    const m = readManifest(dir);
+    const paths = m.assets.map((a) => a.normalizedPath);
+    assert.ok(paths.some((p) => p?.includes('thumb-400')));
+    assert.ok(paths.some((p) => p?.includes('thumb-800')));
+    assert.ok(paths.some((p) => p?.includes('thumb.webp') || p?.endsWith('thumb.webp')));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('video source src and poster — both discovered', async () => {
+  const dir = makeInput({
+    'index.html': `<html><body>
+      <video poster="preview.jpg">
+        <source src="clip.mp4">
+      </video>
+    </body></html>`,
+    'preview.jpg': TINY_PNG,
+    'clip.mp4': Buffer.from('ftyp'),
+  });
+  serverRoot = dir;
+  try {
+    const r = await run(dir, `http://127.0.0.1:${serverPort}/index.html`);
+    assert.equal(r.code, 0, r.stderr);
+    const m = readManifest(dir);
+    const types = m.assets.map((a) => a.type);
+    assert.ok(types.includes('image'), 'poster not found');
+    assert.ok(types.includes('video'), 'video source not found');
+    assert.ok(existsSync(join(dir, 'images/preview.jpg')));
+    assert.ok(existsSync(join(dir, 'videos/clip.mp4')));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('inline style background-image url() — discovered', async () => {
+  const dir = makeInput({
+    'index.html': `<html><body>
+      <div style="background-image: url('bg.jpg')"></div>
+    </body></html>`,
+    'bg.jpg': TINY_PNG,
+  });
+  serverRoot = dir;
+  try {
+    const r = await run(dir, `http://127.0.0.1:${serverPort}/index.html`);
+    assert.equal(r.code, 0, r.stderr);
+    const m = readManifest(dir);
+    assert.ok(m.assets.some((a) => a.type === 'image'));
+    assert.ok(existsSync(join(dir, 'images/bg.jpg')));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('@font-face url() in style block — discovered and vendored', async () => {
+  const dir = makeInput({
+    'index.html': `<html><head>
+      <style>
+        @font-face {
+          font-family: "My Font";
+          src: url("font.woff2") format("woff2");
+          font-weight: 400;
+          font-style: normal;
+        }
+      </style>
+    </head><body></body></html>`,
+    'font.woff2': TINY_WOFF2,
+  });
+  serverRoot = dir;
+  try {
+    const r = await run(dir, `http://127.0.0.1:${serverPort}/index.html`);
+    assert.equal(r.code, 0, r.stderr);
+    const m = readManifest(dir);
+    assert.equal(m.stats.total, 1);
+    assert.equal(m.assets[0].type, 'font');
+    assert.equal(m.assets[0].strategy, 'vendor');
+    assert.ok(existsSync(join(dir, 'fonts/font.woff2')));
+    assert.match(readFileSync(join(dir, 'index.html'), 'utf8'), /fonts\/font\.woff2/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('hash-named font gets semantic name from @font-face context — italic variant', async () => {
+  const dir = makeInput({
+    'index.html': `<html><head>
+      <style>
+        @font-face {
+          font-family: "Adobe Clean";
+          src: url("abcdef1234567890.woff2") format("woff2");
+          font-style: italic;
+        }
+      </style>
+    </head><body></body></html>`,
+    'abcdef1234567890.woff2': TINY_WOFF2,
+  });
+  serverRoot = dir;
+  try {
+    const r = await run(dir, `http://127.0.0.1:${serverPort}/index.html`);
+    assert.equal(r.code, 0, r.stderr);
+    const m = readManifest(dir);
+    assert.ok(existsSync(join(dir, 'fonts/adobe-clean-italic.woff2')), 'expected adobe-clean-italic.woff2');
+    assert.equal(m.assets[0].normalizedPath, 'fonts/adobe-clean-italic.woff2');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('stable CDN assets are left as absolute — no download', async () => {
+  const dir = makeInput({
+    'index.html': `<html><head>
+      <style>
+        @font-face {
+          font-family: "Google Font";
+          src: url("https://fonts.gstatic.com/s/roboto/v30/abc123.woff2") format("woff2");
+        }
+      </style>
+    </head><body>
+      <img src="https://cdn.jsdelivr.net/npm/some-pkg/img.png">
+    </body></html>`,
+  });
+  serverRoot = dir;
+  try {
+    const r = await run(dir, `http://127.0.0.1:${serverPort}/index.html`);
+    assert.equal(r.code, 0, r.stderr);
+    const m = readManifest(dir);
+    // img.png is SVG via cdn.jsdelivr... but it's a .png so it's in scope
+    // Both should be absolute (stable-cdn)
+    for (const a of m.assets) {
+      assert.equal(a.strategy, 'absolute', `Expected absolute for ${a.originalUrl}`);
+      assert.equal(a.normalizedPath, null);
+    }
+    assert.ok(!existsSync(join(dir, 'fonts')), 'no fonts dir should be created');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('cross-origin font warning generated for reachable non-CDN font', async () => {
+  const dir = makeInput({
+    'index.html': `<html><head>
+      <style>
+        @font-face {
+          font-family: "Remote Font";
+          src: url("https://other-domain.com/fonts/myfont.woff2") format("woff2");
+        }
+      </style>
+    </head><body></body></html>`,
+  });
+  serverRoot = dir;
+  try {
+    const r = await run(dir, `http://127.0.0.1:${serverPort}/index.html`);
+    assert.equal(r.code, 0, r.stderr);
+    const m = readManifest(dir);
+    assert.ok(
+      m.warnings.some((w) => w.includes('cross-origin')),
+      `Expected cross-origin warning, got: ${JSON.stringify(m.warnings)}`,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('filename collision — second asset gets -2 suffix', async () => {
+  const dir = makeInput({
+    'index.html': `<html><body>
+      <img src="dir-a/hero.jpg">
+      <img src="dir-b/hero.jpg">
+    </body></html>`,
+    'dir-a/hero.jpg': TINY_PNG,
+    'dir-b/hero.jpg': TINY_PNG,
+  });
+  serverRoot = dir;
+  try {
+    const r = await run(dir, `http://127.0.0.1:${serverPort}/index.html`);
+    assert.equal(r.code, 0, r.stderr);
+    assert.ok(existsSync(join(dir, 'images/hero.jpg')));
+    assert.ok(existsSync(join(dir, 'images/hero-2.jpg')));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('idempotent re-run — second call is a no-op', async () => {
+  const dir = makeInput({
+    'index.html': `<html><body><img src="photo.gif"></body></html>`,
+    'photo.gif': TINY_PNG,
+  });
+  serverRoot = dir;
+  try {
+    const r1 = await run(dir, `http://127.0.0.1:${serverPort}/index.html`);
+    assert.equal(r1.code, 0, r1.stderr);
+    const htmlAfter1 = readFileSync(join(dir, 'index.html'), 'utf8');
+    const manifestAfter1 = readFileSync(join(dir, 'asset-manifest.json'), 'utf8');
+
+    const r2 = await run(dir, `http://127.0.0.1:${serverPort}/index.html`);
+    assert.equal(r2.code, 0, r2.stderr);
+    assert.match(r2.stdout, /already collected/);
+    assert.equal(readFileSync(join(dir, 'index.html'), 'utf8'), htmlAfter1, 'index.html changed on second run');
+    assert.equal(readFileSync(join(dir, 'asset-manifest.json'), 'utf8'), manifestAfter1, 'manifest changed on second run');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('--dry-run — no files written, manifest on stdout', async () => {
+  const dir = makeInput({
+    'index.html': `<html><body><img src="photo.png"></body></html>`,
+  });
+  serverRoot = dir;
+  try {
+    const r = await run(dir, `http://127.0.0.1:${serverPort}/index.html`, ['--dry-run']);
+    assert.equal(r.code, 0, r.stderr);
+    // stdout contains log line + JSON — find the JSON block
+    const jsonStart = r.stdout.indexOf('{');
+    const manifest = JSON.parse(r.stdout.slice(jsonStart));
+    assert.ok(manifest.assets, 'no assets in dry-run output');
+    assert.ok(!existsSync(join(dir, 'asset-manifest.json')), 'manifest written in dry-run');
+    assert.ok(!existsSync(join(dir, 'images')), 'images dir created in dry-run');
+    assert.doesNotMatch(
+      readFileSync(join(dir, 'index.html'), 'utf8'),
+      /images\//,
+      'index.html rewritten in dry-run',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('SVGs are ignored (out of scope)', async () => {
+  const dir = makeInput({
+    'index.html': `<html><body>
+      <img src="icon.svg" alt="">
+      <img src="photo.png" alt="">
+    </body></html>`,
+    'icon.svg': '<svg></svg>',
+    'photo.png': TINY_PNG,
+  });
+  serverRoot = dir;
+  try {
+    const r = await run(dir, `http://127.0.0.1:${serverPort}/index.html`);
+    assert.equal(r.code, 0, r.stderr);
+    const m = readManifest(dir);
+    assert.equal(m.stats.total, 1, 'SVG should not be counted');
+    assert.equal(m.assets[0].normalizedPath, 'images/photo.png');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('all three CSS url() quote forms handled', async () => {
+  const dir = makeInput({
+    'index.html': `<html><head>
+      <style>
+        .a { background-image: url(unquoted.gif); }
+        .b { background-image: url('single.gif'); }
+        .c { background-image: url("double.gif"); }
+      </style>
+    </head><body></body></html>`,
+    'unquoted.gif': TINY_PNG,
+    'single.gif': TINY_PNG,
+    'double.gif': TINY_PNG,
+  });
+  serverRoot = dir;
+  try {
+    const r = await run(dir, `http://127.0.0.1:${serverPort}/index.html`);
+    assert.equal(r.code, 0, r.stderr);
+    const m = readManifest(dir);
+    assert.equal(m.stats.total, 3, `Expected 3 assets, got ${m.stats.total}`);
+    assert.ok(existsSync(join(dir, 'images/unquoted.gif')));
+    assert.ok(existsSync(join(dir, 'images/single.gif')));
+    assert.ok(existsSync(join(dir, 'images/double.gif')));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/plugins/aem/edge-delivery-services/skills/snowflake/scripts/asset-collect.test.mjs
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/scripts/asset-collect.test.mjs
@@ -395,6 +395,60 @@ test('SVGs are ignored (out of scope)', async () => {
   }
 });
 
+test('data URI images — extracted to file, rewritten in HTML, classified da-media', async () => {
+  // Minimal 1×1 PNG as base64
+  const dataUri = `data:image/png;base64,${TINY_PNG.toString('base64')}`;
+  const dir = makeInput({
+    'index.html': `<html><body><img src="${dataUri}" alt="test"></body></html>`,
+  });
+  serverRoot = dir;
+  try {
+    const r = await run(dir, `http://127.0.0.1:${serverPort}/index.html`);
+    assert.equal(r.code, 0, r.stderr);
+    const m = readManifest(dir);
+    assert.equal(m.stats.total, 1);
+    assert.equal(m.assets[0].type, 'image');
+    assert.equal(m.assets[0].strategy, 'da-media');
+    assert.equal(m.assets[0].reachability, 'local');
+    assert.ok(m.assets[0].dataUri, 'dataUri flag missing');
+    // File was extracted
+    const normalizedPath = m.assets[0].normalizedPath;
+    assert.ok(normalizedPath.startsWith('images/'), `unexpected path: ${normalizedPath}`);
+    assert.ok(existsSync(join(dir, normalizedPath)));
+    // data URI was rewritten out of index.html
+    const rewritten = readFileSync(join(dir, 'index.html'), 'utf8');
+    assert.ok(!rewritten.includes('data:image/'), 'data URI still present in index.html');
+    assert.ok(rewritten.includes(normalizedPath), 'normalized path not found in index.html');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('duplicate data URIs — same file written once, both refs rewritten', async () => {
+  const dataUri = `data:image/png;base64,${TINY_PNG.toString('base64')}`;
+  const dir = makeInput({
+    'index.html': `<html><body>
+      <img src="${dataUri}" alt="first">
+      <img src="${dataUri}" alt="second">
+    </body></html>`,
+  });
+  serverRoot = dir;
+  try {
+    const r = await run(dir, `http://127.0.0.1:${serverPort}/index.html`);
+    assert.equal(r.code, 0, r.stderr);
+    const m = readManifest(dir);
+    // Same data URI deduplicated → 1 asset entry
+    assert.equal(m.stats.total, 1);
+    const rewritten = readFileSync(join(dir, 'index.html'), 'utf8');
+    assert.ok(!rewritten.includes('data:image/'), 'data URI still present');
+    // Both img tags now reference the extracted file
+    const occurrences = (rewritten.match(new RegExp(m.assets[0].normalizedPath, 'g')) || []).length;
+    assert.equal(occurrences, 2, 'expected both img srcs to be rewritten');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('all three CSS url() quote forms handled', async () => {
   const dir = makeInput({
     'index.html': `<html><head>


### PR DESCRIPTION
## Summary

- Adds `asset-collect.mjs` — a zero-dependency Node script that runs in Phase 1 for every source page, regardless of origin. It scans `index.html` for in-scope asset references (raster images, videos, fonts), classifies each by reachability and type, downloads local/unreachable ones into normalized subdirectories, renames hash-named font blobs using `@font-face` context, rewrites refs in `index.html` in-place, and emits `asset-manifest.json`.
- Replaces the grep-based asset discovery in Phase 1 with the single script call.
- Updates Phase 2, Phase 3, and `methodology.md` to reflect the per-asset strategy model (replaces the old per-run `absolute`/`vendor`/`da-media` choice).
- Adds 16 tests covering all scan patterns and behaviors.

## Asset strategy (per-asset, not per-run)

| Reachability | Type | Strategy |
|---|---|---|
| Stable public URL | any | `absolute` — leave as-is |
| Local/unreachable | font | `vendor` → `/fonts/` (Code Bus) |
| Local/unreachable | image, video | `da-media` → DA Media Bus upload |

Never vendor images/videos into the git repo.

## Test plan

- [ ] `node --test plugins/aem/edge-delivery-services/skills/snowflake/scripts/asset-collect.test.mjs` — 16/16 pass
- [ ] Dry-run against Claude Design snapshot: `node asset-collect.mjs --input <dir> --base-url http://localhost:8080/ --dry-run` — discovers both OTF fonts, assigns `vendor` strategy, derives semantic names from `@font-face` context
- [ ] Full e2e: snowflake run on Claude Design snapshot (`http://127.0.0.1:8080/`) in `snowflake-demos` — overlay applied, 0 console errors, fonts loaded at `/fonts/adobe-clean-spectrum-vf.otf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)