### PR TITLE
feat(stardust): preserve source signature (hero video/animation/motif) under Mode A

### DIFF
--- a/plugins/stardust/skills/direct/SKILL.md
+++ b/plugins/stardust/skills/direct/SKILL.md
@@ -207,7 +207,13 @@ brand-faithful) catches ambiguous phrases, and the riskier mode
    active by default. The user's phrase moves *expressive*,
    *distinctiveness*, *tone*, and *density* axes inside Mode A — but
    palette and type are pinned to the captured surface, and the
-   image-reuse contract (below) holds. Surface in the plan:
+   image-reuse contract (below) holds. **Signature preservation also
+   holds:** a captured signature hero medium (background video /
+   canvas / Lottie / scroll-motion, elevated as
+   `_brand-extraction.json#voice.heroMedium`) or a site-wide motif is
+   reproduced, not flattened — per `skills/stardust/reference/
+   intent-dimensions.md` § 8b, and exempt from the `surprise` budget.
+   Surface in the plan:
    *"Brand-faithful mode active — palette and type pinned to the
    captured brand surface. Pass `--rebrand` to override."*
 

--- a/plugins/stardust/skills/extract/SKILL.md
+++ b/plugins/stardust/skills/extract/SKILL.md
@@ -259,6 +259,15 @@ extracted pages** to avoid the home-page bias documented in
   § heroImage resolution). Without this elevation, downstream
   prototype reasons over a 16-image list and frequently picks
   the `og:image` instead of the live hero.
+- **Hero medium (signature)** — when the hero/first viewport carries a
+  *moving* asset (background `<video>` / HLS / canvas / WebGL /
+  Lottie / animated SVG / scroll-driven motion), elevate it to
+  `voice.heroMedium` (per `reference/brand-surface.md` § heroMedium
+  resolution). This is the page's **signature**; without elevation it
+  is lost in the raw media list and downstream prototype flattens it
+  to a static hero. A non-null `heroMedium` triggers signature
+  preservation (`skills/stardust/reference/intent-dimensions.md`
+  § 8b) at prototype time.
 - **Icon font** — when detected per `reference/playwright-recipe.md`
   § Capture list 17, populate `_brand-extraction.json#iconFont`
   with family, file path, and the `iconClass → codepoint`

--- a/plugins/stardust/skills/extract/reference/brand-surface.md
+++ b/plugins/stardust/skills/extract/reference/brand-surface.md
@@ -62,7 +62,7 @@ Each field below is sourced from one of two scopes:
 
 | scope | fields | rationale |
 |---|---|---|
-| home-only | `logo`, `voice.heroHeadline`, `voice.heroSubcopy`, `voice.primaryCTALabel`, `voice.firstParagraph`, `register` | These are the landing surface; aggregating across pages would dilute, not clarify |
+| home-only | `logo`, `voice.heroHeadline`, `voice.heroSubcopy`, `voice.heroImage`, `voice.heroMedium`, `voice.primaryCTALabel`, `voice.firstParagraph`, `register` | These are the landing surface; aggregating across pages would dilute, not clarify |
 | cross-page | `palette`, `type` (sizes, weights, families used), `spacing`, `motifs.borderRadius`, `motifs.shadows`, `motifs.gradients`, `componentStyle`, `voice.ctaSamples`, `voice.navItems`, `voice.footerHeadings` | Home-only readings are biased by hero/CTA-heavy markup; the dominant motif on the site as a whole is what `direct` needs |
 
 Cross-page aggregation rules:
@@ -506,6 +506,14 @@ DESIGN.json.
     "localPath": "stardust/current/assets/media/hero-a3f9.avif",
     "rect": { "x": 0, "y": 80, "width": 1440, "height": 720 }
   },
+  "heroMedium": {
+    "kind": "video",                  // "video" | "canvas" | "lottie" | "animated-svg" | "scroll-motion" | null
+    "mechanism": "hls",               // "video-file" | "hls" | "youtube/vimeo-embed" | "webgl" | "lottie" | "css-keyframes" | "scroll-driven"
+    "src": "https://customer-xxxx.cloudflarestream.com/<id>/manifest/video.m3u8",
+    "domPath": "div.home-video-wrapper > video#background-video",
+    "loader": "hls.js@cdn",           // library the source uses to drive it, if any
+    "rect": { "x": 0, "y": 0, "width": 1440, "height": 900 }
+  },
   "primaryCTALabel": "Start free trial",
   "ctaSamples": ["Start free trial", "Talk to sales", "See pricing", "Read the docs"],
   "navItems": ["Product", "Pricing", "Customers", "Docs", "Sign in"],
