### PR TITLE
feat(stardust): add rollout skill — whole-site delivery to AEM Edge Delivery Services

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "stardust",
       "source": "./plugins/stardust",
       "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "category": "design",
       "keywords": [
         "design",

--- a/plugins/stardust/.claude-plugin/plugin.json
+++ b/plugins/stardust/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stardust",
   "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "author": {
     "name": "Adobe"
   },

--- a/plugins/stardust/notes/rollout/PLAN.md
+++ b/plugins/stardust/notes/rollout/PLAN.md
@@ -1,0 +1,240 @@
+# rollout — full-site migration to AEM (Edge Delivery Services)
+
+> Design plan. Status: **proposal for review**. No skill code is written yet —
+> this document plus the JSON schemas under `schemas/` are the deliverable.
+
+## 0. What this is (and what changed)
+
+`deploy` today converts **one page** to AEM. This proposal adds **`rollout`**:
+the whole-site sibling that delivers an **entire** redesigned site to AEM Edge
+Delivery Services.
+
+This is a deliberately **simplified** design (it replaces an earlier proposal
+that introduced a `site` orchestrator, an `optimize` audit subsystem, and a
+depth-ladder campaign model). The simplifications, decided with the user:
+
+- **The platform-agnostic core is unchanged.** `extract`, `direct`, `prototype`,
+  `migrate`, `uplift` keep working exactly as they do today, **page by page**.
+  There is **no orchestrator** wrapping them.
+- **`deploy` is unchanged.** It stays the **single-page** → AEM converter.
+- **One new skill, `rollout`,** owns the full-site concern, and it lives entirely
+  in the **platform-specific** layer.
+- **`rollout` is delivery-only.** It does **not** redesign. It consumes the
+  per-page agnostic outputs that already exist and delivers the whole site.
+- **`rollout` carries two capabilities:** delivery **coverage tracking** and a
+  **dashboard**. (No audit/optimize subsystem for now.)
+
+## 1. Where rollout sits
+
+```
+  ── platform-AGNOSTIC core (UNCHANGED, page by page) ──┐
+   extract → direct → prototype → migrate               │  produces, per page:
+   (uplift as presales entry)                           │    stardust/migrated/<slug>.html
+                                                         │    stardust/migrated/<slug>._meta.json
+                                                         │    stardust/canon/  (block/module defs)
+                                                         ▼
+  ── platform-SPECIFIC (AEM-EDS) ──────────────────────────────────────────────
+   deploy   : ONE page  → AEM        (UNCHANGED)
+   rollout  : WHOLE site → AEM       (NEW)  — calls deploy per page, adds the
+              across-pages layer: block dedup, fragments/sitemap, coverage, dashboard,
+              full-site verify.
+```
+
+`rollout` : `deploy` :: "deliver the whole site" : "deliver one page". Same
+methodology, scaled and coordinated, plus the tracking the user asked for.
+
+## 2. Skill map
+
+| Skill | Status | Role |
+|---|---|---|
+| `extract` `direct` `prototype` `migrate` `uplift` | **unchanged** | Agnostic redesign, page by page. Produce `migrated/` HTML + `_meta.json` + `canon/`. |
+| `deploy` | **unchanged** | Single page → AEM-EDS (section→block conversion, fragments, DA Source API push). |
+| **`rollout`** | **new** | Full-site delivery to AEM-EDS. Inventories the migrated outputs, dedups blocks, calls `deploy` per page, assembles site-level artifacts, verifies, and tracks coverage + renders a dashboard. |
+
+> `rollout` **uses** `deploy` as a black box; it never modifies it. Everything
+> `rollout` adds is *around* `deploy`, not *inside* it.
+
+## 3. What `rollout` does (the pipeline)
+
+A single `stardust:rollout` run is resumable and idempotent — it only acts on
+work that is pending or stale.
+
+1. **Inventory.** Scan `stardust/migrated/*.html` + `*._meta.json` + `canon/` to
+   build/refresh the delivery coverage: every page, the template it uses, and
+   the blocks it composes. Each page records the **source hash** of its migrated
+   HTML so re-runs can detect what changed.
+2. **Block conversion (dedup).** Identify the **distinct** blocks across the
+   site and convert each **once** to an EDS block, recording the canonical
+   `edsBlockName` in `blocks.json`. This is the core efficiency win of doing the
+   site as a unit rather than page-by-page: 134 pages that share 19 blocks
+   convert 19 blocks, not 134. (Mechanism + the deploy-black-box caveat: § 4.)
+3. **Page delivery.** For each page that is pending or stale, invoke `deploy`,
+   reusing the already-converted blocks, and push via the DA Source API. Record
+   `pages[].delivery` (`pending → converting → deployed → verified`) +
+   `deployedUrl`.
+4. **Site-level assembly.** The artifacts that only make sense for the whole
+   site: shared **fragments** (header / nav / footer), **sitemap.xml**, robots,
+   per-page metadata, and self-canonical links. (Platform delivery mechanics —
+   not content audit.)
+5. **Verify.** Full-site verification: every page returns 200, internal links
+   resolve, blocks render. Mark verified pages and surface failures.
+6. **Report + dashboard.** Recompute counts, list what's still missing, and
+   regenerate the dashboard.
+
+## 4. `rollout` ↔ `deploy` (without changing deploy)
+
+`rollout` treats `deploy` as a single-page black box and adds the across-pages
+layer on top:
+
+- **Drive order for dedup.** `rollout` delivers a **representative page per
+  template first**; that establishes the EDS block library. Sibling pages of the
+  same template then reuse those blocks.
+- **Reconciliation.** Because `deploy` is unchanged and converts each page
+  independently, `rollout` **reconciles** the emitted block library after the
+  fact: identical blocks (matched by the canon/section signature captured at
+  inventory) are collapsed to one canonical `edsBlockName`, and `blocks.json`
+  records the mapping. This keeps dedup a `rollout` responsibility and leaves
+  `deploy` untouched.
+- **Idempotency.** A page whose migrated `sourceHash` is unchanged and whose
+  `delivery.status == verified` is skipped on re-run. Re-redesign a page upstream
+  → its hash changes → `rollout` marks it `stale` and re-delivers just that page.
+
+> Open question (§ 10): exact, zero-redundancy dedup would be cleaner if `deploy`
+> accepted an optional block-name map. That's a *small, later, optional* change
+> to `deploy` — deliberately out of scope now to honour "don't change deploy".
+
+## 5. Coverage model (delivery-scoped)
+
+All `rollout` state lives under `stardust/rollout/`, so **nothing in the agnostic
+core or its files changes** (no `state.json` edits):
+
+```
+stardust/
+├── …                                  # agnostic outputs, UNCHANGED
+│   ├── migrated/<slug>.html            #   rollout INPUT (read-only)
+│   ├── migrated/<slug>._meta.json      #   rollout INPUT (read-only)
+│   └── canon/                          #   rollout INPUT (read-only)  block/module defs
+└── rollout/                            # NEW — all platform/full-site state
+    ├── rollout.json                    #   target + DA config + run summary   (schema: rollout-config)
+    ├── coverage/
+    │   ├── pages.json                  #   delivery ledger per page           (schema: rollout-pages)
+    │   ├── templates.json              #   grouping for block reuse           (schema: rollout-templates)
+    │   └── blocks.json                 #   the dedup unit + EDS mapping        (schema: rollout-blocks)
+    └── dashboard/
+        ├── index.html                  #   self-contained delivery dashboard
+        └── data.json                   #   the snapshot the HTML renders
+```
+
+The three coverage dimensions, now scoped purely to **delivery**:
+
+- **pages** — every migrated page, its template, its `sourceHash`, and its
+  delivery status + `deployedUrl`. Answers "how many delivered / how many left".
+- **templates** — the grouping that drives block reuse: which pages share a
+  structure, and which blocks that structure composes. Derived from `_meta.json`
+  / `canon`; used to order delivery (representative first) and to roll up
+  per-template delivery progress.
+- **blocks** — the **dedup unit**. Each distinct block, the templates/pages that
+  use it, its instance count, and its EDS mapping (`edsBlockName`, `blockPath`,
+  delivery status). This is what makes "convert once, reuse everywhere" trackable.
+
+## 6. Dashboard
+
+`stardust/rollout/dashboard/index.html` — **self-contained, no external JS**, in
+the captured brand's styling. Panels:
+
+1. **Headline counts** — pages / templates / blocks totals + delivered vs.
+   remaining.
+2. **Delivery matrix** — pages by status (pending / converting / deployed /
+   verified / failed); per-template delivery %; block conversion grid.
+3. **What's missing** — the explicit list of undelivered or stale pages and
+   unconverted blocks.
+
+`dashboard/data.json` is the inspectable snapshot the HTML renders. `rollout`
+regenerates it at the end of every run.
+
+## 7. Counts & "what's missing" report
+
+Printed at the end of a run (and rendered on the dashboard):
+
+```
+rollout — example.com → aem-eds
+=====================================================================
+Pages       134 total   ·  120 verified   ·  6 deployed (unverified)   ·  8 pending
+            → 8 pages still to deliver · 2 stale (re-migrated upstream)
+Templates     7 total   ·  delivery 112/134 pages verified
+Blocks       19 total   ·  17 converted to EDS   ·  2 pending
+            → pricing-table, comparison-grid not yet converted
+Verify      3 link failures on /resources/* (see report)
+```
+
+## 8. Phasing (build order)
+
+> **Design commitment (recorded for later phases).** Block **dedup** and
+> **optimize** are not afterthoughts — both must become **first-class steps in
+> the rollout flow**, not post-hoc reconciliation or an optional side-audit:
+> - **Block dedup** should drive conversion *up front* (decide the distinct
+>   block set and canonical EDS names before/at conversion, so each block is
+>   converted exactly once), rather than the reconcile-after-the-fact stopgap
+>   described in § 4. Achieving this cleanly may require the small optional
+>   `deploy` block-name-map input noted in § 10.1.
+> - **optimize** (the detect → fix → verify audit) should run *inside* the
+>   rollout flow as a gate on delivery quality, not bolted on after.
+> These are deferred to a future phase but are committed design intent; P1 is
+> built so they slot in without rework.
+
+- **P1 — Inventory + delivery loop.** Build `rollout/coverage/*` from the
+  migrated outputs; deliver the site by calling `deploy` per page; track
+  `pages.delivery`. Deliverable: a whole site pushed to AEM with live coverage.
+- **P2 — Block dedup (first-class) + site assembly + verify.** Dedup-driven
+  conversion + `blocks.json`; fragments/sitemap; full-site verification + stale
+  re-delivery. Deliverable: efficient, coherent, re-runnable full-site rollout.
+- **P3 — optimize in the flow (multi-source audit + AEM autofix).** optimize is
+  an **aggregator** over existing audit skills, not a bespoke audit: a built-in
+  deterministic `rollout:baseline` source plus `impeccable:critique`/`audit`, the
+  marketing SEO skills (`seo-audit`, `schema`, `ai-seo`, `site-architecture`), and
+  `stardust:tensions` — all normalized into one findings ledger (with `source`
+  provenance) + scorecard, gated on open P1. A platform **autofix engine**
+  (AEM-EDS first, aggressive incl. content) resolves the platform-fixable findings
+  by editing the EDS project, then a re-`deploy` + re-`optimize` closes the loop.
+  Sources are **referenced as dependencies**, not vendored. See
+  `skills/rollout/reference/audit-sources.md`. Deliverable: an in-flow quality
+  gate sourced from real audits, with hands-off AEM autofix.
+- **P4 — Dashboard.** The self-contained, no-external-JS dashboard
+  (`dashboard.mjs`), rendered in the **project's design identity** (brand tokens
+  from the migrated `:root`). Centerpiece: a **lifecycle-coloured page tree**
+  (identified → prototyped → deployed → optimised, spanning `state.json` +
+  coverage + optimize). Node colour = most-advanced stage reached; legend counts
+  are cumulative (identified = all pages). Template archetypes badged; plus a
+  templates lifecycle table and the quality scorecard. `dashboard/data.json` is
+  the inspectable snapshot. Deliverable: at-a-glance lifecycle + quality status.
+
+**Status: P1–P4 implemented.** The flow runs end-to-end (inventory → dedup plan →
+deliver → assemble → verify → multi-source optimize → AEM autofix → dashboard),
+tested against fixtures. Live runs against a real AEM/DA target + the external
+audit skills are the remaining validation.
+
+## 9. Reference map
+
+- Built on the existing `skills/deploy/SKILL.md` methodology (section→EDS block,
+  fragments, DA Source API, archetype-cluster parallelism) — `rollout` scales and
+  coordinates it without changing it.
+- Inputs are the unchanged agnostic outputs: `skills/migrate/SKILL.md`
+  (`migrated/` + `_meta.json`), `skills/stardust/reference/artifact-map.md`
+  (file ownership), `canon/`.
+- Schemas accompanying this plan: `schemas/rollout-*.schema.json`; worked
+  example: `examples/rollout-pages.example.json`.
+
+## 10. Open questions for the next review
+
+1. **Exact block dedup vs. deploy black box.** Accept post-hoc reconciliation
+   (this plan), or later add a small optional block-name-map input to `deploy`
+   for zero-redundancy conversion?
+2. **Template/type source.** Where does `rollout` read the template a page
+   belongs to — from `_meta.json`, from a `canon` index, or inferred from shared
+   block signatures? (The schema allows any; confirm the source of truth.)
+3. **Fragment source.** Where do header/nav/footer come from for shared
+   fragments — the chrome captured in `canon`, or the first delivered page?
+4. **Cross-page parallel delivery.** Rely on `deploy`'s in-page parallelism only,
+   or have `rollout` deliver multiple pages concurrently (and if so, how light
+   can the coordination be)?
+```

--- a/plugins/stardust/notes/rollout/README.md
+++ b/plugins/stardust/notes/rollout/README.md
@@ -1,0 +1,40 @@
+# rollout — design package
+
+Proposal for **`rollout`**: a new skill that delivers a **whole redesigned site
+to AEM Edge Delivery Services**. It is the full-site sibling of the existing
+single-page `deploy`. This folder is the review deliverable; **no skill code is
+written yet**.
+
+## Contents
+
+- **`PLAN.md`** — the design document. Start here.
+- **`schemas/`** — JSON Schema (draft 2020-12) for every new file:
+  - `rollout-config.schema.json` — `rollout.json` (target + DA config + run summary).
+  - `rollout-pages.schema.json` — the per-page delivery ledger.
+  - `rollout-templates.schema.json` — template grouping that drives block reuse.
+  - `rollout-blocks.schema.json` — the block dedup unit + EDS mapping.
+- **`examples/`** — `rollout-pages.example.json`, a worked delivery ledger.
+
+## The shape (simplified design)
+
+| Layer | Skill(s) | Status |
+|---|---|---|
+| Platform-agnostic redesign (page by page) | `extract` `direct` `prototype` `migrate` `uplift` | **unchanged** — no orchestrator wraps them |
+| Single page → AEM | `deploy` | **unchanged** |
+| **Whole site → AEM** | **`rollout`** | **new** |
+
+Key decisions:
+
+- `rollout` is **delivery-only**: it consumes the per-page agnostic outputs
+  (`stardust/migrated/`) and delivers the whole site, calling `deploy` per page.
+- It owns two capabilities: **coverage tracking** (pages / templates / blocks,
+  delivery-scoped) and a **dashboard**. No audit/optimize subsystem for now.
+- All `rollout` state lives under `stardust/rollout/`, so the agnostic core and
+  its `state.json` are never touched.
+- Block **dedup** (convert each distinct block once, reuse everywhere) is the
+  core efficiency win and the reason blocks are a first-class tracking dimension.
+
+## Open questions
+
+See `PLAN.md` § 10 — block-dedup vs. the deploy black box, the template/type
+source of truth, the fragment source, and cross-page parallel delivery.

--- a/plugins/stardust/notes/rollout/examples/rollout-pages.example.json
+++ b/plugins/stardust/notes/rollout/examples/rollout-pages.example.json
@@ -1,0 +1,90 @@
+{
+  "_provenance": {
+    "writtenBy": "stardust:rollout",
+    "writtenAt": "2026-06-21T16:10:00Z",
+    "readArtifacts": [
+      "stardust/migrated/",
+      "stardust/canon/"
+    ],
+    "stardustVersion": "0.13.0"
+  },
+  "generatedAt": "2026-06-21T16:10:00Z",
+  "pages": [
+    {
+      "slug": "home",
+      "path": "/",
+      "title": "Example — Home",
+      "templateId": "landing-home",
+      "source": {
+        "migratedHtml": "stardust/migrated/index.html",
+        "metaJson": "stardust/migrated/index._meta.json",
+        "sourceHash": "sha256:7b1e0a…c92"
+      },
+      "blocks": ["hero", "feature-cards", "cta-band", "footer"],
+      "delivery": {
+        "status": "verified",
+        "deployedUrl": "https://main--example--org.aem.live/",
+        "deployedAt": "2026-06-20T16:00:00Z",
+        "verifiedAt": "2026-06-20T16:03:00Z",
+        "error": null
+      }
+    },
+    {
+      "slug": "blog/scaling-teams",
+      "path": "/blog/scaling-teams",
+      "title": "Scaling teams without losing velocity",
+      "templateId": "article",
+      "source": {
+        "migratedHtml": "stardust/migrated/blog/scaling-teams.html",
+        "metaJson": "stardust/migrated/blog/scaling-teams._meta.json",
+        "sourceHash": "sha256:1f4c9d…0aa"
+      },
+      "blocks": ["article-header", "prose", "related-cards", "footer"],
+      "delivery": {
+        "status": "deployed",
+        "deployedUrl": "https://main--example--org.aem.live/blog/scaling-teams",
+        "deployedAt": "2026-06-21T16:08:00Z",
+        "verifiedAt": null,
+        "error": null
+      }
+    },
+    {
+      "slug": "pricing",
+      "path": "/pricing",
+      "title": "Pricing",
+      "templateId": "program",
+      "source": {
+        "migratedHtml": "stardust/migrated/pricing.html",
+        "metaJson": "stardust/migrated/pricing._meta.json",
+        "sourceHash": "sha256:a90b22…f31"
+      },
+      "blocks": ["pricing-table", "faq", "cta-band", "footer"],
+      "delivery": {
+        "status": "stale",
+        "deployedUrl": "https://main--example--org.aem.live/pricing",
+        "deployedAt": "2026-06-19T09:00:00Z",
+        "verifiedAt": "2026-06-19T09:04:00Z",
+        "error": null
+      }
+    },
+    {
+      "slug": "resources/whitepaper",
+      "path": "/resources/whitepaper",
+      "title": "Whitepaper",
+      "templateId": "article",
+      "source": {
+        "migratedHtml": "stardust/migrated/resources/whitepaper.html",
+        "metaJson": "stardust/migrated/resources/whitepaper._meta.json",
+        "sourceHash": "sha256:cc77e1…b40"
+      },
+      "blocks": ["article-header", "prose", "footer"],
+      "delivery": {
+        "status": "pending",
+        "deployedUrl": null,
+        "deployedAt": null,
+        "verifiedAt": null,
+        "error": null
+      }
+    }
+  ]
+}

--- a/plugins/stardust/notes/rollout/schemas/rollout-blocks.schema.json
+++ b/plugins/stardust/notes/rollout/schemas/rollout-blocks.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stardust.dev/schemas/rollout-blocks.schema.json",
+  "title": "stardust rollout/coverage/blocks.json",
+  "description": "The dedup unit. One row per DISTINCT block across the site (matched by a signature derived from canon / migrated sections). rollout converts each block to an EDS block once and reuses it across every page that composes it. Records the EDS mapping + delivery status. Owned by stardust:rollout; deploy is never modified.",
+  "type": "object",
+  "required": ["_provenance", "blocks"],
+  "additionalProperties": false,
+  "properties": {
+    "_provenance": { "$ref": "#/$defs/provenance" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "blocks": { "type": "array", "items": { "$ref": "#/$defs/block" } }
+  },
+  "$defs": {
+    "provenance": {
+      "type": "object",
+      "required": ["writtenBy", "writtenAt", "stardustVersion"],
+      "properties": {
+        "writtenBy": { "type": "string", "examples": ["stardust:rollout"] },
+        "writtenAt": { "type": "string", "format": "date-time" },
+        "readArtifacts": { "type": "array", "items": { "type": "string" } },
+        "stardustVersion": { "type": "string" }
+      }
+    },
+    "block": {
+      "type": "object",
+      "required": ["id", "signature", "delivery"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "label": { "type": "string" },
+        "kind": {
+          "type": "string",
+          "enum": ["chrome", "module", "section"],
+          "description": "chrome = header/nav/footer (delivered as fragments); module = brand module; section = reusable section archetype."
+        },
+        "signature": {
+          "type": "string",
+          "description": "Stable fingerprint used to match identical block instances across pages for dedup (derived from canon module id or the section's structural signature)."
+        },
+        "source": {
+          "type": ["string", "null"],
+          "description": "Canon definition path when the block is canonized, e.g. stardust/canon/modules/<id>.html."
+        },
+        "usedByTemplates": { "type": "array", "items": { "type": "string" } },
+        "usedByPages": { "type": "array", "items": { "type": "string" } },
+        "instanceCount": { "type": "integer", "minimum": 0, "description": "How many page instances deploy this block." },
+        "delivery": {
+          "type": "object",
+          "required": ["status"],
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": ["pending", "converted", "deployed", "verified", "failed"]
+            },
+            "edsBlockName": {
+              "type": ["string", "null"],
+              "description": "Canonical EDS block name this block was converted to (blocks/<name>/). The dedup target."
+            },
+            "blockPath": { "type": ["string", "null"], "description": "Delivered block path / fragment path." },
+            "convertedAt": { "type": ["string", "null"], "format": "date-time" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/stardust/notes/rollout/schemas/rollout-config.schema.json
+++ b/plugins/stardust/notes/rollout/schemas/rollout-config.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stardust.dev/schemas/rollout-config.schema.json",
+  "title": "stardust rollout/rollout.json",
+  "description": "Top-level config + run summary for a full-site rollout to AEM Edge Delivery Services. Owned by stardust:rollout. Keeps all platform/full-site state out of the agnostic core (state.json is never touched).",
+  "type": "object",
+  "required": ["_provenance", "target", "site"],
+  "additionalProperties": false,
+  "properties": {
+    "_provenance": { "$ref": "#/$defs/provenance" },
+    "target": {
+      "type": "string",
+      "const": "aem-eds",
+      "description": "Delivery target. Fixed to AEM Edge Delivery Services for this proposal."
+    },
+    "site": {
+      "type": "object",
+      "required": ["sourceUrl"],
+      "additionalProperties": false,
+      "properties": {
+        "sourceUrl": { "type": "string", "format": "uri", "description": "The original site being migrated." },
+        "da": {
+          "type": "object",
+          "description": "DA (da.live) destination coordinates for the DA Source API push.",
+          "additionalProperties": false,
+          "properties": {
+            "org": { "type": "string" },
+            "site": { "type": "string" },
+            "ref": { "type": "string", "default": "main" }
+          }
+        },
+        "liveHost": { "type": ["string", "null"], "description": "Resolved aem.live host, e.g. main--site--org.aem.live." }
+      }
+    },
+    "lastRun": {
+      "type": ["object", "null"],
+      "description": "Summary of the most recent rollout run (the dashboard headline reads this).",
+      "additionalProperties": false,
+      "properties": {
+        "at": { "type": "string", "format": "date-time" },
+        "pages": { "$ref": "#/$defs/counts" },
+        "blocks": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "total": { "type": "integer", "minimum": 0 },
+            "converted": { "type": "integer", "minimum": 0 },
+            "pending": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "verifyFailures": { "type": "integer", "minimum": 0 }
+      }
+    }
+  },
+  "$defs": {
+    "provenance": {
+      "type": "object",
+      "required": ["writtenBy", "writtenAt", "stardustVersion"],
+      "properties": {
+        "writtenBy": { "type": "string", "examples": ["stardust:rollout"] },
+        "writtenAt": { "type": "string", "format": "date-time" },
+        "stardustVersion": { "type": "string" }
+      }
+    },
+    "counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "total": { "type": "integer", "minimum": 0 },
+        "verified": { "type": "integer", "minimum": 0 },
+        "deployed": { "type": "integer", "minimum": 0 },
+        "pending": { "type": "integer", "minimum": 0 },
+        "stale": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/plugins/stardust/notes/rollout/schemas/rollout-pages.schema.json
+++ b/plugins/stardust/notes/rollout/schemas/rollout-pages.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stardust.dev/schemas/rollout-pages.schema.json",
+  "title": "stardust rollout/coverage/pages.json",
+  "description": "Delivery ledger: one row per migrated page rollout is responsible for delivering to AEM-EDS. Built by inventorying stardust/migrated/. Tracks the source hash (for stale detection) and per-page delivery status. Owned by stardust:rollout; the agnostic core is never modified.",
+  "type": "object",
+  "required": ["_provenance", "pages"],
+  "additionalProperties": false,
+  "properties": {
+    "_provenance": { "$ref": "#/$defs/provenance" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "pages": { "type": "array", "items": { "$ref": "#/$defs/page" } }
+  },
+  "$defs": {
+    "provenance": {
+      "type": "object",
+      "required": ["writtenBy", "writtenAt", "stardustVersion"],
+      "properties": {
+        "writtenBy": { "type": "string", "examples": ["stardust:rollout"] },
+        "writtenAt": { "type": "string", "format": "date-time" },
+        "readArtifacts": { "type": "array", "items": { "type": "string" } },
+        "stardustVersion": { "type": "string" }
+      }
+    },
+    "page": {
+      "type": "object",
+      "required": ["slug", "source", "delivery"],
+      "additionalProperties": false,
+      "properties": {
+        "slug": { "type": "string" },
+        "path": { "type": "string", "description": "Destination path on the delivered site, e.g. /blog/scaling-teams." },
+        "title": { "type": "string" },
+        "templateId": {
+          "type": ["string", "null"],
+          "description": "The template grouping this page belongs to (rollout/coverage/templates.json[].id). Drives delivery order and block reuse."
+        },
+        "source": {
+          "type": "object",
+          "description": "The agnostic input rollout delivers (read-only).",
+          "required": ["migratedHtml", "sourceHash"],
+          "additionalProperties": false,
+          "properties": {
+            "migratedHtml": { "type": "string", "description": "Path, e.g. stardust/migrated/blog/scaling-teams.html." },
+            "metaJson": { "type": ["string", "null"], "description": "Path to the page's _meta.json." },
+            "sourceHash": { "type": "string", "description": "Content hash of the migrated HTML; changes mark the page stale for re-delivery." }
+          }
+        },
+        "blocks": {
+          "type": "array",
+          "description": "Block ids this page composes (rollout/coverage/blocks.json[].id).",
+          "items": { "type": "string" }
+        },
+        "delivery": {
+          "type": "object",
+          "required": ["status"],
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": ["pending", "converting", "deployed", "verified", "stale", "failed"],
+              "description": "stale = source hash changed after a prior delivery; needs re-delivery."
+            },
+            "deployedUrl": { "type": ["string", "null"], "format": "uri" },
+            "deployedAt": { "type": ["string", "null"], "format": "date-time" },
+            "verifiedAt": { "type": ["string", "null"], "format": "date-time" },
+            "error": { "type": ["string", "null"], "description": "Failure detail when status == failed." }
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/stardust/notes/rollout/schemas/rollout-templates.schema.json
+++ b/plugins/stardust/notes/rollout/schemas/rollout-templates.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stardust.dev/schemas/rollout-templates.schema.json",
+  "title": "stardust rollout/coverage/templates.json",
+  "description": "Template grouping for delivery. A template is the structure shared by a set of migrated pages; rollout uses it to deliver a representative page first (establishing the EDS block library), to drive block reuse, and to roll up per-template delivery progress. Derived from the agnostic _meta.json / canon at inventory time. Owned by stardust:rollout.",
+  "type": "object",
+  "required": ["_provenance", "templates"],
+  "additionalProperties": false,
+  "properties": {
+    "_provenance": { "$ref": "#/$defs/provenance" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "templates": { "type": "array", "items": { "$ref": "#/$defs/template" } }
+  },
+  "$defs": {
+    "provenance": {
+      "type": "object",
+      "required": ["writtenBy", "writtenAt", "stardustVersion"],
+      "properties": {
+        "writtenBy": { "type": "string", "examples": ["stardust:rollout"] },
+        "writtenAt": { "type": "string", "format": "date-time" },
+        "readArtifacts": { "type": "array", "items": { "type": "string" } },
+        "stardustVersion": { "type": "string" }
+      }
+    },
+    "template": {
+      "type": "object",
+      "required": ["id", "pages"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "label": { "type": "string" },
+        "type": {
+          "type": ["string", "null"],
+          "description": "The agnostic page type this grouping reflects, when available from _meta.json (landing/article/listing/etc.). Informational for rollout."
+        },
+        "representativeSlug": {
+          "type": ["string", "null"],
+          "description": "The page rollout delivers first to establish this template's EDS block library; siblings then reuse those blocks."
+        },
+        "pages": {
+          "type": "array",
+          "description": "Slugs that share this structure.",
+          "items": { "type": "string" }
+        },
+        "pageCount": { "type": "integer", "minimum": 0 },
+        "blocks": {
+          "type": "array",
+          "description": "Block ids this template composes (rollout/coverage/blocks.json[].id).",
+          "items": { "type": "string" }
+        },
+        "delivery": {
+          "type": "object",
+          "description": "Roll-up of this template's pages by delivery progress.",
+          "additionalProperties": false,
+          "properties": {
+            "verified": { "type": "integer", "minimum": 0 },
+            "deployed": { "type": "integer", "minimum": 0 },
+            "pending": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/stardust/skills/deploy/SKILL.md
+++ b/plugins/stardust/skills/deploy/SKILL.md
@@ -143,6 +143,8 @@ A FOUC is possible (head paints as default content, then reabsorbs); the final l
 
 **The check that catches the #1 mistake:** after preview, grep the delivered `.plain.html` for the expected `<img>`+alt count. "It renders" hides CSS-background images — they're absent from `.plain.html`, carry no alt, and are neither authorable nor AI/SEO-visible.
 
+**When the image src is a SOURCE/external URL (migration), verify it resolves BEFORE you author it.** Re-using an image straight off the source page is the most common way to ship `<img src="about:error">`: the preview ingester fetches the authored URL, and if that fetch fails the delivered image is `about:error` — silent, since the page still renders. So for every authored `<img>` whose src points at the source/CDN, `curl -s -o /dev/null -w '%{http_code}' <url>` first; if it isn't `200`, **omit the image** (the block renders without it) rather than ship a broken one — and never substitute a generic logo/placeholder (`…-logo…`) as if it were editorial. Two real failure signatures (the asset exists — fix the URL, don't drop it): (1) **wrong rendition variant** — the page exposes only a derivative that 404s while a sibling resolves (e.g. a portrait's `…/4x3/768/…` 404 vs `…/original/768/…` 200) → rewrite to the resolver; (2) **missing query delimiter** — `…/<id>&wid=600&hei=…` with no `?` makes `<id>&wid=…` a bogus id → 403 → repair the first `&` after the id to `?`.
+
 ## Steps
 
 ### 1. Audit (light)

--- a/plugins/stardust/skills/rollout/SKILL.md
+++ b/plugins/stardust/skills/rollout/SKILL.md
@@ -143,7 +143,37 @@ Walk `plan.json.steps` in order (representative pages first). For each page:
    these pages is already deployed via their template's archetype; no conversion
    work remains.
 
-2. **Record outcomes** with the state-writer (never hand-edit the ledger):
+2. **Source-fidelity gate — "don't add sections the source doesn't have."**
+   Before flipping a page to `deployed`, confirm every authored section maps to a
+   real region on the *source* page. A migration reproduces the source; it must
+   not invent sections — and the failure is silent, because invented sections
+   render as empty placeholders or, worse, get back-filled with fabricated facts.
+   This recurs as trailing **cross-link rails** (`related-*`, `*-teasers`),
+   **specialist/teaser grids**, and generic **trailing CTAs** appended to every
+   leaf page regardless of source.
+
+   ```bash
+   node skills/rollout/scripts/section-fidelity.mjs \
+     --file <content.html> --source <sourceUrl>   # lays authored vs source side-by-side
+   ```
+
+   The helper is a scaffold, not a judge: it lists the authored block sections
+   (pre-flagging known filler shapes as `⟵ REVIEW`) against the source's heading
+   outline. For each authored section — especially flagged ones — decide:
+   - **HARD-FAIL → remove before `deployed`:** the section carries FABRICATED
+     facts (invented person names, made-up events/dates, boilerplate prose not on
+     the source). Fabricated content on a real site is the worst migration defect.
+   - **Soft call:** an invented rail whose links all point to REAL pages — prefer
+     remove (honor the rule); keep only as a plain text link-row if cross-linking
+     is explicitly wanted, never as an image-card grid that needs assets to exist.
+   - **Pass:** the section backs a real source region.
+
+   Delete the section from the content file (and `git rm` the block if it becomes
+   orphaned — no other page references it). Genuinely-missing *real* content is a
+   different case: leave the block, render gracefully (no placeholder void), and
+   log it as a content gap — do NOT invent filler to fill it.
+
+3. **Record outcomes** with the state-writer (never hand-edit the ledger):
 
    ```bash
    node skills/rollout/scripts/update-coverage.mjs <slug> --status converting
@@ -386,6 +416,10 @@ Normalize each one's output into the ledger via `findings.mjs record`. See
 - `scripts/update-coverage.mjs` — deterministic delivery state-writer for pages
   (`<slug> --status …`) and blocks (`--block <id> --status …`); re-derives all
   roll-ups.
+- `scripts/section-fidelity.mjs` — Phase C source-fidelity gate scaffold: lays a
+  page's authored sections (pre-flagging known invented-filler shapes) against the
+  source page's heading outline, so the agent can remove sections the source lacks
+  before flipping to `deployed`. Informs the gate; never auto-decides (exit 0).
 - `scripts/assemble.mjs` — site-level sitemap / robots / fragments manifest.
 - `scripts/verify.mjs` — full-site structural verification (HTTP or offline `--root`).
 - `scripts/optimize.mjs` — `rollout:baseline` detectors + the multi-source gate:

--- a/plugins/stardust/skills/rollout/SKILL.md
+++ b/plugins/stardust/skills/rollout/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rollout
-description: Deliver a WHOLE redesigned site to AEM Edge Delivery Services. The full-site sibling of `deploy` (which converts one page). Inventories the platform-agnostic migrated tree (stardust/migrated/ + _meta.json sidecars) into a delivery coverage ledger, then delivers each page by invoking the `deploy` methodology, tracking what is done and what is missing across the whole site. Use when the user has a migrated stardust site and wants to push the entire site to AEM, not just one page.
+description: Deliver a WHOLE redesigned site to AEM Edge Delivery Services. The full-site sibling of `deploy` (which converts one page). Inventories the platform-agnostic migrated tree (stardust/migrated/ + _meta.json sidecars) into a delivery coverage ledger, then delivers each page by invoking the `deploy` methodology, tracking what is done and what is missing across the whole site. Use when the user has a migrated stardust site and wants to push the entire site to AEM, not just one page. Supports archetypes-only mode: if only the template archetype pages have been migrated, rollout can deploy all block code immediately and register the remaining pages as content-pending for later population.
 license: Apache-2.0
 ---
 
@@ -22,23 +22,38 @@ coverage model, and the phasing are in
 
 ## When to use
 
