### PR TITLE
docs(aem-cloud-service): consistent report rendering for the 5 guided code-assessment patterns

### DIFF
--- a/plugins/aem/cloud-service/skills/code-assessment/asset-manager/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/asset-manager/SKILL.md
@@ -56,6 +56,30 @@ license: Apache-2.0
 
 ---
 
+## Discovery
+
+Detection is performed by the analyzer ([`../scripts/analyze.sh`](../scripts/README.md)), run by the runbook:
+
+```bash
+bash ../scripts/analyze.sh <workspace-root> --pattern asset-manager
+```
+
+**Match criteria (what the detector flags):** in a file importing **`com.day.cq.dam.api.AssetManager`**, a call to **`createAssetForBinary`**, **`getAssetForBinary`**, **`removeAssetForBinary`**, or **`createAsset`**. **One finding per call site** (each call is individually actionable, unlike the class-level patterns), with the call as the snippet. Parse-level only — gated on the import; the receiver type is not resolved, so an unrelated `createAsset(...)` in the same file could match (rare).
+
+## Resolution contract
+
+**guided** — `migrate (guided)`. The analyzer reports each legacy call site; remediation is judgment-based, routed by the call (create/upload → C1–C3, delete → D1–D3) and applied in an apply session.
+
+| Call site | Disposition |
+|---|---|
+| `createAssetForBinary` / `getAssetForBinary` (removed on CS) | migrate (guided) → C1–C3 |
+| `removeAssetForBinary` (removed on CS) | migrate (guided) → D1–D3 |
+| Client-facing `createAsset(...)` upload | migrate (guided) → C1–C3 (Direct Binary Access) |
+| In-JVM back-office `createAsset(...)` with a service-user resolver | skipped: `already-compliant` |
+| Test code (`src/test/`) | skipped: `test-scope` |
+
+---
+
 ## Complete example — Path A (create / upload)
 
 ### Before (client-facing upload via `AssetManager.createAsset`)

--- a/plugins/aem/cloud-service/skills/code-assessment/asset-manager/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/asset-manager/SKILL.md
@@ -68,13 +68,13 @@ bash ../scripts/analyze.sh <workspace-root> --pattern asset-manager
 
 ## Resolution contract
 
-**guided** — `migrate (guided)`. The analyzer reports each legacy call site; remediation is judgment-based, routed by the call (create/upload → C1–C3, delete → D1–D3) and applied in an apply session.
+**guided** — `apply (guided)`. The analyzer reports each legacy call site; remediation is judgment-based, routed by the call (create/upload → C1–C3, delete → D1–D3) and applied in an apply session.
 
 | Call site | Disposition |
 |---|---|
-| `createAssetForBinary` / `getAssetForBinary` (removed on CS) | migrate (guided) → C1–C3 |
-| `removeAssetForBinary` (removed on CS) | migrate (guided) → D1–D3 |
-| Client-facing `createAsset(...)` upload | migrate (guided) → C1–C3 (Direct Binary Access) |
+| `createAssetForBinary` / `getAssetForBinary` (removed on CS) | apply (guided) → C1–C3 |
+| `removeAssetForBinary` (removed on CS) | apply (guided) → D1–D3 |
+| Client-facing `createAsset(...)` upload | apply (guided) → C1–C3 (Direct Binary Access) |
 | In-JVM back-office `createAsset(...)` with a service-user resolver | skipped: `already-compliant` |
 | Test code (`src/test/`) | skipped: `test-scope` |
 

--- a/plugins/aem/cloud-service/skills/code-assessment/event-migration/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/event-migration/SKILL.md
@@ -75,6 +75,32 @@ A typo'd topic string compiles fine and silently subscribes to a topic that noth
 
 ---
 