@@ -557,6 +565,42 @@ Downstream `prototype` reads `heroImage.url` /
 `heroImage.localPath` directly when composing the hero slot
 under Mode A's image-reuse contract (per
 `skills/direct/SKILL.md` § Mode A).
+
+### `heroMedium` resolution (signature hero medium)
+
+The hero is often **not** a still image but a *moving* asset — a
+background video (file / HLS / Mux / Cloudflare Stream), a
+canvas/WebGL scene, a Lottie/Rive animation, an animated SVG, or a
+scroll-driven motion. This is the page's **signature** and is the most
+common thing a generic redesign silently flattens to a static hero.
+Elevate it here so downstream `prototype` preserves it under
+`intent-dimensions.md` § 8b (Signature preservation) instead of
+re-deriving it from the raw `media` inventory and missing it — the
+exact failure that dropped the moneyhub.com home's HLS brand-animation
+on the first migration pass.
+
+Resolve from the home page's captured media
+(`pages/home.json#media`): the `<video>` / `<iframe>` inventory
+(`playwright-recipe.md` § Capture list — every `<video>`/`<iframe>`
+src), `<canvas>` presence, and any motion library detected among
+loaded scripts (hls.js, lottie, three.js, gsap, lenis).
+
+1. Prefer a `<video>` / `<canvas>` / Lottie mount whose `rect`
+   intersects the first viewport (`rect.top < 800`) and covers a
+   large area (same area/aspect filters as `heroImage`).
+2. Record `kind` + `mechanism` + `src` (the manifest/file/embed URL —
+   reuse it the way image-fidelity reuses image URLs) + `loader`
+   (the driving library, so prototype can wire it).
+3. If the hero's signature is motion without a discrete asset
+   (scroll-pinned, parallax, kinetic type), set
+   `kind: "scroll-motion"` with `mechanism` naming the technique and
+   `src: null`.
+4. When the hero has no moving signature, set `heroMedium: null`
+   (most pages — the still `heroImage` is then the hero).
+
+A non-null `heroMedium` is a § 8b trigger: every Mode A variant must
+reproduce it (graceful fallback + `prefers-reduced-motion` + scrim),
+and doing so is exempt from the per-page `surprise` budget.
 
 The `tone.guess` is a heuristic — never present it as ground truth in
 the user report. `direct` will use it as one of several signals, not

--- a/plugins/stardust/skills/prototype/SKILL.md
+++ b/plugins/stardust/skills/prototype/SKILL.md
@@ -281,6 +281,31 @@ surprise budget is **capped at `low` site-wide**. The validator
 refuses any verbatim-direction brief with `surprise: medium` or
 `high`.
 