-The user has:
-1. A migrated stardust site at `stardust/migrated/` (the output of
+**Full mode** — the user has:
+1. A fully migrated stardust site at `stardust/migrated/` (the output of
    `stardust migrate`: per-page HTML + `_meta.json` sidecars). This is the
    explicit handoff `migrate` documents for downstream AEM conversion.
 2. An EDS/AEM project + DA destination (the same target `deploy` needs — see
    `skills/deploy/SKILL.md` and `da-deploy-protocol.md`).
 3. A goal to deliver the **entire** site, incrementally and resumably.
 
-If there is no `stardust/migrated/` tree, stop and recommend `stardust migrate`
-first. For a single page, use `stardust deploy` directly — `rollout` is for the
-whole site.
+**Archetypes-only mode** — the user has:
+1. One migrated archetype page per template in `stardust/migrated/` (the
+   representative pages, not every sibling), plus a full page inventory in
+   `stardust/state.json` with `type` assignments for all pages.
+2. The same EDS/AEM project + DA destination as above.
+3. A goal to ship all block code immediately without waiting for every page to
+   be individually migrated. Sibling pages are registered as `content-pending`
+   in the coverage ledger; their document content is populated later through a
+   separate content track.
+
+If there is no `stardust/migrated/` tree at all, recommend `stardust migrate`
+on at least the archetype pages first. For a single page, use `stardust deploy`
+directly — `rollout` is for the whole site.
 
 ## Setup
 
 1. Run the master skill's setup (`skills/stardust/SKILL.md` § Setup).
 2. Verify `stardust/migrated/` exists and contains at least one `*.html` page.
-   If not, recommend `stardust migrate` and stop.
+   If not, recommend `stardust migrate` on the template archetypes and stop.
+   - **Full mode**: `migrated/` covers all pages in scope.
+   - **Archetypes-only mode**: `migrated/` covers only the archetype pages (one
+     per template). Verify `stardust/state.json` exists and has `type` populated
+     for all pages whose siblings need coverage. If `state.json` is absent or
+     lacks `type` assignments, recommend resolving those before proceeding.
 3. Verify the EDS/AEM target is ready exactly as `deploy` requires (project
    scaffolding, `DA_TOKEN`, code branch pushable). `rollout` adds no new transport
    — it reuses `deploy`'s.
@@ -52,21 +67,35 @@ Run the inventory script to project the migrated tree into the delivery coverage
 ```bash
 node skills/rollout/scripts/inventory.mjs --site-url <source-url>
 # defaults: --migrated stardust/migrated  --out stardust/rollout
+
+# archetypes-only mode: supplement migrated/ with the full page roster from state.json
+node skills/rollout/scripts/inventory.mjs --site-url <source-url> --state stardust/state.json
 ```
 
 It writes:
-- `stardust/rollout/coverage/pages.json` — one row per migrated page: slug,
-  delivered `path`, `templateId` (from the sidecar `template`/`type`), the
-  `blocks` it composes (from the sidecar `modules`), a `sourceHash`, and the
-  per-page `delivery` status.
+- `stardust/rollout/coverage/pages.json` — one row per page: slug, delivered
+  `path`, `templateId` (from the sidecar `template`/`type`), the `blocks` it
+  composes (from the sidecar `modules`), a `sourceHash`, and the per-page
+  `delivery` status.
 - `stardust/rollout/coverage/templates.json` — pages grouped by template (drives
   delivery order and per-template roll-ups).
 - `stardust/rollout/rollout.json` — target + DA config + a `lastRun` counts
   summary.
 
+**Archetypes-only mode** (triggered by `--state`): inventory reads `state.json`
+for the full page roster and merges it with `migrated/`:
+- Pages with a `_meta.json` in `migrated/` are seeded from their sidecar
+  exactly as in full mode.
+- Pages present only in `state.json` (not yet individually migrated) are seeded
+  with `templateId` inferred from their `type` field and `blocks` inferred from
+  the archetype sidecar for that template. Their `sourceHash` is derived from
+  `state.json[].currentStatePath` content. Their initial `delivery.status` is
+  `content-pending`.
+
 The inventory is **idempotent and incremental**: existing delivery status is
 preserved; a page whose migrated HTML changed after it was delivered is
-re-flagged `stale`. Re-run it any time `migrate` re-emits pages.
+re-flagged `stale`. Re-run it any time `migrate` re-emits pages or `state.json`
+adds new pages.
 
 Fill in the DA coordinates in `stardust/rollout/rollout.json` (`site.da.org`,
 `site.site`, `site.da.ref`, and `site.liveHost`) if the inventory didn't infer
@@ -86,13 +115,16 @@ node skills/rollout/scripts/plan.mjs     # → plan.json + a readable conversion
   `modules` + chrome) into the **distinct** set, assigns each a canonical
   `edsBlockName` (kebab; reserved-class-guarded per deploy #15), and records
   `usedByPages` / `instanceCount`. Chrome (`header`/`nav`/`footer`) is marked
-  `kind: chrome` → delivered as site-wide fragments, not per-page blocks.
+  `kind: chrome` → delivered as site-wide fragments, not per-page blocks. In
+  archetypes-only mode the distinct block set is fully determined by the archetype
+  sidecars alone — `content-pending` sibling pages add no new blocks.
 - `plan.mjs` orders pages **representative-first per template**, walks them once,
   and assigns each distinct block a **single conversion point**: the first page
   in order that uses it CONVERTS it; every later page REUSES it by name. The
   per-page `convert` / `reuse` lists are exactly `deploy`'s Step-7 brief input
   (*"Existing blocks — REUSE, do not recreate: …"*), so each block converts once
-  **without changing deploy**.
+  **without changing deploy**. `content-pending` pages are always assigned
+  `convert: []` / `reuse: [all template blocks]` — they never introduce new blocks.
 
 ### Phase C — Deliver the site (drive `deploy` per page, per the plan)
 
@@ -103,6 +135,14 @@ Walk `plan.json.steps` in order (representative pages first). For each page:
    step into deploy's brief**: create only the blocks in `convert`; for every
    block in `reuse`, instruct deploy to REUSE the existing block by its
    `edsBlockName` (do not recreate). This is the dedup contract in action.
+
+   **`content-pending` pages** (archetypes-only mode): these pages have no
+   migrated HTML. Skip the document push entirely — do not create a shell or
+   placeholder document. Record them as `content-pending` in the coverage ledger
+   and surface them in the report as "awaiting content track." Block code for
+   these pages is already deployed via their template's archetype; no conversion
+   work remains.
+
 2. **Record outcomes** with the state-writer (never hand-edit the ledger):
 
    ```bash
@@ -111,6 +151,8 @@ Walk `plan.json.steps` in order (representative pages first). For each page:
    node skills/rollout/scripts/update-coverage.mjs --block <id> --status converted --eds-name <name>
    # … run the deploy steps …
    node skills/rollout/scripts/update-coverage.mjs <slug> --status deployed --url <branch-preview-url>
+   # for content-pending pages (no document push):
+   node skills/rollout/scripts/update-coverage.mjs <slug> --status content-pending
    ```
 
    On failure: `--status failed --error "<reason>"` and continue (one page's
@@ -227,16 +269,19 @@ and print the counts:
 ```
 rollout — <site> → aem-eds
 ==================================================
-Pages       <N> total · <v> verified · <d> deployed · <p> pending · <s> stale
+Pages       <N> total · <v> verified · <d> deployed · <p> pending · <cp> content-pending · <s> stale
 Templates   <T> (per-template delivered/total)
 Blocks      <B> total · <c> converted · <p> pending
 Quality     health <H>/100 · open P1 <n> / P2 <n> / P3 <n>
 To deliver  <list of remaining slugs>
+Content     <cp> pages awaiting content track (block code deployed, document not yet pushed)
 ```
 
 Surface anything still `pending`/`stale`/`failed` as the explicit "what's
-missing" list. Re-run from Phase B/C to pick up exactly those pages; when
-`migrate` re-emits a page, `inventory` re-flags it `stale` and it re-delivers.
+missing" list. `content-pending` pages are listed separately — they are not
+failures; their block code is live and they advance to `pending` automatically
+when `migrate` emits their individual HTML and `inventory` is re-run. Re-run
+from Phase B/C to pick up exactly the pages that changed.
 
 ### Phase I — Dashboard
 
@@ -277,6 +322,7 @@ optional — without it the tree starts at the `migrated` stage.)
 |---|---|---|
 | `stardust/migrated/*.html` | `migrate` | the pages to deliver (read-only) |
 | `stardust/migrated/**/_meta.json` | `migrate` | `templateId` (`template`/`type`), `blocks` (`modules`), `title` |
+| `stardust/state.json` | stardust core | *(archetypes-only mode)* full page roster + `type` assignments for pages not yet individually migrated |
 | `stardust/rollout/rollout.json` | rollout / user | DA target coordinates |
 
 ## Outputs
@@ -319,11 +365,18 @@ Normalize each one's output into the ledger via `findings.mjs record`. See
 - **No new transport.** Delivery is `deploy`'s DA Source API path, unchanged.
 - **No redesign of the agnostic core.** `extract`/`direct`/`prototype`/`migrate`
   and `deploy` are untouched; rollout is the across-pages delivery layer on top.
+- **No full pre-migration requirement.** Rollout does not require every page to
+  be individually migrated before it runs. Archetypes-only mode is a first-class
+  path: block code is fully deployed from the archetype pages; the remaining
+  pages advance from `content-pending` to `deployed` as `migrate` emits their
+  HTML and `inventory` is re-run — no rollout restart needed.
 
 ## Scripts
 
 - `scripts/inventory.mjs` — migrated tree → page + template coverage (idempotent;
-  stale-aware).
+  stale-aware). `--state <path>` enables archetypes-only mode: supplements the
+  migrated tree with the full page roster from `state.json`, seeding non-migrated
+  pages as `content-pending` with template and blocks inferred from the archetype.
 - `scripts/blocks.mjs` — distinct-block dedup ledger (`blocks.json`).
 - `scripts/plan.mjs` — dedup-driven delivery order + per-page convert/reuse briefs.
 - `scripts/update-coverage.mjs` — deterministic delivery state-writer for pages

--- a/plugins/stardust/skills/rollout/SKILL.md
+++ b/plugins/stardust/skills/rollout/SKILL.md
@@ -126,6 +126,19 @@ node skills/rollout/scripts/plan.mjs     # → plan.json + a readable conversion
   **without changing deploy**. `content-pending` pages are always assigned
   `convert: []` / `reuse: [all template blocks]` — they never introduce new blocks.
 
+> **Extending a DELIVERED site: a "new template" is almost always a new COMPOSITION
+> of the existing block library, not new block code.** When you add page types
+> *after* the first rollout (Hirslanden's later `fachgebiete`, `blog`, `legal`,
+> `center`, and the per-clinic sub-trees), audit `blocks/` BEFORE writing any block:
+> most "new templates" resolve to existing blocks recomposed —
+> blog = `article-header` + `article-body` (the news blocks); legal =
+> `page-header` + `body-text`; specialty landing = `page-header` + `lead-text` +
+> `centers`; center = `page-header` + `lead-text` + `body-text` + `contact-cta`.
+> All four shipped with **zero new block JS/CSS** — only new archetype content
+> files composing existing blocks. Reach for a new block only when no composition
+> of the library reproduces the section. This keeps the library small (David's
+> model) and makes extension an authoring task, not an engineering one.
+
 ### Phase B2 — Dynamic-blocks map + metadata contract (PRE-IMPORT GATE)
 
 **Do this before Phase C — the import is blocked on it.** What a dynamic listing
@@ -380,6 +393,42 @@ which blocks are dynamic, which stay static (editorial curation), and the metada
 contract. Validate one flagship end-to-end (e.g. a doctor directory + search with a
 `?q=` hand-off) before converting the rest.
 
+### Phase D3 — Multilingual (per-language trees) — optional
+
+When the source has language trees (`/fr/…`, `/en/…` beside `/de/…`), add them as
+**parallel content trees that REUSE the same block library** — the block structure
+is language-agnostic; only the authored content and a few wiring pieces change.
+Proven on the Hirslanden FR+EN add (≈90 pages/language, ≥5 per template):
+
+- **Author by mirroring the DE archetype per type, in the target language.** A FR
+  doctor page is the DE doctor page's block composition with FR content at the FR
+  path (`/fr/corporate/doctors/3/<slug>`). Dispatch author agents grouped by
+  template-type (doctors / treatments / diseases / specialty / editorial), each
+  given the DE reference file to mirror — *no new blocks*.
+- **Language-route the static header/footer.** The single `postlcp.js`
+  `loadStaticFragment` serves one fragment for all pages; make it pick by path
+  prefix and fall back to the default:
+  ```js
+  const seg = window.location.pathname.split('/')[1];
+  const lang = (seg === 'fr' || seg === 'en') ? `${seg}/` : '';
+  let resp = await fetch(`${codeBase}/fragments/${lang}${name}.html`);
+  if (!resp.ok && lang) resp = await fetch(`${codeBase}/fragments/${name}.html`);
+  ```
+  Add `fragments/fr/{header,footer}.html` + `fragments/en/…`: translated labels,
+  links localized to *live* same-language pages (else a source bounce), and a
+  **language switcher that targets each language's home** (`/`, `/fr/…/home`,
+  `/en/…/home`) — don't try to compute per-page cross-language equivalents.
+- **Per-language indexes** in `helix-query.yaml`: clone each index with a
+  language-scoped `include` glob + a language-prefixed `target`, and **fix the
+  selectors that encode language** — the doctor specialty facet selector is
+  `a[href*="/specialites-medicales/"]` (FR) / `a[href*="/specialities/"]` (EN), not
+  the DE `/fachgebiete/`. Same metadata contract per type.
+- **Path-safety is per-language too.** The same leading/trailing-`-`, `--`, `_`,
+  and uppercase normalization (gate 4) applies to FR/EN slugs — doctor slugs in
+  particular recur with a leading hyphen across every language tree.
+- The per-language indexes are empty until the FR/EN pages are published under the
+  synced config — see the Phase F republish note.
+
 ### Phase E — Full-site verify
 
 ```bash
@@ -453,6 +502,36 @@ fixes it; `design-pass` → upstream (surface only); `out-of-scope` → informat
 
 The gate **exits non-zero if any open P1 is in scope** — a page is delivery-clean
 only when verify passes *and* the ledger has no open P1.
+
+**Operational learnings (Hirslanden, ~1.1k pages):**
+- **A `head.html`-level fix needs a SITE-WIDE REPUBLISH to land, and to flip the
+  findings.** The dominant baseline finding at scale is `ai-search/jsonld` ("no
+  JSON-LD structured data") — one P2 *per page*. The cheap, legitimate fix is
+  sitewide structured data in `head.html` (for a medical site:
+  `MedicalOrganization` + `WebSite` `@graph`); the detector only checks for the
+  presence of `application/ld+json` in the served `<head>`. But editing `head.html`
+  updates the file immediately while **already-rendered pages stay CDN-cached with
+  the old head** — `/head.html` shows the new JSON-LD yet `/some/page` does not.
+  You must **`POST /live/` every page** to re-render it with the new head (verify on
+  one page first: republish → GET → grep `ld+json`). On the optimize re-run those
+  findings then flip `open → fixed` (715/716 in one pass). Per-page granular schema
+  (`Physician`/`MedicalWebPage`) is a later enhancement, not needed to clear the gate.
+- **A full republish also re-triggers query-index builds.** New indexes added to
+  `helix-query.yaml` sit at `total: building`/404 until the in-scope pages are
+  re-published under the synced config — the same republish that propagates a
+  `head.html` change populates them. (Same root cause as the publish gotcha in D2.)
+- **optimize only audits what's in `coverage/pages.json`.** When EXTENDING a
+  delivered site (new templates, sub-trees, language trees), those pages aren't in
+  the coverage ledger, so Phase F silently skips them. Re-run `inventory.mjs` (add
+  the new pages to `state.json` first) before the gate, or audit them with explicit
+  `--slug`/a second `--base` pass — otherwise "gate passes" covers only the old set.
+- **Faithfully migrating PARALLEL source trees yields legitimate
+  `duplicate-title`/`duplicate-description` findings, not bugs.** Hirslanden serves
+  the same treatment at `/de/corporate/behandlungen/X` *and*
+  `/de/international/behandlungen/X`; reproducing both faithfully trips the cross-page
+  uniqueness detector. The resolution is a **content-model / canonical decision**
+  (canonicalize one tree to the other, or differentiate titles), not a re-author —
+  surface it as such, don't silently rewrite source-faithful titles to dodge the check.
 
 > The judgment layers (brand-tensions, design-ux, content-conversion) are scored
 > `null` (not assessed by the automated baseline) until populated by the

--- a/plugins/stardust/skills/rollout/SKILL.md
+++ b/plugins/stardust/skills/rollout/SKILL.md
@@ -152,6 +152,15 @@ the type's metadata rows to every page's metadata block as it writes it. Author
 line up. A block whose contract can't be met from the source (a relationship like
 center↔disease) stays static — record that in the map, don't fake it.
 
+**Metadata key → meta-name mechanics.** A metadata-block row `<div><div>KEY</div>
+<div>VALUE</div></div>` renders to `<meta name="<key lowercased>">`. Use
+single-token capitalized keys (`PublishDate`→`name="publishdate"`,
+`Canton`→`name="canton"`) and make `helix-query.yaml`'s `select:
+meta[name="publishdate"]` match. Emit dates as ISO `YYYY-MM-DD` (sortable). Emitting
+the contract during authoring is one row per page; retrofitting it across an
+already-imported, already-published batch is a full extra pass + republish — which
+is the whole reason B2 is a gate.
+
 ### Phase C — Deliver the site (drive `deploy` per page, per the plan)
 
 **Blocked on Phase B2** — author each page's metadata contract (above) into its
@@ -244,6 +253,13 @@ Walk `plan.json.steps` in order (representative pages first). For each page:
    # for content-pending pages (no document push):
    node skills/rollout/scripts/update-coverage.mjs <slug> --status content-pending
    ```
+
+   **Publish in the loop (`PUT → preview → live`), don't stop at preview.** If the
+   site has any query-index block (Phase D2), the index builds from the **live**
+   tree — a preview-only delivery leaves every index empty. Make `POST /live/…` a
+   per-page step of the delivery loop, not a deferred batch, so indexes populate as
+   pages land. (Indexing is async; the index `total` settles a little after the
+   publishes.)
 
    On failure: `--status failed --error "<reason>"` and continue (one page's
    failure never aborts the rollout — mirrors `migrate`).

