### PR TITLE
docs: Add type annotation to params

### DIFF
--- a/plugins/app-builder/skills/appbuilder-action-scaffolder/assets/action-scaffold-template.js
+++ b/plugins/app-builder/skills/appbuilder-action-scaffolder/assets/action-scaffold-template.js
@@ -1,5 +1,8 @@
 'use strict';
 
+/**
+ * @param {{ inputId: string, logger?: object }} params
+ */
 exports.main = async function main(params) {
   const logger = params.logger || console;
 


### PR DESCRIPTION
### 问题背景
原始函数参数 'params' 缺少类型注解，导致调用者不清楚其预期结构（如 inputId 和 logger 属性）。这增加了代码的歧义，可能引发错误或误解。

### 修改内容
- 修改了 `plugins/app-builder/skills/appbuilder-action-scaffolder/assets/action-scaffold-template.js` 文件。
- 在 `exports.main` 函数上添加了 JSDoc 注解，指定了 `params` 参数的类型为 `{ inputId: string, logger?: object }`。
- 这样改可以明确参数的预期结构，帮助开发者理解函数接口，提高代码可读性和维护性。
- 提升：增强代码文档，便于 IDE 支持，如自动补全和错误检查，减少开发中的错误。

### 验证方式
- 现有测试应该继续通过，因为只添加了注解，不改变代码行为。
- 没有添加新的测试，因为这是文档性变更。
- 可以通过检查代码或运行现有测试来验证功能不变。

### 其他信息
- 没有 breaking changes。
- 这个 PR 本身就是文档更新，不需要额外文档。
- 没有已知的限制。