### PR TITLE
feat(aem-cloud-service): add guava-cache analyzer detector + expert skill

### DIFF
--- a/plugins/aem/cloud-service/skills/code-assessment/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/SKILL.md
@@ -67,6 +67,7 @@ Route the request to one expert skill. Two pattern families share this skill:
 | `com.day.cq.replication.Replicator`, `org.apache.sling.replication.*`, "publish/preview activation" | [`replication/`](replication/SKILL.md) | `replication` |
 | `javax.jcr.observation.EventListener`, `org.osgi.service.event.EventHandler` on non-resource topics (replication, workflow, custom) | [`event-migration/`](event-migration/SKILL.md) | `eventListener` / `eventHandler` |
 | `com.day.cq.dam.api.AssetManager` create/upload/delete APIs, `createAssetForBinary`, `removeAssetForBinary` | [`asset-manager/`](asset-manager/SKILL.md) | `assetApi` |
+| `import com.google.common.cache.*` (`CacheBuilder`, `LoadingCache`, `CacheLoader`), "guava cache", "swap guava for caffeine" | [`guava-cache/`](guava-cache/SKILL.md) | `guavaCache` |
 | HTL build warning `data-sly-test: redundant constant value comparison` | [`references/data-sly-test-redundant-constant.md`](references/data-sly-test-redundant-constant.md) | `htlLint` (reference, no expert skill subdirectory) |
 
 **Broad / correctness-review asks** ("check my Sling Models are implemented correctly", "review my code", "is my AEM project healthy", "assess this project") are not a single pattern: run the runbook in `discover` mode with intent `report` — the analyzer runs every detector and the report covers all built patterns, explicitly noting aspects not yet supported. Only narrow to one pattern when the user targets a specific fix.