--- a/plugins/stardust/skills/rollout/SKILL.md
+++ b/plugins/stardust/skills/rollout/SKILL.md
@@ -1,0 +1,353 @@
+---
+name: rollout
+description: Deliver a WHOLE redesigned site to AEM Edge Delivery Services. The full-site sibling of `deploy` (which converts one page). Inventories the platform-agnostic migrated tree (stardust/migrated/ + _meta.json sidecars) into a delivery coverage ledger, then delivers each page by invoking the `deploy` methodology, tracking what is done and what is missing across the whole site. Use when the user has a migrated stardust site and wants to push the entire site to AEM, not just one page.
+license: Apache-2.0
+---
+
+# stardust:rollout — whole site → AEM (Edge Delivery Services)
+
+`deploy` converts **one** page to AEM. `rollout` delivers the **whole site**: it
+inventories the agnostic output of `migrate`, then drives `deploy` across every
+page, tracking delivery coverage so you always know what's done and what's left.
+
+`rollout` is **delivery-only** — it does not redesign. The page-by-page redesign
+(`extract → direct → prototype → migrate`) and `deploy` itself are **unchanged**;
+`rollout` is the across-pages layer on top. The full design rationale, the
+coverage model, and the phasing are in
+[`notes/rollout/PLAN.md`](../../notes/rollout/PLAN.md).
+
+> **The full flow is built**: inventory + page coverage (P1); first-class block
+> dedup + site assembly + verify (P2); multi-source optimize + AEM autofix (P3);
+> and the dashboard (P4). The flow runs **A→I** below.
+
+## When to use
+
+The user has:
+1. A migrated stardust site at `stardust/migrated/` (the output of
+   `stardust migrate`: per-page HTML + `_meta.json` sidecars). This is the
+   explicit handoff `migrate` documents for downstream AEM conversion.
+2. An EDS/AEM project + DA destination (the same target `deploy` needs — see
+   `skills/deploy/SKILL.md` and `da-deploy-protocol.md`).
+3. A goal to deliver the **entire** site, incrementally and resumably.
+
+If there is no `stardust/migrated/` tree, stop and recommend `stardust migrate`
+first. For a single page, use `stardust deploy` directly — `rollout` is for the
+whole site.
+
+## Setup
+
+1. Run the master skill's setup (`skills/stardust/SKILL.md` § Setup).
+2. Verify `stardust/migrated/` exists and contains at least one `*.html` page.
+   If not, recommend `stardust migrate` and stop.
+3. Verify the EDS/AEM target is ready exactly as `deploy` requires (project
+   scaffolding, `DA_TOKEN`, code branch pushable). `rollout` adds no new transport
+   — it reuses `deploy`'s.
+
+## Procedure
+
+### Phase A — Inventory (build the coverage)
+
+Run the inventory script to project the migrated tree into the delivery coverage:
+
+```bash
+node skills/rollout/scripts/inventory.mjs --site-url <source-url>
+# defaults: --migrated stardust/migrated  --out stardust/rollout
+```
+
+It writes:
+- `stardust/rollout/coverage/pages.json` — one row per migrated page: slug,
+  delivered `path`, `templateId` (from the sidecar `template`/`type`), the
+  `blocks` it composes (from the sidecar `modules`), a `sourceHash`, and the
+  per-page `delivery` status.
+- `stardust/rollout/coverage/templates.json` — pages grouped by template (drives
+  delivery order and per-template roll-ups).
+- `stardust/rollout/rollout.json` — target + DA config + a `lastRun` counts
+  summary.
+
+The inventory is **idempotent and incremental**: existing delivery status is
+preserved; a page whose migrated HTML changed after it was delivered is
+re-flagged `stale`. Re-run it any time `migrate` re-emits pages.
+
+Fill in the DA coordinates in `stardust/rollout/rollout.json` (`site.da.org`,
+`site.site`, `site.da.ref`, and `site.liveHost`) if the inventory didn't infer
+them — `deploy` needs them for the push and `verify` needs the host.
+
+### Phase B — Block dedup plan (FIRST-CLASS, before any conversion)
+
+Derive the distinct block set and the dedup-driven delivery plan **up front** —
+this is what makes "convert each block once" a driving step, not a cleanup:
+
+```bash
+node skills/rollout/scripts/blocks.mjs   # → coverage/blocks.json (the dedup unit)
+node skills/rollout/scripts/plan.mjs     # → plan.json + a readable conversion plan
+```
+
+- `blocks.mjs` collapses every block instance across the site (the per-page
+  `modules` + chrome) into the **distinct** set, assigns each a canonical
+  `edsBlockName` (kebab; reserved-class-guarded per deploy #15), and records
+  `usedByPages` / `instanceCount`. Chrome (`header`/`nav`/`footer`) is marked
+  `kind: chrome` → delivered as site-wide fragments, not per-page blocks.
+- `plan.mjs` orders pages **representative-first per template**, walks them once,
+  and assigns each distinct block a **single conversion point**: the first page
+  in order that uses it CONVERTS it; every later page REUSES it by name. The
+  per-page `convert` / `reuse` lists are exactly `deploy`'s Step-7 brief input
+  (*"Existing blocks — REUSE, do not recreate: …"*), so each block converts once
+  **without changing deploy**.
+
+### Phase C — Deliver the site (drive `deploy` per page, per the plan)
+
+Walk `plan.json.steps` in order (representative pages first). For each page:
+
+1. **Convert + push** the page's migrated HTML (`source.migratedHtml`) to AEM via
+   the `deploy` methodology (`skills/deploy/SKILL.md`). **Pass the page's plan
+   step into deploy's brief**: create only the blocks in `convert`; for every
+   block in `reuse`, instruct deploy to REUSE the existing block by its
+   `edsBlockName` (do not recreate). This is the dedup contract in action.
+2. **Record outcomes** with the state-writer (never hand-edit the ledger):
+
+   ```bash
+   node skills/rollout/scripts/update-coverage.mjs <slug> --status converting
+   # for each block this page converts:
+   node skills/rollout/scripts/update-coverage.mjs --block <id> --status converted --eds-name <name>
+   # … run the deploy steps …
+   node skills/rollout/scripts/update-coverage.mjs <slug> --status deployed --url <branch-preview-url>
+   ```
+
+   On failure: `--status failed --error "<reason>"` and continue (one page's
+   failure never aborts the rollout — mirrors `migrate`).
+
+Parallelism: deliver multiple template clusters concurrently (one agent per
+cluster, non-overlapping page sets), as `deploy` Step 7 dispatches per-archetype
+agents. **Deliver each template's representative — the page that converts that
+template's blocks — before its siblings**, so the blocks exist to be reused. The
+state-writer is per-unit so concurrent updates don't collide.
+
+### Phase D — Site assembly (whole-site artifacts)
+
+```bash
+node skills/rollout/scripts/assemble.mjs   # → rollout/site/{sitemap.xml,robots.txt,manifest.json}
+```
+
+Generates the artifacts that only make sense site-wide: `sitemap.xml` +
+`robots.txt` from the delivered paths, and a **fragments manifest** mapping the
+chrome blocks to `fragments/header.html` / `fragments/footer.html` with their
+`canon/*.html` source. `deploy` lifts and pushes the actual fragment content
+(Step 6); `assemble` prepares and records what to push.
+
+### Phase E — Full-site verify
+
+```bash
+node skills/rollout/scripts/verify.mjs            # uses rollout.json site.liveHost
+# or: --base <url>   (explicit host)   |   --root <dir>   (offline, against a local export)
+```
+
+For every delivered page, `verify` confirms it's reachable (HTTP 200), has no
+`about:error` (broken-image ingestion, deploy #75), and that every internal
+`href="/…"` resolves to a known delivered path — then flips each page to
+`verified` or `failed` with the reason. It exits non-zero if any page failed.
+
+### Phase F — Optimize: multi-source audit + gate (delivery quality)
+
+The in-flow **quality gate**. optimize aggregates findings from **existing audit
+skills** into one ledger (`optimize/findings.json` + `optimize/scorecard.json`),
+tags each by **fixability**, and gates the rollout. Sources (see
+`reference/audit-sources.md` for the full mapping):
+
+1. **`rollout:baseline`** — built-in deterministic detectors. Run it directly:
+
+   ```bash
+   node skills/rollout/scripts/optimize.mjs        # uses rollout.json site.liveHost
+   # or: --base <url> | --root <dir> | --slug <s> | --all
+   ```
+
+2. **`impeccable:critique` + `impeccable:audit`** — run them against the delivered
+   output for design quality (P-levels) and a11y/perf/responsiveness.
+3. **The marketing SEO skills** (`coreyhaines31/marketingskills`) — `seo-audit`,
+   `schema`, `ai-seo`, `site-architecture`.
+4. **`stardust:tensions`** — the mechanical design tensions from
+   `stardust/current/brand-review.html` (type-scale, CTA-vocab, content-free
+   links, generic/empty alt, contrast…).
+
+These are referenced as **dependencies** (run them by invocation — nothing is
+vendored). Normalize each one's findings into the ledger with the writer:
+
+```bash
+node skills/rollout/scripts/findings.mjs record \
+  --source marketing:seo-audit --layer seo --check thin-content \
+  --severity P2 --fixability platform-migration \
+  --scope-ids blog/post --evidence "…" --recommend "…"
+# resolve/accept/wontfix a finding:
+node skills/rollout/scripts/findings.mjs resolve <id> --status accepted --note "…"
+```
+
+All sources share one id space, dedup, scorecard, and the **detect → fix →
+verify loop**: re-running a source resolves *its own* findings no longer present
+(a baseline run never resolves another source's finding); a regressed `fixed`
+finding re-opens; human `accepted`/`wontfix` are preserved. Each finding also
+carries an **`autofix`** descriptor (the registered AEM fixer, if any).
+
+**Fixability routing:** `platform-migration` → the AEM autofix engine / re-deploy
+fixes it; `design-pass` → upstream (surface only); `out-of-scope` → informational.
+
+The gate **exits non-zero if any open P1 is in scope** — a page is delivery-clean
+only when verify passes *and* the ledger has no open P1.
+
+> The judgment layers (brand-tensions, design-ux, content-conversion) are scored
+> `null` (not assessed by the automated baseline) until populated by the
+> impeccable/tensions sources — the scorecard shows not-assessed rather than
+> faking a score.
+
+### Phase G — AEM autofix (close the loop)
+
+```bash
+node skills/rollout/scripts/autofix-aem.mjs --project <eds-root>   # [--dry-run] [--slug s] [--check c]
+```
+
+The platform autofix engine (AEM-EDS, v1 — **aggressive**). For every open finding
+whose `check` has a registered EDS fixer, it edits the EDS **project** files and
+logs the change on `finding.autofix`, staging the finding `in-progress`:
+
+- **deterministic** — `eds-fix-h1` (promote/demote so exactly one `<h1>`),
+  sitemap (re-assemble).
+- **content-draft** (applied under the aggressive policy, logged for review) —
+  `eds-metadata-title` / `eds-metadata-description` (draft from `<h1>`/first
+  paragraph), `eds-alt-draft` (alt from filename), `eds-disambiguate-title`.
+- **manual** (autofix prepares guidance/payload, a human applies) — `eds-jsonld`
+  (use `marketing:schema` for the payload), `eds-canonical`, `eds-landmark-main`.
+
+Use `--dry-run` first to preview edits. After applying, **re-deploy** the edited
+pages (`deploy`), then re-run **verify** + **optimize** — the staged findings flip
+to `fixed`, closing the loop. `design-pass` findings are surfaced, not auto-fixed.
+
+### Phase H — Report
+
+Read `rollout.json.lastRun` + `optimize/scorecard.json` (or re-run `inventory.mjs`)
+and print the counts:
+
+```
+rollout — <site> → aem-eds
+==================================================
+Pages       <N> total · <v> verified · <d> deployed · <p> pending · <s> stale
+Templates   <T> (per-template delivered/total)
+Blocks      <B> total · <c> converted · <p> pending
+Quality     health <H>/100 · open P1 <n> / P2 <n> / P3 <n>
+To deliver  <list of remaining slugs>
+```
+
+Surface anything still `pending`/`stale`/`failed` as the explicit "what's
+missing" list. Re-run from Phase B/C to pick up exactly those pages; when
+`migrate` re-emits a page, `inventory` re-flags it `stale` and it re-delivers.
+
+### Phase I — Dashboard
+
+```bash
+node skills/rollout/scripts/dashboard.mjs    # → dashboard/index.html + data.json
+```
+
+A **self-contained, no-external-JS** dashboard rendered in the **project's design
+identity** — brand tokens (bg / fg / accent / heading + body fonts / radius) are
+read from the `:root` block of a migrated page (the canonical token interface,
+`token-contract.md`).
+
+Its centerpiece is a **page tree** of every identified page, nested by URL path,
+each node colour-coded by the **most-advanced lifecycle stage** it has reached:
+
+```
+identified → prototyped → deployed → optimised
+```
+
+The stage spans all three sources: `stardust/state.json` (agnostic
+`extracted/directed` → identified, `prototyped/approved/migrated` → prototyped),
+rollout coverage (`deployed`/`verified` → deployed), and optimize (`optimised` =
+verified **and** no open findings for the page). The legend **counts are
+cumulative** — a page counts toward every stage up to the one it reached, so
+`identified` equals the total page count, `prototyped` includes everything
+prototyped-or-beyond, and so on. **Template archetypes** — the page that defines a
+template for its siblings (`templates.json[].representativeSlug`) — are badged
+`T`. A page with open findings shows a red count.
+
+Also: a **templates** table (archetype + member count + a per-stage lifecycle
+bar) and the quality scorecard. `dashboard/data.json` is the inspectable snapshot.
+Regenerate it at every iteration boundary. (`state.json` is read-only and
+optional — without it the tree starts at the `migrated` stage.)
+
+## Inputs
+
+| Input | Source | Used for |
+|---|---|---|
+| `stardust/migrated/*.html` | `migrate` | the pages to deliver (read-only) |
+| `stardust/migrated/**/_meta.json` | `migrate` | `templateId` (`template`/`type`), `blocks` (`modules`), `title` |
+| `stardust/rollout/rollout.json` | rollout / user | DA target coordinates |
+
+## Outputs
+
+| Path | Purpose |
+|---|---|
+| `stardust/rollout/coverage/pages.json` | per-page delivery ledger (schema: `schemas/rollout-pages.schema.json`) |
+| `stardust/rollout/coverage/templates.json` | template grouping + roll-ups (schema: `schemas/rollout-templates.schema.json`) |
+| `stardust/rollout/coverage/blocks.json` | the block dedup ledger + EDS mapping (schema: `schemas/rollout-blocks.schema.json`) |
+| `stardust/rollout/plan.json` | dedup-driven delivery order + per-page convert/reuse briefs |
+| `stardust/rollout/optimize/findings.json` | multi-source quality findings ledger (schema: `schemas/rollout-findings.schema.json`) |
+| `stardust/rollout/optimize/scorecard.json` | quality scorecard + history (schema: `schemas/rollout-scorecard.schema.json`) |
+| `stardust/rollout/rollout.json` | config + `lastRun` summary (schema: `schemas/rollout-config.schema.json`) |
+| `stardust/rollout/site/{sitemap.xml,robots.txt,manifest.json}` | site-level assembly artifacts |
+| `stardust/rollout/dashboard/{index.html,data.json}` | self-contained progress dashboard + snapshot |
+| edits to the **EDS project** (`content/**`, `styles/`) | applied by `autofix-aem` (the only files rollout writes outside `stardust/rollout/`) |
+| the delivered EDS site | produced by `deploy` per page (blocks/, content/, fragments — owned by `deploy`) |
+
+`rollout` writes under `stardust/rollout/` and — only via `autofix-aem` — to the
+**EDS project** it is delivering to. It never modifies the agnostic core,
+`state.json`, or `migrated/` — those are read-only inputs.
+
+## Dependencies (audit sources — referenced, not vendored)
+
+optimize orchestrates existing audit skills by invocation; they must be installed:
+
+- **impeccable** (`critique`, `audit`) — already a stardust dependency.
+- **marketing skills** (`coreyhaines31/marketingskills`) — `seo-audit`, `schema`,
+  `ai-seo`, `site-architecture`. Optional; surface a note if absent.
+- **stardust tensions** — emitted in-repo by `extract` (`brand-review.html`).
+
+Normalize each one's output into the ledger via `findings.mjs record`. See
+`reference/audit-sources.md`.
+
+## What rollout does NOT do
+
+- **No upstream redesign.** `design-pass` findings are surfaced, not fixed here —
+  they belong to `migrate`/`prototype`. autofix only touches platform-fixable
+  findings in the EDS project.
+- **No new transport.** Delivery is `deploy`'s DA Source API path, unchanged.
+- **No redesign of the agnostic core.** `extract`/`direct`/`prototype`/`migrate`
+  and `deploy` are untouched; rollout is the across-pages delivery layer on top.
+
+## Scripts
+
+- `scripts/inventory.mjs` — migrated tree → page + template coverage (idempotent;
+  stale-aware).
+- `scripts/blocks.mjs` — distinct-block dedup ledger (`blocks.json`).
+- `scripts/plan.mjs` — dedup-driven delivery order + per-page convert/reuse briefs.
+- `scripts/update-coverage.mjs` — deterministic delivery state-writer for pages
+  (`<slug> --status …`) and blocks (`--block <id> --status …`); re-derives all
+  roll-ups.
+- `scripts/assemble.mjs` — site-level sitemap / robots / fragments manifest.
+- `scripts/verify.mjs` — full-site structural verification (HTTP or offline `--root`).
+- `scripts/optimize.mjs` — `rollout:baseline` detectors + the multi-source gate:
+  scorecard, fixability routing, detect → fix → verify loop; exits non-zero on open P1.
+- `scripts/findings.mjs` — record/resolve findings from the external audit sources
+  into the shared ledger.
+- `scripts/autofix-aem.mjs` — the AEM autofix engine (edits the EDS project, logs
+  to `finding.autofix`, stages findings for re-deploy).
+- `scripts/dashboard.mjs` — design-identity dashboard: lifecycle-coloured page
+  tree + templates + scorecard, `data.json` snapshot (reads `state.json` for the
+  agnostic stages).
+- `scripts/lib.mjs` — shared IO + roll-up + page-loading + autofix-registry helpers.
+
+## References
+
+- `notes/rollout/PLAN.md` — design, coverage model, phasing, open questions.
+- `reference/audit-sources.md` — the audit-source → layer → fixability → autofix map.
+- `reference/checks.md` — the `rollout:baseline` check catalog.
+- `skills/deploy/SKILL.md` — the single-page conversion methodology rollout drives.
+- `skills/deploy/da-deploy-protocol.md` — the DA Source API transport.
+- `skills/migrate/SKILL.md` — produces the `migrated/` + `_meta.json` inputs.
+- `schemas/*.schema.json` — the coverage + config contracts.

--- a/plugins/stardust/skills/rollout/SKILL.md
+++ b/plugins/stardust/skills/rollout/SKILL.md
@@ -302,9 +302,13 @@ identified → prototyped → deployed → optimised
 ```
 
 The stage spans all three sources: `stardust/state.json` (agnostic
-`extracted/directed` → identified, `prototyped/approved/migrated` → prototyped),
-rollout coverage (`deployed`/`verified` → deployed), and optimize (`optimised` =
-verified **and** no open findings for the page). The legend **counts are
+`rostered/extracted/directed` → identified, `prototyped/approved/migrated` →
+prototyped), rollout coverage (`deployed`/`verified` → deployed), and optimize
+(`optimised` = verified **and** no open findings for the page). **A
+`content-pending` sibling (archetypes-only mode) stays at `identified`** — it sits
+in the coverage ledger so its delivery can be tracked, but it has no designed
+document yet, so being in coverage alone does **not** advance it to `prototyped`
+(only a page in the migrated tree does). The legend **counts are
 cumulative** — a page counts toward every stage up to the one it reached, so
 `identified` equals the total page count, `prototyped` includes everything
 prototyped-or-beyond, and so on. **Template archetypes** — the page that defines a

--- a/plugins/stardust/skills/rollout/SKILL.md
+++ b/plugins/stardust/skills/rollout/SKILL.md
@@ -173,7 +173,38 @@ Walk `plan.json.steps` in order (representative pages first). For each page:
    different case: leave the block, render gracefully (no placeholder void), and
    log it as a content gap — do NOT invent filler to fill it.
 
-3. **Record outcomes** with the state-writer (never hand-edit the ledger):
+3. **Image-fidelity gate — every authored `<img>` src must RESOLVE, or be omitted.**
+   This is the #1 recurring defect at scale: an authored external image URL that
+   the preview ingester can't fetch delivers as `<img src="about:error">` — a
+   silent break that "it renders" hides. Before deploy, for EACH authored `<img>`
+   whose src is an external/source URL, verify it returns 200
+   (`curl -s -o /dev/null -w '%{http_code}' <url>`); if it doesn't, OMIT the image
+   (the block renders without it) rather than ship `about:error`. Never author a
+   logo/placeholder stand-in (`…hirslanden-logo…`) as if it were editorial.
+   Two failure signatures seen on real sites — fix the URL, don't drop the image,
+   when the asset truly exists behind a malformed URL:
+   - **Wrong rendition variant** — the source page exposes only a derivative that
+     404s (e.g. a doctor portrait's `…/4x3/768/…` 404s; the `…/original/768/…`
+     sibling resolves). Rewrite to the resolving variant.
+   - **Missing query delimiter** — a CDN URL built as `…/<id>&wid=600&hei=…`
+     (no `?`) makes the whole `<id>&wid=…` a bogus asset id → 403. Repair the
+     first `&` after the id to `?` (`…/<id>?wid=600&hei=…`).
+   After preview, the authoritative check is `.plain.html`: 0 `about:error` and
+   the expected `<img>`+alt count (CSS-background images are absent from it).
+
+4. **Path-safety gate — source paths must be AEM-Edge-safe, or normalized + redirected.**
+   Real source URLs are not always valid EDS resource paths; DA accepts the `PUT`
+   (`201`) but the preview/serve then 404s/400s, so this is invisible until verify.
+   Before deploy, normalize each path and, when it changes, record the original→
+   normalized pair so the source URL can be redirected (a final-migration must not
+   404 inbound links). Rules: lowercase the whole path; trim a trailing `-`/`_` in
+   any segment; collapse `_`→`-` and runs of `-`; replace the `--` segment
+   delimiter (e.g. `klinik-st--anna`) — AEM reserves `--` as the
+   `branch--repo--owner` host delimiter, so a `--` in a path 400s. Append each
+   change to `stardust/redirects.tsv` (`source<TAB>destination`); wiring those into
+   the EDS redirects config is a Phase D/assembly step.
+
+5. **Record outcomes** with the state-writer (never hand-edit the ledger):
 
    ```bash
    node skills/rollout/scripts/update-coverage.mjs <slug> --status converting
@@ -194,6 +225,30 @@ agents. **Deliver each template's representative — the page that converts that
 template's blocks — before its siblings**, so the blocks exist to be reused. The
 state-writer is per-unit so concurrent updates don't collide.
 
+**Batched delivery at scale (clusters of 6–20+ siblings).** Proven flow for a
+large content track — separate the concerns so an agent crash or a token blowout
+can't corrupt state, and so the gates above run uniformly:
+- **Author-only agents, central deploy.** Each cluster agent reads its work-list
+  + the cleaned archetype template and *only writes content files* — it does NOT
+  deploy. The orchestrator deploys centrally (one idempotent `PUT`+preview loop),
+  which keeps the token in one place, makes retries trivial, and survives a
+  sub-agent dying mid-response (its files are already on disk).
+- **Validate structure BEFORE deploy.** Cheap deterministic check on every
+  authored file — exactly one `<h1>`, the body/`<main>`/`<footer>` wrapper,
+  balanced `<div>`s — catches a truncated/garbled file (e.g. from an agent that
+  crashed) before it reaches DA.
+- **Verify-THEN-flip, never flip blind.** Only flip a page to `deployed` after
+  its rendered `.plain.html` passes (HTTP 200, 0 `about:error`, `<h1>` present).
+  The verify pass is where the image- and path-fidelity defects above actually
+  surface at scale — 4-page samples won't show them; a 130-page batch will.
+- **Long batches run in the background** (a 130-page `PUT`+preview loop far
+  exceeds a 2-min foreground budget); log per-page OK/FAIL and re-drive only the
+  FAILs. Transient `PUT=000` → retry; `PUT=201 PRE=4xx/400` → a path-safety case
+  (gate 4); `200 + about:error` → an image case (gate 3).
+- **zsh gotcha:** `node`/`curl` inside a multi-line `while`/`for` can lose PATH
+  ("command not found") — write the loop to a `bash` script file with absolute
+  binaries and run it, rather than inlining.
+
 ### Phase D — Site assembly (whole-site artifacts)
 
 ```bash
@@ -205,6 +260,13 @@ Generates the artifacts that only make sense site-wide: `sitemap.xml` +
 chrome blocks to `fragments/header.html` / `fragments/footer.html` with their
 `canon/*.html` source. `deploy` lifts and pushes the actual fragment content
 (Step 6); `assemble` prepares and records what to push.
+
+**Redirects.** If Phase C's path-safety gate (#4) emitted `stardust/redirects.tsv`
+(original source path → normalized EDS path), wire it into the site's EDS
+redirects mechanism here so the original inbound URLs don't 404 — a final
+migration must preserve link/SEO continuity. (DA also holds orphan content at the
+pre-normalization paths from the accepted `PUT`s; harmless since they never
+preview-serve, but clean them up if you want the DA tree to match the live tree.)
 
 ### Phase E — Full-site verify
 

--- a/plugins/stardust/skills/rollout/SKILL.md
+++ b/plugins/stardust/skills/rollout/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rollout
-description: Deliver a WHOLE redesigned site to AEM Edge Delivery Services. The full-site sibling of `deploy` (which converts one page). Inventories the platform-agnostic migrated tree (stardust/migrated/ + _meta.json sidecars) into a delivery coverage ledger, then delivers each page by invoking the `deploy` methodology, tracking what is done and what is missing across the whole site. Use when the user has a migrated stardust site and wants to push the entire site to AEM, not just one page. Supports archetypes-only mode — if only the template archetype pages have been migrated, rollout can deploy all block code immediately and register the remaining pages as content-pending for later population.
+description: Deploy a WHOLE redesigned site to AEM Edge Delivery Services — the full-site, bulk sibling of `deploy` (which ships one page). Use to roll out, bulk-deploy, or publish an entire migrated stardust site at once ("deploy all pages", "full site deployment", "deploy the whole/entire website to AEM"), not just a single page. Inventories the migrated tree (stardust/migrated/ + _meta.json) into a delivery ledger, dedups blocks, drives `deploy` per page, verifies, and tracks what's done and what's left. Supports archetypes-only mode — when only the template archetype pages are migrated, it deploys all block code immediately and registers the rest as content-pending.
 license: Apache-2.0
 ---
 
@@ -12,321 +12,140 @@ page, tracking delivery coverage so you always know what's done and what's left.
 
 `rollout` is **delivery-only** — it does not redesign. The page-by-page redesign
 (`extract → direct → prototype → migrate`) and `deploy` itself are **unchanged**;
-`rollout` is the across-pages layer on top. The full design rationale, the
-coverage model, and the phasing are in
-[`notes/rollout/PLAN.md`](../../notes/rollout/PLAN.md).
-
-> **The full flow is built**: inventory + page coverage (P1); first-class block
-> dedup + site assembly + verify (P2); multi-source optimize + AEM autofix (P3);
-> and the dashboard (P4). The flow runs **A→I** below.
+`rollout` is the across-pages layer on top. Design rationale, coverage model, and
+phasing are in [`notes/rollout/PLAN.md`](../../notes/rollout/PLAN.md). The flow
+runs **A→I** below.
 
 ## When to use
 
-**Full mode** — the user has:
-1. A fully migrated stardust site at `stardust/migrated/` (the output of
-   `stardust migrate`: per-page HTML + `_meta.json` sidecars). This is the
-   explicit handoff `migrate` documents for downstream AEM conversion.
-2. An EDS/AEM project + DA destination (the same target `deploy` needs — see
-   `skills/deploy/SKILL.md` and `da-deploy-protocol.md`).
-3. A goal to deliver the **entire** site, incrementally and resumably.
+**Full mode** — the user has a fully migrated site at `stardust/migrated/`
+(per-page HTML + `_meta.json` from `stardust migrate`), an EDS/AEM project + DA
+destination (the same target `deploy` needs), and wants the **entire** site
+delivered, incrementally and resumably.
 
-**Archetypes-only mode** — the user has:
-1. One migrated archetype page per template in `stardust/migrated/` (the
-   representative pages, not every sibling), plus a full page inventory in
-   `stardust/state.json` with `type` assignments for all pages.
-2. The same EDS/AEM project + DA destination as above.
-3. A goal to ship all block code immediately without waiting for every page to
-   be individually migrated. Sibling pages are registered as `content-pending`
-   in the coverage ledger; their document content is populated later through a
-   separate content track.
+**Archetypes-only mode** — the user has one migrated archetype per template plus a
+full page inventory in `stardust/state.json` (with `type` per page), and wants to
+ship all block code immediately without waiting for every page to be migrated.
+Sibling pages register as `content-pending` and get their content later via a
+separate track.
 
-If there is no `stardust/migrated/` tree at all, recommend `stardust migrate`
-on at least the archetype pages first. For a single page, use `stardust deploy`
-directly — `rollout` is for the whole site.
+If there is no `stardust/migrated/` tree at all, recommend `stardust migrate` on at
+least the archetype pages first. For a single page, use `stardust deploy` directly.
 
 ## Setup
 
 1. Run the master skill's setup (`skills/stardust/SKILL.md` § Setup).
-2. Verify `stardust/migrated/` exists and contains at least one `*.html` page.
-   If not, recommend `stardust migrate` on the template archetypes and stop.
-   - **Full mode**: `migrated/` covers all pages in scope.
-   - **Archetypes-only mode**: `migrated/` covers only the archetype pages (one
-     per template). Verify `stardust/state.json` exists and has `type` populated
-     for all pages whose siblings need coverage. If `state.json` is absent or
-     lacks `type` assignments, recommend resolving those before proceeding.
+2. Verify `stardust/migrated/` exists with at least one `*.html` page (full mode:
+   all pages; archetypes-only: the archetypes + a `state.json` with `type`
+   populated). If not, recommend `stardust migrate` on the archetypes and stop.
 3. Verify the EDS/AEM target is ready exactly as `deploy` requires (project
-   scaffolding, `DA_TOKEN`, code branch pushable). `rollout` adds no new transport
-   — it reuses `deploy`'s.
+   scaffolding, `DA_TOKEN`, code branch pushable). `rollout` adds no new transport.
 
 ## Procedure
 
 ### Phase A — Inventory (build the coverage)
 
-Run the inventory script to project the migrated tree into the delivery coverage:
-
 ```bash
 node skills/rollout/scripts/inventory.mjs --site-url <source-url>
 # defaults: --migrated stardust/migrated  --out stardust/rollout
-
-# archetypes-only mode: supplement migrated/ with the full page roster from state.json
+# archetypes-only mode: add the full page roster from state.json
 node skills/rollout/scripts/inventory.mjs --site-url <source-url> --state stardust/state.json
 ```
 
-It writes:
-- `stardust/rollout/coverage/pages.json` — one row per page: slug, delivered
-  `path`, `templateId` (from the sidecar `template`/`type`), the `blocks` it
-  composes (from the sidecar `modules`), a `sourceHash`, and the per-page
-  `delivery` status.
-- `stardust/rollout/coverage/templates.json` — pages grouped by template (drives
-  delivery order and per-template roll-ups).
-- `stardust/rollout/rollout.json` — target + DA config + a `lastRun` counts
-  summary.
+Writes `coverage/pages.json` (one row per page: slug, delivered `path`,
+`templateId`, `blocks`, `sourceHash`, `delivery` status), `coverage/templates.json`
+(pages grouped by template), and `rollout.json` (target + DA config + `lastRun`).
 
-**Archetypes-only mode** (triggered by `--state`): inventory reads `state.json`
-for the full page roster and merges it with `migrated/`:
-- Pages with a `_meta.json` in `migrated/` are seeded from their sidecar
-  exactly as in full mode.
-- Pages present only in `state.json` (not yet individually migrated) are seeded
-  with `templateId` inferred from their `type` field and `blocks` inferred from
-  the archetype sidecar for that template. Their `sourceHash` is derived from
-  `state.json[].currentStatePath` content. Their initial `delivery.status` is
-  `content-pending`.
+**Archetypes-only mode** (`--state`): pages with a `_meta.json` are seeded as in
+full mode; pages present only in `state.json` are seeded with `templateId` from
+`type`, `blocks` from the archetype sidecar, and `delivery.status:
+content-pending`.
 
-The inventory is **idempotent and incremental**: existing delivery status is
-preserved; a page whose migrated HTML changed after it was delivered is
-re-flagged `stale`. Re-run it any time `migrate` re-emits pages or `state.json`
-adds new pages.
-
-Fill in the DA coordinates in `stardust/rollout/rollout.json` (`site.da.org`,
-`site.site`, `site.da.ref`, and `site.liveHost`) if the inventory didn't infer
-them — `deploy` needs them for the push and `verify` needs the host.
+Inventory is **idempotent and incremental**: delivery status is preserved; a page
+whose migrated HTML changed after delivery is re-flagged `stale`. Fill in the DA
+coordinates in `rollout.json` (`site.da.org`, `site.site`, `site.da.ref`,
+`site.liveHost`) if not inferred.
 
 ### Phase B — Block dedup plan (FIRST-CLASS, before any conversion)
-
-Derive the distinct block set and the dedup-driven delivery plan **up front** —
-this is what makes "convert each block once" a driving step, not a cleanup:
 
 ```bash
 node skills/rollout/scripts/blocks.mjs   # → coverage/blocks.json (the dedup unit)
 node skills/rollout/scripts/plan.mjs     # → plan.json + a readable conversion plan
 ```
 
-- `blocks.mjs` collapses every block instance across the site (the per-page
-  `modules` + chrome) into the **distinct** set, assigns each a canonical
-  `edsBlockName` (kebab; reserved-class-guarded per deploy #15), and records
-  `usedByPages` / `instanceCount`. Chrome (`header`/`nav`/`footer`) is marked
-  `kind: chrome` → delivered as site-wide fragments, not per-page blocks. In
-  archetypes-only mode the distinct block set is fully determined by the archetype
-  sidecars alone — `content-pending` sibling pages add no new blocks.
-- `plan.mjs` orders pages **representative-first per template**, walks them once,
-  and assigns each distinct block a **single conversion point**: the first page
-  in order that uses it CONVERTS it; every later page REUSES it by name. The
-  per-page `convert` / `reuse` lists are exactly `deploy`'s Step-7 brief input
-  (*"Existing blocks — REUSE, do not recreate: …"*), so each block converts once
-  **without changing deploy**. `content-pending` pages are always assigned
-  `convert: []` / `reuse: [all template blocks]` — they never introduce new blocks.
+- `blocks.mjs` collapses every block instance (per-page `modules` + chrome) into
+  the **distinct** set, assigns each a canonical `edsBlockName` (kebab,
+  reserved-class-guarded per deploy #15), and records `usedByPages` /
+  `instanceCount`. Chrome (`header`/`nav`/`footer`) is `kind: chrome` → site-wide
+  fragments. In archetypes-only mode the archetype sidecars fully determine the
+  block set; `content-pending` pages add none.
+- `plan.mjs` orders pages **representative-first per template** and gives each
+  distinct block a **single conversion point**: the first page that uses it
+  CONVERTS it, every later page REUSES it by name. The per-page `convert`/`reuse`
+  lists are exactly `deploy`'s Step-7 brief input, so each block converts once
+  **without changing deploy**. `content-pending` pages are always `convert: []`.
 
-> **Extending a DELIVERED site: a "new template" is almost always a new COMPOSITION
-> of the existing block library, not new block code.** When you add page types
-> *after* the first rollout (Hirslanden's later `fachgebiete`, `blog`, `legal`,
-> `center`, and the per-clinic sub-trees), audit `blocks/` BEFORE writing any block:
-> most "new templates" resolve to existing blocks recomposed —
-> blog = `article-header` + `article-body` (the news blocks); legal =
-> `page-header` + `body-text`; specialty landing = `page-header` + `lead-text` +
-> `centers`; center = `page-header` + `lead-text` + `body-text` + `contact-cta`.
-> All four shipped with **zero new block JS/CSS** — only new archetype content
-> files composing existing blocks. Reach for a new block only when no composition
-> of the library reproduces the section. This keeps the library small (David's
-> model) and makes extension an authoring task, not an engineering one.
+> Extending an already-delivered site? A "new template" is almost always a new
+> COMPOSITION of the existing block library, not new block code — audit `blocks/`
+> first. See `reference/operational-learnings.md`.
 
-### Phase B2 — Dynamic-blocks map + metadata contract (PRE-IMPORT GATE)
+### Phase B2 — Metadata contract for dynamic listings (PRE-IMPORT GATE)
 
 **Do this before Phase C — the import is blocked on it.** What a dynamic listing
-block can show is bounded by what each page emits, and an index row can carry only
-page-intrinsic DOM **or** authored metadata (see Phase D2 for the full mechanics).
-So the metadata a block will need must be decided **before** the batch import —
-emitting it per page at write time is one extra field; retrofitting it across
-thousands of already-imported, already-published pages is a second migration.
+block can show is bounded by what each page emits, and retrofitting metadata across
+thousands of already-published pages is a second migration. Before importing,
+produce `dynamic-blocks-map.md` (which blocks are dynamic vs static, the index each
+reads, the fields its cards need) and a **metadata contract** (the `<meta name="…">`
+each content TYPE must carry). Then have Phase C's `deploy` brief emit the contract
+per page, and author `helix-query.yaml` from the same contract.
 
-Produce two artifacts now:
-
-1. **`dynamic-blocks-map.md`** — classify every listing-candidate block: dynamic
-   (index-driven) vs static (editorial curation), and for each dynamic one, the
-   index it reads and the fields its cards need.
-2. **The metadata contract** — the concrete `<meta name="…">` fields each content
-   TYPE must carry for its dynamic blocks to work (e.g. clinic →
-   `canton`/`city`/`address`/`phone`; news → `publishdate`/`category`; event →
-   `eventdate`/`clinic`/`location`). Fields already intrinsic to the DOM (title,
-   image, authored cross-links) need NO metadata — only what the DOM lacks.
-
-**Then make Phase C's `deploy` brief emit the contract**: each authoring agent adds
-the type's metadata rows to every page's metadata block as it writes it. Author
-`helix-query.yaml` (Phase D2) from the same contract so selectors and emitted names
-line up. A block whose contract can't be met from the source (a relationship like
-center↔disease) stays static — record that in the map, don't fake it.
-
-**Metadata key → meta-name mechanics.** A metadata-block row `<div><div>KEY</div>
-<div>VALUE</div></div>` renders to `<meta name="<key lowercased>">`. Use
-single-token capitalized keys (`PublishDate`→`name="publishdate"`,
-`Canton`→`name="canton"`) and make `helix-query.yaml`'s `select:
-meta[name="publishdate"]` match. Emit dates as ISO `YYYY-MM-DD` (sortable). Emitting
-the contract during authoring is one row per page; retrofitting it across an
-already-imported, already-published batch is a full extra pass + republish — which
-is the whole reason B2 is a gate.
+Mechanics (key→meta-name rules, what a row can carry): `reference/dynamic-listings.md`.
 
 ### Phase C — Deliver the site (drive `deploy` per page, per the plan)
 
-**Blocked on Phase B2** — author each page's metadata contract (above) into its
-metadata block during delivery, so the indexes are rich at import time.
+**Blocked on Phase B2** — author each page's metadata contract into its metadata
+block during delivery, so the indexes are rich at import time.
 
 Walk `plan.json.steps` in order (representative pages first). For each page:
 
-1. **Convert + push** the page's migrated HTML (`source.migratedHtml`) to AEM via
-   the `deploy` methodology (`skills/deploy/SKILL.md`). **Pass the page's plan
-   step into deploy's brief**: create only the blocks in `convert`; for every
-   block in `reuse`, instruct deploy to REUSE the existing block by its
-   `edsBlockName` (do not recreate). This is the dedup contract in action.
+1. **Convert + push** the migrated HTML (`source.migratedHtml`) to AEM via the
+   `deploy` methodology. **Pass the plan step into deploy's brief**: create only the
+   blocks in `convert`; for each block in `reuse`, REUSE the existing block by its
+   `edsBlockName` (do not recreate).
 
-   **`content-pending` pages** (archetypes-only mode): these pages have no
-   migrated HTML. Skip the document push entirely — do not create a shell or
-   placeholder document. Record them as `content-pending` in the coverage ledger
-   and surface them in the report as "awaiting content track." Block code for
-   these pages is already deployed via their template's archetype; no conversion
-   work remains.
+   **`content-pending` pages** (archetypes-only): no migrated HTML — skip the
+   document push entirely (no shell/placeholder), record `content-pending`, surface
+   as "awaiting content track." Their block code is already deployed via the
+   archetype.
 
-2. **Source-fidelity gate — "don't add sections the source doesn't have."**
-   Before flipping a page to `deployed`, confirm every authored section maps to a
-   real region on the *source* page. A migration reproduces the source; it must
-   not invent sections — and the failure is silent, because invented sections
-   render as empty placeholders or, worse, get back-filled with fabricated facts.
-   This recurs as trailing **cross-link rails** (`related-*`, `*-teasers`),
-   **specialist/teaser grids**, and generic **trailing CTAs** appended to every
-   leaf page regardless of source.
+2. **Run the delivery gates** before flipping a page to `deployed`. Each is a
+   one-line rule here; mechanics + helpers in `reference/delivery-gates.md`:
+   - **Source-fidelity** — don't add sections the source lacks; never fabricate
+     facts. `node skills/rollout/scripts/section-fidelity.mjs --file <html> --source <url>`
+   - **Image-fidelity** — every authored `<img>` src must return 200 or be omitted;
+     never ship `<img src="about:error">`.
+   - **Path-safety** — normalize source paths to AEM-Edge-safe form (lowercase, no
+     trailing `-`/`_`, no `--` segment); record original→normalized in
+     `stardust/redirects.tsv`.
+   - **Source-content hygiene** — skip dead source URLs; author bodyless/PDF-only
+     sources thin and faithful, don't pad with invented prose.
 
-   ```bash
-   node skills/rollout/scripts/section-fidelity.mjs \
-     --file <content.html> --source <sourceUrl>   # lays authored vs source side-by-side
-   ```
-
-   The helper is a scaffold, not a judge: it lists the authored block sections
-   (pre-flagging known filler shapes as `⟵ REVIEW`) against the source's heading
-   outline. For each authored section — especially flagged ones — decide:
-   - **HARD-FAIL → remove before `deployed`:** the section carries FABRICATED
-     facts (invented person names, made-up events/dates, boilerplate prose not on
-     the source). Fabricated content on a real site is the worst migration defect.
-   - **Soft call:** an invented rail whose links all point to REAL pages — prefer
-     remove (honor the rule); keep only as a plain text link-row if cross-linking
-     is explicitly wanted, never as an image-card grid that needs assets to exist.
-   - **Pass:** the section backs a real source region.
-
-   Delete the section from the content file (and `git rm` the block if it becomes
-   orphaned — no other page references it). Genuinely-missing *real* content is a
-   different case: leave the block, render gracefully (no placeholder void), and
-   log it as a content gap — do NOT invent filler to fill it.
-
-3. **Image-fidelity gate — every authored `<img>` src must RESOLVE, or be omitted.**
-   This is the #1 recurring defect at scale: an authored external image URL that
-   the preview ingester can't fetch delivers as `<img src="about:error">` — a
-   silent break that "it renders" hides. Before deploy, for EACH authored `<img>`
-   whose src is an external/source URL, verify it returns 200
-   (`curl -s -o /dev/null -w '%{http_code}' <url>`); if it doesn't, OMIT the image
-   (the block renders without it) rather than ship `about:error`. Never author a
-   logo/placeholder stand-in (`…hirslanden-logo…`) as if it were editorial.
-   Two failure signatures seen on real sites — fix the URL, don't drop the image,
-   when the asset truly exists behind a malformed URL:
-   - **Wrong rendition variant** — the source page exposes only a derivative that
-     404s (e.g. a doctor portrait's `…/4x3/768/…` 404s; the `…/original/768/…`
-     sibling resolves). Rewrite to the resolving variant.
-   - **Missing query delimiter** — a CDN URL built as `…/<id>&wid=600&hei=…`
-     (no `?`) makes the whole `<id>&wid=…` a bogus asset id → 403. Repair the
-     first `&` after the id to `?` (`…/<id>?wid=600&hei=…`).
-   After preview, the authoritative check is `.plain.html`: 0 `about:error` and
-   the expected `<img>`+alt count (CSS-background images are absent from it).
-
-4. **Path-safety gate — source paths must be AEM-Edge-safe, or normalized + redirected.**
-   Real source URLs are not always valid EDS resource paths; DA accepts the `PUT`
-   (`201`) but the preview/serve then 404s/400s, so this is invisible until verify.
-   Before deploy, normalize each path and, when it changes, record the original→
-   normalized pair so the source URL can be redirected (a final-migration must not
-   404 inbound links). Rules: lowercase the whole path; trim a trailing `-`/`_` in
-   any segment; collapse `_`→`-` and runs of `-`; replace the `--` segment
-   delimiter (e.g. `klinik-st--anna`) — AEM reserves `--` as the
-   `branch--repo--owner` host delimiter, so a `--` in a path 400s. Append each
-   change to `stardust/redirects.tsv` (`source<TAB>destination`); wiring those into
-   the EDS redirects config is a Phase D/assembly step.
-
-4b. **Source-content hygiene — a sitemap roster contains dead and bodyless URLs.**
-   At 1000-page scale the roster comes from the source sitemap, which includes
-   URLs that **404 on the source** (stale entries) and pages with **no HTML body**
-   (PDF-only magazine/publication entries — a title plus a PDF download, nothing
-   else to migrate). Two rules, both proven on the Hirslanden 1k run:
-   - **Verify the source returns 200 before authoring.** A dead source URL is not a
-     page to fabricate — leave it un-authored and let it show as the lone gap in the
-     dashboard (e.g. 814/815). Never invent a body to fill the slot.
-   - **Bodyless/PDF-only source → author metadata + hero + the real download link,
-     then STOP.** Don't pad with invented prose to make it "look complete"; the
-     faithful page is a thin one, and that is correct. (Same root rule as the
-     source-fidelity gate: reproduce the source, never out-author it.)
-
-5. **Record outcomes** with the state-writer (never hand-edit the ledger):
-
+3. **Record outcomes** with the state-writer (never hand-edit the ledger):
    ```bash
    node skills/rollout/scripts/update-coverage.mjs <slug> --status converting
-   # for each block this page converts:
    node skills/rollout/scripts/update-coverage.mjs --block <id> --status converted --eds-name <name>
-   # … run the deploy steps …
    node skills/rollout/scripts/update-coverage.mjs <slug> --status deployed --url <branch-preview-url>
-   # for content-pending pages (no document push):
-   node skills/rollout/scripts/update-coverage.mjs <slug> --status content-pending
+   node skills/rollout/scripts/update-coverage.mjs <slug> --status content-pending   # no document push
    ```
+   **Publish in the loop (`PUT → preview → live`), don't stop at preview** — any
+   query-index (Phase D2) builds from the **live** tree, so a preview-only delivery
+   leaves indexes empty. On failure: `--status failed --error "<reason>"` and
+   continue (one page's failure never aborts the rollout).
 
-   **Publish in the loop (`PUT → preview → live`), don't stop at preview.** If the
-   site has any query-index block (Phase D2), the index builds from the **live**
-   tree — a preview-only delivery leaves every index empty. Make `POST /live/…` a
-   per-page step of the delivery loop, not a deferred batch, so indexes populate as
-   pages land. (Indexing is async; the index `total` settles a little after the
-   publishes.)
-
-   On failure: `--status failed --error "<reason>"` and continue (one page's
-   failure never aborts the rollout — mirrors `migrate`).
-
-Parallelism: deliver multiple template clusters concurrently (one agent per
-cluster, non-overlapping page sets), as `deploy` Step 7 dispatches per-archetype
-agents. **Deliver each template's representative — the page that converts that
-template's blocks — before its siblings**, so the blocks exist to be reused. The
-state-writer is per-unit so concurrent updates don't collide.
-
-**Batched delivery at scale (clusters of 6–20+ siblings).** Proven flow for a
-large content track — separate the concerns so an agent crash or a token blowout
-can't corrupt state, and so the gates above run uniformly:
-- **Author-only agents, central deploy.** Each cluster agent reads its work-list
-  + the cleaned archetype template and *only writes content files* — it does NOT
-  deploy. The orchestrator deploys centrally (one idempotent `PUT`+preview loop),
-  which keeps the token in one place, makes retries trivial, and survives a
-  sub-agent dying mid-response (its files are already on disk).
-- **Validate structure BEFORE deploy.** Cheap deterministic check on every
-  authored file — exactly one `<h1>`, the body/`<main>`/`<footer>` wrapper,
-  balanced `<div>`s — catches a truncated/garbled file (e.g. from an agent that
-  crashed) before it reaches DA.
-- **Verify-THEN-flip, never flip blind.** Only flip a page to `deployed` after
-  its rendered `.plain.html` passes (HTTP 200, 0 `about:error`, `<h1>` present).
-  The verify pass is where the image- and path-fidelity defects above actually
-  surface at scale — 4-page samples won't show them; a 130-page batch will.
-- **Admin 200 ≠ delivered — verify the rendered URL, not the POST codes.** Some
-  path-safety defects pass `PUT`+preview+live ALL `200` yet 404 at the delivery
-  URL. The proven case: an **uppercase segment** (`.../CAR-T-Zellen`) — the admin
-  API accepts and "publishes" it, but `*.aem.live/.../CAR-T-Zellen` 404s (delivery
-  is lower-cased). So the `PUT=201 PRE=4xx` heuristic below MISSES it. Gate 4's
-  "lowercase the whole path" prevents it at author time; the GET-`.plain.html`
-  verify is the only thing that catches it after the fact. Fix = rename to the
-  lowercase path, redeploy, `DELETE` the stale uppercase DA source, add a redirect.
-- **Long batches run in the background** (a 130-page `PUT`+preview loop far
-  exceeds a 2-min foreground budget); log per-page OK/FAIL and re-drive only the
-  FAILs. Transient `PUT=000` → retry; `PUT=201 PRE=4xx/400` → a path-safety case
-  (gate 4); `200 + about:error` → an image case (gate 3).
-- **zsh gotcha:** `node`/`curl` inside a multi-line `while`/`for` can lose PATH
-  ("command not found") — write the loop to a `bash` script file with absolute
-  binaries and run it, rather than inlining.
+**Parallelism + scale.** Deliver template clusters concurrently (one agent per
+cluster, non-overlapping pages), representative-first so blocks exist to be reused.
+For clusters of 6–20+ siblings, use the author-only-agents + central-deploy +
+verify-then-flip flow in `reference/delivery-gates.md` § Batched delivery.
 
 ### Phase D — Site assembly (whole-site artifacts)
 
@@ -334,100 +153,27 @@ can't corrupt state, and so the gates above run uniformly:
 node skills/rollout/scripts/assemble.mjs   # → rollout/site/{sitemap.xml,robots.txt,manifest.json}
 ```
 
-Generates the artifacts that only make sense site-wide: `sitemap.xml` +
-`robots.txt` from the delivered paths, and a **fragments manifest** mapping the
-chrome blocks to `fragments/header.html` / `fragments/footer.html` with their
-`canon/*.html` source. `deploy` lifts and pushes the actual fragment content
-(Step 6); `assemble` prepares and records what to push.
+Generates site-wide artifacts: `sitemap.xml` + `robots.txt` from delivered paths,
+and a fragments manifest mapping chrome blocks to `fragments/{header,footer}.html`
+with their `canon/*.html` source (`deploy` pushes the actual fragment content).
+**Redirects:** if Phase C's path-safety gate emitted `stardust/redirects.tsv`, wire
+it into the EDS redirects mechanism here so original inbound URLs don't 404.
 
-**Redirects.** If Phase C's path-safety gate (#4) emitted `stardust/redirects.tsv`
-(original source path → normalized EDS path), wire it into the site's EDS
-redirects mechanism here so the original inbound URLs don't 404 — a final
-migration must preserve link/SEO continuity. (DA also holds orphan content at the
-pre-normalization paths from the accepted `PUT`s; harmless since they never
-preview-serve, but clean them up if you want the DA tree to match the live tree.)
+### Phase D2 — Dynamic listings (query-index) — optional
 
-### Phase D2 — Dynamic listings (query-index)
-
-Most sites have blocks that LIST other pages (doctor directories, news/event
-feeds, clinic grids, "related" rails). Statically authoring those cards doesn't
-scale and goes stale — they should read an EDS **query-index** (a published JSON
-of pages with per-page properties). The map + metadata contract are decided in the
-**Phase B2 pre-import gate**; this phase covers the mechanics of building the index
-and wiring the blocks. What the blocks can list is bounded by what the import
-emitted — which is why B2 comes first.
-
-**A query-index row can carry only:**
-1. **Page-intrinsic DOM** — `h1`, `og:image`, and links the content already
-   authored. Extract via CSS selectors in `helix-query.yaml`
-   (e.g. a doctor's specialty/clinic from `a[href*="/fachgebiete/"]` /
-   `a[href*="/home"]`). **Zero content change.** Author meaningful internal links
-   in content and they become free index facets.
-2. **Page metadata** — anything NOT in the DOM (article/event date, clinic
-   canton/address/phone) must be emitted as `<meta name="…">` via each page's
-   metadata block. → **Define a metadata contract per content type up front and
-   have Phase C emit it.** Retrofitting metadata across thousands of live pages
-   later is the expensive path.
-3. **NOT relationships.** A flat index can't express many-to-many
-   (centers↔disease, clinic↔specialty). Those need an explicit join field
-   (`treats:`/`topics:` slug list) in metadata on one side — and the related items
-   must themselves BE indexed pages (a block whose cards link only to `tel:` has
-   nothing to fetch). Without that, keep the block static; don't fake it.
-
-**The publish gotcha (cost a debugging cycle):** the query-index builds against the
-**PUBLISHED (live)** tree, not preview. A preview-only rollout has an EMPTY index —
-`query-index.json` 404s and `POST /index/…` returns `"requested path returned a 301
-or 404"` per index (that message == "page not published," not "bad selector").
-**Publish pages (`POST /live/…`) before expecting index rows.** Indexing is async:
-bulk-publish, then poll the index `total` until it settles.
-
-**Also localize internal links.** Migrated content often keeps absolute
-source-site URLs (`https://www.source.com/…`); the index then captures those as
-paths and on-site nav breaks. Rewrite internal links to delivered local paths
-(a Phase C / deploy concern) so index `*Path` fields are usable as links.
-
-Deliverables: `helix-query.yaml` (scoped indexes: include globs + `target`), the
-listing blocks rewritten to `fetch` their index (chunked for scale, with filter/
-sort/paginate + an authored fallback), and a `dynamic-blocks-map.md` recording
-which blocks are dynamic, which stay static (editorial curation), and the metadata
-contract. Validate one flagship end-to-end (e.g. a doctor directory + search with a
-`?q=` hand-off) before converting the rest.
+Blocks that LIST other pages (directories, news/event feeds, "related" rails)
+should read an EDS **query-index** rather than static cards. Build it from the B2
+contract: author `helix-query.yaml` (scoped indexes), rewrite the listing blocks to
+`fetch` their index (with filter/sort/paginate + an authored fallback), and
+validate one flagship end-to-end. The index builds from the **published (live)**
+tree — publish before expecting rows. Full mechanics: `reference/dynamic-listings.md`.
 
 ### Phase D3 — Multilingual (per-language trees) — optional
 
-When the source has language trees (`/fr/…`, `/en/…` beside `/de/…`), add them as
-**parallel content trees that REUSE the same block library** — the block structure
-is language-agnostic; only the authored content and a few wiring pieces change.
-Proven on the Hirslanden FR+EN add (≈90 pages/language, ≥5 per template):
-
-- **Author by mirroring the DE archetype per type, in the target language.** A FR
-  doctor page is the DE doctor page's block composition with FR content at the FR
-  path (`/fr/corporate/doctors/3/<slug>`). Dispatch author agents grouped by
-  template-type (doctors / treatments / diseases / specialty / editorial), each
-  given the DE reference file to mirror — *no new blocks*.
-- **Language-route the static header/footer.** The single `postlcp.js`
-  `loadStaticFragment` serves one fragment for all pages; make it pick by path
-  prefix and fall back to the default:
-  ```js
-  const seg = window.location.pathname.split('/')[1];
-  const lang = (seg === 'fr' || seg === 'en') ? `${seg}/` : '';
-  let resp = await fetch(`${codeBase}/fragments/${lang}${name}.html`);
-  if (!resp.ok && lang) resp = await fetch(`${codeBase}/fragments/${name}.html`);
-  ```
-  Add `fragments/fr/{header,footer}.html` + `fragments/en/…`: translated labels,
-  links localized to *live* same-language pages (else a source bounce), and a
-  **language switcher that targets each language's home** (`/`, `/fr/…/home`,
-  `/en/…/home`) — don't try to compute per-page cross-language equivalents.
-- **Per-language indexes** in `helix-query.yaml`: clone each index with a
-  language-scoped `include` glob + a language-prefixed `target`, and **fix the
-  selectors that encode language** — the doctor specialty facet selector is
-  `a[href*="/specialites-medicales/"]` (FR) / `a[href*="/specialities/"]` (EN), not
-  the DE `/fachgebiete/`. Same metadata contract per type.
-- **Path-safety is per-language too.** The same leading/trailing-`-`, `--`, `_`,
-  and uppercase normalization (gate 4) applies to FR/EN slugs — doctor slugs in
-  particular recur with a leading hyphen across every language tree.
-- The per-language indexes are empty until the FR/EN pages are published under the
-  synced config — see the Phase F republish note.
+When the source has language trees (`/fr/…`, `/en/…`), add them as parallel content
+trees that REUSE the same block library — only authored content and a little wiring
+change (language-routed fragments, per-language indexes, per-language path-safety).
+See `reference/multilingual.md`.
 
 ### Phase E — Full-site verify
 
@@ -436,107 +182,59 @@ node skills/rollout/scripts/verify.mjs            # uses rollout.json site.liveH
 # or: --base <url>   (explicit host)   |   --root <dir>   (offline, against a local export)
 ```
 
-For every delivered page, `verify` confirms it's reachable (HTTP 200), has no
-`about:error` (broken-image ingestion, deploy #75), and that every internal
-`href="/…"` resolves to a known delivered path — then flips each page to
-`verified` or `failed` with the reason. It exits non-zero if any page failed.
+For every delivered page, `verify` confirms HTTP 200, no `about:error` (deploy
+#75), and that every internal `href="/…"` resolves to a known delivered path — then
+flips each page to `verified` or `failed`. Exits non-zero if any page failed.
 
-**Two checks a roster-driven batch misses — run them explicitly (Hirslanden 1k):**
-- **Nav/footer targets + section landing pages are NOT archetype siblings.** A
-  roster built from detail-page sitemaps skips them, so they get committed but never
-  deployed/published — and every header/footer link to them 404s while the batch
-  dashboard still reads 100%. Enumerate the header/footer/nav fragment hrefs (and
-  each section's index/landing page) and confirm each target is in the
-  deploy+publish+verify set, not just the archetype detail pages. (Static header/
-  footer fragments are served from the CODE branch — a fix there is a git push, not
-  a DA write.)
-- **Absolute source-site "bounce" links.** Beyond root-relative `href="/…"` that
-  404, flag `href="https://<source-host>/…"` links whose path HAS a delivered local
-  equivalent — those silently bounce the visitor back to the OLD site (not a 404, so
-  plain link-resolution misses them). Rewrite to the local path. Keep an absolute
-  source link only when no local page exists (e.g. an un-migrated language tree);
-  localizing it would just trade a bounce for a 404.
+> Two checks a roster-driven batch misses: nav/footer/landing targets (not
+> archetype siblings) and absolute source-site "bounce" links. See
+> `reference/operational-learnings.md`.
 
 ### Phase F — Optimize: multi-source audit + gate (delivery quality)
 
 The in-flow **quality gate**. optimize aggregates findings from **existing audit
 skills** into one ledger (`optimize/findings.json` + `optimize/scorecard.json`),
-tags each by **fixability**, and gates the rollout. Sources (see
-`reference/audit-sources.md` for the full mapping):
+tags each by **fixability**, and gates the rollout. Sources (full mapping in
+`reference/audit-sources.md`):
 
-1. **`rollout:baseline`** — built-in deterministic detectors. Run it directly:
-
+1. **`rollout:baseline`** — built-in deterministic detectors:
    ```bash
    node skills/rollout/scripts/optimize.mjs        # uses rollout.json site.liveHost
    # or: --base <url> | --root <dir> | --slug <s> | --all
    ```
+2. **`impeccable:critique` + `impeccable:audit`** — design quality + a11y/perf.
+3. **The marketing SEO skills** — `seo-audit`, `schema`, `ai-seo`,
+   `site-architecture`.
+4. **`stardust:tensions`** — mechanical design tensions from
+   `stardust/current/brand-review.html`.
 
-2. **`impeccable:critique` + `impeccable:audit`** — run them against the delivered
-   output for design quality (P-levels) and a11y/perf/responsiveness.
-3. **The marketing SEO skills** (`coreyhaines31/marketingskills`) — `seo-audit`,
-   `schema`, `ai-seo`, `site-architecture`.
-4. **`stardust:tensions`** — the mechanical design tensions from
-   `stardust/current/brand-review.html` (type-scale, CTA-vocab, content-free
-   links, generic/empty alt, contrast…).
-
-These are referenced as **dependencies** (run them by invocation — nothing is
-vendored). Normalize each one's findings into the ledger with the writer:
+Normalize each source's findings into the ledger with the writer:
 
 ```bash
 node skills/rollout/scripts/findings.mjs record \
   --source marketing:seo-audit --layer seo --check thin-content \
   --severity P2 --fixability platform-migration \
   --scope-ids blog/post --evidence "…" --recommend "…"
-# resolve/accept/wontfix a finding:
 node skills/rollout/scripts/findings.mjs resolve <id> --status accepted --note "…"
 ```
 
-All sources share one id space, dedup, scorecard, and the **detect → fix →
-verify loop**: re-running a source resolves *its own* findings no longer present
-(a baseline run never resolves another source's finding); a regressed `fixed`
-finding re-opens; human `accepted`/`wontfix` are preserved. Each finding also
-carries an **`autofix`** descriptor (the registered AEM fixer, if any).
+All sources share one id space, dedup, scorecard, and the **detect → fix → verify
+loop**: re-running a source resolves *its own* gone findings; a regressed `fixed`
+finding re-opens; human `accepted`/`wontfix` are preserved. **Fixability routing:**
+`platform-migration` → autofix / re-deploy; `design-pass` → upstream (surface
+only); `out-of-scope` → informational. The gate **exits non-zero if any open P1 is
+in scope** — a page is delivery-clean only when verify passes *and* the ledger has
+no open P1.
 
-**Fixability routing:** `platform-migration` → the AEM autofix engine / re-deploy
-fixes it; `design-pass` → upstream (surface only); `out-of-scope` → informational.
+> At ~1k-page scale: a `head.html`-level fix needs a site-wide republish to land
+> and flip its per-page findings; the optimize gate only audits pages in
+> `coverage/pages.json`; and faithfully migrated parallel source trees produce
+> legitimate duplicate-title findings (a canonical decision, not a bug). See
+> `reference/operational-learnings.md`.
 
-The gate **exits non-zero if any open P1 is in scope** — a page is delivery-clean
-only when verify passes *and* the ledger has no open P1.
-
-**Operational learnings (Hirslanden, ~1.1k pages):**
-- **A `head.html`-level fix needs a SITE-WIDE REPUBLISH to land, and to flip the
-  findings.** The dominant baseline finding at scale is `ai-search/jsonld` ("no
-  JSON-LD structured data") — one P2 *per page*. The cheap, legitimate fix is
-  sitewide structured data in `head.html` (for a medical site:
-  `MedicalOrganization` + `WebSite` `@graph`); the detector only checks for the
-  presence of `application/ld+json` in the served `<head>`. But editing `head.html`
-  updates the file immediately while **already-rendered pages stay CDN-cached with
-  the old head** — `/head.html` shows the new JSON-LD yet `/some/page` does not.
-  You must **`POST /live/` every page** to re-render it with the new head (verify on
-  one page first: republish → GET → grep `ld+json`). On the optimize re-run those
-  findings then flip `open → fixed` (715/716 in one pass). Per-page granular schema
-  (`Physician`/`MedicalWebPage`) is a later enhancement, not needed to clear the gate.
-- **A full republish also re-triggers query-index builds.** New indexes added to
-  `helix-query.yaml` sit at `total: building`/404 until the in-scope pages are
-  re-published under the synced config — the same republish that propagates a
-  `head.html` change populates them. (Same root cause as the publish gotcha in D2.)
-- **optimize only audits what's in `coverage/pages.json`.** When EXTENDING a
-  delivered site (new templates, sub-trees, language trees), those pages aren't in
-  the coverage ledger, so Phase F silently skips them. Re-run `inventory.mjs` (add
-  the new pages to `state.json` first) before the gate, or audit them with explicit
-  `--slug`/a second `--base` pass — otherwise "gate passes" covers only the old set.
-- **Faithfully migrating PARALLEL source trees yields legitimate
-  `duplicate-title`/`duplicate-description` findings, not bugs.** Hirslanden serves
-  the same treatment at `/de/corporate/behandlungen/X` *and*
-  `/de/international/behandlungen/X`; reproducing both faithfully trips the cross-page
-  uniqueness detector. The resolution is a **content-model / canonical decision**
-  (canonicalize one tree to the other, or differentiate titles), not a re-author —
-  surface it as such, don't silently rewrite source-faithful titles to dodge the check.
-
-> The judgment layers (brand-tensions, design-ux, content-conversion) are scored
-> `null` (not assessed by the automated baseline) until populated by the
-> impeccable/tensions sources — the scorecard shows not-assessed rather than
-> faking a score.
+The judgment layers (brand-tensions, design-ux, content-conversion) are scored
+`null` until populated by the impeccable/tensions sources — the scorecard shows
+not-assessed rather than faking a score.
 
 ### Phase G — AEM autofix (close the loop)
 
@@ -544,26 +242,22 @@ only when verify passes *and* the ledger has no open P1.
 node skills/rollout/scripts/autofix-aem.mjs --project <eds-root>   # [--dry-run] [--slug s] [--check c]
 ```
 
-The platform autofix engine (AEM-EDS, v1 — **aggressive**). For every open finding
-whose `check` has a registered EDS fixer, it edits the EDS **project** files and
-logs the change on `finding.autofix`, staging the finding `in-progress`:
+The platform autofix engine (AEM-EDS, v1 — aggressive). For every open finding
+whose `check` has a registered EDS fixer, it edits the EDS **project** files, logs
+the change on `finding.autofix`, and stages the finding `in-progress`:
+- **deterministic** — `eds-fix-h1` (exactly one `<h1>`), sitemap (re-assemble).
+- **content-draft** (logged for review) — `eds-metadata-title` /
+  `eds-metadata-description`, `eds-alt-draft`, `eds-disambiguate-title`.
+- **manual** (prepares guidance/payload) — `eds-jsonld` (use `marketing:schema`),
+  `eds-canonical`, `eds-landmark-main`.
 
-- **deterministic** — `eds-fix-h1` (promote/demote so exactly one `<h1>`),
-  sitemap (re-assemble).
-- **content-draft** (applied under the aggressive policy, logged for review) —
-  `eds-metadata-title` / `eds-metadata-description` (draft from `<h1>`/first
-  paragraph), `eds-alt-draft` (alt from filename), `eds-disambiguate-title`.
-- **manual** (autofix prepares guidance/payload, a human applies) — `eds-jsonld`
-  (use `marketing:schema` for the payload), `eds-canonical`, `eds-landmark-main`.
-
-Use `--dry-run` first to preview edits. After applying, **re-deploy** the edited
-pages (`deploy`), then re-run **verify** + **optimize** — the staged findings flip
-to `fixed`, closing the loop. `design-pass` findings are surfaced, not auto-fixed.
+Use `--dry-run` first. After applying, **re-deploy** the edited pages, then re-run
+**verify** + **optimize** — staged findings flip to `fixed`. `design-pass` findings
+are surfaced, not auto-fixed.
 
 ### Phase H — Report
 
-Read `rollout.json.lastRun` + `optimize/scorecard.json` (or re-run `inventory.mjs`)
-and print the counts:
+Read `rollout.json.lastRun` + `optimize/scorecard.json` (or re-run `inventory.mjs`):
 
 ```
 rollout — <site> → aem-eds
@@ -576,11 +270,10 @@ To deliver  <list of remaining slugs>
 Content     <cp> pages awaiting content track (block code deployed, document not yet pushed)
 ```
 
-Surface anything still `pending`/`stale`/`failed` as the explicit "what's
-missing" list. `content-pending` pages are listed separately — they are not
-failures; their block code is live and they advance to `pending` automatically
-when `migrate` emits their individual HTML and `inventory` is re-run. Re-run
-from Phase B/C to pick up exactly the pages that changed.
+Surface `pending`/`stale`/`failed` as the explicit "what's missing" list.
+`content-pending` pages are listed separately — not failures; their block code is
+live and they advance to `pending` automatically when `migrate` emits their HTML
+and `inventory` is re-run.
 
 ### Phase I — Dashboard
 
@@ -589,35 +282,23 @@ node skills/rollout/scripts/dashboard.mjs    # → dashboard/index.html + data.j
 ```
 
 A **self-contained, no-external-JS** dashboard rendered in the **project's design
-identity** — brand tokens (bg / fg / accent / heading + body fonts / radius) are
-read from the `:root` block of a migrated page (the canonical token interface,
-`token-contract.md`).
-
-Its centerpiece is a **page tree** of every identified page, nested by URL path,
-each node colour-coded by the **most-advanced lifecycle stage** it has reached:
+identity** (brand tokens read from a migrated page's `:root`). Centerpiece: a
+**page tree** of every identified page, nested by URL path, each node colour-coded
+by the most-advanced lifecycle stage it reached:
 
 ```
 identified → prototyped → deployed → optimised
 ```
 
-The stage spans all three sources: `stardust/state.json` (agnostic
-`rostered/extracted/directed` → identified, `prototyped/approved/migrated` →
-prototyped), rollout coverage (`deployed`/`verified` → deployed), and optimize
-(`optimised` = verified **and** no open findings for the page). **A
-`content-pending` sibling (archetypes-only mode) stays at `identified`** — it sits
-in the coverage ledger so its delivery can be tracked, but it has no designed
-document yet, so being in coverage alone does **not** advance it to `prototyped`
-(only a page in the migrated tree does). The legend **counts are
-cumulative** — a page counts toward every stage up to the one it reached, so
-`identified` equals the total page count, `prototyped` includes everything
-prototyped-or-beyond, and so on. **Template archetypes** — the page that defines a
-template for its siblings (`templates.json[].representativeSlug`) — are badged
-`T`. A page with open findings shows a red count.
-
-Also: a **templates** table (archetype + member count + a per-stage lifecycle
-bar) and the quality scorecard. `dashboard/data.json` is the inspectable snapshot.
-Regenerate it at every iteration boundary. (`state.json` is read-only and
-optional — without it the tree starts at the `migrated` stage.)
+The stage spans `state.json` (`rostered/extracted/directed` → identified,
+`prototyped/approved/migrated` → prototyped), rollout coverage
+(`deployed`/`verified` → deployed), and optimize (`optimised` = verified **and** no
+open findings). A `content-pending` sibling stays at `identified` (it's in the
+ledger so delivery can be tracked, but has no designed document yet). Legend counts
+are **cumulative**. **Template archetypes** are badged `T`; a page with open
+findings shows a red count. Also a templates table + the quality scorecard.
+`dashboard/data.json` is the inspectable snapshot — regenerate at every iteration
+boundary. (`state.json` is read-only and optional.)
 
 ## Inputs
 
@@ -625,7 +306,7 @@ optional — without it the tree starts at the `migrated` stage.)
 |---|---|---|
 | `stardust/migrated/*.html` | `migrate` | the pages to deliver (read-only) |
 | `stardust/migrated/**/_meta.json` | `migrate` | `templateId` (`template`/`type`), `blocks` (`modules`), `title` |
-| `stardust/state.json` | stardust core | *(archetypes-only mode)* full page roster + `type` assignments for pages not yet individually migrated |
+| `stardust/state.json` | stardust core | *(archetypes-only mode)* full page roster + `type` for pages not yet migrated |
 | `stardust/rollout/rollout.json` | rollout / user | DA target coordinates |
 
 ## Outputs
@@ -645,16 +326,16 @@ optional — without it the tree starts at the `migrated` stage.)
 | the delivered EDS site | produced by `deploy` per page (blocks/, content/, fragments — owned by `deploy`) |
 
 `rollout` writes under `stardust/rollout/` and — only via `autofix-aem` — to the
-**EDS project** it is delivering to. It never modifies the agnostic core,
-`state.json`, or `migrated/` — those are read-only inputs.
+**EDS project** it delivers to. It never modifies the agnostic core, `state.json`,
+or `migrated/` — those are read-only inputs.
 
 ## Dependencies (audit sources — referenced, not vendored)
 
 optimize orchestrates existing audit skills by invocation; they must be installed:
 
 - **impeccable** (`critique`, `audit`) — already a stardust dependency.
-- **marketing skills** (`coreyhaines31/marketingskills`) — `seo-audit`, `schema`,
-  `ai-seo`, `site-architecture`. Optional; surface a note if absent.
+- **marketing skills** — `seo-audit`, `schema`, `ai-seo`, `site-architecture`.
+  Optional; surface a note if absent.
 - **stardust tensions** — emitted in-repo by `extract` (`brand-review.html`).
 
 Normalize each one's output into the ledger via `findings.mjs record`. See
@@ -662,49 +343,41 @@ Normalize each one's output into the ledger via `findings.mjs record`. See
 
 ## What rollout does NOT do
 
-- **No upstream redesign.** `design-pass` findings are surfaced, not fixed here —
-  they belong to `migrate`/`prototype`. autofix only touches platform-fixable
-  findings in the EDS project.
+- **No upstream redesign.** `design-pass` findings are surfaced, not fixed here.
+  autofix only touches platform-fixable findings in the EDS project.
 - **No new transport.** Delivery is `deploy`'s DA Source API path, unchanged.
 - **No redesign of the agnostic core.** `extract`/`direct`/`prototype`/`migrate`
-  and `deploy` are untouched; rollout is the across-pages delivery layer on top.
-- **No full pre-migration requirement.** Rollout does not require every page to
-  be individually migrated before it runs. Archetypes-only mode is a first-class
-  path: block code is fully deployed from the archetype pages; the remaining
-  pages advance from `content-pending` to `deployed` as `migrate` emits their
-  HTML and `inventory` is re-run — no rollout restart needed.
+  and `deploy` are untouched.
+- **No full pre-migration requirement.** Archetypes-only mode is first-class: block
+  code is deployed from the archetypes; remaining pages advance from
+  `content-pending` to `deployed` as `migrate` emits their HTML — no rollout restart.
 
 ## Scripts
 
-- `scripts/inventory.mjs` — migrated tree → page + template coverage (idempotent;
-  stale-aware). `--state <path>` enables archetypes-only mode: supplements the
-  migrated tree with the full page roster from `state.json`, seeding non-migrated
-  pages as `content-pending` with template and blocks inferred from the archetype.
+- `scripts/inventory.mjs` — migrated tree → page + template coverage (idempotent,
+  stale-aware). `--state <path>` enables archetypes-only mode.
 - `scripts/blocks.mjs` — distinct-block dedup ledger (`blocks.json`).
 - `scripts/plan.mjs` — dedup-driven delivery order + per-page convert/reuse briefs.
-- `scripts/update-coverage.mjs` — deterministic delivery state-writer for pages
-  (`<slug> --status …`) and blocks (`--block <id> --status …`); re-derives all
-  roll-ups.
-- `scripts/section-fidelity.mjs` — Phase C source-fidelity gate scaffold: lays a
-  page's authored sections (pre-flagging known invented-filler shapes) against the
-  source page's heading outline, so the agent can remove sections the source lacks
-  before flipping to `deployed`. Informs the gate; never auto-decides (exit 0).
+- `scripts/update-coverage.mjs` — deterministic delivery state-writer for pages and
+  blocks; re-derives all roll-ups.
+- `scripts/section-fidelity.mjs` — source-fidelity gate scaffold (authored sections
+  vs source heading outline; informs the gate, never auto-decides).
 - `scripts/assemble.mjs` — site-level sitemap / robots / fragments manifest.
 - `scripts/verify.mjs` — full-site structural verification (HTTP or offline `--root`).
-- `scripts/optimize.mjs` — `rollout:baseline` detectors + the multi-source gate:
-  scorecard, fixability routing, detect → fix → verify loop; exits non-zero on open P1.
-- `scripts/findings.mjs` — record/resolve findings from the external audit sources
-  into the shared ledger.
-- `scripts/autofix-aem.mjs` — the AEM autofix engine (edits the EDS project, logs
-  to `finding.autofix`, stages findings for re-deploy).
-- `scripts/dashboard.mjs` — design-identity dashboard: lifecycle-coloured page
-  tree + templates + scorecard, `data.json` snapshot (reads `state.json` for the
-  agnostic stages).
+- `scripts/optimize.mjs` — `rollout:baseline` detectors + the multi-source gate;
+  exits non-zero on open P1.
+- `scripts/findings.mjs` — record/resolve findings from the external audit sources.
+- `scripts/autofix-aem.mjs` — the AEM autofix engine (edits the EDS project).
+- `scripts/dashboard.mjs` — design-identity dashboard + `data.json` snapshot.
 - `scripts/lib.mjs` — shared IO + roll-up + page-loading + autofix-registry helpers.
 
 ## References
 
 - `notes/rollout/PLAN.md` — design, coverage model, phasing, open questions.
+- `reference/delivery-gates.md` — Phase C gates + batched-delivery-at-scale flow.
+- `reference/dynamic-listings.md` — metadata contract + query-index mechanics (B2/D2).
+- `reference/multilingual.md` — per-language trees (D3).
+- `reference/operational-learnings.md` — scaled-rollout gotchas (extend, republish, verify).
 - `reference/audit-sources.md` — the audit-source → layer → fixability → autofix map.
 - `reference/checks.md` — the `rollout:baseline` check catalog.
 - `skills/deploy/SKILL.md` — the single-page conversion methodology rollout drives.

--- a/plugins/stardust/skills/rollout/SKILL.md
+++ b/plugins/stardust/skills/rollout/SKILL.md
@@ -242,6 +242,19 @@ Walk `plan.json.steps` in order (representative pages first). For each page:
    change to `stardust/redirects.tsv` (`source<TAB>destination`); wiring those into
    the EDS redirects config is a Phase D/assembly step.
 
+4b. **Source-content hygiene — a sitemap roster contains dead and bodyless URLs.**
+   At 1000-page scale the roster comes from the source sitemap, which includes
+   URLs that **404 on the source** (stale entries) and pages with **no HTML body**
+   (PDF-only magazine/publication entries — a title plus a PDF download, nothing
+   else to migrate). Two rules, both proven on the Hirslanden 1k run:
+   - **Verify the source returns 200 before authoring.** A dead source URL is not a
+     page to fabricate — leave it un-authored and let it show as the lone gap in the
+     dashboard (e.g. 814/815). Never invent a body to fill the slot.
+   - **Bodyless/PDF-only source → author metadata + hero + the real download link,
+     then STOP.** Don't pad with invented prose to make it "look complete"; the
+     faithful page is a thin one, and that is correct. (Same root rule as the
+     source-fidelity gate: reproduce the source, never out-author it.)
+
 5. **Record outcomes** with the state-writer (never hand-edit the ledger):
 
    ```bash
@@ -378,6 +391,22 @@ For every delivered page, `verify` confirms it's reachable (HTTP 200), has no
 `about:error` (broken-image ingestion, deploy #75), and that every internal
 `href="/…"` resolves to a known delivered path — then flips each page to
 `verified` or `failed` with the reason. It exits non-zero if any page failed.
+
+**Two checks a roster-driven batch misses — run them explicitly (Hirslanden 1k):**
+- **Nav/footer targets + section landing pages are NOT archetype siblings.** A
+  roster built from detail-page sitemaps skips them, so they get committed but never
+  deployed/published — and every header/footer link to them 404s while the batch
+  dashboard still reads 100%. Enumerate the header/footer/nav fragment hrefs (and
+  each section's index/landing page) and confirm each target is in the
+  deploy+publish+verify set, not just the archetype detail pages. (Static header/
+  footer fragments are served from the CODE branch — a fix there is a git push, not
+  a DA write.)
+- **Absolute source-site "bounce" links.** Beyond root-relative `href="/…"` that
+  404, flag `href="https://<source-host>/…"` links whose path HAS a delivered local
+  equivalent — those silently bounce the visitor back to the OLD site (not a 404, so
+  plain link-resolution misses them). Rewrite to the local path. Keep an absolute
+  source link only when no local page exists (e.g. an un-migrated language tree);
+  localizing it would just trade a bounce for a 404.
 
 ### Phase F — Optimize: multi-source audit + gate (delivery quality)
 

--- a/plugins/stardust/skills/rollout/SKILL.md
+++ b/plugins/stardust/skills/rollout/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rollout
-description: Deliver a WHOLE redesigned site to AEM Edge Delivery Services. The full-site sibling of `deploy` (which converts one page). Inventories the platform-agnostic migrated tree (stardust/migrated/ + _meta.json sidecars) into a delivery coverage ledger, then delivers each page by invoking the `deploy` methodology, tracking what is done and what is missing across the whole site. Use when the user has a migrated stardust site and wants to push the entire site to AEM, not just one page. Supports archetypes-only mode: if only the template archetype pages have been migrated, rollout can deploy all block code immediately and register the remaining pages as content-pending for later population.
+description: Deliver a WHOLE redesigned site to AEM Edge Delivery Services. The full-site sibling of `deploy` (which converts one page). Inventories the platform-agnostic migrated tree (stardust/migrated/ + _meta.json sidecars) into a delivery coverage ledger, then delivers each page by invoking the `deploy` methodology, tracking what is done and what is missing across the whole site. Use when the user has a migrated stardust site and wants to push the entire site to AEM, not just one page. Supports archetypes-only mode — if only the template archetype pages have been migrated, rollout can deploy all block code immediately and register the remaining pages as content-pending for later population.
 license: Apache-2.0
 ---
 

--- a/plugins/stardust/skills/rollout/SKILL.md
+++ b/plugins/stardust/skills/rollout/SKILL.md
@@ -126,7 +126,36 @@ node skills/rollout/scripts/plan.mjs     # → plan.json + a readable conversion
   **without changing deploy**. `content-pending` pages are always assigned
   `convert: []` / `reuse: [all template blocks]` — they never introduce new blocks.
 
+### Phase B2 — Dynamic-blocks map + metadata contract (PRE-IMPORT GATE)
+
+**Do this before Phase C — the import is blocked on it.** What a dynamic listing
+block can show is bounded by what each page emits, and an index row can carry only
+page-intrinsic DOM **or** authored metadata (see Phase D2 for the full mechanics).
+So the metadata a block will need must be decided **before** the batch import —
+emitting it per page at write time is one extra field; retrofitting it across
+thousands of already-imported, already-published pages is a second migration.
+
+Produce two artifacts now:
+
+1. **`dynamic-blocks-map.md`** — classify every listing-candidate block: dynamic
+   (index-driven) vs static (editorial curation), and for each dynamic one, the
+   index it reads and the fields its cards need.
+2. **The metadata contract** — the concrete `<meta name="…">` fields each content
+   TYPE must carry for its dynamic blocks to work (e.g. clinic →
+   `canton`/`city`/`address`/`phone`; news → `publishdate`/`category`; event →
+   `eventdate`/`clinic`/`location`). Fields already intrinsic to the DOM (title,
+   image, authored cross-links) need NO metadata — only what the DOM lacks.
+
+**Then make Phase C's `deploy` brief emit the contract**: each authoring agent adds
+the type's metadata rows to every page's metadata block as it writes it. Author
+`helix-query.yaml` (Phase D2) from the same contract so selectors and emitted names
+line up. A block whose contract can't be met from the source (a relationship like
+center↔disease) stays static — record that in the map, don't fake it.
+
 ### Phase C — Deliver the site (drive `deploy` per page, per the plan)
+
+**Blocked on Phase B2** — author each page's metadata contract (above) into its
+metadata block during delivery, so the indexes are rich at import time.
 
 Walk `plan.json.steps` in order (representative pages first). For each page:
 
@@ -273,8 +302,10 @@ preview-serve, but clean them up if you want the DA tree to match the live tree.
 Most sites have blocks that LIST other pages (doctor directories, news/event
 feeds, clinic grids, "related" rails). Statically authoring those cards doesn't
 scale and goes stale — they should read an EDS **query-index** (a published JSON
-of pages with per-page properties). **Plan this BEFORE importing 1000s of pages**,
-because what the blocks can list is bounded by what the migration emits.
+of pages with per-page properties). The map + metadata contract are decided in the
+**Phase B2 pre-import gate**; this phase covers the mechanics of building the index
+and wiring the blocks. What the blocks can list is bounded by what the import
+emitted — which is why B2 comes first.
 
 **A query-index row can carry only:**
 1. **Page-intrinsic DOM** — `h1`, `og:image`, and links the content already

--- a/plugins/stardust/skills/rollout/SKILL.md
+++ b/plugins/stardust/skills/rollout/SKILL.md
@@ -268,6 +268,50 @@ migration must preserve link/SEO continuity. (DA also holds orphan content at th
 pre-normalization paths from the accepted `PUT`s; harmless since they never
 preview-serve, but clean them up if you want the DA tree to match the live tree.)
 
+### Phase D2 — Dynamic listings (query-index)
+
+Most sites have blocks that LIST other pages (doctor directories, news/event
+feeds, clinic grids, "related" rails). Statically authoring those cards doesn't
+scale and goes stale — they should read an EDS **query-index** (a published JSON
+of pages with per-page properties). **Plan this BEFORE importing 1000s of pages**,
+because what the blocks can list is bounded by what the migration emits.
+
+**A query-index row can carry only:**
+1. **Page-intrinsic DOM** — `h1`, `og:image`, and links the content already
+   authored. Extract via CSS selectors in `helix-query.yaml`
+   (e.g. a doctor's specialty/clinic from `a[href*="/fachgebiete/"]` /
+   `a[href*="/home"]`). **Zero content change.** Author meaningful internal links
+   in content and they become free index facets.
+2. **Page metadata** — anything NOT in the DOM (article/event date, clinic
+   canton/address/phone) must be emitted as `<meta name="…">` via each page's
+   metadata block. → **Define a metadata contract per content type up front and
+   have Phase C emit it.** Retrofitting metadata across thousands of live pages
+   later is the expensive path.
+3. **NOT relationships.** A flat index can't express many-to-many
+   (centers↔disease, clinic↔specialty). Those need an explicit join field
+   (`treats:`/`topics:` slug list) in metadata on one side — and the related items
+   must themselves BE indexed pages (a block whose cards link only to `tel:` has
+   nothing to fetch). Without that, keep the block static; don't fake it.
+
+**The publish gotcha (cost a debugging cycle):** the query-index builds against the
+**PUBLISHED (live)** tree, not preview. A preview-only rollout has an EMPTY index —
+`query-index.json` 404s and `POST /index/…` returns `"requested path returned a 301
+or 404"` per index (that message == "page not published," not "bad selector").
+**Publish pages (`POST /live/…`) before expecting index rows.** Indexing is async:
+bulk-publish, then poll the index `total` until it settles.
+
+**Also localize internal links.** Migrated content often keeps absolute
+source-site URLs (`https://www.source.com/…`); the index then captures those as
+paths and on-site nav breaks. Rewrite internal links to delivered local paths
+(a Phase C / deploy concern) so index `*Path` fields are usable as links.
+
+Deliverables: `helix-query.yaml` (scoped indexes: include globs + `target`), the
+listing blocks rewritten to `fetch` their index (chunked for scale, with filter/
+sort/paginate + an authored fallback), and a `dynamic-blocks-map.md` recording
+which blocks are dynamic, which stay static (editorial curation), and the metadata
+contract. Validate one flagship end-to-end (e.g. a doctor directory + search with a
+`?q=` hand-off) before converting the rest.
+
 ### Phase E — Full-site verify
 
 ```bash

--- a/plugins/stardust/skills/rollout/SKILL.md
+++ b/plugins/stardust/skills/rollout/SKILL.md
@@ -286,6 +286,14 @@ can't corrupt state, and so the gates above run uniformly:
   its rendered `.plain.html` passes (HTTP 200, 0 `about:error`, `<h1>` present).
   The verify pass is where the image- and path-fidelity defects above actually
   surface at scale — 4-page samples won't show them; a 130-page batch will.
+- **Admin 200 ≠ delivered — verify the rendered URL, not the POST codes.** Some
+  path-safety defects pass `PUT`+preview+live ALL `200` yet 404 at the delivery
+  URL. The proven case: an **uppercase segment** (`.../CAR-T-Zellen`) — the admin
+  API accepts and "publishes" it, but `*.aem.live/.../CAR-T-Zellen` 404s (delivery
+  is lower-cased). So the `PUT=201 PRE=4xx` heuristic below MISSES it. Gate 4's
+  "lowercase the whole path" prevents it at author time; the GET-`.plain.html`
+  verify is the only thing that catches it after the fact. Fix = rename to the
+  lowercase path, redeploy, `DELETE` the stale uppercase DA source, add a redirect.
 - **Long batches run in the background** (a 130-page `PUT`+preview loop far
   exceeds a 2-min foreground budget); log per-page OK/FAIL and re-drive only the
   FAILs. Transient `PUT=000` → retry; `PUT=201 PRE=4xx/400` → a path-safety case

--- a/plugins/stardust/skills/rollout/reference/audit-sources.md
+++ b/plugins/stardust/skills/rollout/reference/audit-sources.md
@@ -1,0 +1,90 @@
+# optimize audit sources → ledger → AEM autofix
+
+optimize does not invent its own audit. It **aggregates existing audit skills**
+into one findings ledger, then **autofixes** the platform-fixable findings for
+AEM. This file is the mapping: each source, how to run it, how its findings
+normalize into the ledger (layer + fixability), and which AEM fixer (if any)
+resolves them.
+
+All sources share one ledger (`optimize/findings.json`), one id space
+(`f-<hash(source|layer|check|scope)>`), one scorecard, one gate, and one loop.
+A run of a source only resolves **its own** findings — never another source's.
+
+## The sources
+
+| source | how rollout uses it | produces (layers) |
+|---|---|---|
+| `rollout:baseline` | built-in deterministic detectors (`optimize.mjs`) — runs automatically | accessibility, seo, ai-search, cross-page |
+| `impeccable:critique` | `$impeccable critique <delivered-or-migrated>` → record findings | design-ux, brand-tensions |
+| `impeccable:audit` | `$impeccable audit <…>` (a11y / perf / responsive) → record | accessibility, seo (CWV) |
+| `marketing:seo-audit` | run the `seo-audit` skill → record its issue/impact/evidence/fix items | seo, cross-page |
+| `marketing:schema` | run the `schema` skill → record missing/!invalid structured data; payload feeds the JSON-LD autofix | ai-search, seo |
+| `marketing:ai-seo` | run the `ai-seo` skill → record AI-search readiness gaps (llms.txt, citability) | ai-search |
+| `marketing:site-architecture` | run the `site-architecture` skill → record crawl/structure issues | seo, cross-page |
+| `stardust:tensions` | read the `T-*` tensions from `stardust/current/brand-review.html` → record | brand-tensions, design-ux, accessibility |
+
+These are **referenced, not vendored** (the user's decision). impeccable is
+already a stardust dependency; the marketing skills come from
+`coreyhaines31/marketingskills`. If a source isn't installed, skip it and note
+the gap — the baseline source always runs.
+
+## Recording an external finding
+
+The agent runs a source, then normalizes each of its findings:
+
+```bash
+node skills/rollout/scripts/findings.mjs record \
+  --source <source> --layer <layer> --check <check-id> \
+  --severity P1|P2|P3 --fixability platform-migration|design-pass|out-of-scope \
+  --scope-level page|site --scope-ids <slug[,slug]> \
+  --evidence "what was observed" --recommend "the fix"
+```
+
+Normalization rules of thumb:
+- **Severity:** the source's "critical / high" → P1, "medium" → P2, "low" → P3.
+- **Fixability:** can the **EDS delivery** fix it (head/metadata/blocks/CWV) →
+  `platform-migration`; is it authored content/design → `design-pass`; infra/external
+  → `out-of-scope`.
+- **check id:** reuse a stable, descriptive slug; if it matches a row in the AEM
+  fixer table below, autofix will pick it up automatically.
+
+## Fixability → who fixes it
+
+- **platform-migration** → the AEM autofix engine and/or a re-`deploy` resolve it.
+- **design-pass** → upstream (`migrate` / `prototype`); rollout **surfaces only**.
+- **out-of-scope** → informational; never gates beyond its severity.
+
+## AEM autofix registry (`autofix-aem.mjs`)
+
+`check` → fixer. `kind`: deterministic (mechanical) · content-draft (generates
+copy, applied under the aggressive policy, logged for review) · manual (prepares
+guidance/payload, a human applies).
+
+| check | fixer (strategy) | kind | what it does |
+|---|---|---|---|
+| `single-h1` | `eds-fix-h1` | deterministic | promote first heading / demote extras so exactly one `<h1>` |
+| `sitemap` | `rollout-assemble` | deterministic | (re)generate `sitemap.xml` via `assemble.mjs` |
+| `title-missing` / `title-length` | `eds-metadata-title` | content-draft | set the `metadata` Title (draft from `<h1>`) |
+| `meta-description` | `eds-metadata-description` | content-draft | set the `metadata` Description (draft from first paragraph) |
+| `img-alt` | `eds-alt-draft` | content-draft | add `alt` drafted from the image filename |
+| `duplicate-title` | `eds-disambiguate-title` | content-draft | append a path-derived qualifier to the Title |
+| `jsonld` | `eds-jsonld` | manual | place JSON-LD via head.html/metadata (payload from `marketing:schema`) |
+| `canonical` | `eds-canonical` | manual | self-canonical is a head.html / project-config change |
+| `landmark-main` | `eds-landmark-main` | manual | ensure block output lands inside `<main>` (structural; fix in the block) |
+
+A finding whose `check` isn't in this table gets `autofix.available = false`
+(surface only). New fixers are added by extending `AEM_AUTOFIX` in `lib.mjs` and
+adding the fixer body in `autofix-aem.mjs` — no schema change.
+
+## The loop
+
+```
+  run sources → record into ledger → optimize gate (open P1?)
+        ▲                                   │ open P1
+        │                                   ▼
+   re-verify ◄── re-deploy ◄── autofix-aem (edits EDS project, stages in-progress)
+```
+
+autofix stages applied findings `in-progress`; a re-`deploy` + re-`optimize`
+(or re-record for external sources) confirms the fix and flips them to `fixed`.
+The gate is clean when no open P1 remains from any source.

--- a/plugins/stardust/skills/rollout/reference/checks.md
+++ b/plugins/stardust/skills/rollout/reference/checks.md
@@ -1,0 +1,63 @@
+# optimize check catalog — `rollout:baseline` source
+
+These are the deterministic detectors of the **`rollout:baseline`** source that
+`optimize.mjs` runs over the delivered (or migrated) HTML. Baseline is **one of
+several audit sources** — the others (impeccable, the marketing SEO skills,
+stardust tensions) feed the same ledger via `findings.mjs record`; see
+`audit-sources.md`. Findings reference a check by `layer` + `check`; this catalog
+can grow without a schema change. Severity drives the gate (any open **P1** fails
+it); fixability routes the fix; a registered `check` is auto-fixed by `autofix-aem`.
+
+`fixability`: **PM** = platform-migration (rollout re-deploys to fix) · **DP** =
+design-pass (upstream — fix in migrate/prototype; rollout only surfaces) · **OOS**
+= out-of-scope (informational).
+
+## accessibility
+
+| check | sev | fix | fires when | recommended move |
+|---|---|---|---|---|
+| `landmark-main` | P1 | PM | no `<main>` in the delivered HTML | ensure block output lands inside `<main>` (deploy anti-pattern 17) |
+| `img-alt` | P2 | DP | one or more `<img>` without `alt=` | author alt text upstream; rollout can't synthesize it |
+
+## seo
+
+| check | sev | fix | fires when | recommended move |
+|---|---|---|---|---|
+| `title-missing` | P1 | PM | no `<title>` | add a metadata block; EDS derives `<title>` (deploy #34) |
+| `title-length` | P3 | PM | `<title>` < 10 or > 70 chars | ~50–60 chars: brand + primary keyword |
+| `meta-description` | P2 | PM | no `<meta name="description">` | add a Description row to the metadata block |
+| `single-h1` | P1 | PM | `<h1>` count ≠ 1 | hero headline = single `<h1>`; others `<h2>` (deploy #35) |
+| `canonical` | P2 | PM | no `<link rel="canonical">` | emit a self-canonical link at delivery |
+| `sitemap` (site) | P2 | PM | `rollout/site/sitemap.xml` absent | run `assemble.mjs` and deploy the sitemap |
+
+## ai-search
+
+| check | sev | fix | fires when | recommended move |
+|---|---|---|---|---|
+| `jsonld` | P2 | PM | no `application/ld+json` | emit page-type JSON-LD in the head |
+
+## cross-page (site-level)
+
+| check | sev | fix | fires when | recommended move |
+|---|---|---|---|---|
+| `duplicate-title` | P2 | DP | ≥2 pages share a `<title>` | unique titles upstream (migrate metadata) |
+| `duplicate-description` | P3 | DP | ≥2 pages share a description | per-page descriptions upstream |
+
+## Layers baseline does not assess
+
+`brand-tensions`, `design-ux`, and `content-conversion` need judgment, not
+deterministic parsing, so the **baseline** source leaves them unscored (`null`).
+They are populated by the **other sources** — `impeccable:critique` (design-ux,
+brand-tensions), `stardust:tensions` (brand-tensions, design-ux), and the
+marketing skills (content-conversion via `cro`/`copywriting` if run) — recorded
+through `findings.mjs`. Once a source records into a layer, the scorecard scores
+it; until then it shows not-assessed rather than faking a number.
+
+## Scope & loop semantics
+
+- A page-level finding is `id`-keyed by `layer|check|page-slug`; site-level by
+  `layer|check|*` (or the involved slug set). Re-runs match by id — no duplicates.
+- A finding is only resolved (→ `fixed`) when **this run actually inspected its
+  scope** (the page was loaded, or site checks ran). A `--slug` run never marks
+  another page's findings fixed.
+- `accepted` / `wontfix` are human decisions and are never auto-reopened.

--- a/plugins/stardust/skills/rollout/reference/coverage-model.md
+++ b/plugins/stardust/skills/rollout/reference/coverage-model.md
@@ -23,17 +23,24 @@ The contract the two scripts maintain. Design rationale is in
 ## Page delivery status lifecycle
 
 ```
-            ┌──────────────── (migrated HTML changed after delivery) ──────────────┐
-            ▼                                                                       │
-  pending ──► converting ──► deployed ──► verified ──────────────────────────► stale
-     ▲            │                                                                 │
-     └─ inventory │                                                                 │
-        seeds new └──► failed ──(retry)──► converting …                             │
-                                                                                    │
-                  stale/failed pages are re-picked by the next Phase B pass ◄───────┘
+                                     ┌──── migrate emits page ────────────────────────┐
+                                     ▼                                                 │
+  content-pending ──► pending ──► converting ──► deployed ──► verified ──────────► stale
+        ▲                ▲            │                                                │
+        │                └─ inventory │                                                │
+        │                   seeds new └──► failed ──(retry)──► converting …           │
+        │                                                                              │
+        └─ inventory seeds (archetypes-only mode, no migrated HTML yet)               │
+                         stale/failed pages are re-picked by the next Phase B pass ◄──┘
 ```
 
-- **pending** — inventoried, not yet delivered. New pages start here.
+- **content-pending** — inventoried from `state.json` in archetypes-only mode;
+  no migrated HTML exists yet. Block code is live (deployed via the archetype);
+  the document push is deferred to the content track. Advances automatically to
+  `pending` when `migrate` emits the page's HTML and `inventory` is re-run. Not
+  a failure — these pages are tracked, not lost.
+- **pending** — inventoried with migrated HTML, not yet delivered. New pages start
+  here (full mode) or transition here from `content-pending`.
 - **converting** — `deploy` is mid-flight on this page.
 - **deployed** — pushed to the branch preview; not yet verified.
 - **verified** — renders live (200, blocks decorate, no `about:error`).
@@ -44,14 +51,19 @@ The contract the two scripts maintain. Design rationale is in
 ## Idempotency rules (inventory)
 
 On every `inventory.mjs` run:
-- A page's `sourceHash` is recomputed from its migrated HTML bytes.
+- A page's `sourceHash` is recomputed from its migrated HTML bytes (migrated
+  pages) or from `state.json[].currentStatePath` content (content-pending pages).
 - If a page already exists in `pages.json`:
   - hash **unchanged** → its `delivery` is preserved verbatim.
   - hash **changed** and prior status ∈ {`deployed`,`verified`} → status becomes
     `stale` (delivered URL retained); otherwise the prior status is kept.
-- A page **not** in prior coverage → seeded `pending`.
+  - prior status was `content-pending` and migrated HTML now exists → status
+    advances to `pending` and `sourceHash` is recomputed from the HTML bytes.
+- A page **not** in prior coverage → seeded `content-pending` (if sourced from
+  `state.json` only) or `pending` (if migrated HTML is present).
 - Pages are keyed by `slug` (from the `_meta.json` sidecar, else derived from the
-  delivered path). The `assets/` bundle is never inventoried.
+  delivered path, else from `state.json[].slug`). The `assets/` bundle is never
+  inventoried.
 
 ## Block delivery status lifecycle
 

--- a/plugins/stardust/skills/rollout/reference/coverage-model.md
+++ b/plugins/stardust/skills/rollout/reference/coverage-model.md
@@ -1,0 +1,113 @@
+# rollout coverage model (operational reference)
+
+The contract the two scripts maintain. Design rationale is in
+`notes/rollout/PLAN.md`; this doc is the runtime behaviour.
+
+## Files (all under `stardust/rollout/`)
+
+| File | Writer | Contract |
+|---|---|---|
+| `rollout.json` | inventory + blocks + update-coverage + verify | target + DA config + `lastRun` counts |
+| `coverage/pages.json` | inventory (rows) + update-coverage/verify (delivery) | one row per migrated page |
+| `coverage/templates.json` | inventory + roll-up writers | pages grouped by `templateId` + roll-ups |
+| `coverage/blocks.json` | blocks (rows) + update-coverage (delivery) | one row per **distinct** block (dedup unit) |
+| `plan.json` | plan | dedup-driven delivery order + per-page convert/reuse |
+| `optimize/findings.json` | optimize + findings + autofix | multi-source quality findings (detect→fix→verify) |
+| `optimize/scorecard.json` | optimize + findings + autofix | per-layer health + overall + history |
+| `site/{sitemap.xml,robots.txt,manifest.json}` | assemble | site-level artifacts |
+| `dashboard/{index.html,data.json}` | dashboard | self-contained progress view + snapshot |
+
+`rollout` writes nothing outside this directory. `stardust/migrated/`,
+`state.json`, and the rest of the agnostic core are read-only inputs.
+
+## Page delivery status lifecycle
+
+```
+            ┌──────────────── (migrated HTML changed after delivery) ──────────────┐
+            ▼                                                                       │
+  pending ──► converting ──► deployed ──► verified ──────────────────────────► stale
+     ▲            │                                                                 │
+     └─ inventory │                                                                 │
+        seeds new └──► failed ──(retry)──► converting …                             │
+                                                                                    │
+                  stale/failed pages are re-picked by the next Phase B pass ◄───────┘
+```
+
+- **pending** — inventoried, not yet delivered. New pages start here.
+- **converting** — `deploy` is mid-flight on this page.
+- **deployed** — pushed to the branch preview; not yet verified.
+- **verified** — renders live (200, blocks decorate, no `about:error`).
+- **failed** — a delivery error; `error` carries the reason. Non-fatal to the run.
+- **stale** — was deployed/verified, but `migrate` re-emitted the page (its
+  `sourceHash` changed). Needs re-delivery.
+
+## Idempotency rules (inventory)
+
+On every `inventory.mjs` run:
+- A page's `sourceHash` is recomputed from its migrated HTML bytes.
+- If a page already exists in `pages.json`:
+  - hash **unchanged** → its `delivery` is preserved verbatim.
+  - hash **changed** and prior status ∈ {`deployed`,`verified`} → status becomes
+    `stale` (delivered URL retained); otherwise the prior status is kept.
+- A page **not** in prior coverage → seeded `pending`.
+- Pages are keyed by `slug` (from the `_meta.json` sidecar, else derived from the
+  delivered path). The `assets/` bundle is never inventoried.
+
+## Block delivery status lifecycle
+
+```
+  pending ──► converted ──► deployed ──► verified
+     ▲            (the distinct block is converted ONCE, on its
+     └─ blocks.mjs  conversion point in plan.json; siblings reuse it)
+```
+
+- **pending** — inventoried as a distinct block, not yet converted.
+- **converted** — its EDS block (`blocks/<edsBlockName>/`) or fragment exists.
+- **deployed / verified** — live on the delivered site.
+
+`blocks.mjs` is idempotent: a block already past `pending` keeps its status and
+`edsBlockName`; only still-`pending` blocks get a freshly derived name.
+
+## Dedup contract (plan.json)
+
+`plan.mjs` guarantees each distinct **module** block is converted on exactly one
+page (the first in delivery order that uses it). Per page it emits:
+- `convert[]` — blocks introduced here → `deploy` creates them;
+- `reuse[]` — blocks already converted → `deploy`'s Step-7 brief reuses them by
+  `edsBlockName`, never recreating.
+
+Chrome (`header`/`nav`/`footer`) is not per-page; it's listed once under
+`plan.json.fragments` and delivered as static fragments.
+
+## Verify
+
+`verify.mjs` flips delivered pages to `verified` or `failed` based on: reachable
+(HTTP 200 / file present), no `about:error` in the body, and every internal
+`href="/…"` resolving to a known delivered path. Offline `--root <dir>` mode maps
+each delivered path back to a file for testing against a local export.
+
+## Optimize gate (findings lifecycle)
+
+```
+  open ──(no longer detected, in scope)──► fixed ──(regression)──► open
+   │                                                                ▲
+   ├──(human)──► accepted / wontfix  (never auto-reopened)          │
+   └────────────────────── still detected ─────────────────────────┘
+```
+
+`optimize.mjs` is the delivery-quality gate. It writes `optimize/findings.json`
+(append-only `runs[]` + status-tracked `findings[]`) and `optimize/scorecard.json`
+(per-layer 0–100, `null` for unassessed judgment layers, + `history[]`). The gate
+exits non-zero while any **open P1** is in scope; fixability routes the fix
+(platform-migration → rollout re-deploys; design-pass → upstream; out-of-scope →
+informational). See `checks.md` for the catalog.
+
+## Roll-ups
+
+`update-coverage.mjs`, `inventory.mjs`, `blocks.mjs`, and `verify.mjs` all
+re-derive, from the per-unit rows:
+- each template's `{ verified, deployed, pending }` in `templates.json`;
+- the site-wide `lastRun.pages` + `lastRun.blocks` counts in `rollout.json`.
+
+So the counts never drift from the per-unit truth — they are always recomputed,
+never incremented.

--- a/plugins/stardust/skills/rollout/reference/delivery-gates.md
+++ b/plugins/stardust/skills/rollout/reference/delivery-gates.md
@@ -1,0 +1,119 @@
+# Delivery gates + batched delivery (Phase C)
+
+The per-page checks Phase C runs before flipping a page to `deployed`, and the
+batched-delivery flow that runs them uniformly at scale. SKILL.md Phase C names
+each gate in one line; the mechanics live here.
+
+## Gate 1 — Source-fidelity ("don't add sections the source doesn't have")
+
+A migration reproduces the source; it must not invent sections. Invented
+sections render as empty placeholders or, worse, get back-filled with fabricated
+facts. This recurs as trailing **cross-link rails** (`related-*`, `*-teasers`),
+**specialist/teaser grids**, and generic **trailing CTAs** appended to leaf pages
+regardless of source.
+
+```bash
+node skills/rollout/scripts/section-fidelity.mjs \
+  --file <content.html> --source <sourceUrl>   # authored vs source, side-by-side
+```
+
+The helper is a scaffold, not a judge: it lists authored block sections
+(pre-flagging known filler shapes as `⟵ REVIEW`) against the source heading
+outline. For each authored section decide:
+- **HARD-FAIL → remove before `deployed`:** the section carries FABRICATED facts
+  (invented names, made-up events/dates, boilerplate not on the source).
+  Fabricated content on a real site is the worst migration defect.
+- **Soft call:** an invented rail whose links all point to REAL pages — prefer
+  remove; keep only as a plain text link-row if cross-linking is explicitly
+  wanted, never as an image-card grid that needs assets to exist.
+- **Pass:** the section backs a real source region.
+
+Delete the section from the content file (and `git rm` the block if it becomes
+orphaned). Genuinely-missing *real* content is different: leave the block, render
+gracefully, log it as a content gap — do NOT invent filler.
+
+## Gate 2 — Image-fidelity (every `<img>` src must RESOLVE, or be omitted)
+
+The #1 recurring defect at scale: an authored external image URL the preview
+ingester can't fetch delivers as `<img src="about:error">` — a silent break that
+"it renders" hides. Before deploy, for each authored `<img>` whose src is an
+external/source URL, verify 200:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}' <url>
+```
+
+If it isn't 200, OMIT the image (the block renders without it) rather than ship
+`about:error`. Never author a logo/placeholder stand-in as if it were editorial.
+Two failure signatures where the asset exists behind a malformed URL — fix the
+URL, don't drop the image:
+- **Wrong rendition variant** — the source exposes only a derivative that 404s
+  (e.g. a portrait's `…/4x3/768/…` 404s; the `…/original/768/…` sibling
+  resolves). Rewrite to the resolving variant.
+- **Missing query delimiter** — a CDN URL built as `…/<id>&wid=600&hei=…` (no
+  `?`) makes the whole `<id>&wid=…` a bogus asset id → 403. Repair the first `&`
+  after the id to `?`.
+
+After preview, the authoritative check is `.plain.html`: 0 `about:error` and the
+expected `<img>`+alt count (CSS-background images are absent from it).
+
+## Gate 3 — Path-safety (source paths must be AEM-Edge-safe, or normalized + redirected)
+
+Real source URLs are not always valid EDS resource paths; DA accepts the `PUT`
+(201) but preview/serve then 404s/400s, so this is invisible until verify. Before
+deploy, normalize each path and, when it changes, record the original→normalized
+pair so the source URL can be redirected (a final migration must not 404 inbound
+links). Rules:
+- lowercase the whole path;
+- trim a trailing `-`/`_` in any segment;
+- collapse `_`→`-` and runs of `-`;
+- replace the `--` segment delimiter (e.g. `klinik-st--anna`) — AEM reserves `--`
+  as the `branch--repo--owner` host delimiter, so a `--` in a path 400s.
+
+Append each change to `stardust/redirects.tsv` (`source<TAB>destination`); wiring
+those into the EDS redirects config is a Phase D/assembly step.
+
+## Gate 4 — Source-content hygiene (a sitemap roster contains dead and bodyless URLs)
+
+At ~1000-page scale the roster comes from the source sitemap, which includes URLs
+that **404 on the source** (stale entries) and pages with **no HTML body**
+(PDF-only publication entries — a title plus a PDF download). Two rules:
+- **Verify the source returns 200 before authoring.** A dead source URL is not a
+  page to fabricate — leave it un-authored and let it show as the lone gap in the
+  dashboard (e.g. 814/815). Never invent a body to fill the slot.
+- **Bodyless/PDF-only source → author metadata + hero + the real download link,
+  then STOP.** Don't pad with invented prose; the faithful page is a thin one, and
+  that is correct. (Same root rule as Gate 1: reproduce the source, never
+  out-author it.)
+
+## Batched delivery at scale (clusters of 6–20+ siblings)
+
+Separate the concerns so an agent crash or token blowout can't corrupt state, and
+so the gates run uniformly:
+- **Author-only agents, central deploy.** Each cluster agent reads its work-list +
+  the cleaned archetype template and *only writes content files* — it does NOT
+  deploy. The orchestrator deploys centrally (one idempotent `PUT`+preview loop):
+  token stays in one place, retries are trivial, and a sub-agent dying mid-response
+  leaves its files already on disk.
+- **Validate structure BEFORE deploy.** Cheap deterministic check on every authored
+  file — exactly one `<h1>`, the body/`<main>`/`<footer>` wrapper, balanced
+  `<div>`s — catches a truncated/garbled file before it reaches DA.
+- **Verify-THEN-flip, never flip blind.** Only flip to `deployed` after the rendered
+  `.plain.html` passes (HTTP 200, 0 `about:error`, `<h1>` present). Verify is where
+  the image- and path-fidelity defects surface at scale — a 4-page sample won't show
+  them; a 130-page batch will.
+- **Admin 200 ≠ delivered — verify the rendered URL, not the POST codes.** Some
+  path-safety defects pass `PUT`+preview+live ALL 200 yet 404 at the delivery URL.
+  The proven case: an **uppercase segment** (`.../CAR-T-Zellen`) — the admin API
+  accepts and "publishes" it, but `*.aem.live/.../CAR-T-Zellen` 404s (delivery is
+  lower-cased). The `PUT=201 PRE=4xx` heuristic MISSES it; Gate 3's "lowercase the
+  whole path" prevents it at author time, and the GET-`.plain.html` verify is the
+  only thing that catches it after the fact. Fix = rename to the lowercase path,
+  redeploy, `DELETE` the stale uppercase DA source, add a redirect.
+- **Long batches run in the background** (a 130-page `PUT`+preview loop exceeds a
+  2-min foreground budget); log per-page OK/FAIL and re-drive only the FAILs.
+  Transient `PUT=000` → retry; `PUT=201 PRE=4xx/400` → a path-safety case (Gate 3);
+  `200 + about:error` → an image case (Gate 2).
+- **zsh gotcha:** `node`/`curl` inside a multi-line `while`/`for` can lose PATH
+  ("command not found") — write the loop to a `bash` script file with absolute
+  binaries and run it, rather than inlining.

--- a/plugins/stardust/skills/rollout/reference/dynamic-listings.md
+++ b/plugins/stardust/skills/rollout/reference/dynamic-listings.md
@@ -1,0 +1,77 @@
+# Dynamic listings: metadata contract + query-index (Phases B2, D2)
+
+Sites have blocks that LIST other pages (directories, news/event feeds, grids,
+"related" rails). Statically authoring those cards doesn't scale and goes stale —
+they should read an EDS **query-index** (a published JSON of pages with per-page
+properties). SKILL.md keeps the gate summary; the mechanics are here.
+
+## Why B2 is a PRE-IMPORT gate
+
+What a dynamic block can show is bounded by what each page emits, and an index row
+carries only page-intrinsic DOM **or** authored metadata. So the metadata a block
+needs must be decided **before** the batch import — emitting it per page at write
+time is one extra field; retrofitting it across thousands of already-imported,
+already-published pages is a second migration.
+
+Produce two artifacts before Phase C:
+1. **`dynamic-blocks-map.md`** — classify every listing-candidate block: dynamic
+   (index-driven) vs static (editorial curation), and for each dynamic one, the
+   index it reads and the fields its cards need.
+2. **The metadata contract** — the concrete `<meta name="…">` fields each content
+   TYPE must carry (e.g. a location type → `canton`/`city`/`address`/`phone`; news
+   → `publishdate`/`category`; event → `eventdate`/`location`). Fields already
+   intrinsic to the DOM (title, image, authored cross-links) need NO metadata —
+   only what the DOM lacks.
+
+Then make Phase C's `deploy` brief emit the contract: each authoring agent adds the
+type's metadata rows to every page as it writes it. Author `helix-query.yaml` from
+the same contract so selectors and emitted names line up. A block whose contract
+can't be met from the source (a relationship the source doesn't express) stays
+static — record that in the map, don't fake it.
+
+### Metadata key → meta-name mechanics
+
+A metadata-block row `<div><div>KEY</div><div>VALUE</div></div>` renders to
+`<meta name="<key lowercased>">`. Use single-token capitalized keys
+(`PublishDate`→`name="publishdate"`, `Canton`→`name="canton"`) and make
+`helix-query.yaml`'s `select: meta[name="publishdate"]` match. Emit dates as ISO
+`YYYY-MM-DD` (sortable).
+
+## What a query-index row can carry (D2)
+
+1. **Page-intrinsic DOM** — `h1`, `og:image`, and links the content already
+   authored. Extract via CSS selectors in `helix-query.yaml` (e.g. a record's
+   category from `a[href*="/category/"]`). **Zero content change.** Author
+   meaningful internal links and they become free index facets.
+2. **Page metadata** — anything NOT in the DOM (article/event date, address,
+   phone) must be emitted as `<meta name="…">` via the metadata block. Define the
+   contract per type up front (B2) and have Phase C emit it. Retrofitting metadata
+   across thousands of live pages later is the expensive path.
+3. **NOT relationships.** A flat index can't express many-to-many. Those need an
+   explicit join field (a `treats:`/`topics:` slug list) in metadata on one side —
+   and the related items must themselves BE indexed pages (a block whose cards link
+   only to `tel:` has nothing to fetch). Without that, keep the block static.
+
+## The publish gotcha (costs a debugging cycle if missed)
+
+The query-index builds against the **PUBLISHED (live)** tree, not preview. A
+preview-only rollout has an EMPTY index — `query-index.json` 404s and
+`POST /index/…` returns `"requested path returned a 301 or 404"` per index (that
+message means "page not published," not "bad selector"). **Publish pages
+(`POST /live/…`) before expecting index rows.** Indexing is async: bulk-publish,
+then poll the index `total` until it settles. Make `POST /live/…` a per-page step
+of the delivery loop, not a deferred batch, so indexes populate as pages land.
+
+## Localize internal links
+
+Migrated content often keeps absolute source-site URLs (`https://www.source.com/…`);
+the index then captures those as paths and on-site nav breaks. Rewrite internal
+links to delivered local paths (a Phase C / deploy concern) so index `*Path` fields
+are usable as links.
+
+## Deliverables
+
+`helix-query.yaml` (scoped indexes: include globs + `target`), the listing blocks
+rewritten to `fetch` their index (chunked for scale, with filter/sort/paginate + an
+authored fallback), and `dynamic-blocks-map.md`. Validate one flagship end-to-end
+(e.g. a directory + search with a `?q=` hand-off) before converting the rest.

--- a/plugins/stardust/skills/rollout/reference/multilingual.md
+++ b/plugins/stardust/skills/rollout/reference/multilingual.md
@@ -1,0 +1,41 @@
+# Multilingual (per-language trees) — Phase D3, optional
+
+When the source has language trees (`/fr/…`, `/en/…` beside `/de/…`), add them as
+**parallel content trees that REUSE the same block library** — block structure is
+language-agnostic; only authored content and a few wiring pieces change. Proven on
+a ~90-pages-per-language add (≥5 per template).
+
+- **Author by mirroring the default-language archetype per type, in the target
+  language.** A target-language page is the default page's block composition with
+  translated content at the localized path (e.g. `/fr/…/<slug>`). Dispatch author
+  agents grouped by template-type, each given the default-language reference file to
+  mirror — *no new blocks*.
+
+- **Language-route the static header/footer.** A single `loadStaticFragment`
+  (`postlcp.js`) serves one fragment for all pages; make it pick by path prefix and
+  fall back to the default:
+  ```js
+  const seg = window.location.pathname.split('/')[1];
+  const lang = (seg === 'fr' || seg === 'en') ? `${seg}/` : '';
+  let resp = await fetch(`${codeBase}/fragments/${lang}${name}.html`);
+  if (!resp.ok && lang) resp = await fetch(`${codeBase}/fragments/${name}.html`);
+  ```
+  Add `fragments/fr/{header,footer}.html` + `fragments/en/…`: translated labels,
+  links localized to *live* same-language pages (else a source bounce), and a
+  **language switcher that targets each language's home** — don't try to compute
+  per-page cross-language equivalents.
+
+- **Per-language indexes** in `helix-query.yaml`: clone each index with a
+  language-scoped `include` glob + a language-prefixed `target`, and **fix the
+  selectors that encode language** — a facet selector like
+  `a[href*="/specialites-medicales/"]` (FR) / `a[href*="/specialities/"]` (EN) is
+  not the default-language `a[href*="/fachgebiete/"]`. Same metadata contract per
+  type.
+
+- **Path-safety is per-language too.** The leading/trailing-`-`, `--`, `_`, and
+  uppercase normalization (delivery-gates Gate 3) applies to every language tree —
+  record slugs in particular recur with a leading hyphen across languages.
+
+- The per-language indexes are empty until the pages are published under the synced
+  config — same republish that propagates a `head.html` change (see
+  operational-learnings).

--- a/plugins/stardust/skills/rollout/reference/operational-learnings.md
+++ b/plugins/stardust/skills/rollout/reference/operational-learnings.md
@@ -1,0 +1,67 @@
+# Operational learnings (scaled rollouts, ~1k pages)
+
+Lessons from large, real full-site rollouts. SKILL.md points here from the phases
+they apply to; none change the per-phase contract, they just save a debugging cycle.
+
+## Extending a delivered site: a "new template" is usually a new COMPOSITION (Phase B)
+
+When you add page types *after* the first rollout, a "new template" is almost
+always a new composition of the existing block library, not new block code. Audit
+`blocks/` BEFORE writing any block — most "new templates" resolve to existing
+blocks recomposed, e.g.:
+- blog = `article-header` + `article-body` (the news blocks)
+- legal = `page-header` + `body-text`
+- specialty landing = `page-header` + `lead-text` + `centers`
+- center = `page-header` + `lead-text` + `body-text` + `contact-cta`
+
+These ship with **zero new block JS/CSS** — only new archetype content files
+composing existing blocks. Reach for a new block only when no composition of the
+library reproduces the section. This keeps the library small and makes extension an
+authoring task, not an engineering one.
+
+## Two verify checks a roster-driven batch misses (Phase E)
+
+A roster built from detail-page sitemaps omits these, so they get committed but
+never deployed/published — and every link to them 404s while the dashboard still
+reads 100%:
+- **Nav/footer targets + section landing pages are NOT archetype siblings.**
+  Enumerate the header/footer/nav fragment hrefs (and each section's index/landing
+  page) and confirm each target is in the deploy+publish+verify set, not just the
+  detail pages. (Static header/footer fragments are served from the CODE branch — a
+  fix there is a git push, not a DA write.)
+- **Absolute source-site "bounce" links.** Beyond root-relative `href="/…"` that
+  404, flag `href="https://<source-host>/…"` links whose path HAS a delivered local
+  equivalent — those silently bounce the visitor back to the OLD site (not a 404, so
+  plain link-resolution misses them). Rewrite to the local path. Keep an absolute
+  source link only when no local page exists (e.g. an un-migrated language tree).
+
+## Optimize-gate learnings (Phase F)
+
+- **A `head.html`-level fix needs a SITE-WIDE REPUBLISH to land, and to flip the
+  findings.** The dominant baseline finding at scale is `ai-search/jsonld` ("no
+  JSON-LD structured data") — one P2 *per page*. The cheap, legitimate fix is
+  sitewide structured data in `head.html` (e.g. an `Organization` + `WebSite`
+  `@graph`); the detector only checks for `application/ld+json` in the served
+  `<head>`. But editing `head.html` updates the file immediately while
+  **already-rendered pages stay CDN-cached with the old head** — `/head.html` shows
+  the new JSON-LD yet `/some/page` does not. You must **`POST /live/` every page** to
+  re-render it (verify on one page first: republish → GET → grep `ld+json`). On the
+  optimize re-run those findings flip `open → fixed` (e.g. 715/716 in one pass).
+  Per-page granular schema is a later enhancement, not needed to clear the gate.
+- **A full republish also re-triggers query-index builds.** New indexes in
+  `helix-query.yaml` sit at `total: building`/404 until in-scope pages are
+  re-published under the synced config — the same republish that propagates a
+  `head.html` change populates them. (Same root cause as the D2 publish gotcha.)
+- **optimize only audits what's in `coverage/pages.json`.** When EXTENDING a
+  delivered site (new templates, sub-trees, language trees), those pages aren't in
+  the coverage ledger, so Phase F silently skips them. Re-run `inventory.mjs` (add
+  the new pages to `state.json` first) before the gate, or audit them with explicit
+  `--slug`/a second `--base` pass — otherwise "gate passes" covers only the old set.
+- **Faithfully migrating PARALLEL source trees yields legitimate
+  `duplicate-title`/`duplicate-description` findings, not bugs.** When a source
+  serves the same content at two paths (e.g. a `/corporate/…` and an
+  `/international/…` tree), reproducing both faithfully trips the cross-page
+  uniqueness detector. The resolution is a **content-model / canonical decision**
+  (canonicalize one tree to the other, or differentiate titles), not a re-author —
+  surface it as such; don't silently rewrite source-faithful titles to dodge the
+  check.

--- a/plugins/stardust/skills/rollout/schemas/rollout-blocks.schema.json
+++ b/plugins/stardust/skills/rollout/schemas/rollout-blocks.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stardust.dev/schemas/rollout-blocks.schema.json",
+  "title": "stardust rollout/coverage/blocks.json",
+  "description": "The dedup unit. One row per DISTINCT block across the site (matched by a signature derived from canon / migrated sections). rollout converts each block to an EDS block once and reuses it across every page that composes it. Records the EDS mapping + delivery status. Owned by stardust:rollout; deploy is never modified.",
+  "type": "object",
+  "required": ["_provenance", "blocks"],
+  "additionalProperties": false,
+  "properties": {
+    "_provenance": { "$ref": "#/$defs/provenance" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "blocks": { "type": "array", "items": { "$ref": "#/$defs/block" } }
+  },
+  "$defs": {
+    "provenance": {
+      "type": "object",
+      "required": ["writtenBy", "writtenAt", "stardustVersion"],
+      "properties": {
+        "writtenBy": { "type": "string", "examples": ["stardust:rollout"] },
+        "writtenAt": { "type": "string", "format": "date-time" },
+        "readArtifacts": { "type": "array", "items": { "type": "string" } },
+        "stardustVersion": { "type": "string" }
+      }
+    },
+    "block": {
+      "type": "object",
+      "required": ["id", "signature", "delivery"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "label": { "type": "string" },
+        "kind": {
+          "type": "string",
+          "enum": ["chrome", "module", "section"],
+          "description": "chrome = header/nav/footer (delivered as fragments); module = brand module; section = reusable section archetype."
+        },
+        "signature": {
+          "type": "string",
+          "description": "Stable fingerprint used to match identical block instances across pages for dedup (derived from canon module id or the section's structural signature)."
+        },
+        "source": {
+          "type": ["string", "null"],
+          "description": "Canon definition path when the block is canonized, e.g. stardust/canon/modules/<id>.html."
+        },
+        "usedByTemplates": { "type": "array", "items": { "type": "string" } },
+        "usedByPages": { "type": "array", "items": { "type": "string" } },
+        "instanceCount": { "type": "integer", "minimum": 0, "description": "How many page instances deploy this block." },
+        "delivery": {
+          "type": "object",
+          "required": ["status"],
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": ["pending", "converted", "deployed", "verified", "failed"]
+            },
+            "edsBlockName": {
+              "type": ["string", "null"],
+              "description": "Canonical EDS block name this block was converted to (blocks/<name>/). The dedup target."
+            },
+            "blockPath": { "type": ["string", "null"], "description": "Delivered block path / fragment path." },
+            "convertedAt": { "type": ["string", "null"], "format": "date-time" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/stardust/skills/rollout/schemas/rollout-config.schema.json
+++ b/plugins/stardust/skills/rollout/schemas/rollout-config.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stardust.dev/schemas/rollout-config.schema.json",
+  "title": "stardust rollout/rollout.json",
+  "description": "Top-level config + run summary for a full-site rollout to AEM Edge Delivery Services. Owned by stardust:rollout. Keeps all platform/full-site state out of the agnostic core (state.json is never touched).",
+  "type": "object",
+  "required": ["_provenance", "target", "site"],
+  "additionalProperties": false,
+  "properties": {
+    "_provenance": { "$ref": "#/$defs/provenance" },
+    "target": {
+      "type": "string",
+      "const": "aem-eds",
+      "description": "Delivery target. Fixed to AEM Edge Delivery Services for this proposal."
+    },
+    "site": {
+      "type": "object",
+      "required": ["sourceUrl"],
+      "additionalProperties": false,
+      "properties": {
+        "sourceUrl": { "type": "string", "format": "uri", "description": "The original site being migrated." },
+        "da": {
+          "type": "object",
+          "description": "DA (da.live) destination coordinates for the DA Source API push.",
+          "additionalProperties": false,
+          "properties": {
+            "org": { "type": "string" },
+            "site": { "type": "string" },
+            "ref": { "type": "string", "default": "main" }
+          }
+        },
+        "liveHost": { "type": ["string", "null"], "description": "Resolved aem.live host, e.g. main--site--org.aem.live." }
+      }
+    },
+    "lastRun": {
+      "type": ["object", "null"],
+      "description": "Summary of the most recent rollout run (the dashboard headline reads this).",
+      "additionalProperties": false,
+      "properties": {
+        "at": { "type": "string", "format": "date-time" },
+        "pages": { "$ref": "#/$defs/counts" },
+        "blocks": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "total": { "type": "integer", "minimum": 0 },
+            "converted": { "type": "integer", "minimum": 0 },
+            "pending": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "verifyFailures": { "type": "integer", "minimum": 0 }
+      }
+    }
+  },
+  "$defs": {
+    "provenance": {
+      "type": "object",
+      "required": ["writtenBy", "writtenAt", "stardustVersion"],
+      "properties": {
+        "writtenBy": { "type": "string", "examples": ["stardust:rollout"] },
+        "writtenAt": { "type": "string", "format": "date-time" },
+        "stardustVersion": { "type": "string" }
+      }
+    },
+    "counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "total": { "type": "integer", "minimum": 0 },
+        "verified": { "type": "integer", "minimum": 0 },
+        "deployed": { "type": "integer", "minimum": 0 },
+        "pending": { "type": "integer", "minimum": 0 },
+        "stale": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/plugins/stardust/skills/rollout/schemas/rollout-findings.schema.json
+++ b/plugins/stardust/skills/rollout/schemas/rollout-findings.schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stardust.dev/schemas/rollout-findings.schema.json",
+  "title": "stardust rollout/optimize/findings.json",
+  "description": "The in-flow delivery-quality findings ledger. stardust:rollout/optimize runs deterministic detectors over the delivered (or migrated) HTML and records findings; the resolving phase flips status to fixed on re-run when the issue is no longer detected (the detect -> fix -> verify loop). Append-only runs[]; findings[] updated in place by status. Findings are keyed by a stable id derived from layer+check+scope, so re-runs match without duplicating.",
+  "type": "object",
+  "required": ["_provenance", "runs", "findings"],
+  "additionalProperties": false,
+  "properties": {
+    "_provenance": { "$ref": "#/$defs/provenance" },
+    "runs": { "type": "array", "items": { "$ref": "#/$defs/run" } },
+    "findings": { "type": "array", "items": { "$ref": "#/$defs/finding" } }
+  },
+  "$defs": {
+    "provenance": {
+      "type": "object",
+      "required": ["writtenBy", "writtenAt", "stardustVersion"],
+      "properties": {
+        "writtenBy": { "type": "string", "examples": ["stardust:rollout/optimize"] },
+        "writtenAt": { "type": "string", "format": "date-time" },
+        "stardustVersion": { "type": "string" }
+      }
+    },
+    "layer": {
+      "type": "string",
+      "enum": ["brand-tensions", "design-ux", "accessibility", "seo", "content-conversion", "ai-search", "cross-page"],
+      "description": "The 7 optimize layers. rollout's automated gate currently assesses accessibility, seo, ai-search, cross-page; the judgment layers are reserved for an LLM-driven enrichment pass."
+    },
+    "run": {
+      "type": "object",
+      "required": ["id", "at", "layersRun"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "at": { "type": "string", "format": "date-time" },
+        "scopePages": { "type": "array", "items": { "type": "string" }, "description": "Slugs this run covered (empty = whole site)." },
+        "layersRun": { "type": "array", "items": { "$ref": "#/$defs/layer" } },
+        "trigger": { "type": "string", "enum": ["deliver", "reverify", "manual"] },
+        "source": { "type": "string", "description": "What was inspected, e.g. a base URL or a local root." }
+      }
+    },
+    "finding": {
+      "type": "object",
+      "required": ["id", "source", "layer", "check", "severity", "scope", "fixability", "status"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "description": "Stable id = f-<hash(source|layer|check|scope)>; re-runs match by this." },
+        "source": {
+          "type": "string",
+          "description": "Which audit produced the finding. Known values: rollout:baseline (built-in deterministic detectors), impeccable:critique, impeccable:audit, marketing:seo-audit, marketing:schema, marketing:ai-seo, marketing:site-architecture, stardust:tensions. Extensible — new sources may be added without a schema change.",
+          "examples": ["rollout:baseline", "impeccable:audit", "marketing:seo-audit", "stardust:tensions"]
+        },
+        "layer": { "$ref": "#/$defs/layer" },
+        "check": { "type": "string", "description": "Check id within the layer (catalog in reference/checks.md; grows without a schema change)." },
+        "severity": { "type": "string", "enum": ["P1", "P2", "P3"] },
+        "scope": {
+          "type": "object",
+          "required": ["level", "ids"],
+          "additionalProperties": false,
+          "properties": {
+            "level": { "type": "string", "enum": ["site", "template", "page", "block"] },
+            "ids": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "evidence": { "type": "string" },
+        "fixability": {
+          "type": "string",
+          "enum": ["platform-migration", "design-pass", "out-of-scope"],
+          "description": "platform-migration = rollout fixes it by re-running deploy (and the AEM autofix engine may auto-apply). design-pass = upstream (fix in migrate/prototype; rollout can only surface). out-of-scope = informational."
+        },
+        "recommendedMove": { "type": "string" },
+        "status": { "type": "string", "enum": ["open", "in-progress", "fixed", "accepted", "wontfix"] },
+        "autofix": {
+          "type": ["object", "null"],
+          "description": "Platform autofix linkage (AEM-EDS in v1). Set by optimize when a fixer is registered for the check; updated by autofix-aem.",
+          "additionalProperties": false,
+          "properties": {
+            "available": { "type": "boolean" },
+            "target": { "type": "string", "examples": ["aem-eds"] },
+            "strategy": { "type": ["string", "null"], "description": "Fixer id, e.g. eds-metadata-title, eds-fix-h1." },
+            "kind": { "type": ["string", "null"], "enum": ["deterministic", "content-draft", "manual", null], "description": "deterministic = mechanical edit; content-draft = generated copy (applied under aggressive policy, logged); manual = payload prepared, human applies." },
+            "status": { "type": "string", "enum": ["unavailable", "pending", "applied", "failed", "manual"] },
+            "appliedBy": { "type": ["string", "null"] },
+            "at": { "type": ["string", "null"], "format": "date-time" },
+            "detail": { "type": ["string", "null"], "description": "What changed (before→after) or why it needs manual handling." }
+          }
+        },
+        "resolvedBy": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "phase": { "type": "string", "enum": ["deploy", "migrate", "prototype", "rollout", "autofix"] },
+            "artifact": { "type": "string" },
+            "at": { "type": "string", "format": "date-time" },
+            "note": { "type": "string" }
+          }
+        },
+        "firstSeenRun": { "type": "string" }
+      }
+    }
+  }
+}

--- a/plugins/stardust/skills/rollout/schemas/rollout-pages.schema.json
+++ b/plugins/stardust/skills/rollout/schemas/rollout-pages.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stardust.dev/schemas/rollout-pages.schema.json",
+  "title": "stardust rollout/coverage/pages.json",
+  "description": "Delivery ledger: one row per migrated page rollout is responsible for delivering to AEM-EDS. Built by inventorying stardust/migrated/. Tracks the source hash (for stale detection) and per-page delivery status. Owned by stardust:rollout; the agnostic core is never modified.",
+  "type": "object",
+  "required": ["_provenance", "pages"],
+  "additionalProperties": false,
+  "properties": {
+    "_provenance": { "$ref": "#/$defs/provenance" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "pages": { "type": "array", "items": { "$ref": "#/$defs/page" } }
+  },
+  "$defs": {
+    "provenance": {
+      "type": "object",
+      "required": ["writtenBy", "writtenAt", "stardustVersion"],
+      "properties": {
+        "writtenBy": { "type": "string", "examples": ["stardust:rollout"] },
+        "writtenAt": { "type": "string", "format": "date-time" },
+        "readArtifacts": { "type": "array", "items": { "type": "string" } },
+        "stardustVersion": { "type": "string" }
+      }
+    },
+    "page": {
+      "type": "object",
+      "required": ["slug", "source", "delivery"],
+      "additionalProperties": false,
+      "properties": {
+        "slug": { "type": "string" },
+        "path": { "type": "string", "description": "Destination path on the delivered site, e.g. /blog/scaling-teams." },
+        "title": { "type": "string" },
+        "templateId": {
+          "type": ["string", "null"],
+          "description": "The template grouping this page belongs to (rollout/coverage/templates.json[].id). Drives delivery order and block reuse."
+        },
+        "source": {
+          "type": "object",
+          "description": "The agnostic input rollout delivers (read-only).",
+          "required": ["migratedHtml", "sourceHash"],
+          "additionalProperties": false,
+          "properties": {
+            "migratedHtml": { "type": "string", "description": "Path, e.g. stardust/migrated/blog/scaling-teams.html." },
+            "metaJson": { "type": ["string", "null"], "description": "Path to the page's _meta.json." },
+            "sourceHash": { "type": "string", "description": "Content hash of the migrated HTML; changes mark the page stale for re-delivery." }
+          }
+        },
+        "blocks": {
+          "type": "array",
+          "description": "Block ids this page composes (rollout/coverage/blocks.json[].id).",
+          "items": { "type": "string" }
+        },
+        "delivery": {
+          "type": "object",
+          "required": ["status"],
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": ["pending", "converting", "deployed", "verified", "stale", "failed"],
+              "description": "stale = source hash changed after a prior delivery; needs re-delivery."
+            },
+            "deployedUrl": { "type": ["string", "null"], "format": "uri" },
+            "deployedAt": { "type": ["string", "null"], "format": "date-time" },
+            "verifiedAt": { "type": ["string", "null"], "format": "date-time" },
+            "error": { "type": ["string", "null"], "description": "Failure detail when status == failed." }
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/stardust/skills/rollout/schemas/rollout-scorecard.schema.json
+++ b/plugins/stardust/skills/rollout/schemas/rollout-scorecard.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stardust.dev/schemas/rollout-scorecard.schema.json",
+  "title": "stardust rollout/optimize/scorecard.json",
+  "description": "Delivery-quality scorecard: per-layer health 0-100 (null = not assessed by the automated gate), an overall health, the open severity mix, and a history[] so progress across rollout runs is visible. Written by stardust:rollout/optimize.",
+  "type": "object",
+  "required": ["_provenance", "current", "history"],
+  "additionalProperties": false,
+  "properties": {
+    "_provenance": { "$ref": "#/$defs/provenance" },
+    "current": { "$ref": "#/$defs/snapshot" },
+    "history": { "type": "array", "items": { "$ref": "#/$defs/snapshot" } }
+  },
+  "$defs": {
+    "provenance": {
+      "type": "object",
+      "required": ["writtenBy", "writtenAt", "stardustVersion"],
+      "properties": {
+        "writtenBy": { "type": "string", "examples": ["stardust:rollout/optimize"] },
+        "writtenAt": { "type": "string", "format": "date-time" },
+        "stardustVersion": { "type": "string" }
+      }
+    },
+    "score": { "type": ["integer", "null"], "minimum": 0, "maximum": 100 },
+    "snapshot": {
+      "type": "object",
+      "required": ["runId", "at", "overall", "dimensions", "severity"],
+      "additionalProperties": false,
+      "properties": {
+        "runId": { "type": "string" },
+        "at": { "type": "string", "format": "date-time" },
+        "overall": { "$ref": "#/$defs/score" },
+        "dimensions": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["brand-tensions", "design-ux", "accessibility", "seo", "content-conversion", "ai-search", "cross-page"],
+          "properties": {
+            "brand-tensions": { "$ref": "#/$defs/score" },
+            "design-ux": { "$ref": "#/$defs/score" },
+            "accessibility": { "$ref": "#/$defs/score" },
+            "seo": { "$ref": "#/$defs/score" },
+            "content-conversion": { "$ref": "#/$defs/score" },
+            "ai-search": { "$ref": "#/$defs/score" },
+            "cross-page": { "$ref": "#/$defs/score" }
+          }
+        },
+        "severity": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "P1": { "type": "integer", "minimum": 0 },
+            "P2": { "type": "integer", "minimum": 0 },
+            "P3": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "fixed": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "P1": { "type": "integer", "minimum": 0 },
+            "P2": { "type": "integer", "minimum": 0 },
+            "P3": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/stardust/skills/rollout/schemas/rollout-templates.schema.json
+++ b/plugins/stardust/skills/rollout/schemas/rollout-templates.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stardust.dev/schemas/rollout-templates.schema.json",
+  "title": "stardust rollout/coverage/templates.json",
+  "description": "Template grouping for delivery. A template is the structure shared by a set of migrated pages; rollout uses it to deliver a representative page first (establishing the EDS block library), to drive block reuse, and to roll up per-template delivery progress. Derived from the agnostic _meta.json / canon at inventory time. Owned by stardust:rollout.",
+  "type": "object",
+  "required": ["_provenance", "templates"],
+  "additionalProperties": false,
+  "properties": {
+    "_provenance": { "$ref": "#/$defs/provenance" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "templates": { "type": "array", "items": { "$ref": "#/$defs/template" } }
+  },
+  "$defs": {
+    "provenance": {
+      "type": "object",
+      "required": ["writtenBy", "writtenAt", "stardustVersion"],
+      "properties": {
+        "writtenBy": { "type": "string", "examples": ["stardust:rollout"] },
+        "writtenAt": { "type": "string", "format": "date-time" },
+        "readArtifacts": { "type": "array", "items": { "type": "string" } },
+        "stardustVersion": { "type": "string" }
+      }
+    },
+    "template": {
+      "type": "object",
+      "required": ["id", "pages"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "label": { "type": "string" },
+        "type": {
+          "type": ["string", "null"],
+          "description": "The agnostic page type this grouping reflects, when available from _meta.json (landing/article/listing/etc.). Informational for rollout."
+        },
+        "representativeSlug": {
+          "type": ["string", "null"],
+          "description": "The page rollout delivers first to establish this template's EDS block library; siblings then reuse those blocks."
+        },
+        "pages": {
+          "type": "array",
+          "description": "Slugs that share this structure.",
+          "items": { "type": "string" }
+        },
+        "pageCount": { "type": "integer", "minimum": 0 },
+        "blocks": {
+          "type": "array",
+          "description": "Block ids this template composes (rollout/coverage/blocks.json[].id).",
+          "items": { "type": "string" }
+        },
+        "delivery": {
+          "type": "object",
+          "description": "Roll-up of this template's pages by delivery progress.",
+          "additionalProperties": false,
+          "properties": {
+            "verified": { "type": "integer", "minimum": 0 },
+            "deployed": { "type": "integer", "minimum": 0 },
+            "pending": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/stardust/skills/rollout/scripts/assemble.mjs
+++ b/plugins/stardust/skills/rollout/scripts/assemble.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * rollout/assemble.mjs — site-level assembly (Phase 2).
+ *
+ * Generates the artifacts that only make sense for the whole site (not any single
+ * page): sitemap.xml + robots.txt from the delivery coverage, and a fragments
+ * manifest mapping the canon chrome to the EDS static fragments deploy injects.
+ * Deterministic outputs staged under stardust/rollout/site/; the actual push of
+ * fragments is deploy's job (this only prepares + records what to push).
+ *
+ * Usage: node skills/rollout/scripts/assemble.mjs [--out <rolloutDir>] [--canon <dir>]
+ */
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { readJSON, writeJSON } from './lib.mjs';
+import { writeFileSync, mkdirSync } from 'node:fs';
+
+function arg(name, fallback) { const i = process.argv.indexOf(`--${name}`); return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback; }
+const OUT = arg('out', 'stardust/rollout');
+const CANON = arg('canon', 'stardust/canon');
+
+const pagesDoc = readJSON(join(OUT, 'coverage', 'pages.json'));
+const blocksDoc = readJSON(join(OUT, 'coverage', 'blocks.json'));
+const config = readJSON(join(OUT, 'rollout.json'), {});
+if (!pagesDoc) { console.error('rollout assemble: run inventory.mjs first.'); process.exit(1); }
+
+const pages = pagesDoc.pages || [];
+const host = (config.site && config.site.liveHost) ? `https://${config.site.liveHost}` : '';
+const siteDir = join(OUT, 'site');
+mkdirSync(siteDir, { recursive: true });
+
+// sitemap.xml — delivered (extensionless) paths.
+const urls = pages.map((p) => `  <url><loc>${host}${p.path}</loc></url>`).join('\n');
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
+writeFileSync(join(siteDir, 'sitemap.xml'), sitemap);
+
+// robots.txt
+const robots = `User-agent: *\nAllow: /\n${host ? `Sitemap: ${host}/sitemap.xml\n` : ''}`;
+writeFileSync(join(siteDir, 'robots.txt'), robots);
+
+// Fragments manifest — chrome blocks → static fragment targets, with canon source.
+const chrome = ((blocksDoc && blocksDoc.blocks) || []).filter((b) => b.kind === 'chrome');
+const fragmentSrc = { header: join(CANON, 'header.html'), nav: join(CANON, 'header.html'), footer: join(CANON, 'footer.html') };
+const fragments = chrome.map((b) => ({
+  id: b.id,
+  target: b.delivery.blockPath || `fragments/${b.id}.html`,
+  canonSource: existsSync(fragmentSrc[b.id]) ? fragmentSrc[b.id] : null,
+  status: b.delivery.status,
+}));
+
+const now = new Date().toISOString();
+writeJSON(join(siteDir, 'manifest.json'), {
+  _provenance: { writtenBy: 'stardust:rollout/assemble', writtenAt: now, stardustVersion: (config._provenance || {}).stardustVersion || '0.0.0' },
+  generatedAt: now,
+  host: host || null,
+  sitemap: join(siteDir, 'sitemap.xml'),
+  robots: join(siteDir, 'robots.txt'),
+  fragments,
+});
+
+console.log(`rollout assemble → ${siteDir}`);
+console.log('='.repeat(60));
+console.log(`sitemap.xml   ${pages.length} urls${host ? ` @ ${host}` : ' (no liveHost set — relative locs)'}`);
+console.log(`robots.txt    written`);
+console.log(`fragments     ${fragments.length}: ${fragments.map((f) => `${f.id}${f.canonSource ? '' : ' (no canon source!)'}`).join(', ') || 'none'}`);
+if (fragments.some((f) => !f.canonSource)) console.log('  ⚠ some chrome has no canon/*.html source — deploy must lift it from a delivered page.');

--- a/plugins/stardust/skills/rollout/scripts/autofix-aem.mjs
+++ b/plugins/stardust/skills/rollout/scripts/autofix-aem.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * rollout/autofix-aem.mjs — the AEM (Edge Delivery) autofix engine (v1, aggressive).
+ *
+ * Consumes the findings ledger and, for every open finding whose `check` has a
+ * registered EDS fixer, applies the fix to the EDS PROJECT files (content pages,
+ * styles), logs the change on finding.autofix, and stages the finding as
+ * `in-progress` (a re-deploy + re-optimize then flips it to `fixed`).
+ *
+ * Policy (aggressive): also applies content fixes (h1 promotion, alt-text drafts,
+ * title/description drafts, title disambiguation). Generated copy is marked
+ * `kind: content-draft` and logged with before→after so it can be reviewed. Fixers
+ * that cannot be applied safely from here (JSON-LD placement, canonical, <main>
+ * landmark) are marked `manual` with guidance rather than risking invalid output.
+ *
+ * Usage: node skills/rollout/scripts/autofix-aem.mjs --project <eds-root>
+ *          [--out <rolloutDir>] [--slug <s>] [--check <check>] [--dry-run]
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import { readJSON, writeJSON, computeScorecard, resolveLocalFile } from './lib.mjs';
+
+function arg(name, fallback) { const i = process.argv.indexOf(`--${name}`); return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback; }
+const PROJECT = arg('project', null);
+const OUT = arg('out', 'stardust/rollout');
+const onlySlug = arg('slug', null);
+const onlyCheck = arg('check', null);
+const DRY = process.argv.includes('--dry-run');
+if (!PROJECT) { console.error('autofix-aem: --project <eds-root> required (the AEM/EDS repo with content/).'); process.exit(2); }
+
+const findingsPath = join(OUT, 'optimize', 'findings.json');
+const scorecardPath = join(OUT, 'optimize', 'scorecard.json');
+const doc = readJSON(findingsPath);
+const pagesDoc = readJSON(join(OUT, 'coverage', 'pages.json'));
+if (!doc) { console.error('autofix-aem: no findings.json — run optimize first.'); process.exit(1); }
+const pageBySlug = new Map(((pagesDoc && pagesDoc.pages) || []).map((p) => [p.slug, p]));
+const contentRoot = join(PROJECT, 'content');
+const now = new Date().toISOString();
+
+// --- HTML edit helpers ----------------------------------------------------------
+const strip = (s) => s.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+const h1Text = (html) => strip((html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i) || [])[1] || '');
+const firstHeadingText = (html) => strip((html.match(/<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/i) || [])[1] || '');
+const firstParaText = (html) => strip((html.match(/<p[^>]*>([\s\S]*?)<\/p>/i) || [])[1] || '');
+const rowRe = (label) => new RegExp(`(<div>\\s*${label}\\s*</div>\\s*<div>)([\\s\\S]*?)(</div>)`, 'i');
+
+function ensureMetaRow(html, label, value) {
+  // EDS metadata block: <div><div class="metadata"><div><div>Label</div><div>Value</div></div>…</div></div>
+  const row = `<div><div>${label}</div><div>${value}</div></div>`;
+  if (/<div class="metadata">/i.test(html)) {
+    const re = rowRe(label);
+    if (re.test(html)) return html.replace(re, `$1${value}$3`); // update existing row's value
+    return html.replace(/<div class="metadata">/i, `<div class="metadata">${row}`); // prepend a new row
+  }
+  const block = `<div><div class="metadata">${row}</div></div>`;
+  if (/<main[^>]*>/i.test(html)) return html.replace(/<main[^>]*>/i, (m) => `${m}${block}`);
+  return html.replace(/<body[^>]*>/i, (m) => `${m}${block}`);
+}
+
+function deriveAlt(src) {
+  const base = basename(src || 'image').replace(/\.[a-z0-9]+$/i, '').replace(/[-_]+/g, ' ').trim();
+  return base ? base.replace(/\b\w/g, (c) => c.toUpperCase()) : 'Image';
+}
+
+// --- Fixers: strategy id -> (html, page, finding) -> {html?, detail, manual?} ----
+const FIXERS = {
+  'eds-metadata-title': (html, page) => {
+    const title = (h1Text(html) || page.title || page.slug).slice(0, 60);
+    return { html: ensureMetaRow(html, 'Title', title), detail: `Title="${title}" (draft from <h1>)` };
+  },
+  'eds-metadata-description': (html, page) => {
+    const desc = (firstParaText(html) || `${page.title || page.slug}.`).slice(0, 155);
+    return { html: ensureMetaRow(html, 'Description', desc), detail: `Description set (${desc.length} chars, draft)` };
+  },
+  'eds-fix-h1': (html, page) => {
+    const count = (html.match(/<h1[\s>]/gi) || []).length;
+    if (count === 1) return { skip: true, detail: 'already exactly one <h1>' };
+    if (count === 0) {
+      const m = html.match(/<(h[2-6])(\s[^>]*)?>([\s\S]*?)<\/\1>/i);
+      if (m) return { html: html.replace(m[0], `<h1${m[2] || ''}>${m[3]}</h1>`), detail: `promoted first <${m[1]}> to <h1>` };
+      const t = page.title || page.slug;
+      return { html: html.replace(/<main[^>]*>/i, (s) => `${s}<h1>${t}</h1>`), detail: `inserted <h1>${t}</h1>` };
+    }
+    let seen = 0;
+    const out = html.replace(/<h1(\s[^>]*)?>([\s\S]*?)<\/h1>/gi, (full, attrs, inner) => { seen += 1; return seen === 1 ? full : `<h2${attrs || ''}>${inner}</h2>`; });
+    return { html: out, detail: `demoted ${count - 1} extra <h1> to <h2>` };
+  },
+  'eds-alt-draft': (html) => {
+    let n = 0;
+    const out = html.replace(/<img\b(?![^>]*\balt=)([^>]*?)>/gi, (full, attrs) => { n += 1; const src = (full.match(/src=["']([^"']+)["']/) || [])[1] || ''; return `<img${attrs} alt="${deriveAlt(src)}">`; });
+    return n ? { html: out, detail: `added draft alt to ${n} <img> (review)` } : { skip: true, detail: 'no alt-less <img>' };
+  },
+  'eds-disambiguate-title': (html, page) => {
+    const seg = (page.path || '/').split('/').filter(Boolean).slice(-1)[0] || 'Home';
+    const q = ` — ${seg.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}`;
+    const re = rowRe('Title');
+    if (re.test(html)) return { html: html.replace(re, (m, a, v, c) => (v.includes(q) ? m : `${a}${v.trim()}${q}${c}`)), detail: `disambiguated Title with "${q.trim()}"` };
+    return { manual: true, detail: 'no metadata Title row to disambiguate; add a metadata block first' };
+  },
+  'eds-jsonld': () => ({ manual: true, detail: 'JSON-LD must be placed via head.html / metadata pipeline (run the marketing:schema skill for the payload).' }),
+  'eds-canonical': () => ({ manual: true, detail: 'self-canonical is a head.html / project-config change.' }),
+  'eds-landmark-main': () => ({ manual: true, detail: 'ensure block output lands inside <main> (deploy anti-pattern 17) — structural, fix in the block.' }),
+  'rollout-assemble': () => ({ manual: true, detail: 'run assemble.mjs to (re)generate sitemap.xml, then deploy it.' }),
+};
+
+// --- Apply ----------------------------------------------------------------------
+const candidates = (doc.findings || []).filter((f) => {
+  if (!(f.status === 'open' || f.status === 'in-progress')) return false;
+  if (!(f.autofix && f.autofix.available && f.autofix.status === 'pending')) return false;
+  if (onlyCheck && f.check !== onlyCheck) return false;
+  if (onlySlug && !(f.scope.level === 'page' && f.scope.ids.includes(onlySlug))) return false;
+  return true;
+});
+
+const fileCache = new Map();
+const results = [];
+for (const f of candidates) {
+  const fixer = FIXERS[f.autofix.strategy];
+  if (!fixer) { results.push({ f, outcome: 'no-fixer' }); continue; }
+
+  // site-level / manual fixers don't touch a page file
+  const isPage = f.scope.level === 'page' && f.scope.ids.length === 1;
+  const page = isPage ? pageBySlug.get(f.scope.ids[0]) : null;
+  let file = null; let html = null;
+  if (isPage) {
+    if (!page) { results.push({ f, outcome: 'no-page' }); continue; }
+    file = resolveLocalFile(contentRoot, page.path);
+    if (!file) { f.autofix = { ...f.autofix, status: 'failed', appliedBy: 'autofix-aem', at: now, detail: `content page not found under ${contentRoot}` }; results.push({ f, outcome: 'no-file' }); continue; }
+    html = fileCache.has(file) ? fileCache.get(file) : readFileSync(file, 'utf8');
+  }
+
+  const r = fixer(html ?? '', page || { slug: f.scope.ids[0], path: '/', title: '' }, f);
+  if (r.manual) {
+    f.autofix = { ...f.autofix, status: 'manual', appliedBy: 'autofix-aem', at: now, detail: r.detail };
+    results.push({ f, outcome: 'manual', detail: r.detail }); continue;
+  }
+  if (r.skip) { results.push({ f, outcome: 'skip', detail: r.detail }); continue; }
+  // applied
+  if (isPage && r.html && r.html !== html) { fileCache.set(file, r.html); }
+  f.autofix = { ...f.autofix, status: 'applied', appliedBy: 'autofix-aem', at: now, detail: r.detail };
+  f.status = 'in-progress';
+  results.push({ f, outcome: DRY ? 'would-apply' : 'applied', file, detail: r.detail });
+}
+
+// --- Persist --------------------------------------------------------------------
+if (!DRY) {
+  for (const [file, html] of fileCache) writeFileSync(file, html);
+  writeJSON(findingsPath, doc);
+  const sc = readJSON(scorecardPath, { history: [] });
+  const snap = computeScorecard(doc.findings, `autofix-${now}`, now);
+  writeJSON(scorecardPath, { _provenance: { writtenBy: 'stardust:rollout/autofix-aem', writtenAt: now, stardustVersion: (doc._provenance || {}).stardustVersion || '0.0.0' }, current: snap, history: [...(sc.history || []), snap] });
+}
+
+// --- Report ---------------------------------------------------------------------
+const by = (o) => results.filter((r) => r.outcome === o);
+console.log(`autofix-aem (${DRY ? 'DRY RUN' : 'apply'}) → project ${PROJECT}`);
+console.log('='.repeat(64));
+console.log(`Candidates ${candidates.length} · applied ${by('applied').length + by('would-apply').length} · manual ${by('manual').length} · skipped ${by('skip').length} · failed ${by('no-file').length + by('no-page').length}`);
+for (const r of results) {
+  const mark = { applied: '✓', 'would-apply': '~', manual: '✋', skip: '·', 'no-file': '✗', 'no-page': '✗', 'no-fixer': '?' }[r.outcome] || '?';
+  console.log(`  ${mark} ${r.f.autofix.strategy.padEnd(24)} [${r.f.scope.ids.join(',')}] ${r.detail || r.outcome}`);
+}
+if (!DRY && (by('applied').length)) console.log('\nNext: re-deploy the edited pages (deploy), then re-run verify + optimize to flip staged findings to fixed.');

--- a/plugins/stardust/skills/rollout/scripts/blocks.mjs
+++ b/plugins/stardust/skills/rollout/scripts/blocks.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * rollout/blocks.mjs — build the block dedup ledger (Phase 2).
+ *
+ * Reads coverage/pages.json (produced by inventory.mjs) and derives the set of
+ * DISTINCT blocks across the whole site — the dedup unit. Each distinct block is
+ * converted to an EDS block (or static fragment, for chrome) exactly ONCE; this
+ * ledger + plan.mjs make that dedup a driving step, not a post-hoc reconcile.
+ *
+ * Dedup signal (Phase 2): brand-module ids carried per page in the _meta.json
+ * sidecar `modules[]` (shared by construction) + chrome (header/nav/footer,
+ * site-wide singletons). Finer section-archetype dedup via structural signatures
+ * is a later refinement; the `signature` field is reserved for it.
+ *
+ * Idempotent: existing block delivery status is preserved.
+ *
+ * Usage: node skills/rollout/scripts/blocks.mjs [--out <rolloutDir>]
+ */
+import { join } from 'node:path';
+import { readJSON, writeJSON, edsName, kindOf, blockCounts } from './lib.mjs';
+
+const i = process.argv.indexOf('--out');
+const OUT = i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : 'stardust/rollout';
+const STARDUST_VERSION = (readJSON(join(OUT, 'rollout.json'), {})._provenance || {}).stardustVersion || '0.0.0';
+
+const pagesDoc = readJSON(join(OUT, 'coverage', 'pages.json'));
+if (!pagesDoc) {
+  console.error(`rollout blocks: ${join(OUT, 'coverage', 'pages.json')} not found — run inventory.mjs first.`);
+  process.exit(1);
+}
+const pages = pagesDoc.pages || [];
+const blocksPath = join(OUT, 'coverage', 'blocks.json');
+const prior = new Map(((readJSON(blocksPath, { blocks: [] }) || {}).blocks || []).map((b) => [b.id, b]));
+
+// Aggregate block instances across pages.
+const agg = new Map(); // id -> { templates:Set, pages:[], count }
+for (const p of pages) {
+  for (const id of p.blocks || []) {
+    if (!agg.has(id)) agg.set(id, { templates: new Set(), pages: [], count: 0 });
+    const a = agg.get(id);
+    a.count += 1;
+    a.pages.push(p.slug);
+    if (p.templateId) a.templates.add(p.templateId);
+  }
+}
+
+const now = new Date().toISOString();
+const blocks = [...agg.entries()].map(([id, a]) => {
+  const kind = kindOf(id);
+  const p = prior.get(id);
+  const delivery = (p && p.delivery) || {
+    status: 'pending',
+    edsBlockName: kind === 'chrome' ? null : edsName(id),
+    blockPath: kind === 'chrome' ? `fragments/${edsName(id)}.html` : null,
+    convertedAt: null,
+  };
+  // Keep the derived EDS name fresh for not-yet-converted blocks.
+  if (delivery.status === 'pending') {
+    delivery.edsBlockName = kind === 'chrome' ? null : edsName(id);
+    delivery.blockPath = kind === 'chrome' ? `fragments/${edsName(id)}.html` : delivery.blockPath || null;
+  }
+  return {
+    id,
+    label: id,
+    kind,
+    signature: `${kind}:${id}`,
+    source: null,
+    usedByTemplates: [...a.templates].sort(),
+    usedByPages: [...new Set(a.pages)].sort(),
+    instanceCount: a.count,
+    delivery,
+  };
+}).sort((x, y) => x.id.localeCompare(y.id));
+
+writeJSON(blocksPath, {
+  _provenance: { writtenBy: 'stardust:rollout/blocks', writtenAt: now, readArtifacts: [join(OUT, 'coverage', 'pages.json')], stardustVersion: STARDUST_VERSION },
+  generatedAt: now,
+  blocks,
+});
+
+// Refresh the block counts in rollout.json.
+const configPath = join(OUT, 'rollout.json');
+const config = readJSON(configPath);
+if (config) {
+  config.lastRun = { ...(config.lastRun || {}), blocks: blockCounts(blocks) };
+  writeJSON(configPath, config);
+}
+
+const modules = blocks.filter((b) => b.kind === 'module');
+const chrome = blocks.filter((b) => b.kind === 'chrome');
+console.log(`rollout blocks → ${blocksPath}`);
+console.log('='.repeat(60));
+console.log(`Distinct blocks  ${blocks.length}  (${modules.length} module · ${chrome.length} chrome/fragment)`);
+console.log(`Reuse leverage   ${pages.reduce((n, p) => n + (p.blocks || []).length, 0)} instances → ${blocks.length} conversions`);
+const top = [...modules].sort((a, b) => b.instanceCount - a.instanceCount).slice(0, 6);
+if (top.length) console.log(`Most reused      ${top.map((b) => `${b.id}×${b.instanceCount}`).join(', ')}`);
+if (chrome.length) console.log(`Fragments        ${chrome.map((b) => b.id).join(', ')}`);

--- a/plugins/stardust/skills/rollout/scripts/dashboard.mjs
+++ b/plugins/stardust/skills/rollout/scripts/dashboard.mjs
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+/**
+ * rollout/dashboard.mjs — self-contained progress dashboard (Phase 4).
+ *
+ * Rendered in the stardust DESIGN IDENTITY (brand tokens read from the :root block
+ * of a migrated page — the canonical token interface, token-contract.md). The
+ * centerpiece is a PAGE TREE of every identified page, each node colour-coded by
+ * its lifecycle stage:
+ *
+ *   identified → prototyped → migrated → deployed → optimised
+ *
+ * spanning stardust/state.json (agnostic stages) + rollout coverage (deployed) +
+ * optimize (optimised = verified & no open findings). Template archetypes (the
+ * pages that define a template for their siblings) are marked distinctly.
+ *
+ * Emits dashboard/index.html (self-contained, no external JS) + dashboard/data.json.
+ * Usage: node skills/rollout/scripts/dashboard.mjs [--out <rolloutDir>]
+ */
+import { join } from 'node:path';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { readJSON, writeJSON } from './lib.mjs';
+
+const i = process.argv.indexOf('--out');
+const OUT = i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : 'stardust/rollout';
+
+const config = readJSON(join(OUT, 'rollout.json'), {});
+const pagesDoc = readJSON(join(OUT, 'coverage', 'pages.json'));
+if (!pagesDoc) { console.error('rollout dashboard: run inventory.mjs first.'); process.exit(1); }
+const covPages = pagesDoc.pages || [];
+const templates = (readJSON(join(OUT, 'coverage', 'templates.json'), {}).templates) || [];
+const blocks = (readJSON(join(OUT, 'coverage', 'blocks.json'), {}).blocks) || [];
+const findingsDoc = readJSON(join(OUT, 'optimize', 'findings.json'), { findings: [], runs: [] });
+const scorecard = readJSON(join(OUT, 'optimize', 'scorecard.json'), null);
+const state = readJSON(join(OUT, '..', 'state.json'), null); // agnostic lifecycle (optional)
+const findings = findingsDoc.findings || [];
+const optimizeRan = (findingsDoc.runs || []).length > 0;
+
+// ---- design identity: read brand tokens from a migrated page's :root -----------
+function readIdentity() {
+  const d = { bg: '#ffffff', fg: '#1a1f26', accent: '#147aff', heading: 'Georgia, serif', body: '-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif', radius: '10px', maxw: '1100px' };
+  // Scan migrated pages (home first) for one that actually exposes a :root token block.
+  const candidates = covPages.filter((p) => p.source && p.source.migratedHtml)
+    .sort((a, b) => (a.path === '/' ? -1 : 0) - (b.path === '/' ? -1 : 0));
+  for (const c of candidates) {
+    let html; try { html = readFileSync(c.source.migratedHtml, 'utf8'); } catch { continue; }
+    const root = (html.match(/:root\s*\{([\s\S]*?)\}/) || [])[1];
+    if (!root) continue;
+    const clean = root.replace(/\/\*[\s\S]*?\*\//g, '');
+    const v = (name) => { const m = clean.match(new RegExp(`--${name}\\s*:\\s*([^;]+);`, 'i')); return m ? m[1].trim() : null; };
+    return {
+      bg: v('color-bg') || d.bg, fg: v('color-fg') || d.fg, accent: v('color-accent') || d.accent,
+      heading: v('heading-font-family') || d.heading, body: v('body-font-family') || d.body,
+      radius: v('radius') || d.radius, maxw: v('max-width') || d.maxw,
+    };
+  }
+  return d;
+}
+
+// ---- merge agnostic state + coverage + optimize into one page model ------------
+// Four lifecycle checkpoints. A page's stage is the MOST ADVANCED it has reached
+// (drives the node colour). "migrated" folds into prototyped (designed, not yet
+// deployed). Legend counts are CUMULATIVE — a page counts toward every stage up
+// to and including the one it reached (so identified = all pages).
+const STAGES = ['identified', 'prototyped', 'deployed', 'optimised'];
+const STAGE_COLOR = { identified: '#9aa3ad', prototyped: '#5b8def', deployed: '#18a0a0', optimised: '#2e9e5b' };
+const AG = { extracted: 0, directed: 0, prototyped: 1, approved: 1, migrated: 1 };
+const rankOf = (stage) => STAGES.indexOf(stage);
+
+const openByPage = {};
+for (const f of findings) {
+  if ((f.status === 'open' || f.status === 'in-progress') && f.scope.level === 'page') {
+    for (const id of f.scope.ids) openByPage[id] = (openByPage[id] || 0) + 1;
+  }
+}
+
+const statePages = new Map();
+if (state && Array.isArray(state.pages)) for (const p of state.pages) statePages.set(p.slug, p);
+const covBySlug = new Map(covPages.map((p) => [p.slug, p]));
+
+function pathOf(slug, cov, stp) {
+  if (cov && cov.path) return cov.path;
+  if (stp && stp.url) { try { return new URL(stp.url).pathname.replace(/\/$/, '') || '/'; } catch { /* fall through */ } }
+  return slug === 'home' ? '/' : `/${slug}`;
+}
+function stageOf(p) {
+  let r = AG[p.agnosticStatus] ?? 0;
+  if (p.inCoverage) r = Math.max(r, 1); // in the migrated tree → at least prototyped/designed
+  if (p.delivery && (p.delivery.status === 'deployed' || p.delivery.status === 'verified')) r = Math.max(r, 2);
+  if (p.delivery && p.delivery.status === 'verified' && (openByPage[p.slug] || 0) === 0 && optimizeRan) r = 3;
+  return STAGES[r];
+}
+
+const repSlugs = new Set(templates.map((t) => t.representativeSlug).filter(Boolean));
+const allSlugs = new Set([...covBySlug.keys(), ...statePages.keys()]);
+const model = [...allSlugs].map((slug) => {
+  const cov = covBySlug.get(slug); const stp = statePages.get(slug);
+  const p = {
+    slug, title: (cov && cov.title) || (stp && (stp.title || stp.slug)) || slug,
+    path: pathOf(slug, cov, stp),
+    templateId: (cov && cov.templateId) || (stp && stp.type) || null,
+    delivery: cov && cov.delivery, inCoverage: !!cov,
+    agnosticStatus: (stp && stp.status) || (cov ? 'migrated' : 'identified'),
+    isTemplate: repSlugs.has(slug), openFindings: openByPage[slug] || 0,
+  };
+  p.stage = stageOf(p);
+  return p;
+}).sort((a, b) => a.path.localeCompare(b.path));
+
+// ---- page tree by path ----------------------------------------------------------
+function buildTree(pages) {
+  const root = { seg: '', name: 'Home', children: new Map(), page: null };
+  for (const p of pages) {
+    const segs = p.path === '/' ? [] : p.path.replace(/^\//, '').split('/');
+    let node = root;
+    for (const seg of segs) {
+      if (!node.children.has(seg)) node.children.set(seg, { seg, name: seg, children: new Map(), page: null });
+      node = node.children.get(seg);
+    }
+    node.page = p;
+  }
+  return root;
+}
+const tree = buildTree(model);
+
+// ---- snapshot -------------------------------------------------------------------
+// stageCount: CUMULATIVE (reached this stage or beyond). stageExclusive: each page
+// in exactly its most-advanced stage (sums to total — used for the stacked bars).
+const stageCount = STAGES.reduce((m, s) => { m[s] = model.filter((p) => rankOf(p.stage) >= rankOf(s)).length; return m; }, {});
+const stageExclusive = STAGES.reduce((m, s) => { m[s] = model.filter((p) => p.stage === s).length; return m; }, {});
+const countBy = (arr, get) => arr.reduce((m, x) => { const k = get(x); m[k] = (m[k] || 0) + 1; return m; }, {});
+const open = findings.filter((f) => f.status === 'open' || f.status === 'in-progress');
+const snapshot = {
+  generatedAt: new Date().toISOString(),
+  target: config.target || 'aem-eds',
+  site: { sourceUrl: (config.site && config.site.sourceUrl) || null, liveHost: (config.site && config.site.liveHost) || null },
+  stageCount, stageExclusive,
+  pages: model.map((p) => ({ slug: p.slug, path: p.path, stage: p.stage, templateId: p.templateId, isTemplate: p.isTemplate, openFindings: p.openFindings })),
+  templates: templates.map((t) => {
+    const members = model.filter((p) => p.templateId === t.id);
+    return { id: t.id, archetype: t.representativeSlug, pageCount: members.length, stages: STAGES.reduce((m, s) => { m[s] = members.filter((p) => p.stage === s).length; return m; }, {}) };
+  }),
+  blocks: { total: blocks.length, converted: blocks.filter((b) => ['converted', 'deployed', 'verified'].includes(b.delivery && b.delivery.status)).length },
+  quality: scorecard ? { overall: scorecard.current.overall, dimensions: scorecard.current.dimensions, severity: scorecard.current.severity, history: (scorecard.history || []).map((h) => h.overall) } : null,
+  findings: { byFixability: countBy(open, (f) => f.fixability), byAutofix: countBy(open.filter((f) => f.autofix && f.autofix.available), (f) => f.autofix.status) },
+};
+
+const dashDir = join(OUT, 'dashboard');
+mkdirSync(dashDir, { recursive: true });
+writeJSON(join(dashDir, 'data.json'), snapshot);
+writeFileSync(join(dashDir, 'index.html'), render(snapshot, tree, readIdentity()));
+
+console.log(`rollout dashboard → ${join(dashDir, 'index.html')}`);
+console.log('='.repeat(60));
+console.log(`Pages ${model.length} (cumulative): ${STAGES.map((s) => `${s} ${stageCount[s]}`).join(' · ')}`);
+
+// ================================================================ rendering
+function esc(s) { return String(s).replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])); }
+function pct(n, d) { return d ? Math.round((n / d) * 100) : 0; }
+function dot(stage) { return `<i class="dot" style="background:${STAGE_COLOR[stage]}" title="${stage}"></i>`; }
+
+function renderNode(node, isRoot = false) {
+  const kids = [...node.children.values()].sort((a, b) => a.seg.localeCompare(b.seg));
+  const p = node.page;
+  let label;
+  if (p) {
+    const badge = p.isTemplate ? `<span class="tmpl-badge" title="template archetype for ${esc(p.templateId || '')}">T</span>` : '';
+    const tref = p.templateId ? `<span class="tref">${esc(p.templateId)}</span>` : '';
+    const fnd = p.openFindings ? `<span class="fnd" title="${p.openFindings} open findings">●${p.openFindings}</span>` : '';
+    label = `${dot(p.stage)}<span class="nm${p.isTemplate ? ' is-t' : ''}">${esc(p.title || node.seg || 'Home')}</span>${badge}${tref}<span class="pth">${esc(p.path)}</span>${fnd}`;
+  } else {
+    label = `<i class="dot folder"></i><span class="nm dir">${esc(node.seg || 'Home')}/</span>`;
+  }
+  const childHtml = kids.length ? `<ul>${kids.map((k) => renderNode(k)).join('')}</ul>` : '';
+  return `<li${isRoot ? ' class="root"' : ''}>${label}${childHtml}</li>`;
+}
+
+function stageStack(stages, total) {
+  return STAGES.filter((s) => stages[s]).map((s) => `<span style="width:${pct(stages[s], total)}%;background:${STAGE_COLOR[s]}" title="${s}: ${stages[s]}"></span>`).join('');
+}
+
+function dimBars(dims) {
+  const labels = { 'brand-tensions': 'Brand', 'design-ux': 'Design/UX', accessibility: 'A11y', seo: 'SEO', 'content-conversion': 'Content', 'ai-search': 'AI-search', 'cross-page': 'Cross-page' };
+  return Object.entries(labels).map(([k, label]) => {
+    const v = dims[k];
+    if (v === null || v === undefined) return `<div class="dim"><span class="dl">${label}</span><span class="dn na">—</span></div>`;
+    const c = v >= 80 ? '#2e9e5b' : v >= 50 ? '#e0a72e' : '#d6473b';
+    return `<div class="dim"><span class="dl">${label}</span><span class="dbar"><i style="width:${v}%;background:${c}"></i></span><span class="dn">${v}</span></div>`;
+  }).join('');
+}
+function sparkline(hist, ac) {
+  if (!hist || hist.length < 2) return '';
+  const w = 200; const h = 36;
+  const pts = hist.map((v, idx) => `${(idx / (hist.length - 1)) * w},${h - (v / 100) * h}`).join(' ');
+  return `<svg width="${w}" height="${h}" viewBox="0 0 ${w} ${h}"><polyline fill="none" stroke="${ac}" stroke-width="2" points="${pts}"/></svg>`;
+}
+
+function render(s, treeRoot, id) {
+  const legend = STAGES.map((st) => `<span class="lg">${dot(st)}${st} <b>${s.stageCount[st]}</b></span>`).join('');
+  const q = s.quality;
+  const tmplRows = s.templates.map((t) => `<tr><td>${esc(t.id)}</td><td class="mono">${esc(t.archetype || '—')}</td><td>${t.pageCount}</td><td><span class="stack">${stageStack(t.stages, t.pageCount)}</span></td></tr>`).join('');
+  const total = s.pages.length;
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>rollout — ${esc(s.site.sourceUrl || s.target)}</title>
+<style>
+:root{--bg:${id.bg};--fg:${id.fg};--accent:${id.accent};--heading:${id.heading};--body:${id.body};--radius:${id.radius};--maxw:${id.maxw};
+--muted:color-mix(in srgb,var(--fg) 55%,transparent);--line:color-mix(in srgb,var(--fg) 12%,transparent);--card:color-mix(in srgb,var(--fg) 3%,var(--bg))}
+*{box-sizing:border-box}body{margin:0;font-family:var(--body);color:var(--fg);background:var(--bg);line-height:1.5}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:30px 22px 70px}
+header{border-bottom:3px solid var(--accent);padding-bottom:14px;margin-bottom:22px}
+h1{font-family:var(--heading);font-size:26px;margin:0}h1 b{color:var(--accent)}
+h2{font-family:var(--heading);font-size:15px;letter-spacing:.02em;margin:30px 0 12px}
+.sub{color:var(--muted);font-size:12px;margin-top:4px}
+.cards{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:8px}
+.card{background:var(--card);border:1px solid var(--line);border-radius:var(--radius);padding:15px}
+.card .n{font-family:var(--heading);font-size:28px;line-height:1}.card .l{font-size:12px;color:var(--muted);margin-top:6px}
+.panel{background:var(--card);border:1px solid var(--line);border-radius:var(--radius);padding:18px;margin-bottom:14px}
+.legend{display:flex;flex-wrap:wrap;gap:16px;margin:2px 0 14px;align-items:center}
+.lg{font-size:12px;color:var(--muted)}.lg b{color:var(--fg)}.muted-note{font-style:italic;margin-left:auto}
+.dot{display:inline-block;width:11px;height:11px;border-radius:50%;margin-right:7px;vertical-align:-1px}
+.dot.folder{background:transparent;border:1.5px solid var(--line)}
+.tree{font-size:14px}.tree ul{list-style:none;margin:0;padding-left:20px;border-left:1px dotted var(--line)}
+.tree>ul{padding-left:4px;border-left:none}.tree li{margin:3px 0}
+.nm{font-weight:600}.nm.is-t{color:var(--accent)}.nm.dir{color:var(--muted);font-weight:600}
+.tmpl-badge{display:inline-block;background:var(--accent);color:var(--bg);font-size:10px;font-weight:700;border-radius:4px;padding:0 5px;margin-left:6px;vertical-align:1px}
+.tref{font-size:11px;color:var(--muted);margin-left:7px}
+.pth{font-size:11px;color:var(--muted);margin-left:8px;font-family:ui-monospace,Menlo,Consolas,monospace}
+.fnd{font-size:11px;color:#d6473b;margin-left:8px}
+table{width:100%;border-collapse:collapse;font-size:13px}td,th{text-align:left;padding:7px 8px;border-bottom:1px solid var(--line)}
+th{font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}.mono{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:12px}
+.stack{display:flex;height:12px;width:160px;border-radius:6px;overflow:hidden;background:color-mix(in srgb,var(--fg) 8%,transparent)}.stack span{display:block}
+.grid2{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+.gauge{display:flex;align-items:center;gap:16px}.gauge .big{font-family:var(--heading);font-size:42px}
+.sev{display:flex;gap:8px;margin-top:6px}.pill{border-radius:20px;padding:2px 10px;font-size:12px;font-weight:600;color:#fff}
+.dim{display:flex;align-items:center;gap:10px;margin:6px 0}.dl{width:88px;font-size:12px;color:var(--muted)}.dbar{flex:1;height:9px;background:color-mix(in srgb,var(--fg) 8%,transparent);border-radius:5px;overflow:hidden}.dbar i{display:block;height:100%}.dn{width:30px;text-align:right;font-variant-numeric:tabular-nums}.dn.na{color:var(--muted)}
+.chip{display:inline-block;border:1px solid var(--line);border-radius:20px;padding:2px 10px;margin:3px 4px 0 0;font-size:12px}.chip b{color:var(--accent)}
+footer{margin-top:26px;color:var(--muted);font-size:11px;border-top:1px solid var(--line);padding-top:12px}
+@media(max-width:720px){.cards{grid-template-columns:repeat(2,1fr)}.grid2{grid-template-columns:1fr}}
+</style></head><body><div class="wrap">
+<header><h1>rollout <b>→ ${esc(s.target)}</b></h1><div class="sub">${esc(s.site.sourceUrl || '')}${s.site.liveHost ? ` · ${esc(s.site.liveHost)}` : ''} · ${esc(s.generatedAt.slice(0, 16).replace('T', ' '))} · rendered in the project's design identity</div></header>
+
+<div class="cards">
+  <div class="card"><div class="n">${total}</div><div class="l">pages identified</div></div>
+  <div class="card"><div class="n">${s.stageCount.deployed}<span style="font-size:15px;color:var(--muted)">/${total}</span></div><div class="l">deployed or beyond</div></div>
+  <div class="card"><div class="n">${s.stageCount.optimised}<span style="font-size:15px;color:var(--muted)">/${total}</span></div><div class="l">optimised</div></div>
+  <div class="card"><div class="n">${q ? q.overall : '—'}</div><div class="l">quality health</div></div>
+</div>
+
+<h2>Page tree</h2>
+<div class="legend">${legend}<span class="lg"><span class="tmpl-badge">T</span> template archetype</span><span class="lg muted-note">counts are cumulative — pages reached this stage or beyond</span></div>
+<div class="panel tree"><ul>${renderNode(treeRoot, true)}</ul></div>
+
+<h2>Templates</h2>
+<div class="panel"><table><thead><tr><th>template</th><th>archetype</th><th>pages</th><th>lifecycle</th></tr></thead><tbody>${tmplRows || '<tr><td colspan="4" class="dn na">no templates</td></tr>'}</tbody></table></div>
+
+<h2>Quality</h2>
+${q ? `<div class="grid2">
+  <div class="panel"><div class="gauge"><div class="big" style="color:${q.overall >= 80 ? '#2e9e5b' : q.overall >= 50 ? '#e0a72e' : '#d6473b'}">${q.overall}</div><div><div class="sub">overall health</div><div class="sev"><span class="pill" style="background:#d6473b">P1 ${q.severity.P1}</span><span class="pill" style="background:#e0a72e">P2 ${q.severity.P2}</span><span class="pill" style="background:#9aa3ad">P3 ${q.severity.P3}</span></div></div></div><div style="margin-top:12px">${sparkline(q.history, id.accent)}</div></div>
+  <div class="panel">${dimBars(q.dimensions)}</div>
+</div>
+<div class="panel">fixability: ${Object.entries(s.findings.byFixability).map(([k, n]) => `<span class="chip">${esc(k)} <b>${n}</b></span>`).join('') || '<span class="sub">none open</span>'} &nbsp; autofix: ${Object.entries(s.findings.byAutofix).map(([k, n]) => `<span class="chip">${esc(k)} <b>${n}</b></span>`).join('') || '<span class="sub">none</span>'}</div>` : '<div class="panel sub">optimize has not been run yet.</div>'}
+
+<footer>stardust:rollout/dashboard · brand tokens from the migrated :root · status spans state.json + coverage + optimize · self-contained, no external JS · data.json holds this snapshot.</footer>
+</div></body></html>`;
+}

--- a/plugins/stardust/skills/rollout/scripts/dashboard.mjs
+++ b/plugins/stardust/skills/rollout/scripts/dashboard.mjs
@@ -63,7 +63,7 @@ function readIdentity() {
 // to and including the one it reached (so identified = all pages).
 const STAGES = ['identified', 'prototyped', 'deployed', 'optimised'];
 const STAGE_COLOR = { identified: '#9aa3ad', prototyped: '#5b8def', deployed: '#18a0a0', optimised: '#2e9e5b' };
-const AG = { extracted: 0, directed: 0, prototyped: 1, approved: 1, migrated: 1 };
+const AG = { rostered: 0, extracted: 0, directed: 0, prototyped: 1, approved: 1, migrated: 1 };
 const rankOf = (stage) => STAGES.indexOf(stage);
 
 const openByPage = {};
@@ -84,7 +84,11 @@ function pathOf(slug, cov, stp) {
 }
 function stageOf(p) {
   let r = AG[p.agnosticStatus] ?? 0;
-  if (p.inCoverage) r = Math.max(r, 1); // in the migrated tree → at least prototyped/designed
+  // Being in the coverage ledger only counts as "prototyped/designed" if the page
+  // is actually in the migrated tree. A `content-pending` sibling (archetypes-only
+  // mode) sits in coverage but has no designed document yet — it stays "identified".
+  const designed = p.inCoverage && !(p.delivery && p.delivery.status === 'content-pending');
+  if (designed) r = Math.max(r, 1);
   if (p.delivery && (p.delivery.status === 'deployed' || p.delivery.status === 'verified')) r = Math.max(r, 2);
   if (p.delivery && p.delivery.status === 'verified' && (openByPage[p.slug] || 0) === 0 && optimizeRan) r = 3;
   return STAGES[r];
@@ -99,7 +103,9 @@ const model = [...allSlugs].map((slug) => {
     path: pathOf(slug, cov, stp),
     templateId: (cov && cov.templateId) || (stp && stp.type) || null,
     delivery: cov && cov.delivery, inCoverage: !!cov,
-    agnosticStatus: (stp && stp.status) || (cov ? 'migrated' : 'identified'),
+    agnosticStatus: (stp && stp.status)
+      || (cov && cov.delivery && cov.delivery.status === 'content-pending' ? 'rostered'
+        : (cov ? 'migrated' : 'identified')),
     isTemplate: repSlugs.has(slug), openFindings: openByPage[slug] || 0,
   };
   p.stage = stageOf(p);

--- a/plugins/stardust/skills/rollout/scripts/findings.mjs
+++ b/plugins/stardust/skills/rollout/scripts/findings.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * rollout/findings.mjs — record/resolve findings from external audit sources.
+ *
+ * optimize.mjs runs the deterministic BASELINE source. The other sources are
+ * existing audit skills run by the agent (impeccable:critique, impeccable:audit,
+ * the marketing SEO skills, stardust:tensions). Their findings enter the SAME
+ * ledger through this writer, so dedup, scorecard, gate, and autofix all apply
+ * uniformly. See reference/audit-sources.md.
+ *
+ * Record:  node findings.mjs record --source <s> --layer <l> --check <c>
+ *            --severity P1|P2|P3 --fixability platform-migration|design-pass|out-of-scope
+ *            [--scope-level page|site|template|block] --scope-ids <a,b>
+ *            --evidence "…" [--recommend "…"]
+ * Resolve: node findings.mjs resolve <id> --status fixed|accepted|wontfix|open [--note "…"]
+ */
+import { createHash } from 'node:crypto';
+import { join } from 'node:path';
+import { readJSON, writeJSON, computeScorecard, autofixFor, ALL_LAYERS } from './lib.mjs';
+
+function arg(name, fallback) { const i = process.argv.indexOf(`--${name}`); return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback; }
+const cmd = process.argv[2];
+const OUT = arg('out', 'stardust/rollout');
+const findingsPath = join(OUT, 'optimize', 'findings.json');
+const scorecardPath = join(OUT, 'optimize', 'scorecard.json');
+const now = new Date().toISOString();
+const version = (readJSON(join(OUT, 'rollout.json'), {})._provenance || {}).stardustVersion || '0.0.0';
+
+function loadDoc() {
+  return readJSON(findingsPath, { _provenance: { writtenBy: 'stardust:rollout', writtenAt: now, stardustVersion: version }, runs: [], findings: [] });
+}
+function persist(doc) {
+  doc._provenance = { writtenBy: 'stardust:rollout/findings', writtenAt: now, stardustVersion: version };
+  writeJSON(findingsPath, doc);
+  const sc = readJSON(scorecardPath, { history: [] });
+  const snap = computeScorecard(doc.findings, (doc.runs.at(-1) || {}).id || 'record', now);
+  writeJSON(scorecardPath, { _provenance: { writtenBy: 'stardust:rollout/findings', writtenAt: now, stardustVersion: version }, current: snap, history: sc.history || [] });
+  return snap;
+}
+
+if (cmd === 'record') {
+  const source = arg('source', null);
+  const layer = arg('layer', null);
+  const check = arg('check', null);
+  const severity = arg('severity', null);
+  const fixability = arg('fixability', null);
+  const level = arg('scope-level', 'page');
+  const ids = (arg('scope-ids', '') || '').split(',').map((s) => s.trim()).filter(Boolean);
+  const evidence = arg('evidence', '');
+  const recommendedMove = arg('recommend', '');
+  const errs = [];
+  if (!source) errs.push('--source required');
+  if (!ALL_LAYERS.includes(layer)) errs.push(`--layer must be one of ${ALL_LAYERS.join('|')}`);
+  if (!check) errs.push('--check required');
+  if (!['P1', 'P2', 'P3'].includes(severity)) errs.push('--severity P1|P2|P3');
+  if (!['platform-migration', 'design-pass', 'out-of-scope'].includes(fixability)) errs.push('--fixability platform-migration|design-pass|out-of-scope');
+  if (!ids.length && level !== 'site') errs.push('--scope-ids required (or --scope-level site)');
+  if (errs.length) { console.error(`record: ${errs.join('; ')}`); process.exit(2); }
+
+  const scopeIds = ids.length ? ids : ['*'];
+  const id = `f-${createHash('sha1').update(`${source}|${layer}|${check}|${level}|${[...scopeIds].sort().join(',')}`).digest('hex').slice(0, 10)}`;
+  const doc = loadDoc();
+  const existing = doc.findings.find((f) => f.id === id);
+  if (existing && (existing.status === 'accepted' || existing.status === 'wontfix')) {
+    console.log(`record: ${id} is ${existing.status} — left unchanged.`); process.exit(0);
+  }
+  const finding = {
+    id, source, layer, check, severity, scope: { level, ids: scopeIds }, evidence, fixability, recommendedMove,
+    status: 'open', autofix: (existing && existing.autofix) || autofixFor(check),
+    resolvedBy: null, firstSeenRun: (existing && existing.firstSeenRun) || 'recorded',
+  };
+  doc.findings = [...doc.findings.filter((f) => f.id !== id), finding].sort((a, b) => a.id.localeCompare(b.id));
+  const snap = persist(doc);
+  console.log(`recorded ${id}  ${source} ${layer}/${check} ${severity}  → open   (health ${snap.overall}/100)`);
+  process.exit(0);
+}
+
+if (cmd === 'resolve') {
+  const id = process.argv[3];
+  const status = arg('status', null);
+  const note = arg('note', null);
+  if (!id || !['fixed', 'accepted', 'wontfix', 'open', 'in-progress'].includes(status)) {
+    console.error('resolve <id> --status fixed|accepted|wontfix|open|in-progress [--note "…"]'); process.exit(2);
+  }
+  const doc = loadDoc();
+  const f = doc.findings.find((x) => x.id === id);
+  if (!f) { console.error(`resolve: no finding ${id}`); process.exit(1); }
+  f.status = status;
+  f.resolvedBy = (status === 'fixed') ? { phase: 'rollout', at: now, note: note || 'manually resolved' } : f.resolvedBy;
+  const snap = persist(doc);
+  console.log(`${id} → ${status}   (health ${snap.overall}/100, open P1 ${snap.severity.P1})`);
+  process.exit(0);
+}
+
+console.error('usage: findings.mjs record …   |   findings.mjs resolve <id> --status …');
+process.exit(2);

--- a/plugins/stardust/skills/rollout/scripts/inventory.mjs
+++ b/plugins/stardust/skills/rollout/scripts/inventory.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * rollout/inventory.mjs — build the delivery coverage from a migrated tree.
+ *
+ * Reads stardust/migrated/ (the platform-agnostic output of `migrate`) plus the
+ * per-page _meta.json sidecars, and writes the rollout coverage:
+ *   - stardust/rollout/coverage/pages.json     (one row per migrated page)
+ *   - stardust/rollout/coverage/templates.json (grouping for delivery order/reuse)
+ *   - stardust/rollout/rollout.json            (config + lastRun summary; created if absent)
+ *
+ * Idempotent + incremental: existing delivery status is preserved. When a page's
+ * migrated HTML changed (sourceHash differs) after it was already deployed/verified,
+ * it is re-flagged `stale` so the delivery loop re-delivers just that page.
+ *
+ * Phase 1 scope: pages + template grouping only. Block dedup (blocks.json) is a
+ * first-class step deferred to Phase 2 — see notes/rollout/PLAN.md § 8.
+ *
+ * Usage:
+ *   node skills/rollout/scripts/inventory.mjs [--migrated <dir>] [--out <rolloutDir>] [--site-url <url>]
+ *   defaults: --migrated stardust/migrated  --out stardust/rollout
+ */
+import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync, statSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { join, dirname, relative, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+const MIGRATED = arg('migrated', 'stardust/migrated');
+const OUT = arg('out', 'stardust/rollout');
+const SITE_URL = arg('site-url', null);
+
+const STARDUST_VERSION = (() => {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pj = JSON.parse(readFileSync(join(here, '..', '..', '..', '.claude-plugin', 'plugin.json'), 'utf8'));
+    return pj.version || '0.0.0';
+  } catch { return '0.0.0'; }
+})();
+
+function sha256(buf) { return `sha256:${createHash('sha256').update(buf).digest('hex')}`; }
+
+/** Recursively collect *.html under dir, skipping the assets/ bundle. */
+function walkHtml(dir, root = dir, acc = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'assets') continue;
+      walkHtml(full, root, acc);
+    } else if (entry.name.endsWith('.html')) {
+      acc.push(relative(root, full));
+    }
+  }
+  return acc;
+}
+
+/** Sidecar path for a migrated HTML rel path (index.html -> _meta.json; x.html -> x._meta.json). */
+function sidecarFor(relHtml) {
+  const dir = dirname(relHtml);
+  const leaf = basename(relHtml);
+  const name = leaf === 'index.html' ? '_meta.json' : `${leaf.replace(/\.html$/, '')}._meta.json`;
+  return dir === '.' ? name : join(dir, name);
+}
+
+/** Delivered (extensionless) path on the EDS site for a migrated HTML rel path. */
+function deliveredPath(relHtml) {
+  const noExt = relHtml.replace(/\.html$/, '');
+  if (noExt === 'index') return '/';
+  if (noExt.endsWith('/index')) return `/${noExt.slice(0, -'/index'.length)}`;
+  return `/${noExt}`;
+}
+
+function readJSON(path, fallback = null) {
+  try { return JSON.parse(readFileSync(path, 'utf8')); } catch { return fallback; }
+}
+
+if (!existsSync(MIGRATED)) {
+  console.error(`rollout inventory: migrated tree not found at "${MIGRATED}". Run \`stardust migrate\` first.`);
+  process.exit(1);
+}
+
+// --- Load prior coverage to preserve delivery state ----------------------------
+const coverageDir = join(OUT, 'coverage');
+const pagesPath = join(coverageDir, 'pages.json');
+const templatesPath = join(coverageDir, 'templates.json');
+const configPath = join(OUT, 'rollout.json');
+
+const priorPages = readJSON(pagesPath, { pages: [] });
+const priorBySlug = new Map((priorPages.pages || []).map((p) => [p.slug, p]));
+
+// --- Inventory the migrated tree -----------------------------------------------
+const htmlFiles = walkHtml(MIGRATED).sort();
+const pages = [];
+
+for (const relHtml of htmlFiles) {
+  const absHtml = join(MIGRATED, relHtml);
+  const sourceHash = sha256(readFileSync(absHtml));
+  const sidecarRel = sidecarFor(relHtml);
+  const meta = readJSON(join(MIGRATED, sidecarRel), {});
+  const path = deliveredPath(relHtml);
+  const slug = meta.slug || (path === '/' ? 'home' : path.replace(/^\//, ''));
+
+  const prior = priorBySlug.get(slug);
+  let delivery;
+  if (prior && prior.delivery) {
+    const changed = prior.source && prior.source.sourceHash !== sourceHash;
+    if (changed && ['deployed', 'verified'].includes(prior.delivery.status)) {
+      delivery = { ...prior.delivery, status: 'stale' };
+    } else {
+      delivery = prior.delivery;
+    }
+  } else {
+    delivery = { status: 'pending', deployedUrl: null, deployedAt: null, verifiedAt: null, error: null };
+  }
+
+  pages.push({
+    slug,
+    path,
+    title: (meta.metadata && meta.metadata.title) || meta.slug || slug,
+    templateId: meta.template || meta.type || null,
+    source: {
+      migratedHtml: join(MIGRATED, relHtml),
+      metaJson: existsSync(join(MIGRATED, sidecarRel)) ? join(MIGRATED, sidecarRel) : null,
+      sourceHash,
+    },
+    blocks: Array.isArray(meta.modules) ? meta.modules : [],
+    delivery,
+  });
+}
+
+pages.sort((a, b) => a.slug.localeCompare(b.slug));
+
+// --- Derive the template grouping ----------------------------------------------
+const tmap = new Map();
+for (const p of pages) {
+  const id = p.templateId || 'untyped';
+  if (!tmap.has(id)) tmap.set(id, { id, pages: [], blocks: new Set() });
+  const t = tmap.get(id);
+  t.pages.push(p.slug);
+  p.blocks.forEach((b) => t.blocks.add(b));
+}
+const templates = [...tmap.values()].map((t) => {
+  const tp = pages.filter((p) => t.pages.includes(p.slug));
+  const count = (s) => tp.filter((p) => p.delivery.status === s).length;
+  return {
+    id: t.id,
+    representativeSlug: t.pages[0] || null,
+    pages: t.pages.sort(),
+    pageCount: t.pages.length,
+    blocks: [...t.blocks].sort(),
+    delivery: {
+      verified: count('verified'),
+      deployed: count('deployed'),
+      pending: t.pages.length - count('verified') - count('deployed'),
+    },
+  };
+}).sort((a, b) => a.id.localeCompare(b.id));
+
+// --- Counts summary ------------------------------------------------------------
+const status = (s) => pages.filter((p) => p.delivery.status === s).length;
+const counts = {
+  total: pages.length,
+  verified: status('verified'),
+  deployed: status('deployed'),
+  pending: status('pending'),
+  stale: status('stale'),
+  failed: status('failed'),
+};
+
+// --- Write ---------------------------------------------------------------------
+const now = new Date().toISOString();
+mkdirSync(coverageDir, { recursive: true });
+
+const prov = (writtenBy) => ({
+  writtenBy, writtenAt: now, readArtifacts: [MIGRATED], stardustVersion: STARDUST_VERSION,
+});
+
+writeFileSync(pagesPath, `${JSON.stringify({ _provenance: prov('stardust:rollout/inventory'), generatedAt: now, pages }, null, 2)}\n`);
+writeFileSync(templatesPath, `${JSON.stringify({ _provenance: prov('stardust:rollout/inventory'), generatedAt: now, templates }, null, 2)}\n`);
+
+const priorConfig = readJSON(configPath, null);
+const config = {
+  _provenance: { writtenBy: 'stardust:rollout/inventory', writtenAt: now, stardustVersion: STARDUST_VERSION },
+  target: 'aem-eds',
+  site: {
+    sourceUrl: SITE_URL || (priorConfig && priorConfig.site && priorConfig.site.sourceUrl) || 'about:blank',
+    da: (priorConfig && priorConfig.site && priorConfig.site.da) || { org: '', site: '', ref: 'main' },
+    liveHost: (priorConfig && priorConfig.site && priorConfig.site.liveHost) || null,
+  },
+  lastRun: { at: now, pages: counts, blocks: { total: 0, converted: 0, pending: 0 }, verifyFailures: 0 },
+};
+writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+
+// --- Report --------------------------------------------------------------------
+console.log(`rollout inventory → ${OUT}`);
+console.log('='.repeat(60));
+console.log(`Pages       ${counts.total} total · ${counts.verified} verified · ${counts.deployed} deployed · ${counts.pending} pending · ${counts.stale} stale`);
+console.log(`Templates   ${templates.length} (${templates.map((t) => `${t.id}:${t.pageCount}`).join(', ')})`);
+const todo = pages.filter((p) => ['pending', 'stale', 'failed'].includes(p.delivery.status));
+if (todo.length) console.log(`To deliver  ${todo.length}: ${todo.slice(0, 8).map((p) => p.slug).join(', ')}${todo.length > 8 ? ' …' : ''}`);
+else console.log('To deliver  0 — all pages delivered.');

--- a/plugins/stardust/skills/rollout/scripts/inventory.mjs
+++ b/plugins/stardust/skills/rollout/scripts/inventory.mjs
@@ -15,8 +15,15 @@
  * Phase 1 scope: pages + template grouping only. Block dedup (blocks.json) is a
  * first-class step deferred to Phase 2 — see notes/rollout/PLAN.md § 8.
  *
+ * Archetypes-only mode (`--state <state.json>`): the migrated tree holds only the
+ * template archetypes (one per template); the full page roster lives in state.json.
+ * Pages present only in state.json (not yet individually migrated) are merged in as
+ * `content-pending` siblings — keyed to the archetype their `type` names, inheriting
+ * that archetype's blocks, pushing no document. Block code ships from the archetypes;
+ * sibling content is populated later by a separate content track.
+ *
  * Usage:
- *   node skills/rollout/scripts/inventory.mjs [--migrated <dir>] [--out <rolloutDir>] [--site-url <url>]
+ *   node skills/rollout/scripts/inventory.mjs [--migrated <dir>] [--out <rolloutDir>] [--site-url <url>] [--state <state.json>]
  *   defaults: --migrated stardust/migrated  --out stardust/rollout
  */
 import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync, statSync } from 'node:fs';
@@ -32,6 +39,7 @@ function arg(name, fallback) {
 const MIGRATED = arg('migrated', 'stardust/migrated');
 const OUT = arg('out', 'stardust/rollout');
 const SITE_URL = arg('site-url', null);
+const STATE = arg('state', null);
 
 const STARDUST_VERSION = (() => {
   try {
@@ -72,6 +80,22 @@ function deliveredPath(relHtml) {
   if (noExt === 'index') return '/';
   if (noExt.endsWith('/index')) return `/${noExt.slice(0, -'/index'.length)}`;
   return `/${noExt}`;
+}
+
+/** Delivered (extensionless) path for an absolute page URL (archetypes-only roster). */
+function urlToDeliveredPath(url) {
+  let p;
+  try { p = new URL(url).pathname; } catch { p = String(url); }
+  p = p.replace(/\.html$/, '');
+  if (p === '' || p === '/' || p === '/index') return '/';
+  if (p.endsWith('/index')) return p.slice(0, -'/index'.length);
+  return p;
+}
+
+/** Stable slug from a delivered path (de/x/y -> de-x-y; '/' -> home). */
+function pathToSlug(path) {
+  if (path === '/') return 'home';
+  return path.replace(/^\//, '').replace(/\/+$/, '').replace(/\//g, '-');
 }
 
 function readJSON(path, fallback = null) {
@@ -132,6 +156,48 @@ for (const relHtml of htmlFiles) {
   });
 }
 
+// --- Archetypes-only mode: merge content-pending siblings from state.json -------
+// In --state mode each migrated archetype is keyed by its own fine slug (the
+// archetypes are genuinely distinct templates that share only chrome). A roster
+// page's `type` names the archetype slug it clones; it joins that archetype's
+// template group as a `content-pending` sibling, inheriting the archetype's blocks
+// and pushing no document of its own.
+if (STATE) {
+  for (const p of pages) p.templateId = p.slug;
+  const archetypeBySlug = new Map(pages.map((p) => [p.slug, p]));
+  const coveredPaths = new Set(pages.map((p) => p.path));
+  const usedSlugs = new Set(pages.map((p) => p.slug));
+  const state = readJSON(STATE, { pages: [] });
+  for (const sp of (state.pages || [])) {
+    if (!sp || !sp.url) continue;
+    const path = urlToDeliveredPath(sp.url);
+    if (coveredPaths.has(path)) continue; // the archetype itself — already inventoried
+    // A roster sibling names the archetype it clones via `representative` (preferred)
+    // or its `type`; that archetype supplies the template grouping + block set.
+    const rep = archetypeBySlug.get(sp.representative) || archetypeBySlug.get(sp.type) || null;
+    let slug = sp.slug && !usedSlugs.has(sp.slug) ? sp.slug : pathToSlug(path);
+    while (usedSlugs.has(slug)) slug = `${slug}-x`;
+    usedSlugs.add(slug);
+    const csPath = sp.currentStatePath && existsSync(sp.currentStatePath) ? sp.currentStatePath : null;
+    const sourceHash = csPath ? sha256(readFileSync(csPath)) : sha256(Buffer.from(String(sp.url)));
+    const prior = priorBySlug.get(slug);
+    const delivery = (prior && prior.delivery)
+      ? prior.delivery
+      : { status: 'content-pending', deployedUrl: null, deployedAt: null, verifiedAt: null, error: null };
+    pages.push({
+      slug,
+      path,
+      title: sp.title || slug,
+      templateId: rep ? rep.slug : (sp.type || 'untyped'),
+      representative: rep ? rep.slug : null,
+      source: { migratedHtml: null, metaJson: null, sourceHash, currentStatePath: csPath },
+      blocks: rep ? rep.blocks.slice() : [],
+      delivery,
+    });
+    coveredPaths.add(path);
+  }
+}
+
 pages.sort((a, b) => a.slug.localeCompare(b.slug));
 
 // --- Derive the template grouping ----------------------------------------------
@@ -146,16 +212,20 @@ for (const p of pages) {
 const templates = [...tmap.values()].map((t) => {
   const tp = pages.filter((p) => t.pages.includes(p.slug));
   const count = (s) => tp.filter((p) => p.delivery.status === s).length;
+  // The representative is the migrated archetype that converts the blocks — never a
+  // content-pending sibling (which pushes no document).
+  const rep = tp.find((p) => p.delivery.status !== 'content-pending') || tp[0];
   return {
     id: t.id,
-    representativeSlug: t.pages[0] || null,
+    representativeSlug: (rep && rep.slug) || null,
     pages: t.pages.sort(),
     pageCount: t.pages.length,
     blocks: [...t.blocks].sort(),
     delivery: {
       verified: count('verified'),
       deployed: count('deployed'),
-      pending: t.pages.length - count('verified') - count('deployed'),
+      contentPending: count('content-pending'),
+      pending: t.pages.length - count('verified') - count('deployed') - count('content-pending'),
     },
   };
 }).sort((a, b) => a.id.localeCompare(b.id));
@@ -167,6 +237,7 @@ const counts = {
   verified: status('verified'),
   deployed: status('deployed'),
   pending: status('pending'),
+  contentPending: status('content-pending'),
   stale: status('stale'),
   failed: status('failed'),
 };
@@ -176,7 +247,7 @@ const now = new Date().toISOString();
 mkdirSync(coverageDir, { recursive: true });
 
 const prov = (writtenBy) => ({
-  writtenBy, writtenAt: now, readArtifacts: [MIGRATED], stardustVersion: STARDUST_VERSION,
+  writtenBy, writtenAt: now, readArtifacts: STATE ? [MIGRATED, STATE] : [MIGRATED], stardustVersion: STARDUST_VERSION,
 });
 
 writeFileSync(pagesPath, `${JSON.stringify({ _provenance: prov('stardust:rollout/inventory'), generatedAt: now, pages }, null, 2)}\n`);
@@ -198,7 +269,7 @@ writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
 // --- Report --------------------------------------------------------------------
 console.log(`rollout inventory → ${OUT}`);
 console.log('='.repeat(60));
-console.log(`Pages       ${counts.total} total · ${counts.verified} verified · ${counts.deployed} deployed · ${counts.pending} pending · ${counts.stale} stale`);
+console.log(`Pages       ${counts.total} total · ${counts.verified} verified · ${counts.deployed} deployed · ${counts.pending} pending · ${counts.contentPending} content-pending · ${counts.stale} stale`);
 console.log(`Templates   ${templates.length} (${templates.map((t) => `${t.id}:${t.pageCount}`).join(', ')})`);
 const todo = pages.filter((p) => ['pending', 'stale', 'failed'].includes(p.delivery.status));
 if (todo.length) console.log(`To deliver  ${todo.length}: ${todo.slice(0, 8).map((p) => p.slug).join(', ')}${todo.length > 8 ? ' …' : ''}`);

--- a/plugins/stardust/skills/rollout/scripts/lib.mjs
+++ b/plugins/stardust/skills/rollout/scripts/lib.mjs
@@ -1,0 +1,153 @@
+/**
+ * rollout/lib.mjs — shared IO + roll-up helpers so every script derives the same
+ * counts from the same per-unit truth (counts are always recomputed, never
+ * incremented).
+ */
+import { readFileSync, writeFileSync, mkdirSync, existsSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+export function readJSON(path, fallback = null) {
+  try { return JSON.parse(readFileSync(path, 'utf8')); } catch { return fallback; }
+}
+
+export function writeJSON(path, obj) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(obj, null, 2)}\n`);
+}
+
+const countBy = (rows, get, val) => rows.filter((r) => get(r) === val).length;
+
+/** Page delivery counts from coverage/pages.json rows. */
+export function pageCounts(pages) {
+  const g = (p) => (p.delivery && p.delivery.status) || 'pending';
+  return {
+    total: pages.length,
+    verified: countBy(pages, g, 'verified'),
+    deployed: countBy(pages, g, 'deployed'),
+    pending: countBy(pages, g, 'pending'),
+    stale: countBy(pages, g, 'stale'),
+    failed: countBy(pages, g, 'failed'),
+  };
+}
+
+/** Block conversion counts from coverage/blocks.json rows. */
+export function blockCounts(blocks) {
+  const converted = blocks.filter((b) => ['converted', 'deployed', 'verified']
+    .includes(b.delivery && b.delivery.status)).length;
+  return { total: blocks.length, converted, pending: blocks.length - converted };
+}
+
+/** Recompute each template's delivery roll-up in place from the page rows. */
+export function rollupTemplates(templatesDoc, pages) {
+  if (!templatesDoc || !Array.isArray(templatesDoc.templates)) return;
+  for (const t of templatesDoc.templates) {
+    const tp = pages.filter((p) => (t.pages || []).includes(p.slug));
+    const g = (p) => (p.delivery && p.delivery.status) || 'pending';
+    t.delivery = {
+      verified: countBy(tp, g, 'verified'),
+      deployed: countBy(tp, g, 'deployed'),
+      pending: tp.length - countBy(tp, g, 'verified') - countBy(tp, g, 'deployed'),
+    };
+  }
+}
+
+/** Recompute rollout.json lastRun from the page + (optional) block rows. */
+export function rollupConfig(config, pages, blocks, now) {
+  if (!config) return;
+  const counts = pageCounts(pages);
+  config.lastRun = {
+    ...(config.lastRun || {}),
+    at: now,
+    pages: counts,
+    blocks: blocks ? blockCounts(blocks) : (config.lastRun && config.lastRun.blocks) || { total: 0, converted: 0, pending: 0 },
+    verifyFailures: counts.failed,
+  };
+}
+
+/** EDS block name from a block id: kebab + guard against reserved EDS classes (#15). */
+const RESERVED = new Set(['section', 'default-content', 'block-content', 'wrap', 'button']);
+export function edsName(id) {
+  let n = String(id).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  if (!n) n = 'block';
+  if (RESERVED.has(n)) n = `blk-${n}`;
+  return n;
+}
+
+/** Chrome ids deliver as static fragments, not per-page blocks. */
+export const CHROME_IDS = new Set(['header', 'nav', 'footer']);
+export const kindOf = (id) => (CHROME_IDS.has(String(id).toLowerCase()) ? 'chrome' : 'module');
+
+/** Map a delivered (extensionless) path to a file under root (migrated-tree shape). */
+export function resolveLocalFile(root, p) {
+  const candidates = p === '/' ? ['index.html'] : [`${p.slice(1)}.html`, `${p.slice(1)}/index.html`, p.slice(1)];
+  for (const c of candidates) { const f = join(root, c); if (existsSync(f) && statSync(f).isFile()) return f; }
+  return null;
+}
+
+/** Load a page's HTML by HTTP (base) or from a local root. Returns {ok, body, reason}. */
+export async function loadPageHTML(page, { root, base }) {
+  if (root) {
+    const f = resolveLocalFile(root, page.path);
+    if (!f) return { ok: false, reason: `not found under ${root}` };
+    return { ok: true, body: readFileSync(f, 'utf8') };
+  }
+  try {
+    const res = await fetch(`${base}${page.path}`);
+    const body = await res.text();
+    if (!res.ok) return { ok: false, reason: `HTTP ${res.status}` };
+    return { ok: true, body };
+  } catch (e) { return { ok: false, reason: `fetch error: ${e.message}` }; }
+}
+
+// --- optimize: layers, scoring, and the AEM autofix registry --------------------
+export const ALL_LAYERS = ['brand-tensions', 'design-ux', 'accessibility', 'seo', 'content-conversion', 'ai-search', 'cross-page'];
+export const ASSESSED_BY_BASELINE = ['accessibility', 'seo', 'ai-search', 'cross-page'];
+export const SEV_WEIGHT = { P1: 25, P2: 10, P3: 4 };
+
+/**
+ * AEM autofix registry: maps a finding's `check` to the EDS fixer that resolves it.
+ * kind: 'deterministic' (mechanical edit) | 'content-draft' (generates copy needing
+ * review — applied under the aggressive policy, logged) | 'manual' (autofix prepares
+ * a payload/guidance but a human applies it). target is aem-eds for v1.
+ */
+export const AEM_AUTOFIX = {
+  'title-missing': { strategy: 'eds-metadata-title', kind: 'content-draft' },
+  'title-length': { strategy: 'eds-metadata-title', kind: 'content-draft' },
+  'meta-description': { strategy: 'eds-metadata-description', kind: 'content-draft' },
+  'single-h1': { strategy: 'eds-fix-h1', kind: 'deterministic' },
+  'img-alt': { strategy: 'eds-alt-draft', kind: 'content-draft' },
+  'duplicate-title': { strategy: 'eds-disambiguate-title', kind: 'content-draft' },
+  'sitemap': { strategy: 'rollout-assemble', kind: 'deterministic' },
+  'jsonld': { strategy: 'eds-jsonld', kind: 'manual' },
+  'canonical': { strategy: 'eds-canonical', kind: 'manual' },
+  'landmark-main': { strategy: 'eds-landmark-main', kind: 'manual' },
+};
+
+/** The autofix descriptor for a finding (check), or an unavailable stub. */
+export function autofixFor(check) {
+  const a = AEM_AUTOFIX[check];
+  if (!a) return { available: false, target: 'aem-eds', strategy: null, kind: null, status: 'unavailable', appliedBy: null, at: null, detail: null };
+  return { available: true, target: 'aem-eds', strategy: a.strategy, kind: a.kind, status: 'pending', appliedBy: null, at: null, detail: null };
+}
+
+/** Compute a scorecard snapshot from the full findings list. */
+export function computeScorecard(findings, runId, now) {
+  const open = findings.filter((x) => x.status === 'open' || x.status === 'in-progress');
+  const fixed = findings.filter((x) => x.status === 'fixed');
+  const assessed = new Set();
+  for (const f of findings) assessed.add(f.layer);
+  const dimensions = {};
+  for (const layer of ALL_LAYERS) {
+    if (!assessed.has(layer)) { dimensions[layer] = null; continue; }
+    const penalty = open.filter((x) => x.layer === layer).reduce((n, x) => n + (SEV_WEIGHT[x.severity] || 0), 0);
+    dimensions[layer] = Math.max(0, 100 - penalty);
+  }
+  const scored = ALL_LAYERS.map((l) => dimensions[l]).filter((v) => v !== null);
+  const overall = scored.length ? Math.round(scored.reduce((a, b) => a + b, 0) / scored.length) : null;
+  const sev = (arr, s) => arr.filter((x) => x.severity === s).length;
+  return {
+    runId, at: now, overall, dimensions,
+    severity: { P1: sev(open, 'P1'), P2: sev(open, 'P2'), P3: sev(open, 'P3') },
+    fixed: { P1: sev(fixed, 'P1'), P2: sev(fixed, 'P2'), P3: sev(fixed, 'P3') },
+  };
+}

--- a/plugins/stardust/skills/rollout/scripts/lib.mjs
+++ b/plugins/stardust/skills/rollout/scripts/lib.mjs
@@ -25,6 +25,7 @@ export function pageCounts(pages) {
     verified: countBy(pages, g, 'verified'),
     deployed: countBy(pages, g, 'deployed'),
     pending: countBy(pages, g, 'pending'),
+    contentPending: countBy(pages, g, 'content-pending'),
     stale: countBy(pages, g, 'stale'),
     failed: countBy(pages, g, 'failed'),
   };
@@ -43,10 +44,12 @@ export function rollupTemplates(templatesDoc, pages) {
   for (const t of templatesDoc.templates) {
     const tp = pages.filter((p) => (t.pages || []).includes(p.slug));
     const g = (p) => (p.delivery && p.delivery.status) || 'pending';
+    const cp = countBy(tp, g, 'content-pending');
     t.delivery = {
       verified: countBy(tp, g, 'verified'),
       deployed: countBy(tp, g, 'deployed'),
-      pending: tp.length - countBy(tp, g, 'verified') - countBy(tp, g, 'deployed'),
+      contentPending: cp,
+      pending: tp.length - countBy(tp, g, 'verified') - countBy(tp, g, 'deployed') - cp,
     };
   }
 }

--- a/plugins/stardust/skills/rollout/scripts/optimize.mjs
+++ b/plugins/stardust/skills/rollout/scripts/optimize.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/**
+ * rollout/optimize.mjs — the in-flow delivery-quality gate (Phase 3).
+ *
+ * Runs deterministic detectors over the delivered (or migrated) HTML, records a
+ * findings ledger + scorecard, and GATES the rollout: exits non-zero if any open
+ * P1 finding is in scope. Implements the detect -> fix -> verify loop — on re-run,
+ * a prior open finding no longer detected flips to `fixed`; a regressed `fixed`
+ * finding re-opens. Findings are tagged by fixability so the report routes them:
+ *   platform-migration → rollout fixes by re-running deploy
+ *   design-pass        → upstream (fix in migrate/prototype); rollout surfaces only
+ *   out-of-scope       → informational
+ *
+ * Automated layers: accessibility, seo, ai-search, cross-page. The judgment layers
+ * (brand-tensions, design-ux, content-conversion) are left null (not assessed) for
+ * a future LLM-driven enrichment pass.
+ *
+ * Usage: node skills/rollout/scripts/optimize.mjs [--base <url> | --root <dir>]
+ *          [--slug <s>] [--all] [--out <rolloutDir>]
+ */
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { readJSON, writeJSON, loadPageHTML, computeScorecard, autofixFor, ASSESSED_BY_BASELINE } from './lib.mjs';
+
+function arg(name, fallback) { const i = process.argv.indexOf(`--${name}`); return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback; }
+const OUT = arg('out', 'stardust/rollout');
+const ROOT = arg('root', null);
+const onlySlug = arg('slug', null);
+const ALL = process.argv.includes('--all');
+
+const SOURCE = 'rollout:baseline';
+const ASSESSED = ASSESSED_BY_BASELINE;
+const PHASE_FOR = { 'platform-migration': 'deploy', 'design-pass': 'migrate', 'out-of-scope': 'rollout' };
+
+const config = readJSON(join(OUT, 'rollout.json'), {});
+const BASE = arg('base', (config.site && config.site.liveHost) ? `https://${config.site.liveHost}` : null);
+const pagesDoc = readJSON(join(OUT, 'coverage', 'pages.json'));
+if (!pagesDoc) { console.error('rollout optimize: run inventory.mjs first.'); process.exit(1); }
+if (!ROOT && !BASE) { console.error('rollout optimize: need --base <url> or --root <dir> (or set site.liveHost).'); process.exit(2); }
+const pages = pagesDoc.pages || [];
+
+const fid = (layer, check, level, ids) => `f-${createHash('sha1').update(`${SOURCE}|${layer}|${check}|${level}|${[...ids].sort().join(',')}`).digest('hex').slice(0, 10)}`;
+const mk = (layer, check, severity, fixability, level, ids, evidence, recommendedMove) =>
+  ({ id: fid(layer, check, level, ids), source: SOURCE, layer, check, severity, fixability, scope: { level, ids }, evidence, recommendedMove, autofix: autofixFor(check) });
+
+// --- Detectors -----------------------------------------------------------------
+const has = (re, s) => re.test(s);
+const titleOf = (html) => (html.match(/<title[^>]*>([\s\S]*?)<\/title>/i) || [])[1]?.trim() || null;
+const descOf = (html) => (html.match(/<meta[^>]+name=["']description["'][^>]*content=["']([^"']*)["']/i) || [])[1]?.trim() || null;
+
+function detectPage(html, slug) {
+  const f = [];
+  const lvl = 'page'; const id = [slug];
+  // accessibility
+  if (!has(/<main[\s>]/i, html)) f.push(mk('accessibility', 'landmark-main', 'P1', 'platform-migration', lvl, id, 'no <main> landmark in delivered HTML', 'EDS decorates <main>; ensure block output lands inside <main> (deploy anti-pattern 17).'));
+  const imgsNoAlt = (html.match(/<img\b(?![^>]*\balt=)[^>]*>/gi) || []).length;
+  if (imgsNoAlt) f.push(mk('accessibility', 'img-alt', 'P2', 'design-pass', lvl, id, `${imgsNoAlt} <img> without alt`, 'Author alt text upstream (migrate/prototype); rollout cannot synthesize it.'));
+  // seo
+  const title = titleOf(html);
+  if (!title) f.push(mk('seo', 'title-missing', 'P1', 'platform-migration', lvl, id, 'no <title>', 'Add a metadata block (deploy #34); EDS derives <title> from it.'));
+  else if (title.length < 10 || title.length > 70) f.push(mk('seo', 'title-length', 'P3', 'platform-migration', lvl, id, `<title> is ${title.length} chars ("${title.slice(0, 40)}")`, 'Aim for ~50-60 chars: brand + primary keyword (deploy #34).'));
+  if (!descOf(html)) f.push(mk('seo', 'meta-description', 'P2', 'platform-migration', lvl, id, 'no <meta name="description">', 'Add a Description row to the metadata block (deploy #34).'));
+  const h1 = (html.match(/<h1[\s>]/gi) || []).length;
+  if (h1 !== 1) f.push(mk('seo', 'single-h1', 'P1', 'platform-migration', lvl, id, `${h1} <h1> (expected exactly 1)`, 'Hero/lead headline = the page\'s single <h1>; other titles <h2> (deploy #35).'));
+  if (!has(/<link[^>]+rel=["']canonical["']/i, html)) f.push(mk('seo', 'canonical', 'P2', 'platform-migration', lvl, id, 'no rel=canonical', 'Emit a self-canonical link at delivery.'));
+  // ai-search
+  if (!has(/application\/ld\+json/i, html)) f.push(mk('ai-search', 'jsonld', 'P2', 'platform-migration', lvl, id, 'no JSON-LD structured data', 'Emit page-type JSON-LD in the head (metadata-and-jsonld).'));
+  return f;
+}
+
+function detectSite(loaded) {
+  const f = [];
+  // cross-page title / description uniqueness
+  const byTitle = new Map(); const byDesc = new Map();
+  for (const { slug, title, desc } of loaded) {
+    if (title) { if (!byTitle.has(title)) byTitle.set(title, []); byTitle.get(title).push(slug); }
+    if (desc) { if (!byDesc.has(desc)) byDesc.set(desc, []); byDesc.get(desc).push(slug); }
+  }
+  for (const [title, slugs] of byTitle) if (slugs.length > 1) f.push(mk('cross-page', 'duplicate-title', 'P2', 'design-pass', 'page', slugs, `${slugs.length} pages share <title> "${title.slice(0, 40)}"`, 'Give each page a unique title upstream (migrate metadata).'));
+  for (const [, slugs] of byDesc) if (slugs.length > 1) f.push(mk('cross-page', 'duplicate-description', 'P3', 'design-pass', 'page', slugs, `${slugs.length} pages share a meta description`, 'Write per-page descriptions upstream.'));
+  // sitemap present
+  const sitemapLocal = existsSync(join(OUT, 'site', 'sitemap.xml'));
+  if (!sitemapLocal) f.push(mk('seo', 'sitemap', 'P2', 'platform-migration', 'site', ['*'], 'no sitemap.xml assembled', 'Run assemble.mjs and deploy the sitemap.'));
+  return f;
+}
+
+// --- Select pages + load HTML --------------------------------------------------
+const target = pages.filter((p) => {
+  if (onlySlug) return p.slug === onlySlug;
+  if (ALL) return true;
+  return ['deployed', 'verified'].includes(p.delivery && p.delivery.status);
+});
+
+const inspectedSlugs = new Set();
+const loaded = [];
+const detected = [];
+for (const p of target) {
+  const r = await loadPageHTML(p, { root: ROOT, base: BASE });
+  if (!r.ok) continue; // unreachable pages are verify.mjs's concern, not optimize's
+  inspectedSlugs.add(p.slug);
+  loaded.push({ slug: p.slug, title: titleOf(r.body), desc: descOf(r.body) });
+  detected.push(...detectPage(r.body, p.slug));
+}
+const ranSite = target.length === pages.length || ALL || !onlySlug;
+if (ranSite) detected.push(...detectSite(loaded));
+
+// --- Merge with prior findings (detect -> fix -> verify) -----------------------
+const findingsPath = join(OUT, 'optimize', 'findings.json');
+const scorecardPath = join(OUT, 'optimize', 'scorecard.json');
+const prior = readJSON(findingsPath, { runs: [], findings: [] });
+const priorById = new Map((prior.findings || []).map((x) => [x.id, x]));
+const detectedById = new Map(detected.map((d) => [d.id, d]));
+const now = new Date().toISOString();
+const runId = `run-${(prior.runs || []).length + 1}`;
+
+// scope test: is a prior finding inside what this run actually inspected?
+const inScope = (fnd) => {
+  if (fnd.scope.level === 'site') return ranSite;
+  return fnd.scope.ids.every((s) => inspectedSlugs.has(s));
+};
+
+const out = [];
+const seen = new Set();
+for (const d of detected) {
+  seen.add(d.id);
+  const p = priorById.get(d.id);
+  if (p && (p.status === 'accepted' || p.status === 'wontfix')) { out.push(p); continue; }
+  if (p && (p.status === 'open' || p.status === 'in-progress')) {
+    out.push({ ...p, severity: d.severity, fixability: d.fixability, evidence: d.evidence, recommendedMove: d.recommendedMove });
+  } else if (p && p.status === 'fixed') {
+    out.push({ ...d, status: 'open', firstSeenRun: p.firstSeenRun, resolvedBy: null }); // regression
+  } else {
+    out.push({ ...d, status: 'open', firstSeenRun: runId, resolvedBy: null });
+  }
+}
+for (const p of prior.findings || []) {
+  if (seen.has(p.id)) continue;
+  // Only a run of THIS source may auto-resolve its own findings. Findings from
+  // other sources (impeccable, marketing skills, stardust tensions) are preserved
+  // untouched — they are resolved by re-recording from their own audit.
+  if (p.source === SOURCE && (p.status === 'open' || p.status === 'in-progress') && inScope(p)) {
+    out.push({ ...p, status: 'fixed', resolvedBy: { phase: PHASE_FOR[p.fixability] || 'rollout', at: now, note: 'no longer detected on delivered page' } });
+  } else {
+    out.push(p); // other source, out-of-scope, or already-terminal — preserve
+  }
+}
+const sevRank = { P1: 0, P2: 1, P3: 2 };
+out.sort((a, b) => (sevRank[a.severity] - sevRank[b.severity]) || a.id.localeCompare(b.id));
+
+const runs = [...(prior.runs || []), { id: runId, at: now, scopePages: [...inspectedSlugs].sort(), layersRun: ASSESSED, trigger: onlySlug ? 'reverify' : 'deliver', source: ROOT ? `root:${ROOT}` : BASE }];
+writeJSON(findingsPath, { _provenance: { writtenBy: 'stardust:rollout/optimize', writtenAt: now, stardustVersion: (config._provenance || {}).stardustVersion || '0.0.0' }, runs, findings: out });
+
+// --- Scorecard (over ALL sources in the ledger, not just baseline) -------------
+const open = out.filter((x) => x.status === 'open' || x.status === 'in-progress');
+const snapshot = computeScorecard(out, runId, now);
+const dimensions = snapshot.dimensions;
+const overall = snapshot.overall;
+const priorSc = readJSON(scorecardPath, { history: [] });
+writeJSON(scorecardPath, { _provenance: { writtenBy: 'stardust:rollout/optimize', writtenAt: now, stardustVersion: (config._provenance || {}).stardustVersion || '0.0.0' }, current: snapshot, history: [...(priorSc.history || []), snapshot] });
+
+// --- Report + gate -------------------------------------------------------------
+const openP1 = open.filter((x) => x.severity === 'P1');
+console.log(`rollout optimize (${ROOT ? `root:${ROOT}` : BASE})  run ${runId}`);
+console.log('='.repeat(64));
+console.log(`Inspected   ${inspectedSlugs.size} pages${ranSite ? ' + site checks' : ''}`);
+console.log(`Health      ${overall}/100   (a11y ${dimensions.accessibility} · seo ${dimensions.seo} · ai ${dimensions['ai-search']} · xpage ${dimensions['cross-page']})`);
+console.log(`Open        P1 ${snapshot.severity.P1} · P2 ${snapshot.severity.P2} · P3 ${snapshot.severity.P3}   ·   Fixed this history: P1 ${snapshot.fixed.P1} · P2 ${snapshot.fixed.P2} · P3 ${snapshot.fixed.P3}`);
+const route = (fx) => open.filter((x) => x.fixability === fx);
+for (const fx of ['platform-migration', 'design-pass', 'out-of-scope']) {
+  const items = route(fx);
+  if (!items.length) continue;
+  const who = fx === 'platform-migration' ? 'rollout re-deploy fixes' : fx === 'design-pass' ? 'UPSTREAM (migrate/prototype)' : 'informational';
+  console.log(`\n${fx} — ${who}:`);
+  for (const x of items.slice(0, 12)) console.log(`  ${x.severity} ${x.layer}/${x.check} [${x.scope.ids.join(',')}] — ${x.evidence}`);
+  if (items.length > 12) console.log(`  … ${items.length - 12} more`);
+}
+if (openP1.length) { console.log(`\n✗ GATE: ${openP1.length} open P1 finding(s) — rollout is not delivery-clean.`); process.exit(1); }
+console.log('\n✓ GATE: no open P1 findings.');

--- a/plugins/stardust/skills/rollout/scripts/plan.mjs
+++ b/plugins/stardust/skills/rollout/scripts/plan.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * rollout/plan.mjs — the dedup-driven delivery + conversion plan (Phase 2).
+ *
+ * This is what makes block dedup a FIRST-CLASS driving step. It orders pages
+ * representative-first per template, walks them once, and assigns each distinct
+ * block a single conversion point: the first page in delivery order that uses it
+ * CONVERTS it; every later page REUSES it by its canonical EDS name. The per-page
+ * convert/reuse lists are exactly the input to `deploy`'s Step-7 brief
+ * ("Existing blocks — REUSE, do not recreate: …"), so each block converts once
+ * WITHOUT changing deploy.
+ *
+ * Chrome (header/nav/footer) loads as site-wide static fragments, so it is listed
+ * once under `fragments`, not per page.
+ *
+ * Writes stardust/rollout/plan.json and prints a readable plan.
+ * Usage: node skills/rollout/scripts/plan.mjs [--out <rolloutDir>] [--pending-only]
+ */
+import { join } from 'node:path';
+import { readJSON, writeJSON } from './lib.mjs';
+
+const OUT = (() => { const i = process.argv.indexOf('--out'); return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : 'stardust/rollout'; })();
+const PENDING_ONLY = process.argv.includes('--pending-only');
+
+const pagesDoc = readJSON(join(OUT, 'coverage', 'pages.json'));
+const tmplDoc = readJSON(join(OUT, 'coverage', 'templates.json'));
+const blocksDoc = readJSON(join(OUT, 'coverage', 'blocks.json'));
+if (!pagesDoc || !blocksDoc) {
+  console.error('rollout plan: run inventory.mjs then blocks.mjs first.');
+  process.exit(1);
+}
+const pages = pagesDoc.pages || [];
+const bySlug = new Map(pages.map((p) => [p.slug, p]));
+const blockById = new Map((blocksDoc.blocks || []).map((b) => [b.id, b]));
+const edsNameOf = (id) => { const b = blockById.get(id); return b ? b.delivery.edsBlockName : null; };
+const isChrome = (id) => { const b = blockById.get(id); return b && b.kind === 'chrome'; };
+
+// --- Delivery order: representative-first per template ---------------------------
+const templates = (tmplDoc && tmplDoc.templates) || [];
+// Stable, deterministic template order: most pages first (unblocks the most), then id.
+const orderedTemplates = [...templates].sort((a, b) => (b.pageCount - a.pageCount) || a.id.localeCompare(b.id));
+
+const order = [];
+const seen = new Set();
+for (const t of orderedTemplates) {
+  const rep = t.representativeSlug;
+  const sibs = (t.pages || []).filter((s) => s !== rep).sort();
+  for (const s of [rep, ...sibs]) {
+    if (s && bySlug.has(s) && !seen.has(s)) { seen.add(s); order.push(s); }
+  }
+}
+// Any pages not covered by a template grouping (shouldn't happen) appended.
+for (const p of pages) if (!seen.has(p.slug)) { seen.add(p.slug); order.push(p.slug); }
+
+// --- Walk once, assign each block a single conversion point -----------------------
+const converted = new Map(); // block id -> slug that converts it
+const steps = [];
+for (const slug of order) {
+  const p = bySlug.get(slug);
+  const modules = (p.blocks || []).filter((id) => !isChrome(id));
+  const convert = [];
+  const reuse = [];
+  for (const id of modules) {
+    if (!converted.has(id)) { converted.set(id, slug); convert.push({ id, edsBlockName: edsNameOf(id) }); }
+    else reuse.push({ id, edsBlockName: edsNameOf(id), convertedBy: converted.get(id) });
+  }
+  const pending = ['pending', 'stale', 'failed'].includes(p.delivery && p.delivery.status);
+  steps.push({ slug, path: p.path, templateId: p.templateId, status: p.delivery.status, isRepresentative: convert.length > 0, convert, reuse });
+}
+
+const fragments = (blocksDoc.blocks || []).filter((b) => b.kind === 'chrome')
+  .map((b) => ({ id: b.id, blockPath: b.delivery.blockPath, status: b.delivery.status }));
+
+const now = new Date().toISOString();
+const plan = {
+  _provenance: { writtenBy: 'stardust:rollout/plan', writtenAt: now, readArtifacts: [join(OUT, 'coverage')], stardustVersion: (pagesDoc._provenance || {}).stardustVersion || '0.0.0' },
+  generatedAt: now,
+  fragments,
+  deliveryOrder: steps.map((s) => s.slug),
+  steps: PENDING_ONLY ? steps.filter((s) => ['pending', 'stale', 'failed'].includes(s.status)) : steps,
+};
+writeJSON(join(OUT, 'plan.json'), plan);
+
+// --- Readable plan ---------------------------------------------------------------
+console.log(`rollout plan → ${join(OUT, 'plan.json')}`);
+console.log('='.repeat(64));
+if (fragments.length) console.log(`Fragments (site-wide, deliver once): ${fragments.map((f) => `${f.id}${f.status === 'pending' ? '' : `[${f.status}]`}`).join(', ')}`);
+console.log(`Delivery order (representative-first), ${steps.length} pages:\n`);
+const show = PENDING_ONLY ? steps.filter((s) => ['pending', 'stale', 'failed'].includes(s.status)) : steps;
+for (const s of show) {
+  const tag = s.isRepresentative ? '◆ rep ' : '  sib ';
+  const conv = s.convert.length ? `convert: ${s.convert.map((c) => c.edsBlockName).join(', ')}` : '';
+  const reuse = s.reuse.length ? `reuse: ${s.reuse.map((c) => c.edsBlockName).join(', ')}` : '';
+  console.log(`${tag}${s.slug.padEnd(28)} ${s.status.padEnd(10)} ${[conv, reuse].filter(Boolean).join('  |  ')}`);
+}
+const totalConvert = steps.reduce((n, s) => n + s.convert.length, 0);
+console.log(`\nEach of ${totalConvert} distinct module blocks converts on exactly ONE page; the rest reuse.`);

--- a/plugins/stardust/skills/rollout/scripts/section-fidelity.mjs
+++ b/plugins/stardust/skills/rollout/scripts/section-fidelity.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * rollout/section-fidelity.mjs — "don't add sections the source doesn't have".
+ *
+ * A SCAFFOLD for the per-page source-fidelity gate (Phase C), not an auto-judge.
+ * Mapping an authored EDS page's sections onto an arbitrary source page is fuzzy
+ * and needs the delivering agent's judgment; this just lays the two side-by-side
+ * so that judgment is fast and consistent — and pre-flags the section shapes
+ * that have historically been invented (trailing cross-link rails, specialist
+ * grids, generic CTAs).
+ *
+ *   node section-fidelity.mjs --file <content.html> --source <url>
+ *   node section-fidelity.mjs --file <content.html> --source-file <path>
+ *
+ * Prints:
+ *   - AUTHORED: ordered block sections in the content file (+ default-content prose)
+ *   - SOURCE:   the source page's heading outline (h1/h2/h3) and landmark count
+ *   - REVIEW:   authored blocks whose NAME matches a known "invented filler"
+ *               pattern — the agent must confirm each maps to a real source region
+ *               or remove it (hard-fail if it carries fabricated facts).
+ * Exit code is always 0 — this informs the gate; it does not decide it.
+ */
+import { readFileSync } from 'node:fs';
+
+function arg(name, fallback = null) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+const file = arg('file');
+const source = arg('source');
+const sourceFile = arg('source-file');
+if (!file || (!source && !sourceFile)) {
+  console.error('usage: section-fidelity.mjs --file <content.html> (--source <url> | --source-file <path>)');
+  process.exit(2);
+}
+
+// Section shapes that have historically been invented onto leaf pages — append
+// -only "related/weitere" rails, specialist/teaser grids, generic trailing CTAs.
+const FILLER = [
+  /^related-/, /-related$/, /^weitere-/, /related$/,
+  /specialists?$/, /-teasers?$/, /^teaser/, /conditions$/,
+  /articles$/, /events$/, /-cta$/,
+];
+
+const html = readFileSync(file, 'utf8');
+
+// AUTHORED sections: each top-level section is `<div><div class="BLOCK">…`.
+// Default content (prose) sections have no block class.
+const authored = [];
+const sectionRe = /<div>\s*<div class="([a-z0-9-]+)"/gi;
+let m;
+while ((m = sectionRe.exec(html))) authored.push(m[1]);
+// crude default-content detector: a `<div>` whose first child is not a classed div
+const dcCount = (html.match(/<div>\s*<div>\s*<(h[1-6]|p|ul|ol)\b/gi) || []).length;
+
+async function getSource() {
+  if (sourceFile) return readFileSync(sourceFile, 'utf8');
+  const r = await fetch(source, { headers: { 'user-agent': 'stardust-fidelity' } });
+  if (!r.ok) { console.error(`source fetch ${r.status} for ${source}`); process.exit(1); }
+  return r.text();
+}
+
+const src = await getSource();
+const stripTags = (s) => s.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+const outline = [];
+const hRe = /<(h[1-3])\b[^>]*>([\s\S]*?)<\/\1>/gi;
+let h;
+while ((h = hRe.exec(src))) {
+  const text = stripTags(h[2]).slice(0, 80);
+  if (text) outline.push(`${h[1]}  ${text}`);
+}
+const landmarks = (src.match(/<(section|article|aside)\b/gi) || []).length;
+
+const review = authored.filter((b) => FILLER.some((re) => re.test(b)));
+
+console.log(`\n# section-fidelity — ${file}`);
+console.log(`source: ${source || sourceFile}\n`);
+console.log(`AUTHORED sections (${authored.length} blocks + ~${dcCount} default-content):`);
+authored.forEach((b, i) => console.log(`  ${i + 1}. ${b}${review.includes(b) ? '   ⟵ REVIEW' : ''}`));
+console.log(`\nSOURCE outline (${outline.length} headings, ${landmarks} <section|article|aside>):`);
+outline.slice(0, 40).forEach((o) => console.log(`  ${o}`));
+if (outline.length > 40) console.log(`  … +${outline.length - 40} more`);
+console.log('\nGATE: for each AUTHORED block — especially ⟵ REVIEW ones — confirm a real');
+console.log('source region backs it. Remove any section with no source equivalent.');
+console.log('HARD-FAIL (must remove before deployed) if the section carries FABRICATED');
+console.log('facts: invented person names, made-up events/dates, or boilerplate prose');
+console.log('not present on the source. A cross-link rail to REAL pages is a softer call.');

--- a/plugins/stardust/skills/rollout/scripts/update-coverage.mjs
+++ b/plugins/stardust/skills/rollout/scripts/update-coverage.mjs
@@ -62,7 +62,7 @@ if (blockId) {
 }
 
 // Page update
-const STATUSES = ['pending', 'converting', 'deployed', 'verified', 'stale', 'failed'];
+const STATUSES = ['pending', 'converting', 'deployed', 'verified', 'content-pending', 'stale', 'failed'];
 if (!slug || !status || !STATUSES.includes(status)) {
   console.error(`usage: update-coverage.mjs <slug> --status <${STATUSES.join('|')}> [--url <u>] [--error <m>]`);
   console.error('   or: update-coverage.mjs --block <id> --status <pending|converted|deployed|verified|failed> [--eds-name <n>]');

--- a/plugins/stardust/skills/rollout/scripts/update-coverage.mjs
+++ b/plugins/stardust/skills/rollout/scripts/update-coverage.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * rollout/update-coverage.mjs — deterministic state-writer for the delivery loop.
+ *
+ * The per-page delivery itself is the LLM-driven `deploy` methodology; this helper
+ * just records the outcome so the loop stays honest and resumable. Call it after
+ * each page's deploy step, and after each block converts.
+ *
+ * Page:   node update-coverage.mjs <slug>  --status <s> [--url <deployedUrl>] [--error <msg>]
+ * Block:  node update-coverage.mjs --block <id> --status <s> [--eds-name <name>]
+ *   page  <status>: pending | converting | deployed | verified | stale | failed
+ *   block <status>: pending | converted | deployed | verified | failed
+ *
+ * Re-derives templates.json + rollout.json roll-ups after every write.
+ */
+import { join } from 'node:path';
+import { readJSON, writeJSON, rollupTemplates, rollupConfig } from './lib.mjs';
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+const OUT = arg('out', 'stardust/rollout');
+const status = arg('status', null);
+const blockId = arg('block', null);
+const slug = process.argv[2] && !process.argv[2].startsWith('--') ? process.argv[2] : null;
+
+const pagesPath = join(OUT, 'coverage', 'pages.json');
+const blocksPath = join(OUT, 'coverage', 'blocks.json');
+const templatesPath = join(OUT, 'coverage', 'templates.json');
+const configPath = join(OUT, 'rollout.json');
+const now = new Date().toISOString();
+
+function reRoll() {
+  const pagesDoc = readJSON(pagesPath);
+  const blocksDoc = readJSON(blocksPath);
+  const tDoc = readJSON(templatesPath);
+  const config = readJSON(configPath);
+  const pages = (pagesDoc && pagesDoc.pages) || [];
+  if (tDoc) { rollupTemplates(tDoc, pages); tDoc.generatedAt = now; writeJSON(templatesPath, tDoc); }
+  if (config) { rollupConfig(config, pages, blocksDoc && blocksDoc.blocks, now); writeJSON(configPath, config); }
+}
+
+if (blockId) {
+  const STATUSES = ['pending', 'converted', 'deployed', 'verified', 'failed'];
+  if (!status || !STATUSES.includes(status)) { console.error(`block status must be one of ${STATUSES.join('|')}`); process.exit(2); }
+  const doc = readJSON(blocksPath);
+  if (!doc) { console.error(`rollout: ${blocksPath} not found — run blocks.mjs first.`); process.exit(1); }
+  const b = (doc.blocks || []).find((x) => x.id === blockId);
+  if (!b) { console.error(`rollout: no block "${blockId}".`); process.exit(1); }
+  b.delivery = b.delivery || {};
+  b.delivery.status = status;
+  const edsNameArg = arg('eds-name', null);
+  if (edsNameArg) b.delivery.edsBlockName = edsNameArg;
+  if (status === 'converted') b.delivery.convertedAt = now;
+  doc.generatedAt = now;
+  writeJSON(blocksPath, doc);
+  reRoll();
+  console.log(`block ${blockId} → ${status}`);
+  process.exit(0);
+}
+
+// Page update
+const STATUSES = ['pending', 'converting', 'deployed', 'verified', 'stale', 'failed'];
+if (!slug || !status || !STATUSES.includes(status)) {
+  console.error(`usage: update-coverage.mjs <slug> --status <${STATUSES.join('|')}> [--url <u>] [--error <m>]`);
+  console.error('   or: update-coverage.mjs --block <id> --status <pending|converted|deployed|verified|failed> [--eds-name <n>]');
+  process.exit(2);
+}
+const doc = readJSON(pagesPath);
+if (!doc) { console.error(`rollout: ${pagesPath} not found — run inventory.mjs first.`); process.exit(1); }
+const page = (doc.pages || []).find((p) => p.slug === slug);
+if (!page) { console.error(`rollout: no page with slug "${slug}".`); process.exit(1); }
+
+const url = arg('url', null);
+page.delivery = page.delivery || {};
+page.delivery.status = status;
+if (status === 'deployed') { page.delivery.deployedAt = now; if (url) page.delivery.deployedUrl = url; }
+if (status === 'verified') { page.delivery.verifiedAt = now; if (url) page.delivery.deployedUrl = url; }
+page.delivery.error = status === 'failed' ? (arg('error', 'unspecified')) : null;
+doc.generatedAt = now;
+writeJSON(pagesPath, doc);
+reRoll();
+
+const config = readJSON(configPath);
+const c = config && config.lastRun && config.lastRun.pages;
+console.log(`${slug} → ${status}${c ? `   (${c.verified} verified / ${c.deployed} deployed / ${c.pending + c.stale} remaining of ${c.total})` : ''}`);

--- a/plugins/stardust/skills/rollout/scripts/verify.mjs
+++ b/plugins/stardust/skills/rollout/scripts/verify.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * rollout/verify.mjs — full-site verification (Phase 2).
+ *
+ * For every delivered page, confirm it actually renders and that its internal
+ * links resolve to known delivered paths. Flips each page to `verified` or
+ * `failed` in the coverage ledger (re-deriving roll-ups), so the "what's missing"
+ * report reflects reality, not just "we pushed it".
+ *
+ * Two modes:
+ *   --base <url>     fetch <base><path> over HTTP (uses rollout.json liveHost if omitted)
+ *   --root <dir>     offline: resolve <path> to a file under <dir> (for the migrated
+ *                    tree or a local export) — checks existence + content
+ *
+ * Checks per page: reachable (HTTP 200 / file exists), body has no `about:error`
+ * (#75 broken-image ingestion), and every internal href="/…" resolves to a page
+ * in coverage.
+ *
+ * Usage: node skills/rollout/scripts/verify.mjs [--base <url> | --root <dir>] [--slug <s>] [--all] [--out <rolloutDir>]
+ */
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { readJSON, writeJSON, rollupTemplates, rollupConfig } from './lib.mjs';
+
+function arg(name, fallback) { const i = process.argv.indexOf(`--${name}`); return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback; }
+const OUT = arg('out', 'stardust/rollout');
+const ROOT = arg('root', null);
+const onlySlug = arg('slug', null);
+const ALL = process.argv.includes('--all');
+
+const pagesPath = join(OUT, 'coverage', 'pages.json');
+const config = readJSON(join(OUT, 'rollout.json'), {});
+const pagesDoc = readJSON(pagesPath);
+if (!pagesDoc) { console.error('rollout verify: run inventory.mjs first.'); process.exit(1); }
+const pages = pagesDoc.pages || [];
+const BASE = arg('base', (config.site && config.site.liveHost) ? `https://${config.site.liveHost}` : null);
+
+if (!ROOT && !BASE) { console.error('rollout verify: need --base <url> or --root <dir> (or set site.liveHost).'); process.exit(2); }
+
+const knownPaths = new Set(pages.map((p) => p.path.replace(/\/$/, '') || '/'));
+const norm = (p) => (p.split(/[?#]/)[0].replace(/\/$/, '') || '/');
+
+function resolveLocal(p) {
+  // map a delivered extensionless path to a file under ROOT (migrated tree shape)
+  const candidates = p === '/'
+    ? ['index.html']
+    : [`${p.slice(1)}.html`, `${p.slice(1)}/index.html`, p.slice(1)];
+  for (const c of candidates) { const f = join(ROOT, c); if (existsSync(f) && statSync(f).isFile()) return f; }
+  return null;
+}
+
+async function fetchPage(p) {
+  if (ROOT) {
+    const f = resolveLocal(p.path);
+    if (!f) return { ok: false, reason: `not found under ${ROOT}` };
+    return { ok: true, body: readFileSync(f, 'utf8') };
+  }
+  try {
+    const res = await fetch(`${BASE}${p.path}`);
+    const body = await res.text();
+    if (!res.ok) return { ok: false, reason: `HTTP ${res.status}` };
+    return { ok: true, body };
+  } catch (e) { return { ok: false, reason: `fetch error: ${e.message}` }; }
+}
+
+function checkLinks(body) {
+  const broken = [];
+  for (const m of body.matchAll(/href="(\/[^"]*)"/g)) {
+    const target = norm(m[1]);
+    if (target.startsWith('//')) continue; // protocol-relative external
+    if (/\.(css|js|png|jpe?g|webp|svg|ico|woff2?|xml|txt|json)$/i.test(target)) continue; // assets
+    if (!knownPaths.has(target)) broken.push(target);
+  }
+  return [...new Set(broken)];
+}
+
+const target = pages.filter((p) => {
+  if (onlySlug) return p.slug === onlySlug;
+  if (ALL) return true;
+  return ['deployed', 'verified'].includes(p.delivery && p.delivery.status);
+});
+
+const now = new Date().toISOString();
+const results = [];
+for (const p of target) {
+  const r = await fetchPage(p);
+  let status = 'verified'; let reason = null;
+  if (!r.ok) { status = 'failed'; reason = r.reason; }
+  else if (r.body.includes('about:error')) { status = 'failed'; reason = 'about:error in body (#75 broken image)'; }
+  else {
+    const broken = checkLinks(r.body);
+    if (broken.length) { status = 'failed'; reason = `broken internal links: ${broken.slice(0, 5).join(', ')}`; }
+  }
+  p.delivery = p.delivery || {};
+  p.delivery.status = status;
+  if (status === 'verified') { p.delivery.verifiedAt = now; p.delivery.error = null; }
+  else p.delivery.error = reason;
+  results.push({ slug: p.slug, status, reason });
+}
+
+// persist + re-roll
+pagesDoc.generatedAt = now;
+writeJSON(pagesPath, pagesDoc);
+const tDoc = readJSON(join(OUT, 'coverage', 'templates.json'));
+const blocksDoc = readJSON(join(OUT, 'coverage', 'blocks.json'));
+if (tDoc) { rollupTemplates(tDoc, pages); tDoc.generatedAt = now; writeJSON(join(OUT, 'coverage', 'templates.json'), tDoc); }
+if (config && config.lastRun !== undefined) { rollupConfig(config, pages, blocksDoc && blocksDoc.blocks, now); writeJSON(join(OUT, 'rollout.json'), config); }
+
+const ok = results.filter((r) => r.status === 'verified').length;
+const bad = results.filter((r) => r.status === 'failed');
+console.log(`rollout verify (${ROOT ? `root:${ROOT}` : BASE})`);
+console.log('='.repeat(60));
+console.log(`Checked ${results.length} · ${ok} verified · ${bad.length} failed`);
+for (const r of bad) console.log(`  ✗ ${r.slug}: ${r.reason}`);
+if (!target.length) console.log('Nothing to verify (no deployed pages). Deliver pages first, or pass --all.');
+process.exit(bad.length ? 1 : 0);

--- a/plugins/stardust/tile.json
+++ b/plugins/stardust/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe/stardust",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "summary": "Redesign an existing website to make it better. Built on top of impeccable.",
   "skills": {
     "stardust": { "path": "skills/stardust/SKILL.md" },

--- a/plugins/stardust/tile.json
+++ b/plugins/stardust/tile.json
@@ -11,6 +11,7 @@
     "prepare-migration": { "path": "skills/prepare-migration/SKILL.md" },
     "uplift": { "path": "skills/uplift/SKILL.md" },
     "deploy": { "path": "skills/deploy/SKILL.md" },
+    "rollout": { "path": "skills/rollout/SKILL.md" },
     "diff": { "path": "skills/diff/SKILL.md" }
   },
   "softDependencies": [


### PR DESCRIPTION
## Summary

Adds **`rollout`**, the whole-site sibling of `deploy`. Where `deploy` converts **one** page to AEM Edge Delivery Services, `rollout` delivers an **entire** migrated stardust site: it inventories the platform-agnostic `migrate` output (`stardust/migrated/` + `_meta.json`), dedups blocks, drives `deploy` per page, assembles site-level artifacts, verifies, runs a multi-source optimize gate + AEM autofix, and renders a design-identity dashboard — the **A→I** flow documented in the skill.

`rollout` is **delivery-only**: it does not redesign. The agnostic core (`extract → direct → prototype → migrate`) and `deploy` itself are unchanged; rollout is the across-pages delivery layer on top.

## What's in here

- `skills/rollout/` — `SKILL.md`, 12 scripts, 6 schemas, 3 reference docs (coverage-model, audit-sources, checks).
- `notes/rollout/` — design `PLAN.md`, README, schemas, worked example.
- Capabilities added on top of the initial port: archetypes-only `--state` inventory (deploy block code without a full pre-migration), Phase C source-fidelity gate, Phase B2 metadata contract + publish-in-loop, Phase D2 dynamic listings (query-index), and verify hardening (verify the rendered URL, nav targets, source-content hygiene) — codified from Hirslanden-scale (~1.1k pages) runs.

## Scope / blast radius

Overwhelmingly additive (everything new lives under `skills/rollout/` + `notes/rollout/`). Existing-file changes are minimal:

- `tile.json` — registers `rollout`.
- `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `tile.json` — version bump **0.12.0 → 0.13.0** (new skill).
- `skills/deploy/SKILL.md` — **+2 lines**, a doc-only note: verify an image src resolves (curl) before authoring it, to avoid shipping `<img src="about:error">`. No behavior change.

## Verification

- All 12 `skills/rollout/scripts/*.mjs` pass `node --check`.
- All `skills/rollout/schemas/*.json`, `notes/rollout/**/*.json`, and the plugin manifests parse as JSON.
- Flow validated end-to-end against fixtures and real migration runs (Hirslanden scale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
