### PR TITLE
fix: remove XML tag from deploy skill description

### DIFF
--- a/plugins/stardust/skills/deploy/SKILL.md
+++ b/plugins/stardust/skills/deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy
-description: Convert per-page styled HTML prototypes (stardust under stardust/prototypes/**, or claude-design / Mobirise / Relume / Lovable / v0 / Figma-derived pages, or JSX prototypes pre-rendered to HTML, often under samples/) into Edge Delivery Services (EDS / AEM) blocks and content pages, then deploy via DA. Each prototype <section> becomes one EDS block; the prototype's per-section CSS becomes that block's CSS scoped under the block class. Use when the user wants to lift styled per-page HTML prototypes into a working EDS site under blocks/ and content/.
+description: Convert per-page styled HTML prototypes (stardust under stardust/prototypes/**, or claude-design / Mobirise / Relume / Lovable / v0 / Figma-derived pages, or JSX prototypes pre-rendered to HTML, often under samples/) into Edge Delivery Services (EDS / AEM) blocks and content pages, then deploy via DA. Each prototype section becomes one EDS block; the prototype's per-section CSS becomes that block's CSS scoped under the block class. Use when the user wants to lift styled per-page HTML prototypes into a working EDS site under blocks/ and content/.
 license: Apache-2.0
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #202. The `deploy` skill's `description` frontmatter contains an XML tag (`<section>`), which `tessl-review`'s deterministic validation rejects (`description must not contain XML tags`) — zeroing the skill's review score (17%, LLM judge skipped).

This one-line fix landed on the PR #202 branch but **raced the merge** and didn't make it into `main`. This PR carries just that fix.

```diff
-Each prototype <section> becomes one EDS block; ...
+Each prototype section becomes one EDS block; ...
```

## Verification

- `skills-ref validate` passes on `deploy`.
- Removes the only `tessl-review` deterministic-validation error; `diff` already passes at 88%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)