+## Discovery
+
+Detection is performed by the analyzer ([`../scripts/analyze.sh`](../scripts/README.md)), run by the runbook:
+
+```bash
+bash ../scripts/analyze.sh <workspace-root> --pattern event-migration
+```
+
+**Match criteria (what the detector flags):** a class that **`implements org.osgi.service.event.EventHandler`** or **`javax.jcr.observation.EventListener`** (import-aware) — both map here per the BPA subtype taxonomy.
+
+Emitted at the class declaration, with the class header as the snippet. Parse-level only — direct `implements` clause; the subscribed topic (resource vs non-resource) is not resolved at detection, so topic-based routing to `resource-change-listener` happens during remediation (see Routing / Classification).
+
+## Resolution contract
+
+**guided** — `migrate (guided)`. The analyzer locates each handler/listener; remediation is judgment-based and applied via E0–E5 (per the Classification above) in an apply session.
+
+| Site shape | Disposition |
+|---|---|
+| `EventHandler` on a non-resource topic (replication / workflow / custom), `handleEvent()` does heavy work | migrate (guided) → E1–E5 |
+| Legacy `javax.jcr.observation.EventListener` that cannot be a `ResourceChangeListener` | migrate (guided) → E0 then E1–E5 |
+| Handler observes repository content / a resource topic (`org/apache/sling/api/resource/Resource/*`) | skipped: `wrong-pattern` (use `resource-change-listener`) |
+| `EventHandler` on a non-resource topic, `handleEvent()` only enqueues a Sling Job | skipped: `already-compliant` |
+| Test code (`src/test/`) | skipped: `test-scope` |
+
+---
+
 ## Complete example — before and after
 
 ### Before (replication EventHandler with inline business logic)

--- a/plugins/aem/cloud-service/skills/code-assessment/event-migration/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/event-migration/SKILL.md
@@ -85,17 +85,17 @@ bash ../scripts/analyze.sh <workspace-root> --pattern event-migration
 
 **Match criteria (what the detector flags):** a class that **`implements org.osgi.service.event.EventHandler`** or **`javax.jcr.observation.EventListener`** (import-aware) — both map here per the BPA subtype taxonomy.
 
-Emitted at the class declaration, with the class header as the snippet. Parse-level only — direct `implements` clause; the subscribed topic (resource vs non-resource) is not resolved at detection, so topic-based routing to `resource-change-listener` happens during remediation (see Routing / Classification).
+Emitted at the class declaration, with the class header as the snippet. Parse-level only — direct `implements` clause; the subscribed topic (resource vs non-resource) is not resolved at detection, so topic-based routing to `resource-change-listener` happens during remediation (see Routing / Classification). A class implementing both an event interface and `ResourceChangeListener` is flagged by both patterns (rare).
 
 ## Resolution contract
 
-**guided** — `apply (guided)`. The analyzer locates each handler/listener; remediation is judgment-based and applied via E0–E5 (per the Classification above) in an apply session.
+**guided** — `apply (guided)`. The analyzer locates each handler/listener; remediation is judgment-based and applied via E0–E5 (per the Classification above) in an apply session. **Rows are evaluated top-down — first match wins**, so resource/content observation routes to `resource-change-listener` *before* the E0 fall-through is considered.
 
 | Site shape | Disposition |
 |---|---|
+| Observes repository content — a `javax.jcr.observation.EventListener` watching content, or an `EventHandler` on a resource topic (`org/apache/sling/api/resource/Resource/*`) | skipped: `wrong-pattern` (use `resource-change-listener`) |
 | `EventHandler` on a non-resource topic (replication / workflow / custom), `handleEvent()` does heavy work | apply (guided) → E1–E5 |
-| Legacy `javax.jcr.observation.EventListener` that cannot be a `ResourceChangeListener` | apply (guided) → E0 then E1–E5 |
-| Handler observes repository content / a resource topic (`org/apache/sling/api/resource/Resource/*`) | skipped: `wrong-pattern` (use `resource-change-listener`) |
+| Legacy `javax.jcr.observation.EventListener` that **genuinely cannot** be modeled as a `ResourceChangeListener` (rare residual) | apply (guided) → E0 then E1–E5 |
 | `EventHandler` on a non-resource topic, `handleEvent()` only enqueues a Sling Job | skipped: `already-compliant` |
 | Test code (`src/test/`) | skipped: `test-scope` |
 

--- a/plugins/aem/cloud-service/skills/code-assessment/event-migration/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/event-migration/SKILL.md
@@ -89,12 +89,12 @@ Emitted at the class declaration, with the class header as the snippet. Parse-le
 
 ## Resolution contract
 
-**guided** — `migrate (guided)`. The analyzer locates each handler/listener; remediation is judgment-based and applied via E0–E5 (per the Classification above) in an apply session.
+**guided** — `apply (guided)`. The analyzer locates each handler/listener; remediation is judgment-based and applied via E0–E5 (per the Classification above) in an apply session.
 
 | Site shape | Disposition |
 |---|---|