--- a/plugins/aem/cloud-service/skills/code-assessment/guava-cache/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/guava-cache/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: guava-cache
+description: AEM Cloud Service expert skill for the Guava cache → Caffeine swap. Covers bundles importing com.google.common.cache.* (Cache, CacheBuilder, LoadingCache, CacheLoader, RemovalListener). Classification, the near-1:1 Caffeine API mapping, pom dependency swap, import + call-site edits (getUnchecked→get, Callable→Function, RemovalNotification→3-arg), review checklist, and test generation. Routes detail to recipe.md.
+license: Apache-2.0
+---
+
+# Guava cache → Caffeine — AEM as a Cloud Service
+
+> This pattern is executed by the code-assessment runbook — follow [`../references/runbook.md`](../references/runbook.md) for the full flow (preflight → plan → apply → verify, run log). This skill supplies the detection + recipe the runbook applies.
+
+## Overview
+
+On AEM as a Cloud Service the supported in-process cache library is **Caffeine** (`com.github.benmanes.caffeine.cache.*`). Bundles importing `com.google.common.cache.*` are flagged because Guava is shrinking in the CS uber-jar and relying on Guava's cache from a third-party classloader is unstable. Caffeine is the recommended successor (same author as Guava cache) and its API is intentionally near-identical, so the swap is mechanical with a few well-known call-site renames.
+
+## Classification — confirm this pattern applies
+
+A file is in scope when it imports `com.google.common.cache.*` — `Cache`, `CacheBuilder`, `LoadingCache`, `CacheLoader`, `RemovalListener`, or `RemovalNotification`.
+
+1. **Bundle uses Guava cache** (import + real usage) → apply the full recipe: **C1 (pom)** + **C2 (imports)** + **C3 (builder / API call sites)**.
+2. **Leftover import, no real usage** → just remove the dead `com.google.common.cache.*` import; no Caffeine dependency needed.
+3. **Cache plus unrelated Guava utilities** (`com.google.common.collect.*`, `com.google.common.base.*`) → only the cache portion is in scope; leave other Guava usages alone unless the user asks. Keep the `guava` dependency if other code still imports `com.google.common.*`.
+
+**Not in scope (no false positive):** look-alike cache classes from other packages — e.g. `io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics` — are not `com.google.common.cache.*` and are not flagged.
+
+## Discovery
+
+Detection is performed by the analyzer ([`../scripts/analyze.sh`](../scripts/README.md)), run by the runbook:
+
+```bash
+bash ../scripts/analyze.sh <workspace-root> --pattern guava-cache
+```
+
+**Match criteria (what the detector flags):** each `import com.google.common.cache.…` (explicit type or the package wildcard `.*`) in a parsed Java file, emitted with the import line and snippet. The match is an exact package-prefix on the import — Java-only, parse-level, import-anchored; no classpath or type resolution.
+
+## Resolution contract
+
+**self-evident** — the Guava → Caffeine API mapping is fixed (see [recipe.md](recipe.md)); no user input is required to plan the edit. The only judgment is the Caffeine version: pin it to the AEM CS SDK BOM (default `3.1.8`).
+
+## Review checklist
+
+- [ ] No `import com.google.common.cache.*` remains in changed files.
+- [ ] No `CacheBuilder.newBuilder()` remains; all builders use `Caffeine.newBuilder()`.
+- [ ] No `LoadingCache.getUnchecked(...)` remains; replaced with `.get(...)`.
+- [ ] No `cache.get(key, Callable)` remains; the `Callable` is a `Function` (lambda).
+- [ ] `RemovalListener` callbacks use the `(key, value, cause)` signature, not `RemovalNotification`.
+- [ ] `Caffeine` is on the bundle's `pom.xml` with `<scope>provided</scope>`, version pinned to the AEM CS SDK BOM.
+- [ ] `mvn clean install` passes; **aemanalyser** reports no `com.google.common.cache` API leaks.
+- [ ] Guava dependency kept only if non-cache `com.google.common.*` usage remains.
+
+## Common pitfalls
+
+- **Embedding Caffeine** — use `<scope>provided</scope>`; Caffeine is supplied by the CS runtime, never embed it in the bundle.
+- **Removing Guava too eagerly** — if other code still imports `com.google.common.collect/base`, keep the dependency and add Caffeine alongside.
+- **`getUnchecked` left in place** — Caffeine has no `getUnchecked`; `LoadingCache.get(key)` already throws unchecked.
+- **`Callable` vs `Function`** — `cache.get(key, …)` takes a `Function<K,V>` in Caffeine, not a `Callable<V>`.
+
+## Recipe
+
+Read [recipe.md](recipe.md) in full before editing: input contract, the C1/C2/C3 edits, the API mapping table, unlocatable / skip reasons, before/after examples, and test generation.
+
+## Handoff
+
+The skill never commits. See [`../references/git-workflow.md`](../references/git-workflow.md) for git vs in-place handoff and the suggested commit message.

