### PR TITLE
feat(stardust): capture gated content, flag media coverage, exempt verbatim copy

### DIFF
--- a/plugins/stardust/.claude-plugin/plugin.json
+++ b/plugins/stardust/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stardust",
   "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "author": {
     "name": "Adobe"
   },

--- a/plugins/stardust/skills/extract/SKILL.md
+++ b/plugins/stardust/skills/extract/SKILL.md
@@ -360,15 +360,16 @@ After all Phase 2-5 writes succeed:
      _crawl-log.json
 
    Per-page evidence:
-     slug         live  waitMode               waitMs   status
-     /            yes   medium                 2380     200
-     /about       yes   medium                 2110     200
-     /pricing     yes   medium                 1940     200
-     /products    yes   medium                 2640     200
-     /contact     yes   domcontentloaded(fb)   8000     200
+     slug         live  waitMode               waitMs   status  media(img/bg)
+     /            yes   medium                 2380     200     38/6
+     /about       yes   medium                 2110     200     12/2
+     /pricing     yes   medium                 1940     200     9/0   ⚠ low-media
+     /products    yes   medium                 2640     200     21/4
+     /contact     yes   domcontentloaded(fb)   8000     200     3/0
 
    Wait summary: 4 resolved at medium (avg 2.4s), 1 fallback (timed out at 8s)
      → /contact may be under-captured; consider --refresh
+   Media summary: 1 page flagged low-media (/pricing) — see media-coverage check
 
    Open stardust/current/brand-review.html to verify the extraction
    before running $stardust direct.
@@ -397,6 +398,29 @@ After all Phase 2-5 writes succeed:
    and averaging `waitMs`. List slugs whose `waitMode` ends in
    `(fallback)` (rendered as `(fb)` in the table for width) as
    candidates for `--refresh`.
+
+   The **`media(img/bg)` column** is the analogous defense-in-depth
+   signal for imagery. It prints `<count of media.imgs> / <count of
+   media.cssBackgrounds>`. Flag a row `⚠ low-media` when the page
+   reads as brand/marketing (register `brand`, or a landing/solution/
+   product template) yet has `cssBackgrounds: []` **and** few large
+   rasters (no `media.imgs` entry with intrinsic width ≥ 600). That
+   combination is the signature of a silently-failed background /
+   lazy-media walk — `getComputedStyle(el).backgroundImage` read
+   before the element was styled, a `::before`/`::after` host missed,
+   or product imagery gated behind interaction the reveal pass did not
+   trigger. The recipe already specs the full background walk
+   (`playwright-recipe.md` § Capture list 11, hardened after the
+   2026-05-04 ups.com dropped-hero failure), but a thorough spec that
+   silently produces nothing still ships an image-less capture: the
+   2026-06-26 knack.com run returned `cssBackgrounds: []` on every
+   page and lost all product screenshots, hero art, and customer
+   logos, and nothing surfaced it because no column reported media
+   coverage. A flagged row is the cue to re-run that page with
+   `--refresh` (and, if it persists, to fall back to headed Chrome per
+   § Bot-management fallback). A maintainer scanning the summary should
+   treat a `brand`-register site with all-zero `bg` counts as suspect,
+   not as "this site uses no background images."
 
 ## Outputs
 

--- a/plugins/stardust/skills/extract/reference/playwright-recipe.md
+++ b/plugins/stardust/skills/extract/reference/playwright-recipe.md
@@ -307,6 +307,7 @@ goto(url, { waitUntil: <mode>, timeout: <hardCap> })
 wait <grace> ms              // grace period for late JS paints
 scroll the page to bottom in 4 viewport-height steps with 300 ms pauses
 scroll back to top
