### PR TITLE
fix(6.5-lts): update aem-replication skill to reference code-assessment instead of best-practices

### DIFF
--- a/plugins/aem/6.5-lts/skills/aem-replication/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-replication/SKILL.md
@@ -129,5 +129,5 @@ All skills reference official Adobe AEM 6.5 LTS documentation:
 
 AEM as a Cloud Service uses the **Sling Distribution API** instead of replication agents. If planning migration:
 - Review [Cloud Service Distribution Documentation](https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/operations/distribution.html)
-- For code migration patterns, see `skills/aem/cloud-service/skills/best-practices/references/replication.md`
+- For code migration patterns, use the `code-assessment` skill: `skills/aem/cloud-service/skills/code-assessment/replication/SKILL.md`
 - Avoid agent-specific coupling (filter by agent ID) to reduce migration complexity

--- a/plugins/aem/6.5-lts/skills/aem-replication/SKILL.md
+++ b/plugins/aem/6.5-lts/skills/aem-replication/SKILL.md
@@ -3,7 +3,9 @@ name: aem-replication
 description: |
   Single entry point for all AEM 6.5 LTS Replication skills. Covers configuring replication agents,
   activating/deactivating content, using the Replication API programmatically, and troubleshooting
-  distribution issues for Adobe Experience Manager 6.5 LTS.
+  distribution issues for Adobe Experience Manager 6.5 LTS. Use when the user asks about publishing,
+  unpublishing, replicating, or distributing content in AEM 6.5 LTS or AMS — including flushing the
+  dispatcher cache, fixing stuck or blocked replication queues, or configuring replication agents.
 license: Apache-2.0
 compatibility: Requires AEM 6.5 LTS or Adobe Managed Services (AMS). NOT compatible with AEM as a Cloud Service (use Sling Distribution API instead).
 metadata:
@@ -31,61 +33,15 @@ Route user requests to the appropriate specialist skill based on intent.
 2. Read the linked SKILL.md for that specialist skill.
 3. Follow the workflow and guidance defined in that skill.
 4. For complex scenarios spanning multiple skills (e.g., configure agent then troubleshoot), start with the primary intent and cross-reference as needed.
+5. If the request doesn't clearly match a single row, ask the user to clarify before proceeding.
 
 ## Skill Overview
 
-### Configure Replication Agent
-
-Set up and configure replication agents for:
-- **Default agents**: Author to Publish content distribution
-- **Dispatcher Flush agents**: Cache invalidation
-- **Reverse replication**: Publish to Author user-generated content flow
-- **Multiple publish instances**: Load balancing and high availability
-
-**When to use:** First-time setup, adding new publish instances, reconfiguring agents
-
-### Replicate Content
-
-Activate and deactivate content through:
-- **Quick Publish**: Simple one-click activation
-- **Manage Publication**: Advanced scheduling and approval workflows
-- **Tree Activation**: Hierarchical bulk publishing
-- **Package Manager**: Specific content set distribution
-- **Workflows**: Approval-based publishing
-- **Scheduled Activation**: Time-based content publishing
-
-**When to use:** Publishing pages, assets, or DAM content; unpublishing content
-
-### Replication API
-
-Programmatic replication using official AEM 6.5 LTS public APIs:
-- **Replicator interface**: Core replication methods
-- **ReplicationOptions**: Configure synchronous/asynchronous, agent filtering
-- **ReplicationStatus**: Query replication state
-- **AgentManager, ReplicationQueue, ReplicationListener**: Advanced queue management and monitoring
-
-**When to use:** Custom code integration, bulk operations, workflow process steps, servlets
-
-### Troubleshoot Replication
-
-Diagnose and fix common issues:
-- **Blocked queues**: FIFO queue failures
-- **Connection errors**: Network, authentication, SSL issues
-- **Content not appearing**: Dispatcher cache, permissions
-- **Agent configuration**: URI, credentials, triggers
-- **Event queue issues**: Stuck replication jobs
-
-**When to use:** Replication failures, performance issues, content not distributing
-
-### Replication Orchestrator
-
-Coordinates end-to-end replication workflows spanning multiple sub-skills:
-- **New Environment Setup**: Configure agents → Test replication → Troubleshoot
-- **Production Incident Response**: Diagnose → Fix → Verify
-- **Performance Optimization**: Monitor → Tune → Validate
-- **Migration Preparation**: Audit → Plan → Execute
-
-**When to use:** Multi-step scenarios requiring coordination across configure, replicate, API, and troubleshoot skills
+- **Configure Replication Agent** — Set up default, Dispatcher Flush, reverse, and multi-publish agents. Use for first-time setup, adding publish instances, or reconfiguring agents.
+- **Replicate Content** — Activate/deactivate content via Quick Publish, Manage Publication, Tree Activation, Package Manager, workflows, or scheduled activation. Use for publishing/unpublishing pages, assets, or DAM content.
+- **Replication API** — Programmatic replication via `Replicator`, `ReplicationOptions`, `ReplicationStatus`, `AgentManager`, `ReplicationQueue`, and `ReplicationListener`. Use for custom code integration, bulk operations, workflow process steps, or servlets.
+- **Troubleshoot Replication** — Diagnose blocked queues, connection errors, missing content, agent misconfiguration, and stuck jobs. Use when replication fails, underperforms, or content isn't distributing.
+- **Replication Orchestrator** — Coordinates multi-step scenarios across the other sub-skills: environment setup, incident response, performance optimization, migration prep.
 
 ## Common Workflows
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The best-practices skill under aem-cloud-service was eliminated in favour of the code-assessment skill (which restructured replication content into a dedicated replication/SKILL.md sub-skill). The reference in the 6.5-lts aem-replication skill's migration section still pointed to the old best-practices/references/replication.md path. This updates it to the correct code-assessment/replication/SKILL.md location.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