-| `EventHandler` on a non-resource topic (replication / workflow / custom), `handleEvent()` does heavy work | migrate (guided) → E1–E5 |
-| Legacy `javax.jcr.observation.EventListener` that cannot be a `ResourceChangeListener` | migrate (guided) → E0 then E1–E5 |
+| `EventHandler` on a non-resource topic (replication / workflow / custom), `handleEvent()` does heavy work | apply (guided) → E1–E5 |
+| Legacy `javax.jcr.observation.EventListener` that cannot be a `ResourceChangeListener` | apply (guided) → E0 then E1–E5 |
 | Handler observes repository content / a resource topic (`org/apache/sling/api/resource/Resource/*`) | skipped: `wrong-pattern` (use `resource-change-listener`) |
 | `EventHandler` on a non-resource topic, `handleEvent()` only enqueues a Sling Job | skipped: `already-compliant` |
 | Test code (`src/test/`) | skipped: `test-scope` |

--- a/plugins/aem/cloud-service/skills/code-assessment/references/runbook.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/references/runbook.md
@@ -181,15 +181,18 @@ Copy this structure; keep section headings so runs are comparable across session
 ## Candidates
 | File | Finding | Planned action | Target / notes |
 |------|---------|----------------|----------------|
-| <path>:<line> | <snippet> | apply \| skipped \| migrate (guided) | <before → after, skip reason, or guide to open> |
+| <path>:<line> | <snippet> | apply \| skipped \| apply (guided) | <before → after, skip reason, or guide to open> |
 
 **Same columns for every pattern — mechanical *and* guided.** `Finding` is the analyzer `snippet`