+reveal interactive content   // open every closed <details>, click [aria-expanded="false"] disclosure triggers, surface non-active tab panels
 ```
 
 The grace period catches lazy-loaded hero media, fonts that swap after
@@ -315,6 +316,22 @@ scroll-to-bottom pass triggers IntersectionObserver-driven content
 (carousels, fold-in sections, lazy images) so it lands in the captured
 DOM. **Skipping the scroll pass is a recipe violation** — even
 server-rendered sites use lazy images.
+
+The **reveal pass** is the analogous requirement for content gated
+behind interaction rather than scroll. Sites routinely defer FAQ
+answers, tabbed feature panels, and "read more" bodies until a click,
+and the disclosed DOM is frequently *injected on demand* — so it is
+absent (not merely hidden) until the trigger fires. Before the capture
+list runs, set `open` on every closed `<details>`, click each
+`[aria-expanded="false"]` / `[role="button"][aria-controls]`
+disclosure trigger, and activate every non-active `role="tab"` once,
+re-reading content afterward. Guard against dialogs (skip triggers
+inside `[role="dialog"]` and anything whose click navigates away).
+**Skipping the reveal pass is a recipe violation** on any page with
+accordions or tabs. The 2026-06-26 knack.com run captured only 1 of 6
+FAQ answers without it — the five collapsed answers were never in the
+DOM, so they were absent from `qa[]` and from the prototype, which
+then had to placeholder them.
 
 ## Capture list
 
@@ -355,6 +372,14 @@ For each page, capture:
    - `qa[]` — when an accordion (`<details>` or
      ARIA-driven disclosure) is detected within the section, capture
      each entry as `{ q: <trigger text>, a: <disclosed textContent> }`.
+     Read `a` from `textContent`, **not** `innerText`: the disclosure
+     is captured after the Navigation reveal pass has expanded it, but
+     a panel whose CSS still resolves to `display:none` yields empty
+     `innerText`, silently dropping the answer. `textContent` survives
+     that. If a trigger has no resolvable answer after the reveal pass
+     (genuinely click-injected and not yet present), emit the entry
+     with `a: null` rather than omitting it — a recorded gap is
+     auditable downstream; a missing entry is not.
    - `quotes[]` — when a review-card / testimonial / pullquote
      pattern is detected (a `<blockquote>` or `[class*="testimonial"
      i]` containing prose plus an optional attribution / rating),

--- a/plugins/stardust/skills/prototype/SKILL.md
+++ b/plugins/stardust/skills/prototype/SKILL.md
@@ -402,10 +402,11 @@ the user with the specific rule violated and a suggested fix.
 
 #### Craft-time disciplines (pre-write validators)
 
-Three disciplines fire on the rendered file *before* it lands on
+Four disciplines fire on the rendered file *before* it lands on
 disk. These run after craft returns its output and before the file
 is written; failure refuses the write with a substitute proposal
-(Discipline 6) or a rule citation (7, 8).
+(Discipline 6) or a rule citation (7, 8), and Discipline 9 registers
+detector ignores rather than refusing.
 
 **Discipline 6 — Reflex-reject font pre-flight.** Grep the
 declared `font-family` declarations against the reject list in
@@ -484,6 +485,38 @@ expressive position.
 
 The tier is declared in the run invocation; persisted in
 `_provenance.fidelity`. Default is `quick`.
+
+**Discipline 9 — Copy-cadence detector bypass under verbatim
+fidelity.** This extends the Mode-A reasoning of Discipline 6 from
+fonts to prose. impeccable's design detector ships prose-voice rules
+(`em-dash-overuse`, `marketing-buzzword`, and similar copy-cadence
+checks) that assume the copy is the agent's to rewrite. Under
+`ia-fidelity: verbatim` — or any faithful/Mode-A render where the body
+copy is `captured-verbatim` — that assumption is false by
+construction: the prose is the source brand's, reproduced exactly per
+the content-sourcing hierarchy, and rewriting it to satisfy a cadence
+rule *is* the fabrication the fidelity setting exists to prevent. So
+when the rendered file's copy classification is `captured-verbatim`
+(per Discipline 5's `voiceClassification`), register those copy-cadence
+rules as intentional ignores for the `<slug>-proposed.html` files
+before the design hook fires — the same way Discipline 6 bypasses the
+font reflex-reject check for pinned families. Scope the ignore to the
+proposed files only, **never** to the project's own source (blocks,
+styles, components), where the rules still apply because that copy
+*is* the agent's. Record the bypass in
+`_provenance.copyCadenceBypass` with the rules ignored and the
+classification basis. The 2026-06-26 knack.com run hit this: the hook
+flagged em-dashes and "enterprise-grade" on Knack's own headings
+("Built on Enterprise-Grade Components") under a verbatim direction,
+and the only correct response was to leave the captured copy untouched
+and record the bypass.
+
+Bound the bypass: it covers prose-cadence rules only. Structural and
+craft detector rules (`design-system-radius`, contrast failures,
+reflex layout slop) are *not* exempted by verbatim fidelity — those
+govern the agent's own CSS and structure, which faithful mode does not
+freeze. Listing a rule under this bypass requires it be a copy-voice
+rule whose subject is the captured prose.
 
 ### Phase 2.4 — Motion application (when `--cinematic`)
 

--- a/plugins/stardust/tile.json
+++ b/plugins/stardust/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe/stardust",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "summary": "Redesign an existing website to make it better. Built on top of impeccable.",
   "skills": {
     "stardust": { "path": "skills/stardust/SKILL.md" },


### PR DESCRIPTION
Three spec improvements to the stardust skills, each surfaced and validated by a full end-to-end knack.com → AEM Edge Delivery redesign run. All three extend an existing mechanism rather than introducing new surface, and each cites the run as a dated precedent in the established house style.

## 1. `extract` — reveal click-gated content before capture
`playwright-recipe.md` already specs a scroll pass for lazy/IntersectionObserver content, and capture list 13 *detects* accordions/tabs — but nothing **expands** them, and capture list 7 reads `innerText` (which omits `display:none`). Result: collapsed FAQ answers, hidden tab panels, and click-injected bodies are lost.

- Adds a **reveal pass** to the Navigation recipe: open every closed `<details>`, click `[aria-expanded="false"]` disclosure triggers, activate non-active tabs — guarded against dialogs/navigation.
- `qa[]` answers now read from `textContent` (not `innerText`); unresolved triggers emit `a: null` instead of being omitted.

_Run evidence:_ only **1 of 6** home FAQ answers was captured; the other five were never in the DOM and had to be placeholdered downstream.

## 2. `extract` — surface media coverage in the per-page evidence table
The background/lazy-media walk is thoroughly specced (capture list 11, hardened after the 2026-05-04 ups.com dropped-hero failure) but **unverified** — a silent failure ships an image-less capture with nothing flagging it.

- Adds a `media(img/bg)` column and a `⚠ low-media` flag for brand/marketing pages with `cssBackgrounds: []` and no large rasters — the silent-failure signature — pointing to `--refresh` / headed-Chrome fallback.

_Run evidence:_ every page returned `cssBackgrounds: []`; all product screenshots, hero art, and customer logos were lost, and no report column surfaced it.

## 3. `prototype` — exempt captured-verbatim copy from prose-cadence detector rules
Under `ia-fidelity: verbatim`, impeccable's design hook flags `em-dash-overuse` / `marketing-buzzword` on brand copy that is **captured-verbatim and not the agent's to rewrite** — rewriting it *is* the fabrication the fidelity setting prevents.

- Adds **Discipline 9**, extending Discipline 6's existing Mode-A font bypass to prose: register copy-cadence rules as intentional ignores for `*-proposed.html` only (never project source), recorded in `_provenance.copyCadenceBypass`. Bounded to copy-voice rules — structural rules (radius, contrast) stay enforced.

_Run evidence:_ the hook repeatedly flagged em-dashes and "enterprise-grade" on Knack's own heading "Built on Enterprise-Grade Components".

## Notes
- Cross-references verified to resolve (capture list 11 = Media inventory; § Bot-management fallback exists).
- Bumps stardust `0.13.0` → `0.13.1` (`plugin.json` + `tile.json`).
- Markdown-only spec changes; no executable code paths altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)