### PR TITLE
stardust: delivery-contract guardrails, media reconciliation, fidelity tiers

### DIFF
--- a/plugins/stardust/CHANGELOG-delivery-media-fidelity.md
+++ b/plugins/stardust/CHANGELOG-delivery-media-fidelity.md
@@ -1,0 +1,70 @@
+# Changelog — delivery contract, media reconciliation, fidelity tiers
+
+Branch `stardust/delivery-media-fidelity`. Three generalized improvements drawn
+from a real CE Credits Online → EDS migration (full notes in the project's
+`stardust/skill-feedback.md`). The throughline: move what the *agent* had to
+remember (the EDS delivery contract, per-image handling, the quality/coverage
+trade) into what the *plugin* enforces.
+
+## B — Encode the EDS/DA delivery contract as guardrails
+
+The contract rules were tribal knowledge the pipeline re-learned by shipping a
+broken page and reading it back. Now they're code, split into two halves:
+
+- **Static, pre-PUT:** `rollout/scripts/delivery-lint.mjs` +
+  `rollout/reference/delivery-lint.md`. Deterministic, offline checks over
+  authored DA HTML: `<body><main>` wrapper, exactly-one-`<h1>` (typed),
+  **one-CTA-per-`<p>`** (the silent buttonization defect), trailing-slash /
+  `.html` links, `/img/` srcs, `about:error`, path-safety, metadata presence,
+  cross-origin-in-optimizing-block. P0/P1 blocks the PUT.
+- **Dynamic, post-deploy:** `rollout/scripts/verify.mjs` is now **artifact-type
+  aware** (`page | fragment | index`). A page must render exactly one `<h1>`; a
+  fragment (nav/footer) is no longer false-failed for lacking one; an index is
+  validated as JSON with rows. Output reports the type distribution.
+
+Wired into `rollout/SKILL.md` Phase C (new step 2, before the gates) and
+cross-referenced from `rollout/reference/delivery-gates.md` (§ Two halves).
+
+## C — Make media reconciliation a first-class decision
+
+Imagery is the #1 fidelity risk. `rollout/scripts/media-reconcile.mjs` +
+`migrate/reference/media-reconciliation.md` resolve **every** image on the
+network and decide per image: **optimize** (same-origin Content Bus),
+**keep** (external, 200 — skip block optimization), **rewrite** (repairable:
+missing `?`-delimiter, wrong host), or **omit** (unresolvable — drop the `<img>`,
+never ship `about:error`). `--apply` performs the rewrite/omit in place.
+
+Documents the `createOptimizedPicture` cross-origin trap (it drops the `?v=`
+key and corrupts external renditions) as a **block-code** rule: optimize
+same-origin only. Wired into `migrate/SKILL.md` Phase 2 (new "Media
+reconciliation" step) and `rollout` Gate 2 as the authoritative resolver.
+
+## D — Formalize fidelity tiers (the budget/coverage trade)
+
+`migrate/reference/fidelity-tiers.md` turns the existing render branches
+(A / A′ / unique) into **declared, gated tiers**:
+
+- **archetype** (Path A) — craft-gated once per template (full prototype stack).
+- **sibling** (Path A′) — canon-fork; inherits the archetype's validated
+  structure, re-checks only content-fidelity + delivery-lint + media-reconcile.
+  **The cheap default for breadth** — the reflex for "page N of an established
+  template" is *fork the archetype*, never *re-author*.
+- **thin** — bodyless/PDF pages rendered gracefully, no fabricated filler.
+
+Each page declares `fidelityTier` + `archetypeSource` + `gatesPassed[]`
+(`migrate/SKILL.md` Phase 2). The rollout dashboard surfaces the **tier
+distribution** so "92/92 deployed" can't hide "1 craft-gated, 91 ungated"
+(`rollout/reference/coverage-model.md` § Artifact type + fidelity tier).
+
+## Files
+
+New: `rollout/scripts/delivery-lint.mjs`, `rollout/scripts/media-reconcile.mjs`,
+`rollout/reference/delivery-lint.md`, `migrate/reference/media-reconciliation.md`,
+`migrate/reference/fidelity-tiers.md`.
+Modified: `rollout/scripts/verify.mjs` (typed), `rollout/SKILL.md`,
+`migrate/SKILL.md`, `rollout/reference/delivery-gates.md`,
+`rollout/reference/coverage-model.md`.
+
+All scripts are dependency-free Node, `node --check` clean, and were smoke-tested
+against the CE Credits Online migrated tree (home, nav fragment, synthetic
+broken-image and bad-path fixtures).

--- a/plugins/stardust/skills/migrate/SKILL.md
+++ b/plugins/stardust/skills/migrate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: migrate
-description: Apply DESIGN, canon, and modules to every page in the inventory, producing a deployable static HTML site. Three render branches (approved page, template-applied sibling, unique render). Per-page, incremental, idempotent, content-preserving by default.
+description: Apply DESIGN, canon, and modules to every page in the inventory, producing a deployable static HTML site. Use to migrate or render the whole captured site into the redesigned static tree ("migrate the pages", "render the migrated site", "apply the design to all pages", "build the deployable site", "convert the approved prototype into the full site") — the page-rendering step between prototype and deploy/rollout. Three render branches (approved page, template-applied sibling, unique render), with a declared fidelity tier per page. Per-page, incremental, idempotent, content-preserving by default.
 license: Apache-2.0
 ---
 

--- a/plugins/stardust/skills/migrate/SKILL.md
+++ b/plugins/stardust/skills/migrate/SKILL.md
@@ -151,7 +151,12 @@ For each page in scope, follow
   present — the user fills the missing content in the proposed
   file before re-invoking migrate. No bypass flag.
 - **Render branch selection** (LLM judgment per T&M §
-  Render path selection): A / A′ / B.
+  Render path selection): A / A′ / B. **Declare the page's
+  `fidelityTier`** from the branch — A → `archetype` (craft-gated),
+  A′ → `sibling` (canon-fork, the cheap default for breadth),
+  B/bodyless → `thin` — per `reference/fidelity-tiers.md`. Record
+  `fidelityTier`, `archetypeSource`, and `gatesPassed[]` in
+  `_meta.json` so coverage shows what was craft-gated vs cloned.
 - **Render** per the chosen branch's procedure in T&M.
 - **Canon application** — chrome injection, canon.css
   injection, deviation logging.
@@ -180,6 +185,15 @@ For each page in scope, follow
   `state.json.migrate.bundledAssets[]`. Missing source assets
   warn-and-skip per § Edge cases; the bundle stays internally
   consistent.
