### PR TITLE
Remove adobe-for-creativity from marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,25 +10,6 @@
   "allowCrossMarketplaceDependenciesOn": ["impeccable"],
   "plugins": [
     {
-      "name": "adobe-for-creativity",
-      "source": "./plugins/creative-cloud/adobe-for-creativity",
-      "description": "Brings together Adobe Creative Cloud tools for images, vectors, design, and video. Edit multiple assets at once, adapt for different platforms, and complete multi-step creative workflows for polished results.",
-      "version": "1.0.2",
-      "category": "creative-cloud",
-      "keywords": [
-        "adobe",
-        "creative-cloud",
-        "image-editing",
-        "design"
-      ],
-      "author": {
-        "name": "Adobe"
-      },
-      "homepage": "https://github.com/adobe/skills",
-      "repository": "https://github.com/adobe/skills",
-      "license": "Apache-2.0"
-    },
-    {
       "name": "stardust",
       "source": "./plugins/stardust",
       "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",


### PR DESCRIPTION
This PR removes the `adobe-for-creativity` plugin from the marketplace configuration as it does not need to be listed there. Anthropic picks up updates from [`plugins/creative-cloud/adobe-for-creativity/.claude-plugin/plugin.json`](https://github.com/adobe/skills/blob/main/plugins/creative-cloud/adobe-for-creativity/.claude-plugin/plugin.json) and does not look at the root `.claude-plugin/marketplace.json` for updates.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