--- a/plugins/aem/cloud-service/skills/code-assessment/guava-cache/recipe.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/guava-cache/recipe.md
@@ -1,0 +1,193 @@
+# Recipe — Guava cache → Caffeine
+
+> Read this fully before editing. Control plane: [SKILL.md](SKILL.md).
+
+## Input contract
+
+Per finding, regardless of how it was obtained:
+
+| Field | Example | Source |
+|---|---|---|
+| `file` | `core/.../UserCache.java` | Repo-relative path to the flagged Java file |
+| `line` | `7` | Line of the `com.google.common.cache.*` import |
+| `snippet` | `import com.google.common.cache.CacheBuilder;` | The flagged import |
+
+The fix parameters are **self-evident** — the Guava → Caffeine mapping below is fixed. The only choice is the Caffeine version: pin to the AEM CS SDK BOM (default `3.1.8`).
+
+## API mapping (Guava → Caffeine)
+
+| Guava | Caffeine |
+|---|---|
+| `com.google.common.cache.Cache` | `com.github.benmanes.caffeine.cache.Cache` |
+| `com.google.common.cache.LoadingCache` | `com.github.benmanes.caffeine.cache.LoadingCache` |
+| `com.google.common.cache.CacheBuilder` | `com.github.benmanes.caffeine.cache.Caffeine` |
+| `com.google.common.cache.CacheLoader` | `com.github.benmanes.caffeine.cache.CacheLoader` |
+| `com.google.common.cache.RemovalListener` | `com.github.benmanes.caffeine.cache.RemovalListener` |
+| `com.google.common.cache.RemovalNotification` | callback signature `(K key, V value, RemovalCause cause)` |
+| `CacheBuilder.newBuilder()` | `Caffeine.newBuilder()` |
+| `.maximumSize(n)` / `.weakKeys()` / `.softValues()` / `.recordStats()` / `.removalListener(l)` | identical |
+| `.expireAfterWrite(d, TimeUnit)` | `.expireAfterWrite(Duration)` (preferred) or `(d, TimeUnit)` |
+| `.expireAfterAccess(d, TimeUnit)` / `.refreshAfterWrite(d, TimeUnit)` | `.expireAfterAccess(Duration)` / `.refreshAfterWrite(Duration)` |
+| `.build()` | identical (returns `Cache<K,V>`) |
+| `.build(cacheLoader)` | identical (returns `LoadingCache<K,V>`) |
+| `cache.getIfPresent(key)` / `.asMap()` / `.invalidate(key)` / `.invalidateAll()` | identical |
+| `cache.get(key, Callable<V>)` | `cache.get(key, Function<K,V>)` — argument is a `Function`, not `Callable` |
+| `LoadingCache.getUnchecked(key)` | `LoadingCache.get(key)` — Caffeine's `get` already throws unchecked |
+| `LoadingCache.refresh(key)` | identical |
+
+## C1 — Maven dependency swap (bundle pom)
+
+```xml
+<!-- BEFORE -->
+<dependency>
+    <groupId>com.google.guava</groupId>
+    <artifactId>guava</artifactId>
+    <version>31.1-jre</version>
+    <scope>provided</scope>
+</dependency>
+```
+
+```xml
+<!-- AFTER -->
+<dependency>
+    <groupId>com.github.ben-manes.caffeine</groupId>
+    <artifactId>caffeine</artifactId>
+    <version>3.1.8</version>
+    <scope>provided</scope>
+</dependency>
+```
+
+Rules:
+- `<scope>provided</scope>` — Caffeine is supplied by the AEM CS runtime; never embed it.
+- If Guava is also used elsewhere in the bundle (not just cache), **keep** the `guava` dependency and add Caffeine alongside.
+- Pin the Caffeine version to whatever the AEM CS SDK BOM exports.
+
+## C2 — Imports
+
+```java
+// REMOVE
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+```
+
+```java
+// ADD (only those actually used)
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.RemovalListener;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+```
+
+## C3 — Builder + API call sites
+
+```java
+// BEFORE — Guava
+LoadingCache<String, User> users = CacheBuilder.newBuilder()
+        .maximumSize(10_000)
+        .expireAfterWrite(10, TimeUnit.MINUTES)
+        .recordStats()
+        .build(new CacheLoader<String, User>() {
+            @Override
+            public User load(String id) throws Exception {
+                return userRepo.findById(id);
+            }
+        });
+
+User u = users.getUnchecked("u-42");
+```
+
+```java
+// AFTER — Caffeine
+LoadingCache<String, User> users = Caffeine.newBuilder()
+        .maximumSize(10_000)
+        .expireAfterWrite(Duration.ofMinutes(10))
+        .recordStats()
+        .build(id -> userRepo.findById(id));
+
+User u = users.get("u-42");
+```
+
+```java
+// BEFORE — get-or-compute (Callable)        // AFTER — Caffeine (Function)
+String v = cache.get(key, () -> compute(key));   String v = cache.get(key, k -> compute(k));
+```
+
+```java
+// BEFORE — RemovalListener (RemovalNotification)
+RemovalListener<String, User> rl = notification ->
+        log.info("evicted {} cause={}", notification.getKey(), notification.getCause());
+
+// AFTER — RemovalListener (3-arg)
+RemovalListener<String, User> rl = (key, value, cause) ->
+        log.info("evicted {} cause={}", key, cause);
+```
+
+## Unlocatable / skip
+
+- `import-not-found: com.google.common.cache.* not present in <file>` — the flagged import is no longer there (already migrated). Record `skipped`.
+- `guava-still-required: non-cache com.google.common.* usage in <file>` — only remove the cache imports; keep the Guava dependency. Record as a partial apply note, not a skip.
+
+## Editing strategy
+
+Surgical, formatting-preserving text edits — no reformatting / re-serialization:
+1. Replace each `com.google.common.cache.X` import with its Caffeine counterpart (C2); drop imports for types no longer referenced.
+2. Replace `CacheBuilder.newBuilder()` → `Caffeine.newBuilder()` (C3).
+3. Replace `getUnchecked(` → `get(`, and convert any `cache.get(key, Callable)` to a `Function` lambda.
+4. Convert anonymous `CacheLoader` to a lambda where the `load` body is a single expression.
+5. Swap the C1 pom dependency.
+
+Anchor each replace on the smallest unique substring so unrelated identical text is not touched.
+
+## Test generation
+
+After the swap, generate a JUnit test that confirms cache behaviour is preserved — `getIfPresent` returns `null` for unknown keys, `cache.get(key, Function)` computes and caches, `invalidate(key)` removes the entry, and `LoadingCache.get(key)` does not throw checked exceptions. One test class per production class changed, suffix `Test`, under `src/test/java/…`.
+
+```java
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class UserCacheTest {
+
+    private UserCache service;
+
+    @Before
+    public void setUp() {
+        service = new UserCache();
+        service.activate(java.util.Collections.emptyMap());
+    }
+
+    @Test
+    public void shouldReturnNullForUnknownKey() {
+        assertNull(service.getIfPresent("u-unknown"));
+    }
+
+    @Test
+    public void shouldComputeAndCache() {
+        Object first = service.get("u-42");
+        assertNotNull(first);
+        assertEquals(first, service.get("u-42"));
+    }
+
+    @Test
+    public void shouldInvalidateEntry() {
+        service.get("u-42");
+        service.invalidate("u-42");
+        assertNull(service.getIfPresent("u-42"));
+    }
+}
+```
+
+## See also
+
+- [`../references/aem-cloud-service-pattern-prerequisites.md`](../references/aem-cloud-service-pattern-prerequisites.md) — SCR → DS, service-user resolvers, SLF4J.
+- Caffeine wiki: <https://github.com/ben-manes/caffeine/wiki> — behaviour differences (async loading, weight-based eviction) beyond this near-1:1 swap.