-(present for every pattern). `Planned action` follows the pattern's catalog `fix`: `fix: mechanical`
-→ `apply` or `skipped — <reason>`; `fix: guided` → `migrate (guided)` (the analyzer locates the
-site; remediation opens the pattern's expert guide — name it in *Target / notes*). When several
-patterns are in play, group rows under per-pattern subheadings ordered by `severity`, but **never
-drop a column or render a guided pattern as a bare file list** — guided patterns carry concrete
-findings exactly like mechanical ones.
+(present for every pattern). `Planned action` is the **per-site disposition from that pattern's own
+Resolution contract** — `apply`, `apply → N`, `skipped — <reason>` (e.g. `needs-pagination`,
+`test-scope`, `already-compliant`), or `apply (guided)` for architectural patterns whose
+Resolution contract has no finer per-site action (remediation opens the expert guide — name it in
+*Target / notes*). **Do not collapse a pattern to one blanket action from its `fix` kind:** a
+`fix: guided` pattern that triages sites (e.g. `unbounded-query`: bound some, skip others) shows
+that triage per row, not a uniform `apply (guided)`. When several patterns are in play, group rows
+under per-pattern subheadings ordered by `severity`; never drop a column or render a pattern as a
+bare file list.
 
 ## Summary counts
 - Apply: <n>

--- a/plugins/aem/cloud-service/skills/code-assessment/references/runbook.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/references/runbook.md
@@ -51,7 +51,7 @@ Match the request to one expert skill under `code-assessment/<pattern>/` using t
 
 ### 2. Read reference module
 
-Read the chosen expert skill's `SKILL.md` then its `recipe.md` (or `path-*.md`) in full — **Discovery**, input contract, recipe, Unlocatable, editing strategy.
+Read the chosen expert skill's `SKILL.md` in full, then its `recipe.md` / `path-*.md` if present (guided patterns may carry the migration steps inline instead) — **Discovery**, **Resolution contract**, input contract, recipe/steps, Unlocatable, editing strategy.
 
 ### 3. Resolve findings (with_findings or discover)
 
@@ -181,7 +181,15 @@ Copy this structure; keep section headings so runs are comparable across session
 ## Candidates
 | File | Finding | Planned action | Target / notes |
 |------|---------|----------------|----------------|
-| <path> | <id> | apply \| skipped | <before → after, or skip reason> |
+| <path>:<line> | <snippet> | apply \| skipped \| migrate (guided) | <before → after, skip reason, or guide to open> |
+
+**Same columns for every pattern — mechanical *and* guided.** `Finding` is the analyzer `snippet`
+(present for every pattern). `Planned action` follows the pattern's catalog `fix`: `fix: mechanical`
+→ `apply` or `skipped — <reason>`; `fix: guided` → `migrate (guided)` (the analyzer locates the
+site; remediation opens the pattern's expert guide — name it in *Target / notes*). When several
+patterns are in play, group rows under per-pattern subheadings ordered by `severity`, but **never
+drop a column or render a guided pattern as a bare file list** — guided patterns carry concrete
+findings exactly like mechanical ones.
 
 ## Summary counts
 - Apply: <n>

--- a/plugins/aem/cloud-service/skills/code-assessment/replication/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/replication/SKILL.md
@@ -53,6 +53,30 @@ Identify the source pattern in the file:
 
 ---
 
+## Discovery
+
+Detection is performed by the analyzer ([`../scripts/analyze.sh`](../scripts/README.md)), run by the runbook:
+
+```bash
+bash ../scripts/analyze.sh <workspace-root> --pattern replication
+```
+
+**Match criteria (what the detector flags):** a file that imports **`com.day.cq.replication.Replicator`** or any **`org.apache.sling.replication.*`** type — the legacy replication APIs removed on Cloud Service. One finding per file, at the file's primary type, with the class header as the snippet. Parse-level only — import-based, no type resolution. The modern `org.apache.sling.distribution.*` API is not flagged.
+
+> Analyzer-only: `replication` has no BPA subtype, so a `replication` finding originates from the local analyzer, never from a BPA/CAM report.
+
+## Resolution contract
+
+**guided** — `migrate (guided)`. The analyzer locates each legacy replication caller; remediation is judgment-based (CQ `Replicator` / Sling Replication Agent → Sling Distribution API) and applied via P1–P4 in an apply session.
+
+| Site shape | Disposition |
+|---|---|
+| `Replicator` / Sling Replication Agent usage in custom code | migrate (guided) → P1–P4 |
+| Replication tied to a workflow step (workflow owns it) | skipped: `workflow-owned` |
+| Test code (`src/test/`) | skipped: `test-scope` |
+
+---
+
 ## Complete example — before and after
 
 ### Before (legacy CQ Replicator with admin resolver)

--- a/plugins/aem/cloud-service/skills/code-assessment/replication/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/replication/SKILL.md
@@ -67,11 +67,11 @@ bash ../scripts/analyze.sh <workspace-root> --pattern replication
 
 ## Resolution contract
 
-**guided** — `migrate (guided)`. The analyzer locates each legacy replication caller; remediation is judgment-based (CQ `Replicator` / Sling Replication Agent → Sling Distribution API) and applied via P1–P4 in an apply session.
+**guided** — `apply (guided)`. The analyzer locates each legacy replication caller; remediation is judgment-based (CQ `Replicator` / Sling Replication Agent → Sling Distribution API) and applied via P1–P4 in an apply session.
 
 | Site shape | Disposition |
 |---|---|
-| `Replicator` / Sling Replication Agent usage in custom code | migrate (guided) → P1–P4 |
+| `Replicator` / Sling Replication Agent usage in custom code | apply (guided) → P1–P4 |
 | Replication tied to a workflow step (workflow owns it) | skipped: `workflow-owned` |
 | Test code (`src/test/`) | skipped: `test-scope` |
 

--- a/plugins/aem/cloud-service/skills/code-assessment/resource-change-listener/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/resource-change-listener/SKILL.md
@@ -63,7 +63,7 @@ bash ../scripts/analyze.sh <workspace-root> --pattern resource-change-listener
 
 **Match criteria (what the detector flags):** a class that **`implements org.apache.sling.api.resource.observation.ResourceChangeListener`** or **`ExternalResourceChangeListener`** (import-aware) — the modern API, flagged for review against the lightweight + JobConsumer contract.
 
-Emitted at the class declaration, with the class header as the snippet. Parse-level only — direct `implements` clause; reached-via-base-class is not resolved. Legacy `javax.jcr.observation.EventListener` is detected by the `event-migration` pattern (matching the BPA subtype taxonomy); when its logic is plain content observation, that guide routes it back here.
+Emitted at the class declaration, with the class header as the snippet. Parse-level only — direct `implements` clause; reached-via-base-class is not resolved. Legacy `javax.jcr.observation.EventListener` is detected by the `event-migration` pattern (matching the BPA subtype taxonomy); when its logic is plain content observation, that guide routes it back here. A class implementing both `ResourceChangeListener` and an event interface is flagged by both patterns (rare).
 
 ## Resolution contract
 
@@ -72,7 +72,7 @@ Emitted at the class declaration, with the class header as the snippet. Parse-le
 | Site shape | Disposition |
 |---|---|
 | `implements ResourceChangeListener`, `onChange()` does repository/JCR/heavy work | apply (guided) → R1–R5 |
-| Legacy `javax.jcr.observation.EventListener` / resource-topic `EventHandler` routed here | apply (guided) → R0 then R1–R5 |
+| Legacy `javax.jcr.observation.EventListener` / resource-topic `EventHandler` routed here *(arrives via `event-migration` redirect or migration handoff — this pattern's own detector flags only the modern API)* | apply (guided) → R0 then R1–R5 |
 | `implements ResourceChangeListener`, `onChange()` only enqueues a Sling Job | skipped: `already-compliant` |
 | Test code (`src/test/`) | skipped: `test-scope` |
 

--- a/plugins/aem/cloud-service/skills/code-assessment/resource-change-listener/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/resource-change-listener/SKILL.md
@@ -67,12 +67,12 @@ Emitted at the class declaration, with the class header as the snippet. Parse-le
 
 ## Resolution contract
 
-**guided** — `migrate (guided)`. The analyzer locates each `ResourceChangeListener`; remediation is judgment-based and applied via R0–R5 (per the Classification above) in an apply session.
+**guided** — `apply (guided)`. The analyzer locates each `ResourceChangeListener`; remediation is judgment-based and applied via R0–R5 (per the Classification above) in an apply session.
 
 | Site shape | Disposition |
 |---|---|
-| `implements ResourceChangeListener`, `onChange()` does repository/JCR/heavy work | migrate (guided) → R1–R5 |
-| Legacy `javax.jcr.observation.EventListener` / resource-topic `EventHandler` routed here | migrate (guided) → R0 then R1–R5 |
+| `implements ResourceChangeListener`, `onChange()` does repository/JCR/heavy work | apply (guided) → R1–R5 |
+| Legacy `javax.jcr.observation.EventListener` / resource-topic `EventHandler` routed here | apply (guided) → R0 then R1–R5 |
 | `implements ResourceChangeListener`, `onChange()` only enqueues a Sling Job | skipped: `already-compliant` |
 | Test code (`src/test/`) | skipped: `test-scope` |
 

--- a/plugins/aem/cloud-service/skills/code-assessment/resource-change-listener/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/resource-change-listener/SKILL.md
@@ -53,6 +53,31 @@ Three CS-specific constraints every listener must satisfy:
 
 ---
 
+## Discovery
+
+Detection is performed by the analyzer ([`../scripts/analyze.sh`](../scripts/README.md)), run by the runbook:
+
+```bash
+bash ../scripts/analyze.sh <workspace-root> --pattern resource-change-listener
+```
+
+**Match criteria (what the detector flags):** a class that **`implements org.apache.sling.api.resource.observation.ResourceChangeListener`** or **`ExternalResourceChangeListener`** (import-aware) — the modern API, flagged for review against the lightweight + JobConsumer contract.
+
+Emitted at the class declaration, with the class header as the snippet. Parse-level only — direct `implements` clause; reached-via-base-class is not resolved. Legacy `javax.jcr.observation.EventListener` is detected by the `event-migration` pattern (matching the BPA subtype taxonomy); when its logic is plain content observation, that guide routes it back here.
+
+## Resolution contract
+
+**guided** — `migrate (guided)`. The analyzer locates each `ResourceChangeListener`; remediation is judgment-based and applied via R0–R5 (per the Classification above) in an apply session.
+
+| Site shape | Disposition |
+|---|---|
+| `implements ResourceChangeListener`, `onChange()` does repository/JCR/heavy work | migrate (guided) → R1–R5 |
+| Legacy `javax.jcr.observation.EventListener` / resource-topic `EventHandler` routed here | migrate (guided) → R0 then R1–R5 |
+| `implements ResourceChangeListener`, `onChange()` only enqueues a Sling Job | skipped: `already-compliant` |
+| Test code (`src/test/`) | skipped: `test-scope` |
+
+---
+
 ## Complete example — before and after
 
 ### Before (legacy JCR `EventListener` with inline logic and admin resolver)

--- a/plugins/aem/cloud-service/skills/code-assessment/scheduler/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/scheduler/SKILL.md
@@ -61,12 +61,12 @@ Emitted at the class declaration, with the class header as the snippet. Parse-le
 
 ## Resolution contract
 
-**guided** — `migrate (guided)`. The analyzer locates and reports each scheduler class; remediation is judgment-based and routed by the Classification above to **Path A** ([path-a.md](path-a.md), Runnable + OSGi properties) or **Path B** ([path-b.md](path-b.md), Sling Jobs via `JobManager`). Open the chosen path and apply its steps in an apply session.
+**guided** — `apply (guided)`. The analyzer locates and reports each scheduler class; remediation is judgment-based and routed by the Classification above to **Path A** ([path-a.md](path-a.md), Runnable + OSGi properties) or **Path B** ([path-b.md](path-b.md), Sling Jobs via `JobManager`). Open the chosen path and apply its steps in an apply session.
 
 | Site shape | Disposition |
 |---|---|
-| Single-schedule, hardcoded cron, `implements Runnable` | migrate (guided) → path-a.md |
-| Config-driven cron, multiple schedules, `implements Job`, or `ScheduleOptions.config()` | migrate (guided) → path-b.md |
+| Single-schedule, hardcoded cron, `implements Runnable` | apply (guided) → path-a.md |
+| Config-driven cron, multiple schedules, `implements Job`, or `ScheduleOptions.config()` | apply (guided) → path-b.md |
 | Already Sling Jobs via `JobManager` with single-execution guard | skipped: `already-compliant` |
 | Test code (`src/test/`) | skipped: `test-scope` |
 

--- a/plugins/aem/cloud-service/skills/code-assessment/scheduler/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/scheduler/SKILL.md
@@ -43,6 +43,35 @@ Three properties control every scheduler:
 
 ---
 
+## Discovery
+
+Detection is performed by the analyzer ([`../scripts/analyze.sh`](../scripts/README.md)), run by the runbook:
+
+```bash
+bash ../scripts/analyze.sh <workspace-root> --pattern scheduler
+```
+
+**Match criteria (what the detector flags):**
+
+- A class that **`implements org.apache.sling.commons.scheduler.Job`** (import-aware).
+- The **OSGi-property scheduler** shape — a class that **`implements Runnable`** and carries an OSGi `@Component` declaring a `scheduler.expression` / `scheduler.name` / `scheduler.period` property.
+- A file that **imports `org.apache.sling.commons.scheduler.Scheduler`** (programmatic use via an injected `Scheduler`) but has no class-level match — one finding at the file's primary type.
+
+Emitted at the class declaration, with the class header as the snippet. Parse-level only — direct `implements` clause and same-file `@Component`; reached-via-base-class and constant-valued properties are not resolved.
+
+## Resolution contract
+
+**guided** — `migrate (guided)`. The analyzer locates and reports each scheduler class; remediation is judgment-based and routed by the Classification above to **Path A** ([path-a.md](path-a.md), Runnable + OSGi properties) or **Path B** ([path-b.md](path-b.md), Sling Jobs via `JobManager`). Open the chosen path and apply its steps in an apply session.
+
+| Site shape | Disposition |
+|---|---|
+| Single-schedule, hardcoded cron, `implements Runnable` | migrate (guided) → path-a.md |
+| Config-driven cron, multiple schedules, `implements Job`, or `ScheduleOptions.config()` | migrate (guided) → path-b.md |
+| Already Sling Jobs via `JobManager` with single-execution guard | skipped: `already-compliant` |
+| Test code (`src/test/`) | skipped: `test-scope` |
+
+---
+
 ## Review Checklist
 
 Use the path-specific checklists in [path-a.md](path-a.md) and [path-b.md](path-b.md) for scheduler mechanics.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Each of the 5 guided patterns gained two sections (mirroring unbounded-query / outbound-call-timeouts):

## Discovery — the analyze.sh --pattern <slug> command + match criteria that mirror the merged detector logic exactly, and the emitted snippet. Drives the Finding column.
## Resolution contract — labeled guided, with a per-site disposition table. Drives the Planned action column.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

The five architectural patterns under code-assessment/ (scheduler, resource-change-listener, replication, event-migration, asset-manager) lacked the two sections that drive the code-assessment report table 

## How Has This Been Tested?

- bash plugins/aem/cloud-service/test/code-assessment/run-tests.sh → 103/103 pass.
- Verified each pattern's Discovery match criteria against the live analyzer output (analyze.sh --pattern <slug> per fixture).
- Migration-skill consistency checked: migration reads each guide's SKILL.md directly and skips analyzer discovery on handoff, so these sections don't affect the BPA-driven path; routing already matches the detector taxonomy.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