+**`low` ≠ generic.** The budget bounds *added* divergence, not craft
+or fidelity. `low` means **brand-faithful + improvements + full
+signature preservation**, NOT "the most obvious faithful
+interpretation." The recurring failure mode (moneyhub.com migration)
+is the agent reading `low` / `verbatim` as license to strip the page
+to a plain type-hero on a flat ground — the result is faithful but
+forgettable and under-sells the redesign. Hold the craft bar at `low`:
+keep the brand's distinctive elements, apply the improvements list,
+and reproduce the signature.
+
+**Signature preservation is mandatory and budget-exempt.** When the
+captured page has a signature hero medium (background video / canvas /
+WebGL / Lottie), signature motion (scroll / parallax / kinetic), or a
+signature visual motif (per `intent-dimensions.md` § 8b), the brief
+**must** reproduce it — with a static fallback, `prefers-reduced-
+motion` alternative, and (for overlaid text) a legibility scrim. This
+does **not** consume the `low` allowance: carrying the brand's own
+signature forward is fidelity, not divergence (§ 8b § Surprise-budget
+exemption). Record the kept signatures in
+`_provenance.signatureElements[]` as `{ kind, capturedSource,
+mechanism, fallback }`. **Render-refusal:** a brief that flattens a
+captured video/canvas/animation hero to a still, gradient, or
+type-only hero — or drops a site-wide motif — is rejected at the
+shape-brief audit; reproduce the signature instead.
+
 **Type-scale yield clause.** When a tier-`medium`-or-higher variant's
 captured-trait amplification structurally conflicts with a
 brand-level type-scale rule from `DESIGN.md` (e.g. a

--- a/plugins/stardust/skills/prototype/reference/page-shape-brief.md
+++ b/plugins/stardust/skills/prototype/reference/page-shape-brief.md
@@ -194,6 +194,13 @@ than discover them in the proposed HTML.
   more than two transitions appear.
 - `_provenance.voiceClassification[]` — Discipline 5; one entry
   per section with `{ classification, copy?, source? }`.
+- `_provenance.signatureElements[]` — § 8b signature preservation;
+  one entry per captured signature reproduced (hero video / canvas /
+  Lottie / scroll-motion / site-wide motif), with
+  `{ kind, capturedSource, mechanism, fallback }`. Required whenever
+  the captured page (`_brand-extraction.json#voice.heroMedium` or a
+  `#motifs` signature) triggers § 8b — even at `surprise: low`, since
+  signature preservation is budget-exempt.
 - `_provenance.surpriseTier_typeScaleYields[]` — friction #4
   carve-out; populated only when a tier-medium-or-higher variant
   yields a brand-level type-scale rule. Schema:

--- a/plugins/stardust/skills/stardust/reference/intent-dimensions.md
+++ b/plugins/stardust/skills/stardust/reference/intent-dimensions.md
@@ -234,6 +234,86 @@ sites (the common stardust use case). For product-register sites
 *workflow-priority preservation*: the primary task path on the page
 stays the primary task path. The same principle, different surface.
 
+## 8b. Signature preservation (Mode A constraint)
+
+Brand-faithful inheritance includes the page's *signature* — the
+distinctive, memorable element that makes the page recognizably
+**this** brand and not a template. The signature is usually the first
+thing a returning visitor recognizes and the first thing a generic
+redesign destroys. A refresh that keeps the palette and the type but
+flattens the signature to a static hero has missed the brand as badly
+as one that inverts its IA priority (§ 8). **Preserving the signature
+is fidelity, not surprise** — see the budget-exemption note below.
+
+#### Trigger conditions
+
+When the captured page (`stardust/current/pages/<slug>.json` +
+`_brand-extraction.json`) shows **any** of the following, the
+signature-preservation rule fires for every Mode A variant:
+
+- **Signature hero medium** — a background `<video>` (incl. HLS /
+  `.m3u8` / Cloudflare-Stream / Mux), a `<canvas>` / WebGL / Three.js
+  scene, a Lottie/Rive animation, or an animated SVG that occupies the
+  hero or first viewport. (The moneyhub.com home — an autoplay HLS
+  brand-animation behind the hero — is the canonical example.)
+- **Signature motion** — scroll-driven / parallax / pinned-section
+  motion, a marquee, a hero typewriter/kinetic-type effect, or a
+  recurring entrance choreography that reads as part of the brand
+  voice (not incidental fade-ins).
+- **Signature visual motif** — a distinctive recurring shape language,
+  illustration system, branded interaction, or layout silhouette that
+  the brand surface shows on multiple pages (extract's
+  `_brand-extraction.json#motifs` / `systemComponents`).
+
+#### Rule
+
+When the trigger fires, every Mode A variant must:
+
+1. **Reproduce the signature, do not flatten it.** A captured hero
+   video stays a hero video; a captured canvas/Lottie animation is
+   reproduced (or, if the exact asset can't be carried, replaced with
+   an equivalent brand-faithful motion in the same role) — **never**
+   silently swapped for a still image, a CSS gradient, or a
+   type-only hero. The asset URL/mechanism captured by extract is the
+   source of truth; reuse it the way the real brand asset is reused
+   (same rule as image-fidelity).
+2. **Carry it with production hygiene, not as a toy.** A reproduced
+   signature ships with a graceful static fallback, a
+   `prefers-reduced-motion` alternative, and (for overlaid text) a
+   legibility scrim — the absence of these is what makes a kept
+   signature feel cheap, and is a frequent reason an agent drops it
+   instead of doing it properly.
+3. **Keep it in its captured role / position.** A first-viewport
+   signature stays in the first viewport; a site-wide motif stays
+   site-wide. Demoting the signature below the fold to make room for a
+   generic display headline is the same off-brand move as § 8's
+   IA-priority demotion.
+
+#### Surprise-budget exemption
+
+Reproducing a captured signature is **fidelity, and is exempt from the
+per-page `surprise` budget** (§ 9). It does **not** consume the `low`
+allowance and is **required even at `surprise: low` under
+`ia-fidelity: verbatim`**. The budget governs *added* divergence
+(replacing a captured cliché with a move from the bank); carrying the
+brand's own signature forward is the opposite of divergence. A variant
+may not cite "low surprise" or "verbatim IA" as a reason to drop a
+signature — that reasoning inverts the budget.
+
+#### Render-refusal
+
+A variant that:
+
+- replaces a captured background video / canvas / Lottie hero with a
+  static image, gradient, or type-only hero,
+- strips a signature scroll/parallax/kinetic effect to a plain
+  static page "to stay faithful,"
+- drops a site-wide signature motif present in the brand surface,
+
+is rejected at the Phase 4 / prototype shape-brief audit stage.
+Surface the violation explicitly and reproduce the signature (with the
+hygiene of Rule 2) rather than shipping the flattened variant.
+
 ## 9. IA-fidelity (variant-fork ceiling)
 
 How much the variant set is allowed to move on the *spine* of the
@@ -290,6 +370,14 @@ page-shape-brief.md`). `ia-fidelity` sets a ceiling on `surprise`:
 |---|---|
 | `verbatim` | every page capped at `low` (A1/A2/A3 are surface forks; no IA moves) |
 | `reimagined` | `low` / `medium` / `high` per page; variant A defaults `low`, B `medium`, C `high` |
+
+**`low` is not "generic."** The budget bounds *added* divergence, not
+craft or fidelity. A `low` / `verbatim` page is still **brand-faithful
++ improvements + full § 8b signature preservation** — never the most
+obvious, stripped-down faithful interpretation. Signature media/motion
+(§ 8b) is exempt from this ceiling and is required even at `low`:
+dropping the source's video/animation/motif is a fidelity failure, not
+a low-surprise choice.
 
 The two axes are kept distinct because they have different scopes:
 the ceiling is a site-wide commitment the user pins once at direct


### PR DESCRIPTION
## Problem

Under Mode A (brand-faithful migration), the default `surprise: low` / `ia-fidelity: verbatim` was producing **too-obvious, stripped-down designs** that flatten the source's distinctive *signature*. In the moneyhub.com migration the home page's autoplay HLS background-video hero was dropped to a static type-hero on the first pass — faithful, but forgettable, and it under-sold the redesign.

Root cause: the agent reads `low` / `verbatim` as license to reduce the page to a plain hero on a flat ground, and treats keeping the source's video/animation as "added surprise" that the budget forbids.

## Fix

Reframe the model: **reproducing the brand's own signature is fidelity, not surprise** — so it is exempt from the surprise budget and required even at `low` / `verbatim`.

- **`intent-dimensions.md` — new § 8b "Signature preservation (Mode A constraint)"** (companion to § 8 IA-priority). Triggers on a signature hero medium (background video / HLS / canvas / WebGL / Lottie / animated SVG), signature motion (scroll / parallax / kinetic), or a site-wide visual motif. Rule: reproduce it with graceful fallback + `prefers-reduced-motion` + legibility scrim, keep it in its captured role, never flatten it. Includes a budget-exemption note and a render-refusal.
- **`intent-dimensions.md` § 9** — clarify `low` ≠ "generic": it is brand-faithful + improvements + full signature preservation, not the most obvious faithful interpretation.
- **`prototype/SKILL.md` Discipline 3** — same reframing + budget-exempt signature rule + render-refusal; record `_provenance.signatureElements[]`.
- **`extract/brand-surface.md`** — elevate a new `voice.heroMedium` signal (kind / mechanism / src / loader) so prototype can't miss a signature hero video/animation in the raw media list (mirrors the existing `heroImage` elevation).
- **`extract/SKILL.md`** — instruct Phase 3 to actually populate `voice.heroMedium` (review follow-up: the format spec defined it but the procedure didn't).
- **`direct/SKILL.md` + `page-shape-brief.md`** — wire the contract end-to-end.

## Notes

- Numbered the new section `§ 8b` deliberately to avoid renumbering `§ 9`, which has many cross-references.
- Self-reviewed; the one gap found (extract procedure not populating `heroMedium`) is fixed in the second commit.
- Scope: this addresses the "keep the signature / `low` ≠ generic" half of the prototype-uplift learning. The broader "offer 3 differentiated variants like Uplift" idea is intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