--- a/plugins/aem/cloud-service/skills/code-assessment/references/patterns.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/references/patterns.md
@@ -39,6 +39,7 @@ Adding a pattern: add a row here, then build the expert skill from
 | [`asset-manager`](../asset-manager/SKILL.md) | migrate DAM `AssetManager` create/upload via Direct Binary Access (`@adobe/aem-upload`) and delete via in-JVM `resolver.delete()` + `commit()` or HTTP Assets API; removes `createAssetForBinary` / `getAssetForBinary` / `removeAssetForBinary` (not available on CS) | high | ready | analyzer | guided |
 | [`outbound-call-timeouts`](../outbound-call-timeouts/SKILL.md) | add connect/read/socket timeouts to outbound HTTP client construction (Apache HttpClient, OkHttp, JDK HttpClient) | high | ready | analyzer | mechanical |
 | [`unbounded-query`](../unbounded-query/SKILL.md) | bound or escalate an explicitly-unbounded query (`p.limit=-1` predicate / `setLimit(-1)`) — safe-cap where provable, else flag for pagination | high | ready | analyzer | guided |
+| [`guava-cache`](../guava-cache/SKILL.md) | swap Guava cache (`com.google.common.cache.*`) for Caffeine (`com.github.benmanes.caffeine.cache.*`) — pom dependency + imports + API call sites | low | ready | analyzer | guided |
 | `unclosed-resources` | close `ResourceResolver` / `Session` / streams via try-with-resources | high | planned | - | - |
 | `thread-lock-contention` | replace coarse `synchronized` / synchronized collections on shared state with concurrent types | high | planned | - | - |
 | `heavy-model-init` | move heavy work (I/O, queries) out of `@PostConstruct` / Sling Model init | medium | planned | - | - |

--- a/plugins/aem/cloud-service/skills/code-assessment/scripts/analyzer/Registry.java
+++ b/plugins/aem/cloud-service/skills/code-assessment/scripts/analyzer/Registry.java
@@ -2,6 +2,7 @@ package analyzer;
 
 import analyzer.detectors.AssetManager;
 import analyzer.detectors.EventMigration;