+- **Media reconciliation.** For every image **not** bundled to
+  same-origin (reused source-CDN URLs under Mode A image-reuse),
+  decide optimize/keep/rewrite/omit per
+  `reference/media-reconciliation.md`. Cross-origin `<img>` kept
+  as source URLs must **skip `createOptimizedPicture`** (it drops
+  the `?v=` key and corrupts the rendition); broken URLs are
+  repaired (missing `?`-delimiter, wrong host) or omitted, never
+  shipped as `about:error`. `rollout` re-runs the authoritative
+  network resolve at delivery (`media-reconcile.mjs`).
 - **Write** the migrated `index.html` and the `_meta.json`
   sidecar in the same directory. Provenance block as first
   child of `<head>`. Record `assetsBundled` (count of unique

--- a/plugins/stardust/skills/migrate/reference/fidelity-tiers.md
+++ b/plugins/stardust/skills/migrate/reference/fidelity-tiers.md
@@ -1,0 +1,66 @@
+# Fidelity tiers (declared coverage/quality contract)
+
+The migrate render branches (Path A approved-prototype, Path A′ canon-forked
+sibling, unique render) describe *how* a page is built. **Fidelity tiers**
+describe *how much quality assurance it carries* — and make that an explicit,
+declared, per-page decision instead of a silent consequence of which branch ran.
+
+The tension this resolves: craft-gating every page through `prototype` (critique
++ audit + anti-template + content-sourcing gates) is unaffordable at 50–100
+pages, but generic per-page authoring bypasses **every** quality gate. A real
+migration hit exactly this — one page (home) got full craft, ~90 siblings got
+faithful generic authoring with no declared gate between them. Tiers name the
+trade so a reviewer can see, per page, what was and wasn't checked.
+
+## The three tiers
+
+| Tier | Render branch | Gates it MUST pass | When |
+|---|---|---|---|
+| **archetype** | Path A (approved prototype) | Full `prototype` gate stack: critique, audit, mobile-adapt, anti-template, content-sourcing, `:root` + data-attribute contracts | One representative page **per template**. The design canon. |
+| **sibling** | Path A′ (canon-fork) | Structural clone of the archetype + **content-fidelity** (verbatim source copy, no fabrication) + **delivery-lint** + **media-reconcile**. NOT full craft. | Every other page of a template the archetype already covers. **The cheap default for breadth.** |
+| **thin** | unique (graceful) | delivery-lint + media-reconcile + a declared `contentGap`. Renders metadata + hero + whatever real content exists (e.g. a PDF link). No fabricated filler. | Pages with little/no body content (PDF-only, redirect stubs, bodyless landing). |
+
+The point of the table: **archetype is craft-gated once per template; siblings
+inherit that validated structure and only re-check the things that vary per page
+(content + media + the delivery contract).** That keeps breadth affordable
+without dropping to zero gates. Make sibling-clone the path of least resistance —
+the reflex for "page N of an established template" should be *fork the archetype*,
+never *re-author from scratch*.
+
+## Declaration (per page)
+
+Every page row in `state.json` and `coverage/pages.json` carries:
+
+```json
+"fidelityTier": "archetype" | "sibling" | "thin",
+"archetypeSource": "<slug>",        // for sibling/thin: which archetype it forked
+"gatesPassed": ["delivery-lint", "media-reconcile", "content-fidelity"],
+"contentGap": "source is a PDF download; no HTML body"   // thin only
+```
+
+`inventory.mjs` seeds the tier from the render branch; `migrate` confirms it;
+`verify.mjs` reads `delivery.type` (page/fragment/index) independently. Tier and
+type are orthogonal — a fragment is always tier `thin` or `sibling`, never an
+archetype.
+
+## Coverage reporting
+
+The rollout dashboard surfaces the **tier distribution**, not just delivery
+status, so "92/92 deployed" can't hide "1 craft-gated, 91 ungated". A healthy
+distribution is one archetype per template with the rest as siblings; a run with
+many `unique`/`thin` pages for what should be one template signals a missing
+archetype (the template was never craft-gated — fix by prototyping it, then
+re-forking its siblings).
+
+> Silent-cap rule: if breadth forces dropping a tier (e.g. delivering siblings
+> without an approved archetype because the template was never prototyped),
+> `log()` it as a coverage gap. An ungated page that reads as "deployed" is the
+> failure this tier model exists to make visible.
+
+## Why declared, not inferred
+
+A tier the reviewer can read is a tier the reviewer can challenge. The migration
+prompt's "invoke prototype, never hand-author" rule is really "every page is at
+least sibling-tier — forked from a craft-gated archetype". Declaring the tier per
+page turns that from a hope into an auditable record, and turns the
+quality/coverage trade from an accident into a decision.

--- a/plugins/stardust/skills/migrate/reference/media-reconciliation.md
+++ b/plugins/stardust/skills/migrate/reference/media-reconciliation.md
@@ -30,9 +30,12 @@ For every authored image URL (`<img src>`, `srcset`, inline/`<style>` `url(...)`
    - **wrong rendition variant** — a derivative 404s where a sibling resolves
      (`…/4x3/768/…` 404, `…/original/768/…` 200). Not auto-repaired; flag for
      manual rewrite.
-4. **omit** — external, unresolvable and unrepairable. **Drop the `<img>`** so
-   the block renders gracefully. Never ship `about:error`, and never substitute
-   a logo/placeholder as if it were editorial.
+4. **omit** — external, a **definitive 4xx** (404/403/410) with no repair.
+   **Drop the `<img>`** (and its enclosing `<picture>`/`<source>`) so the block
+   renders gracefully. Never ship `about:error`, never substitute a placeholder.
+5. **unresolved** — a network error, timeout, or **5xx** (transient). The image
+   may be fine; the script flags it for a human and **never auto-deletes it on
+   `--apply`**. Re-run, or resolve manually. The gate fails until it's cleared.
 
 ## Run it
 

--- a/plugins/stardust/skills/migrate/reference/media-reconciliation.md
+++ b/plugins/stardust/skills/migrate/reference/media-reconciliation.md
@@ -1,0 +1,75 @@
+# Media reconciliation (per-image delivery decision)
+
+Imagery is the #1 fidelity risk at scale. A migration reuses source images at
+their original URLs (Mode A image-reuse contract), but those URLs live on hosts
+the EDS preview ingester treats in three incompatible ways — and the failure is
+silent: `<img src="about:error">` still "renders". This reference makes the
+per-image decision **explicit and resolvable** instead of ad-hoc.
+
+It is the systematized form of delivery Gate 2 (`reference/delivery-gates.md`).
+Where Gate 2 says "curl each external image, omit if not 200", this adds the
+*decision tree* — optimize / keep / rewrite / omit — and a script that resolves
+every image on the network and can apply the fix.
+
+## The four decisions
+
+For every authored image URL (`<img src>`, `srcset`, inline/`<style>` `url(...)`):
+
+1. **optimize** — the URL is **same-origin** with the deploy host (a Content Bus
+   asset). Safe to run `createOptimizedPicture`; EDS owns the rendition pipeline.
+2. **keep** — **external**, resolves `200`. Reference as-is, but the block must
+   **skip optimization** for it (see § Cross-origin optimization). Most reused
+   source images land here.
+3. **rewrite** — external, the literal URL breaks but a known repair resolves:
+   - **missing query delimiter** — `…/<id>&wid=600` (no `?`) makes `<id>&wid=600`
+     a bogus asset id → 403. Repair the first `&` after the id to `?`.
+   - **wrong host** — the same asset family lives on two CDNs and only one
+     serves to EDS (e.g. `cdn.shopify.com/s/files/...` returns `about:error`
+     while the store's own `www.store.com/cdn/shop/files/...` resolves). Prefer
+     the store-domain host. Provide the mapping with `--host-rewrite bad=good`.
+   - **wrong rendition variant** — a derivative 404s where a sibling resolves
+     (`…/4x3/768/…` 404, `…/original/768/…` 200). Not auto-repaired; flag for
+     manual rewrite.
+4. **omit** — external, unresolvable and unrepairable. **Drop the `<img>`** so
+   the block renders gracefully. Never ship `about:error`, and never substitute
+   a logo/placeholder as if it were editorial.
+
+## Run it
+
+```bash
+node skills/rollout/scripts/media-reconcile.mjs --file <content.html> \
+  --deploy-host <branch>--<repo>--<owner>.aem.live \
+  [--host-rewrite cdn.shopify.com/s/files=www.store.com/cdn/shop/files] \
+  [--json] [--apply]
+```
+
+Without `--apply` it reports the decision per image (exit `1` if any `omit`).
+With `--apply` it rewrites the file in place: `rewrite` → suggested URL,
+`omit` → the `<img>` (and any emptied `<picture>`) removed. Run it in Phase C
+after `delivery-lint`, before the PUT.
+
+## Cross-origin optimization (the createOptimizedPicture trap)
+
+`createOptimizedPicture` rebuilds a URL from `origin + pathname` and appends
+`?width=&format=webply&optimize=medium` — **dropping the original query** (e.g.
+a Shopify `?v=` cache key) and adding params foreign CDNs mishandle. The result
+is a broken `<source>`/rendition for any **cross-origin** image. Therefore:
+
+> Blocks that call `createOptimizedPicture` (cards, columns, hero, …) must guard
+> it: optimize **same-origin** assets only; for cross-origin `src`, keep the
+> original `<img>` untouched.
+
+This is a block-code rule, not just an authoring rule — bake the same-origin
+guard into the stardust block templates so reused source imagery survives. The
+`cross-origin-optimize` P2 in `delivery-lint` flags candidates; `media-reconcile`
+is the authoritative resolver.
+
+## Rehost vs reference
+
+`keep` references the source CDN forever — fine for a faithful migration, but it
+couples delivery to the source host staying up. When a project wants assets on
+the Content Bus (decoupled, EDS-optimized), **rehost**: download the resolving
+rendition into the migrated tree / DA and rewrite the `src` to the same-origin
+path — which then qualifies for `optimize`. Asset bundling
+(`reference/asset-bundling.md`) is the bulk mechanism; media-reconciliation is
+the per-image decision that precedes it.

--- a/plugins/stardust/skills/rollout/SKILL.md
+++ b/plugins/stardust/skills/rollout/SKILL.md
@@ -118,19 +118,36 @@ Walk `plan.json.steps` in order (representative pages first). For each page:
    as "awaiting content track." Their block code is already deployed via the
    archetype.
 
-2. **Run the delivery gates** before flipping a page to `deployed`. Each is a
+2. **Static contract lint (pre-PUT, deterministic).** Before the push, run the
+   delivery-contract linter — it catches the cheap, deterministic failures
+   (wrapper, one-CTA-per-`<p>`, trailing-slash, path-safety, `/img/` src,
+   `about:error`) offline so a broken page never reaches preview. Mechanics in
+   `reference/delivery-lint.md`. **A P0/P1 blocks the PUT.**
+   ```bash
+   node skills/rollout/scripts/delivery-lint.mjs --file <html> --path </da/path>
+   node skills/rollout/scripts/media-reconcile.mjs --file <html> --deploy-host <branch>--<repo>--<owner>.aem.live [--apply]
+   ```
+   `media-reconcile` resolves every image on the network and decides
+   optimize/keep/rewrite/omit (`reference/media-reconciliation.md`) — the
+   authoritative form of the image-fidelity gate below.
+
+3. **Run the delivery gates** before flipping a page to `deployed`. Each is a
    one-line rule here; mechanics + helpers in `reference/delivery-gates.md`:
    - **Source-fidelity** — don't add sections the source lacks; never fabricate
      facts. `node skills/rollout/scripts/section-fidelity.mjs --file <html> --source <url>`
    - **Image-fidelity** — every authored `<img>` src must return 200 or be omitted;
-     never ship `<img src="about:error">`.
+     never ship `<img src="about:error">`. Run `media-reconcile.mjs` (step 2).
    - **Path-safety** — normalize source paths to AEM-Edge-safe form (lowercase, no
      trailing `-`/`_`, no `--` segment); record original→normalized in
-     `stardust/redirects.tsv`.
+     `stardust/redirects.tsv`. (delivery-lint flags violations.)
    - **Source-content hygiene** — skip dead source URLs; author bodyless/PDF-only
-     sources thin and faithful, don't pad with invented prose.
+     sources thin and faithful (tier `thin`, `reference/fidelity-tiers.md`),
+     don't pad with invented prose.
+   - **Fidelity tier declared** — record each page's `fidelityTier`
+     (archetype/sibling/thin) so coverage shows what was craft-gated vs cloned
+     (`reference/fidelity-tiers.md`).
 
-3. **Record outcomes** with the state-writer (never hand-edit the ledger):
+4. **Record outcomes** with the state-writer (never hand-edit the ledger):
    ```bash
    node skills/rollout/scripts/update-coverage.mjs <slug> --status converting
    node skills/rollout/scripts/update-coverage.mjs --block <id> --status converted --eds-name <name>

--- a/plugins/stardust/skills/rollout/reference/coverage-model.md
+++ b/plugins/stardust/skills/rollout/reference/coverage-model.md
@@ -48,6 +48,27 @@ The contract the two scripts maintain. Design rationale is in
 - **stale** — was deployed/verified, but `migrate` re-emitted the page (its
   `sourceHash` changed). Needs re-delivery.
 
+## Artifact type + fidelity tier (orthogonal to status)
+
+Two further per-page fields make delivery quality auditable; both are independent
+of `delivery.status`:
+
+- **`delivery.type`** — `page | fragment | index`. Drives what "renders
+  correctly" means: a fragment has no `<h1>`, an index is JSON with rows.
+  `verify.mjs` infers it from the path when unset and reports the distribution;
+  a one-size `<h1>` check false-fails fragments without it.
+- **`fidelityTier`** — `archetype | sibling | thin` (+ `archetypeSource`,
+  `gatesPassed[]`), set by `migrate` from the render branch
+  (`migrate/reference/fidelity-tiers.md`). Records *how much QA the page carries*:
+  `archetype` is craft-gated once per template; `sibling` is a canon-fork that
+  inherits that structure and re-checks only content + media + the delivery
+  contract; `thin` is a bodyless/PDF page rendered gracefully.
+
+The dashboard surfaces the **tier distribution** alongside status, so
+"92/92 deployed" cannot hide "1 craft-gated, 91 ungated clones". Many
+`unique`/`thin` pages where one template was expected signals a missing
+archetype — prototype it, then re-fork its siblings.
+
 ## Idempotency rules (inventory)
 
 On every `inventory.mjs` run:

--- a/plugins/stardust/skills/rollout/reference/delivery-gates.md
+++ b/plugins/stardust/skills/rollout/reference/delivery-gates.md
@@ -4,6 +4,15 @@ The per-page checks Phase C runs before flipping a page to `deployed`, and the
 batched-delivery flow that runs them uniformly at scale. SKILL.md Phase C names
 each gate in one line; the mechanics live here.
 
+**Two halves.** The gates split into a **static** pre-PUT lint
+(`reference/delivery-lint.md` → `scripts/delivery-lint.mjs`: wrapper,
+one-CTA-per-`<p>`, trailing-slash, path-safety — deterministic and offline) and a
+**dynamic** post-deploy check (`scripts/verify.mjs` § typed render-truth: does it
+actually render, typed by page/fragment/index). Run the static lint first — it
+catches the cheap failures before a network round-trip. Gate 2 (image-fidelity)
+has its own network resolver, `scripts/media-reconcile.mjs`
+(`migrate/reference/media-reconciliation.md`).
+
 ## Gate 1 — Source-fidelity ("don't add sections the source doesn't have")
 
 A migration reproduces the source; it must not invent sections. Invented
@@ -36,11 +45,13 @@ gracefully, log it as a content gap — do NOT invent filler.
 
 The #1 recurring defect at scale: an authored external image URL the preview
 ingester can't fetch delivers as `<img src="about:error">` — a silent break that
-"it renders" hides. Before deploy, for each authored `<img>` whose src is an
-external/source URL, verify 200:
+"it renders" hides. The systematic resolver is `media-reconcile.mjs` (it decides
+optimize/keep/rewrite/omit per image and can `--apply` the fix); the manual
+form, for a single image, is a 200 check:
 
 ```bash
-curl -s -o /dev/null -w '%{http_code}' <url>
+node skills/rollout/scripts/media-reconcile.mjs --file <html> --deploy-host <host>   # all images
+curl -s -o /dev/null -w '%{http_code}' <url>                                          # one image
 ```
 
 If it isn't 200, OMIT the image (the block renders without it) rather than ship

--- a/plugins/stardust/skills/rollout/reference/delivery-lint.md
+++ b/plugins/stardust/skills/rollout/reference/delivery-lint.md
@@ -1,0 +1,55 @@
+# Delivery-contract lint (static pre-deploy gate)
+
+The delivery gates have two halves. **Static** — can this authored HTML even
+satisfy the EDS/DA contract — runs *before* PUT, offline, deterministically:
+`scripts/delivery-lint.mjs`. **Dynamic** — does the delivered page actually
+render — runs *after* preview/live: `scripts/verify.mjs` (§ Typed render-truth).
+
+This file documents the static half. It exists because the contract rules below
+are deterministic truths the pipeline otherwise re-learns by shipping a broken
+page and reading it back — the migration prompt is essentially a long list of
+them. Encoding them as a linter moves the knowledge from "the agent remembers"
+to "the tool enforces".
+
+## Run it
+
+```bash
+node skills/rollout/scripts/delivery-lint.mjs --file <content.html> \
+  --path </da/target/path> [--type page|fragment|index] [--json]
+```
+
+`--type` is inferred from the path when omitted (`/nav`, `/footer`, `*/fragments/*`
+→ fragment; `*/query-index`, `*.json` → index; else page). Exit `1` on any
+**P0 or P1** — wire it as a blocking gate in Phase C before the PUT. P2 is
+advisory (surfaced, never blocks).
+
+## What it checks
+
+| Rule | Sev | Why it breaks delivery |
+|---|---|---|
+| `wrapper` | P0 | No `<body>…<main>…</main></body>` → DA silently discards the content. `<header>`/`<footer>` absent → P1. |
+| `h1` | P0/P1 | A page needs exactly one `<h1>` (SEO + decoration). 0 → P0; >1 → P1. A fragment must have none. |
+| `one-cta-per-p` | P1 | `decorateButtons` only buttonizes a link that is the **sole** content of its `<p>`. Two emphasized links in one paragraph ship as unstyled text — invisible on light grounds, glaring on a photo hero. Split each CTA into its own `<p>`. |
+| `about-error` | P0 | `about:error` in the source means a broken image rendition already shipped. |
+| `img-path` | P0 | A `/img/...` src 404s at delivery. |
+| `cross-origin-optimize` | P2 | An external `<img>` inside a block that runs `createOptimizedPicture` (cards/columns/hero) may be corrupted (dropped `?v=`, added `&format=webply`). Advisory — the authoritative resolve is `media-reconcile.mjs`. |
+| `trailing-slash` / `html-extension` | P1 | Internal links with a trailing slash or `.html` 404 on EDS (it serves extensionless, no-trailing-slash). |
+| `path-safety` | P0 | The target DA path must be lowercase, hyphenated, no `_`, no `//`. A double slash makes the PUT 400 while preview/live still 200 — a silent partial. Normalize and record the original → safe mapping in `redirects.tsv`. |
+| `metadata` | P2 | No metadata block → thin query-index rows (no description/og:image at import time). |
+
+`--optimizing-blocks a,b,c` overrides the block list for the cross-origin check
+(default `cards,columns,hero`) when a project's block set differs.
+
+## Where it sits in Phase C
+
+```
+author content.html
+  → delivery-lint  (static; P0/P1 blocks)         ← THIS FILE
+  → media-reconcile (resolve every image; C)       ← reference/media-reconciliation.md
+  → PUT → preview → live
+  → verify.mjs (typed render-truth; D below)       ← reference/delivery-gates.md
+  → flip to deployed/verified
+```
+
+The static lint catches the cheap, deterministic failures before spending a
+network round-trip; the dynamic verify catches what only the renderer knows.

--- a/plugins/stardust/skills/rollout/scripts/delivery-lint.mjs
+++ b/plugins/stardust/skills/rollout/scripts/delivery-lint.mjs
@@ -31,7 +31,9 @@ const html = readFileSync(FILE, 'utf8');
 function inferType(p) {
   if (!p) return 'page';
   const s = p.toLowerCase();
-  if (/\/(nav|footer)$/.test(s) || /\/fragments?\//.test(s)) return 'fragment';
+  // anchor fragment detection: only top-level /nav,/footer or a /fragments/ path —
+  // a content page like /about/nav must NOT be downgraded out of the P0 gates.
+  if (/^\/(nav|footer)$/.test(s) || /\/fragments?\//.test(s)) return 'fragment';
   if (/query-index(\.json)?$/.test(s) || /\.json$/.test(s)) return 'index';
   return 'page';
 }
@@ -66,7 +68,7 @@ for (const m of html.matchAll(/<p\b[^>]*>([\s\S]*?)<\/p>/gi)) {
 }
 
 /* ---- image hygiene ---- */
-const imgs = [...html.matchAll(/<img\b[^>]*\bsrc="([^"]+)"[^>]*>/gi)].map((m) => m[1]);
+const imgs = [...html.matchAll(/<img\b[^>]*\ssrc="([^"]+)"[^>]*>/gi)].map((m) => m[1]);
 if (/about:error/i.test(html)) add('P0', 'about-error', 'about:error present — a broken image rendition shipped');
 for (const src of imgs) {
   if (/^\/img\//i.test(src)) add('P0', 'img-path', `/img/ src will 404 at delivery: ${src.slice(0, 60)}`);
@@ -76,7 +78,7 @@ for (const blk of OPTIMIZING) {
   const re = new RegExp(`class="${blk}(\\s[^"]*)?"([\\s\\S]*?)(?=<div class="(?!${blk})|</main>)`, 'i');
   const seg = html.match(re);
   if (!seg) continue;
-  for (const m of seg[2].matchAll(/<img\b[^>]*\bsrc="(https?:\/\/[^"]+)"/gi)) {
+  for (const m of seg[2].matchAll(/<img\b[^>]*\ssrc="(https?:\/\/[^"]+)"/gi)) {
     add('P2', 'cross-origin-optimize', `external <img> inside .${blk} (optimizing block) — run media-reconcile (skip-optimize or rehost) to confirm it renders: ${m[1].slice(0, 50)}…`);
   }
 }

--- a/plugins/stardust/skills/rollout/scripts/delivery-lint.mjs
+++ b/plugins/stardust/skills/rollout/scripts/delivery-lint.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * rollout/delivery-lint.mjs — PRE-deploy static linter for the EDS/DA delivery
+ * contract. Encodes the deterministic rendering rules the pipeline otherwise
+ * re-learns by failing (one-CTA-per-<p>, wrapper, trailing-slash, path-safety,
+ * cross-origin image optimization, metadata). Run BEFORE PUT; a P0 blocks deploy.
+ *
+ * This is the static half of the delivery gates (the dynamic half — does it
+ * actually render — is verify.mjs § renderer-truth). Reference:
+ * reference/delivery-lint.md and reference/delivery-gates.md.
+ *
+ * Usage:
+ *   node skills/rollout/scripts/delivery-lint.mjs --file <html> [--path </da/path>]
+ *        [--type page|fragment|index] [--json]
+ * Exit: 0 = clean (no P0/P1), 1 = P0/P1 findings, 2 = bad invocation.
+ *
+ * Blocks known to run createOptimizedPicture over their images (cross-origin
+ * breakage risk) — extend per project via --optimizing-blocks a,b,c.
+ */
+import { readFileSync } from 'node:fs';
+
+function arg(name, fb) { const i = process.argv.indexOf(`--${name}`); return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fb; }
+const FILE = arg('file', null);
+const DAPATH = arg('path', null);
+const TYPE = arg('type', null); // page | fragment | index — inferred if absent
+const JSON_OUT = process.argv.includes('--json');
+const OPTIMIZING = (arg('optimizing-blocks', 'cards,columns,hero')).split(',').map((s) => s.trim()).filter(Boolean);
+if (!FILE) { console.error('delivery-lint: need --file <html>'); process.exit(2); }
+const html = readFileSync(FILE, 'utf8');
+
+function inferType(p) {
+  if (!p) return 'page';
+  const s = p.toLowerCase();
+  if (/\/(nav|footer)$/.test(s) || /\/fragments?\//.test(s)) return 'fragment';
+  if (/query-index(\.json)?$/.test(s) || /\.json$/.test(s)) return 'index';
+  return 'page';
+}
+const type = TYPE || inferType(DAPATH);
+const findings = [];
+const add = (sev, rule, msg) => findings.push({ sev, rule, msg });
+
+/* ---- structural wrapper (DA silently discards content without it) ---- */
+if (type !== 'index') {
+  const hasBody = /<body[\s>]/i.test(html);
+  const hasMain = /<main[\s>]/i.test(html);
+  if (!hasBody || !hasMain) add('P0', 'wrapper', 'missing <body>…<main>…</main>…</body> wrapper — DA discards content without it');
+  if (!/<header>\s*<\/header>|<header[\s>]/i.test(html)) add('P1', 'wrapper', 'missing <header> tag (DA expects <header></header>)');
+  if (!/<footer>\s*<\/footer>|<footer[\s>]/i.test(html)) add('P1', 'wrapper', 'missing <footer> tag (DA expects <footer></footer>)');
+}
+
+/* ---- h1 cardinality (typed) ---- */
+const h1Count = (html.match(/<h1[\s>]/gi) || []).length;
+if (type === 'page' && h1Count !== 1) add(h1Count === 0 ? 'P0' : 'P1', 'h1', `expected exactly one <h1>, found ${h1Count}`);
+if (type === 'fragment' && h1Count > 0) add('P1', 'h1', `fragment should not contain an <h1> (found ${h1Count})`);
+
+/* ---- one CTA per <p> (decorateButtons only buttonizes a link that is the
+   sole content of its <p>; two links in one <p> ship as unstyled text) ---- */
+for (const m of html.matchAll(/<p\b[^>]*>([\s\S]*?)<\/p>/gi)) {
+  const inner = m[1];
+  const links = (inner.match(/<a\b[^>]*>/gi) || []).length;
+  const emphasized = /<(strong|em)\b/i.test(inner);
+  // a buttonizable paragraph wraps its link(s) in strong/em; >1 link there breaks buttonization
+  if (links > 1 && emphasized) {
+    add('P1', 'one-cta-per-p', 'paragraph contains >1 emphasized link — split each CTA into its own <p> or they ship unstyled');
+  }
+}
+
+/* ---- image hygiene ---- */
+const imgs = [...html.matchAll(/<img\b[^>]*\bsrc="([^"]+)"[^>]*>/gi)].map((m) => m[1]);
+if (/about:error/i.test(html)) add('P0', 'about-error', 'about:error present — a broken image rendition shipped');
+for (const src of imgs) {
+  if (/^\/img\//i.test(src)) add('P0', 'img-path', `/img/ src will 404 at delivery: ${src.slice(0, 60)}`);
+}
+/* cross-origin <img> inside an optimizing block → createOptimizedPicture breaks it */
+for (const blk of OPTIMIZING) {
+  const re = new RegExp(`class="${blk}(\\s[^"]*)?"([\\s\\S]*?)(?=<div class="(?!${blk})|</main>)`, 'i');
+  const seg = html.match(re);
+  if (!seg) continue;
+  for (const m of seg[2].matchAll(/<img\b[^>]*\bsrc="(https?:\/\/[^"]+)"/gi)) {
+    add('P2', 'cross-origin-optimize', `external <img> inside .${blk} (optimizing block) — run media-reconcile (skip-optimize or rehost) to confirm it renders: ${m[1].slice(0, 50)}…`);
+  }
+}
+
+/* ---- internal link hygiene: no trailing slash, no .html ---- */
+for (const m of html.matchAll(/href="(\/[^"]*)"/gi)) {
+  const href = m[1];
+  if (href === '/') continue;
+  if (/\/(#|$)/.test(href.replace(/[?#].*/, '')) && href.replace(/[?#].*/, '').endsWith('/')) {
+    add('P1', 'trailing-slash', `internal link has a trailing slash (404s on EDS): ${href}`);
+  }
+  if (/\.html(\?|#|$)/i.test(href)) add('P1', 'html-extension', `internal link ends in .html (EDS serves extensionless): ${href}`);
+}
+
+/* ---- path-safety of the target DA path ---- */
+if (DAPATH) {
+  const norm = DAPATH.toLowerCase()
+    .split('/').map((s) => s.replace(/_/g, '-').replace(/-+/g, '-').replace(/^-+|-+$/g, '')).join('/')
+    .replace(/\/{2,}/g, '/').replace(/(.)\/$/, '$1');
+  if (norm !== DAPATH) add('P0', 'path-safety', `path is not delivery-safe; normalize ${DAPATH} → ${norm} (record in redirects.tsv)`);
+  if (/\/\//.test(DAPATH)) add('P0', 'path-safety', 'double slash in path makes the DA PUT 400 while preview/live still 200');
+}
+
+/* ---- metadata block present (rich indexes at import time) ---- */
+if (type === 'page' && !/class="metadata"/i.test(html)) {
+  add('P2', 'metadata', 'no metadata block — query-index rows will be thin (title/description/og:image)');
+}
+
+const p0 = findings.filter((f) => f.sev === 'P0');
+const p1 = findings.filter((f) => f.sev === 'P1');
+if (JSON_OUT) {
+  console.log(JSON.stringify({ file: FILE, type, findings, gate: p0.length || p1.length ? 'FAIL' : 'PASS' }, null, 2));
+} else {
+  console.log(`delivery-lint ${FILE} (type:${type})`);
+  console.log('='.repeat(60));
+  if (!findings.length) console.log('  clean — no contract violations');
+  for (const f of findings) console.log(`  ${f.sev} ${f.rule.padEnd(22)} ${f.msg}`);
+  console.log(`\n${p0.length} P0 · ${p1.length} P1 · ${findings.filter((f) => f.sev === 'P2').length} P2`);
+}
+process.exit(p0.length || p1.length ? 1 : 0);

--- a/plugins/stardust/skills/rollout/scripts/media-reconcile.mjs
+++ b/plugins/stardust/skills/rollout/scripts/media-reconcile.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * rollout/media-reconcile.mjs — per-image reconciliation for migrations.
+ *
+ * Imagery is the #1 fidelity risk at scale. This systematizes the decision the
+ * delivery gates make ad-hoc: for every authored image URL, classify origin,
+ * RESOLVE it on the network, apply known repairs, and emit a decision:
+ *   optimize  — same-origin (Content Bus) asset; safe to run createOptimizedPicture
+ *   keep      — external, resolves 200; reference as-is but skip block optimization
+ *   rewrite   — repairable break (missing ?-delimiter, wrong host) → suggested URL
+ *   omit      — unresolvable; drop the <img> (render gracefully), never ship about:error
+ *
+ * Reference: skills/migrate/reference/media-reconciliation.md and
+ * skills/rollout/reference/delivery-gates.md § Gate 2.
+ *
+ * Usage:
+ *   node skills/rollout/scripts/media-reconcile.mjs --file <html>
+ *        --deploy-host <host> [--host-rewrite badhost=goodhost] [--json] [--apply]
+ *   --apply rewrites the file in place (rewrite → suggested URL, omit → remove <img>).
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+
+function arg(name, fb) { const i = process.argv.indexOf(`--${name}`); return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fb; }
+const FILE = arg('file', null);
+const DEPLOY_HOST = arg('deploy-host', null);
+const JSON_OUT = process.argv.includes('--json');
+const APPLY = process.argv.includes('--apply');
+const rewrites = process.argv.filter((a, i) => process.argv[i - 1] === '--host-rewrite').map((s) => s.split('='));
+if (!FILE) { console.error('media-reconcile: need --file <html>'); process.exit(2); }
+let html = readFileSync(FILE, 'utf8');
+
+/* collect image URLs: <img src>, srcset, inline style url(), <style> url() */
+function collect(h) {
+  const urls = new Set();
+  for (const m of h.matchAll(/<img\b[^>]*\bsrc="([^"]+)"/gi)) urls.add(m[1]);
+  for (const m of h.matchAll(/\bsrcset="([^"]+)"/gi)) m[1].split(',').forEach((part) => { const u = part.trim().split(/\s+/)[0]; if (u) urls.add(u); });
+  for (const m of h.matchAll(/url\((['"]?)(https?:\/\/[^)'"]+)\1\)/gi)) urls.add(m[2]);
+  return [...urls].filter((u) => u && !u.startsWith('data:'));
+}
+
+function repairUrl(u) {
+  // missing query delimiter: …/<id>&wid=… → …/<id>?wid=…
+  if (!u.includes('?') && u.includes('&')) return u.replace('&', '?');
+  // host rewrite (e.g. cdn.shopify.com → www.store.com)
+  for (const [bad, good] of rewrites) { if (u.includes(bad)) return u.replace(bad, good); }
+  return null;
+}
+
+async function resolve(u) {
+  try {
+    const r = await fetch(u, { method: 'GET', headers: { 'user-agent': 'stardust-media-reconcile' } });
+    return r.status;
+  } catch (e) { return 0; }
+}
+
+function originOf(u) { try { return new URL(u).host; } catch { return null; } }
+
+const results = [];
+for (const u of collect(html)) {
+  const host = originOf(u);
+  const sameOrigin = DEPLOY_HOST && host && host === DEPLOY_HOST;
+  let decision; let suggested = null; let status = null;
+  if (sameOrigin) {
+    decision = 'optimize';
+  } else {
+    status = await resolve(u);
+    if (status === 200) {
+      decision = 'keep';
+    } else {
+      const fixed = repairUrl(u);
+      if (fixed) {
+        const fstatus = await resolve(fixed);
+        if (fstatus === 200) { decision = 'rewrite'; suggested = fixed; status = fstatus; } else { decision = 'omit'; }
+      } else {
+        decision = 'omit';
+      }
+    }
+  }
+  results.push({ url: u, host, status, decision, suggested });
+}
+
+/* optionally apply rewrites/omits */
+if (APPLY) {
+  for (const r of results) {
+    if (r.decision === 'rewrite' && r.suggested) {
+      html = html.split(r.url).join(r.suggested);
+    } else if (r.decision === 'omit') {
+      // remove the whole <img …src="url"…> (and an empty wrapping <picture>)
+      const imgRe = new RegExp(`<img\\b[^>]*\\bsrc="${r.url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"[^>]*>`, 'gi');
+      html = html.replace(imgRe, '');
+      html = html.replace(/<picture>\s*<\/picture>/gi, '');
+    }
+  }
+  writeFileSync(FILE, html);
+}
+
+const counts = results.reduce((a, r) => { a[r.decision] = (a[r.decision] || 0) + 1; return a; }, {});
+const broken = results.filter((r) => r.decision === 'omit');
+if (JSON_OUT) {
+  console.log(JSON.stringify({ file: FILE, deployHost: DEPLOY_HOST, applied: APPLY, counts, results }, null, 2));
+} else {
+  console.log(`media-reconcile ${FILE}${APPLY ? ' (APPLIED)' : ''}`);
+  console.log('='.repeat(60));
+  for (const r of results) {
+    const tag = { optimize: '✓ optimize', keep: '✓ keep    ', rewrite: '→ rewrite ', omit: '✗ omit    ' }[r.decision];
+    console.log(`  ${tag} ${r.status ? `[${r.status}] ` : ''}${r.url.slice(0, 70)}${r.suggested ? `\n              → ${r.suggested.slice(0, 70)}` : ''}`);
+  }
+  console.log(`\n${Object.entries(counts).map(([k, v]) => `${v} ${k}`).join(' · ')}`);
+}
+process.exit(broken.length ? 1 : 0);

--- a/plugins/stardust/skills/rollout/scripts/media-reconcile.mjs
+++ b/plugins/stardust/skills/rollout/scripts/media-reconcile.mjs
@@ -32,7 +32,7 @@ let html = readFileSync(FILE, 'utf8');
 /* collect image URLs: <img src>, srcset, inline style url(), <style> url() */
 function collect(h) {
   const urls = new Set();
-  for (const m of h.matchAll(/<img\b[^>]*\bsrc="([^"]+)"/gi)) urls.add(m[1]);
+  for (const m of h.matchAll(/<img\b[^>]*\ssrc="([^"]+)"/gi)) urls.add(m[1]);
   for (const m of h.matchAll(/\bsrcset="([^"]+)"/gi)) m[1].split(',').forEach((part) => { const u = part.trim().split(/\s+/)[0]; if (u) urls.add(u); });
   for (const m of h.matchAll(/url\((['"]?)(https?:\/\/[^)'"]+)\1\)/gi)) urls.add(m[2]);
   return [...urls].filter((u) => u && !u.startsWith('data:'));
@@ -47,13 +47,32 @@ function repairUrl(u) {
 }
 
 async function resolve(u) {
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), 15000);
   try {
-    const r = await fetch(u, { method: 'GET', headers: { 'user-agent': 'stardust-media-reconcile' } });
-    return r.status;
-  } catch (e) { return 0; }
+    const r = await fetch(u, { method: 'GET', signal: ac.signal, headers: { 'user-agent': 'stardust-media-reconcile' } });
+    return r.status; // 0 is reserved for network error / timeout
+  } catch (e) { return 0; } finally { clearTimeout(t); }
 }
 
 function originOf(u) { try { return new URL(u).host; } catch { return null; } }
+
+// boundary-anchored replace: only swap the URL where it ends at a real delimiter,
+// so a URL that is a prefix of a longer one is never corrupted.
+function replaceUrl(h, from, to) {
+  const esc = from.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return h.replace(new RegExp(`${esc}(?=["'\\s,)>])`, 'g'), to);
+}
+
+// remove an image by URL: drop the whole enclosing <picture> if present (so no
+// dangling <source>), else the standalone <img>, else a <source> carrying it.
+function removeImageUrl(h, url) {
+  const esc = url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  let out = h.replace(new RegExp(`<picture>(?:(?!</picture>)[\\s\\S])*?${esc}[\\s\\S]*?</picture>`, 'gi'), '');
+  out = out.replace(new RegExp(`<img\\b[^>]*\\ssrc="${esc}"[^>]*>`, 'gi'), '');
+  out = out.replace(new RegExp(`<source\\b[^>]*${esc}[^>]*>`, 'gi'), '');
+  return out;
+}
 
 const results = [];
 for (const u of collect(html)) {
@@ -70,10 +89,12 @@ for (const u of collect(html)) {
       const fixed = repairUrl(u);
       if (fixed) {
         const fstatus = await resolve(fixed);
-        if (fstatus === 200) { decision = 'rewrite'; suggested = fixed; status = fstatus; } else { decision = 'omit'; }
-      } else {
-        decision = 'omit';
+        if (fstatus === 200) { decision = 'rewrite'; suggested = fixed; status = fstatus; }
       }
+      // only a definitive 4xx (gone/forbidden/not-found) is safe to auto-omit;
+      // a 0 (network/timeout) or 5xx is transient — flag 'unresolved' for a human,
+      // never delete a possibly-good image on a blip.
+      if (!decision) decision = (status >= 400 && status < 500) ? 'omit' : 'unresolved';
     }
   }
   results.push({ url: u, host, status, decision, suggested });
@@ -82,29 +103,26 @@ for (const u of collect(html)) {
 /* optionally apply rewrites/omits */
 if (APPLY) {
   for (const r of results) {
-    if (r.decision === 'rewrite' && r.suggested) {
-      html = html.split(r.url).join(r.suggested);
-    } else if (r.decision === 'omit') {
-      // remove the whole <img …src="url"…> (and an empty wrapping <picture>)
-      const imgRe = new RegExp(`<img\\b[^>]*\\bsrc="${r.url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"[^>]*>`, 'gi');
-      html = html.replace(imgRe, '');
-      html = html.replace(/<picture>\s*<\/picture>/gi, '');
-    }
+    // 'unresolved' is left untouched on purpose — never auto-delete on a transient.
+    if (r.decision === 'rewrite' && r.suggested) html = replaceUrl(html, r.url, r.suggested);
+    else if (r.decision === 'omit') html = removeImageUrl(html, r.url);
   }
+  html = html.replace(/<picture>\s*<\/picture>/gi, ''); // sweep any now-empty <picture>
   writeFileSync(FILE, html);
 }
 
 const counts = results.reduce((a, r) => { a[r.decision] = (a[r.decision] || 0) + 1; return a; }, {});
-const broken = results.filter((r) => r.decision === 'omit');
+// gate fails on omit (broken) AND unresolved (needs a human) — neither is shippable as-is.
+const failing = results.filter((r) => r.decision === 'omit' || r.decision === 'unresolved');
 if (JSON_OUT) {
   console.log(JSON.stringify({ file: FILE, deployHost: DEPLOY_HOST, applied: APPLY, counts, results }, null, 2));
 } else {
   console.log(`media-reconcile ${FILE}${APPLY ? ' (APPLIED)' : ''}`);
   console.log('='.repeat(60));
   for (const r of results) {
-    const tag = { optimize: '✓ optimize', keep: '✓ keep    ', rewrite: '→ rewrite ', omit: '✗ omit    ' }[r.decision];
+    const tag = { optimize: '✓ optimize', keep: '✓ keep    ', rewrite: '→ rewrite ', omit: '✗ omit    ', unresolved: '? manual  ' }[r.decision];
     console.log(`  ${tag} ${r.status ? `[${r.status}] ` : ''}${r.url.slice(0, 70)}${r.suggested ? `\n              → ${r.suggested.slice(0, 70)}` : ''}`);
   }
   console.log(`\n${Object.entries(counts).map(([k, v]) => `${v} ${k}`).join(' · ')}`);
 }
-process.exit(broken.length ? 1 : 0);
+process.exit(failing.length ? 1 : 0);

--- a/plugins/stardust/skills/rollout/scripts/verify.mjs
+++ b/plugins/stardust/skills/rollout/scripts/verify.mjs
@@ -74,6 +74,36 @@ function checkLinks(body) {
   return [...new Set(broken)];
 }
 
+// Artifact type drives what "renders correctly" means — a fragment has no <h1>,
+// an index is JSON not a page. A one-size <h1> check false-fails fragments.
+function artifactType(p) {
+  const t = (p.delivery && p.delivery.type) || p.type;
+  if (t) return t; // explicit wins
+  const s = (p.path || '').toLowerCase();
+  if (/\/(nav|footer)$/.test(s) || /\/fragments?\//.test(s)) return 'fragment';
+  if (/query-index(\.json)?$/.test(s) || /\.json$/.test(s)) return 'index';
+  return 'page';
+}
+
+// Typed render-truth: returns a failure reason or null. Pages must render one
+// <h1> and carry no about:error; fragments skip the <h1> rule; indexes must be
+// valid JSON with rows. Link integrity applies to pages and fragments.
+function renderCheck(type, body) {
+  if (type === 'index') {
+    try { const j = JSON.parse(body); if (!Array.isArray(j.data) || !j.data.length) return 'index has no rows (data[] empty)'; }
+    catch { return 'index is not valid JSON'; }
+    return null;
+  }
+  if (/about:error/.test(body)) return 'about:error in body (#75 broken image)';
+  if (type === 'page') {
+    const h1 = (body.match(/<h1[\s>]/gi) || []).length;
+    if (h1 !== 1) return `page should render exactly one <h1>, found ${h1}`;
+  }
+  const broken = checkLinks(body);
+  if (broken.length) return `broken internal links: ${broken.slice(0, 5).join(', ')}`;
+  return null;
+}
+
 const target = pages.filter((p) => {
   if (onlySlug) return p.slug === onlySlug;
   if (ALL) return true;
@@ -84,18 +114,15 @@ const now = new Date().toISOString();
 const results = [];
 for (const p of target) {
   const r = await fetchPage(p);
+  const type = artifactType(p);
   let status = 'verified'; let reason = null;
   if (!r.ok) { status = 'failed'; reason = r.reason; }
-  else if (r.body.includes('about:error')) { status = 'failed'; reason = 'about:error in body (#75 broken image)'; }
-  else {
-    const broken = checkLinks(r.body);
-    if (broken.length) { status = 'failed'; reason = `broken internal links: ${broken.slice(0, 5).join(', ')}`; }
-  }
+  else { reason = renderCheck(type, r.body); if (reason) status = 'failed'; }
   p.delivery = p.delivery || {};
   p.delivery.status = status;
   if (status === 'verified') { p.delivery.verifiedAt = now; p.delivery.error = null; }
   else p.delivery.error = reason;
-  results.push({ slug: p.slug, status, reason });
+  results.push({ slug: p.slug, type, status, reason });
 }
 
 // persist + re-roll
@@ -108,9 +135,10 @@ if (config && config.lastRun !== undefined) { rollupConfig(config, pages, blocks
 
 const ok = results.filter((r) => r.status === 'verified').length;
 const bad = results.filter((r) => r.status === 'failed');
+const byType = results.reduce((a, r) => { a[r.type] = (a[r.type] || 0) + 1; return a; }, {});
 console.log(`rollout verify (${ROOT ? `root:${ROOT}` : BASE})`);
 console.log('='.repeat(60));
-console.log(`Checked ${results.length} · ${ok} verified · ${bad.length} failed`);
-for (const r of bad) console.log(`  ✗ ${r.slug}: ${r.reason}`);
+console.log(`Checked ${results.length} · ${ok} verified · ${bad.length} failed · types: ${Object.entries(byType).map(([k, v]) => `${k}:${v}`).join(' ')}`);
+for (const r of bad) console.log(`  ✗ ${r.slug} (${r.type}): ${r.reason}`);
 if (!target.length) console.log('Nothing to verify (no deployed pages). Deliver pages first, or pass --all.');
 process.exit(bad.length ? 1 : 0);

--- a/plugins/stardust/skills/rollout/scripts/verify.mjs
+++ b/plugins/stardust/skills/rollout/scripts/verify.mjs
@@ -37,7 +37,7 @@ const BASE = arg('base', (config.site && config.site.liveHost) ? `https://${conf
 
 if (!ROOT && !BASE) { console.error('rollout verify: need --base <url> or --root <dir> (or set site.liveHost).'); process.exit(2); }
 
-const knownPaths = new Set(pages.map((p) => p.path.replace(/\/$/, '') || '/'));
+const knownPaths = new Set(pages.map((p) => (p.path || '/').replace(/\/$/, '') || '/'));
 const norm = (p) => (p.split(/[?#]/)[0].replace(/\/$/, '') || '/');
 
 function resolveLocal(p) {
@@ -68,7 +68,7 @@ function checkLinks(body) {
   for (const m of body.matchAll(/href="(\/[^"]*)"/g)) {
     const target = norm(m[1]);
     if (target.startsWith('//')) continue; // protocol-relative external
-    if (/\.(css|js|png|jpe?g|webp|svg|ico|woff2?|xml|txt|json)$/i.test(target)) continue; // assets
+    if (/\.(css|js|png|jpe?g|gif|webp|avif|svg|ico|woff2?|xml|txt|json|pdf|mp4|webm|mov|zip)$/i.test(target)) continue; // assets
     if (!knownPaths.has(target)) broken.push(target);
   }
   return [...new Set(broken)];
@@ -80,7 +80,9 @@ function artifactType(p) {
   const t = (p.delivery && p.delivery.type) || p.type;
   if (t) return t; // explicit wins
   const s = (p.path || '').toLowerCase();
-  if (/\/(nav|footer)$/.test(s) || /\/fragments?\//.test(s)) return 'fragment';
+  // anchor to top-level /nav,/footer or a /fragments/ path so a content page
+  // named e.g. /about/nav is not mistyped out of the page render checks.
+  if (/^\/(nav|footer)$/.test(s) || /\/fragments?\//.test(s)) return 'fragment';
   if (/query-index(\.json)?$/.test(s) || /\.json$/.test(s)) return 'index';
   return 'page';
 }
@@ -90,7 +92,9 @@ function artifactType(p) {
 // valid JSON with rows. Link integrity applies to pages and fragments.
 function renderCheck(type, body) {
   if (type === 'index') {
-    try { const j = JSON.parse(body); if (!Array.isArray(j.data) || !j.data.length) return 'index has no rows (data[] empty)'; }
+    // a valid index with zero rows is a legitimate state (nothing published yet),
+    // not a failure — only malformed JSON or a missing data[] array fails.
+    try { const j = JSON.parse(body); if (!Array.isArray(j.data)) return 'index missing data[] array'; }
     catch { return 'index is not valid JSON'; }
     return null;
   }


### PR DESCRIPTION
## What & why

Three generalized improvements to the stardust plugin, drawn from a real
CE Credits Online → EDS migration. The throughline: **move what the agent had to
remember (the EDS/DA delivery contract, per-image handling, the quality/coverage
trade) into what the plugin enforces.**

Extends existing structure (rollout delivery-gates, verify, migrate asset
handling, coverage model) rather than duplicating it.

### B — Encode the EDS/DA delivery contract as guardrails
- **NEW `rollout/scripts/delivery-lint.mjs`** — static, offline, pre-PUT linter:
  `<body><main>` wrapper, **one-CTA-per-`<p>`** (the silent buttonization
  defect), `<h1>` cardinality (typed), trailing-slash/`.html` links, `/img/`
  srcs, `about:error`, path-safety, metadata. **P0/P1 blocks the PUT.**
- **`verify.mjs` → artifact-type aware** (`page`/`fragment`/`index`): pages need
  exactly one `<h1>`; fragments (nav/footer) are no longer false-failed for
  lacking one; indexes are validated as JSON with rows.
- NEW `reference/delivery-lint.md`; wired into rollout Phase C + delivery-gates.

### C — Make media reconciliation a first-class decision
- **NEW `rollout/scripts/media-reconcile.mjs`** — resolves every image on the
  network and decides **optimize / keep / rewrite / omit** (`--apply` fixes in
  place: missing `?`-delimiter, host rewrite, or drop the `<img>` — never ship
  `about:error`).
- NEW `migrate/reference/media-reconciliation.md` documents the
  `createOptimizedPicture` cross-origin trap as a **block-code rule** (optimize
  same-origin only). Wired into migrate Phase 2 + rollout Gate 2.

### D — Formalize fidelity tiers (budget/coverage trade made explicit)
- **NEW `migrate/reference/fidelity-tiers.md`** — turns the render branches into
  declared, gated tiers: **archetype** (craft-gated once per template) /
  **sibling** (cheap canon-fork, the breadth default) / **thin** (graceful
  bodyless). Each page declares `fidelityTier` + `archetypeSource` +
  `gatesPassed[]`.
- `coverage-model.md` surfaces the **tier distribution** so "92/92 deployed"
  can't hide "1 craft-gated, 91 ungated".

## Testing
All scripts are dependency-free Node, `node --check` clean, and smoke-tested
against the CE Credits Online migrated tree:
- delivery-lint: flagged the multi-CTA / trailing-slash / path-safety fixtures,
  passed the nav fragment (type-aware h1 skip).
- media-reconcile: resolved all 8 home images to `keep`, correctly `omit`ted a
  synthetic 404 and applied a host-rewrite.

## Base
Single commit against `main` (the parent branch it originally built on was deleted from the remote; the unrelated parent commit was dropped — zero file overlap with this work).
so the diff is exactly this one commit; rebases onto `main` once the parent lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