+import analyzer.detectors.GuavaCache;
 import analyzer.detectors.InjectInSlingModel;
 import analyzer.detectors.OutboundCallTimeouts;
 import analyzer.detectors.OutdatedDependencies;
@@ -26,7 +27,8 @@ public final class Registry {
             new EventMigration(),
             new AssetManager(),
             new OutboundCallTimeouts(),
-            new UnboundedQuery()
+            new UnboundedQuery(),
+            new GuavaCache()
         ));
     }
 }

--- a/plugins/aem/cloud-service/skills/code-assessment/scripts/analyzer/detectors/GuavaCache.java
+++ b/plugins/aem/cloud-service/skills/code-assessment/scripts/analyzer/detectors/GuavaCache.java
@@ -1,0 +1,41 @@
+package analyzer.detectors;
+
+import analyzer.Corpus;
+import analyzer.Detector;
+import analyzer.Finding;
+import analyzer.JavaUnit;
+import com.sun.source.tree.ImportTree;
+
+import java.util.List;
+
+/**
+ * guava-cache — a bundle importing {@code com.google.common.cache.*} (Guava's in-process cache
+ * API). On AEM as a Cloud Service the supported in-process cache library is Caffeine
+ * ({@code com.github.benmanes.caffeine.cache.*}); Guava cache is flagged because Guava is shrinking
+ * in the CS uber-jar and relying on {@code com.google.common.cache} from a third-party classloader
+ * is unstable. The remediation is a near-1:1 swap (pom dependency + imports + a few API call sites).
+ *
+ * <p>Parse-level and import-anchored: it flags each {@code import com.google.common.cache.…}
+ * (explicit type or the package wildcard {@code .*}). Other Guava packages
+ * ({@code com.google.common.collect} / {@code .base} / …) are out of scope, and look-alike cache
+ * classes from other packages (e.g. {@code io.micrometer…cache.GuavaCacheMetrics}) are not matched
+ * because the prefix is exact — avoiding the known BPA false positive.
+ */
+public final class GuavaCache implements Detector {
+
+    public String pattern() { return "guava-cache"; }
+    public boolean needsPoms() { return false; }   // Java-only detector (import-anchored)
+
+    private static final String GUAVA_CACHE_PKG = "com.google.common.cache.";
+
+    public void detect(Corpus c, List<Finding> out, List<String> warnings) {
+        for (JavaUnit u : c.java) {
+            for (ImportTree imp : u.cu.getImports()) {
+                String q = imp.getQualifiedIdentifier().toString();
+                if (q.startsWith(GUAVA_CACHE_PKG)) {
+                    out.add(new Finding(pattern(), u.rel, u.lineOf(imp), u.snippetOf(imp)));
+                }
+            }
+        }
+    }
+}

--- a/plugins/aem/cloud-service/test/code-assessment/fixtures/guava-cache/CleanCaffeineCache.java
+++ b/plugins/aem/cloud-service/test/code-assessment/fixtures/guava-cache/CleanCaffeineCache.java
@@ -1,0 +1,23 @@
+package fixtures;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+
+import java.time.Duration;
+
+/** Clean: already migrated to Caffeine — must NOT be flagged by guava-cache. */
+public class CleanCaffeineCache {
+
+    private final LoadingCache<String, String> titles = Caffeine.newBuilder()
+            .maximumSize(10_000)
+            .expireAfterWrite(Duration.ofMinutes(10))
+            .build(this::resolve);
+
+    public String title(String id) {
+        return titles.get(id);
+    }
+
+    private String resolve(String id) {
+        return id.toUpperCase();
+    }
+}

--- a/plugins/aem/cloud-service/test/code-assessment/fixtures/guava-cache/LegacyGuavaCache.java
+++ b/plugins/aem/cloud-service/test/code-assessment/fixtures/guava-cache/LegacyGuavaCache.java
@@ -1,0 +1,29 @@
+package fixtures;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+import java.util.concurrent.TimeUnit;
+
+/** Antipattern: imports com.google.common.cache.* — must be flagged by guava-cache. */
+public class LegacyGuavaCache {
+
+    private final LoadingCache<String, String> titles = CacheBuilder.newBuilder()
+            .maximumSize(10_000)
+            .expireAfterWrite(10, TimeUnit.MINUTES)
+            .build(new CacheLoader<String, String>() {
+                @Override
+                public String load(String id) {
+                    return resolve(id);
+                }
+            });
+
+    public String title(String id) {
+        return titles.getUnchecked(id);
+    }
+
+    private String resolve(String id) {
+        return id.toUpperCase();
+    }
+}

--- a/plugins/aem/cloud-service/test/code-assessment/fixtures/guava-cache/MicrometerGuavaMetrics.java
+++ b/plugins/aem/cloud-service/test/code-assessment/fixtures/guava-cache/MicrometerGuavaMetrics.java
@@ -1,0 +1,15 @@
+package fixtures;
+
+import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;
+
+/**
+ * Negative / false-positive guard: a look-alike "GuavaCache" class from a different package
+ * (Micrometer's metrics binder, not com.google.common.cache.*). Must NOT be flagged — the BPA
+ * report's known guava false positive.
+ */
+public class MicrometerGuavaMetrics {
+
+    public Class<?> binder() {
+        return GuavaCacheMetrics.class;
+    }
+}

--- a/plugins/aem/cloud-service/test/code-assessment/run-tests.sh
+++ b/plugins/aem/cloud-service/test/code-assessment/run-tests.sh
@@ -225,6 +225,13 @@ assert_contains "setLimit(-1) flagged"             "$OUT" 'UnboundedJcr.java'
 assert_contains "unbounded via final constant flagged" "$OUT" 'UnboundedConst.java'
 assert_absent  "bounded query (incl. bounded const) not flagged" "$OUT" 'BoundedQuery.java'
 
+echo "[guava-cache] com.google.common.cache.* imports flagged; caffeine + micrometer look-alike not flagged"
+OUT="$(run "$FIX/guava-cache")"
+assert_contains "pattern present"                      "$OUT" '"pattern":"guava-cache"'
+assert_contains "LegacyGuavaCache flagged"             "$OUT" 'LegacyGuavaCache.java'
+assert_absent  "CleanCaffeineCache not flagged"        "$OUT" 'CleanCaffeineCache.java'
+assert_absent  "MicrometerGuavaMetrics not flagged"    "$OUT" 'MicrometerGuavaMetrics.java'
+
 echo "----"
 echo "PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Adds the **guava-cache** code-assessment pattern — Guava cache (`com.google.common.cache.*`) → Caffeine (`com.github.benmanes.caffeine.cache.*`) on AEM as a Cloud Service. Follows the `references/adding-a-pattern.md` procedure; the slug `guava-cache` is wired into all four required places so the `[wiring]` test stays green.

## Changes

- **Detector** — `scripts/analyzer/detectors/GuavaCache.java`, registered in `Registry.all()`. Import-anchored on `com.google.common.cache.*` (Java-only). Exact package prefix means the `io.micrometer…GuavaCacheMetrics` BPA false positive is **not** flagged.
- **Expert skill** — `guava-cache/SKILL.md` (control plane) + `guava-cache/recipe.md` (C1 pom swap, C2 imports, C3 builder/API mapping incl. `getUnchecked`→`get`, `Callable`→`Function`, `RemovalNotification`→3-arg; test generation).
- **Catalog + routing** — `references/patterns.md` row (`low | ready | analyzer | guided`) and Manual Pattern Hints row in `code-assessment/SKILL.md`.
- **Fixtures + test** — `test/code-assessment/fixtures/guava-cache/` (legacy guava / clean caffeine / micrometer guard) + a block in `run-tests.sh`.

## Test Plan

- [x] `run-tests.sh` — **109 PASS / 0 FAIL** (incl. `[wiring]` and the new `[guava-cache]` block)
- [x] Detector flags `com.google.common.cache.*` imports; does **not** flag Caffeine or `GuavaCacheMetrics`
- [x] End-to-end on a real legacy AEM project: analyzer detects → recipe transform applied → analyzer re-scan clean → `mvn compile` BUILD SUCCESS
