### PR TITLE
feat(extract): robust content/image capture for JS-rendered enterprise CMSes

### DIFF
--- a/plugins/stardust/skills/extract/SKILL.md
+++ b/plugins/stardust/skills/extract/SKILL.md
@@ -194,6 +194,12 @@ Capture per page (full schema in `reference/current-state-schema.md`):
 
 - Page metadata (title, meta description, OG tags, theme-color)
 - Semantic structure: heading outline, landmark roles, sections
+- **Hero headline + lede (resolved)** — `heroHeadline` / `heroLede`
+  picked by font-size × hero-region with a junk/hidden-state filter and
+  a clean meta-description fallback (per `reference/playwright-recipe.md`
+  § Capture list 5-bis). Required for JS-rendered enterprise CMSes,
+  where document-order headings surface modal / promo / count junk
+  instead of the real tagline.
 - Content: visible text per section (full innerText, **no
   truncation** per `reference/playwright-recipe.md` § Capture
   list 7), structured paragraphs (`body[]`), lists, FAQ Q/A
@@ -204,11 +210,14 @@ Capture per page (full schema in `reference/current-state-schema.md`):
 - CTA labels and href targets, link inventory (internal vs external)
 - Per-section computed style summary: dominant colors, font families
   in use, spacing rhythm, border-radius, shadows
-- Media inventory: img/srcset with original URLs and intrinsic
-  dimensions, inline SVG count, video/iframe presence,
-  `cssBackgrounds[]` (including pseudo-element `::before`/
+- Media inventory: img with `currentSrc`/`srcset` captured **with
+  query strings intact** plus a `resolves` flag (HEAD/GET with browser
+  UA + Referer), intrinsic dimensions, inline SVG count, video/iframe
+  presence, `cssBackgrounds[]` (including pseudo-element `::before`/
   `::after` walks per § Capture list 11) so `background-image`
-  heroes and motifs do not silently disappear from extract.
+  heroes and motifs do not silently disappear from extract — and so
+  enterprise-CDN images that 404 are flagged before migrate ships
+  `about:error`.
 - Font files captured via network-intercept (per § Capture list
   16): every `woff2`/`woff`/`ttf`/`otf` response saved under
   `assets/fonts/` and recorded in `_brand-extraction.json#type.files[]`

--- a/plugins/stardust/skills/extract/reference/current-state-schema.md
+++ b/plugins/stardust/skills/extract/reference/current-state-schema.md
@@ -24,13 +24,16 @@ The file is JSON because every consumer is non-human. It carries a
     "waitMode": "networkidle",       // configured mode: fast | medium | spec | networkidle | domcontentloaded(fallback)
     "waitMs": 3820,                  // actual wait time, including grace and scroll pass — must be > 0
     "httpStatus": 200,               // final response status after redirects
-    "contentType": "text/html"       // final response content-type (without charset)
+    "contentType": "text/html",      // final response content-type (without charset)
+    "heroSource": "dom"              // "dom" | "meta-fallback" — which source heroHeadline/heroLede came from (see § Hero headline)
   },
   "slug": "about",
   "url": "https://example.com/about",
   "finalUrl": "https://example.com/about/",
   "title": "About Example",
   "metaDescription": "...",
+  "heroHeadline": "Designed for the way you actually work",   // see § Hero headline
+  "heroLede": "One platform for your whole team, from intake to delivery.",
   "og": {
     "title": "...",
     "description": "...",
@@ -87,6 +90,27 @@ Document order. Computed style snapshot of the heading itself.
   }
 }
 ```
+
+## § Hero headline
+
+Two resolved convenience fields for the page's hero copy, computed per
+`playwright-recipe.md` § Capture list (5-bis). They exist because
+document-order heuristics (`headings[0]`) are unreliable on
+JS-rendered enterprise CMSes, where the visually-dominant tagline is
+buried among many `<h2>`s and the DOM carries hidden modal / promo /
+count states.
+
+- `heroHeadline` — the largest-font-size heading in the hero band
+  (top ≤ ~820 px), after the junk-state filter; or, when that is
+  empty / junk, the first sentence of `metaDescription`.
+- `heroLede` — the first substantial paragraph in the top ~1300 px,
+  after the junk filter; or the full `metaDescription` as fallback.
+- `_provenance.heroSource` records `"dom"` or `"meta-fallback"`.
+
+Both are **required** (emit `""` only when even the meta-description
+fallback is empty). `headings[]` remains the full, unfiltered outline;
+these fields do not replace it. Downstream `prototype` / `migrate`
+prefer `heroHeadline` / `heroLede` over re-deriving from `headings[]`.
 
 ## § Landmarks
 
@@ -190,11 +214,13 @@ De-duplicate by `(href, text)`. Keep the first occurrence's `domPath`.
 {
   "images": [
     {
-      "src": "https://example.com/img/hero.jpg",
+      "src": "https://cdn.example.com/connect/9f.../hero.jpg?MOD=AJPERES&CACHEID=...",
+      "currentSrc": "https://cdn.example.com/connect/9f.../hero.jpg?MOD=AJPERES&CACHEID=...",
       "srcset": "...",
       "alt": "Two engineers at a whiteboard",
       "naturalWidth": 2400,
       "naturalHeight": 1600,
+      "resolves": true,
       "localPath": "stardust/current/assets/media/hero-a3f9.jpg"
     }
   ],
@@ -221,6 +247,15 @@ De-duplicate by `(href, text)`. Keep the first occurrence's `domPath`.
 
 `localPath` is set only for media stardust successfully downloaded.
 Failed downloads have `localPath: null` and a `downloadError` field.
+
+`src` / `currentSrc` are captured **with the query string intact**
+(enterprise DAM/CDN URLs carry load-bearing `?MOD=…&CACHEID=…`
+params; stripping them 404s). `resolves` is the result of a
+capture-time `HEAD`/`GET` (2xx + image `content-type`) issued with a
+browser `User-Agent` + `Referer` — see `playwright-recipe.md`
+§ Capture list (11) § Source-URL fidelity. `migrate` omits or repairs
+(never authors) any image whose `resolves` is `false`, which is how
+`about:error` is prevented before it ships.
 
 `cssBackgrounds[]` captures every element whose computed
 `backgroundImage` resolves to one or more `url(...)` references

--- a/plugins/stardust/skills/extract/reference/playwright-recipe.md
+++ b/plugins/stardust/skills/extract/reference/playwright-recipe.md
@@ -296,6 +296,20 @@ the site is JS-driven and `spec` is appropriate. Record the chosen
 mode and the auto-detect basis in `_crawl-log.json` under
 `discovery.waitMode`.
 
+**Enterprise-CMS caveat.** A near-empty-shell test under-detects the
+common hard case: enterprise CMSes (React / SPA layers over WebSphere,
+AEM, Sitecore, or bespoke app shells) ship *some* server markup that
+then re-renders / hydrates client-side, so the raw HTML is not empty
+yet the meaningful content paints after `domcontentloaded`. Treat as
+JS-driven (→ `spec`, and the scroll + reveal passes are non-optional)
+when the raw HTML shows any of: a framework bootstrap
+(`window.__INITIAL_STATE__`, `data-reactroot`, `ng-version`,
+`<div id="__next">`), a vendor app marker, or a body whose visible
+headings don't match the `<title>` / `og:title`. On these sites the
+hero copy and child links arrive late and the DOM carries hidden
+modal / promo / count states — which is exactly what § Capture list
+(5-bis) `heroHeadline` + the junk filter exist to survive.
+
 The default remains `medium` regardless of auto-detect until the
 heuristic is validated across more sites; auto-detect is opt-in via
 `--wait auto`.
@@ -345,6 +359,57 @@ For each page, capture:
 5. **Heading outline** — every `h1`-`h6` in document order with text
    and computed font-family, font-weight, font-size, line-height,
    letter-spacing, color.
+
+5-bis. **Hero headline + lede (resolved) — JS-rendered robustness.**
+   On semantic / SSR sites the first `<h1>`/`<h2>` *is* the hero
+   headline. On **JS-rendered enterprise CMSes** (React / SPA layers
+   over WebSphere, AEM, Sitecore, Salesforce, and bespoke "SNAPS" /
+   "FUZE"-style shells) the real tagline is buried among many `<h2>`s,
+   and the DOM also carries hidden modal / error / promo / count states
+   that a document-order heuristic grabs as the headline (observed on a
+   3m.com run: `"Thank You!"`, `"Our Apologies…"`, `"629 products"`,
+   `"Limited-time offer…"` all out-ranked the real hero line). Resolve
+   two dedicated fields instead of trusting `headings[0]`:
+
+   - **`heroHeadline`** — among `h1, h2, h3` whose post-layout
+     `getBoundingClientRect().top` is within the hero band (≤ ~820 px)
+     and `width ≥ 120 px`, pick the element with the **largest computed
+     `font-size`**, after dropping any text caught by the junk-state
+     filter below. That is the visually-dominant hero line, which is
+     what `prototype` / `migrate` actually need.
+   - **`heroLede`** — the first `<p>` in the top ~1300 px with
+     `40 ≤ textLength ≤ 400` that is not caught by the junk filter.
+   - **Clean fallback (load-bearing).** When either resolves to empty
+     or junk, fall back to the editor-written
+     `<meta name="description">` — first sentence → `heroHeadline`,
+     full text → `heroLede`. Meta descriptions are present and clean
+     on virtually every enterprise page and are the single most
+     reliable recovery; without this fallback roughly half of
+     JS-rendered pages yield a junk or empty hero. Record which source
+     won in `_provenance` (`heroSource: "dom" | "meta-fallback"`).
+
+   Record both fields per `current-state-schema.md` § Hero headline.
+   The full `headings[]` list is unchanged — these are an additional
+   resolved convenience, not a replacement.
+
+   **Junk / hidden-state filter (shared).** JS frameworks inject hidden
+   modal, error, newsletter, promo, and result-count nodes that are
+   absent from the *rendered* page but present in the *tree*. Drop any
+   candidate heading / lede / CTA-label whose normalised text matches
+   (case-insensitive):
+   - status / modal chrome: `thank you`, `our apologies`, `sign in`,
+     `sign up`, `subscribe`, `newsletter`, `follow us`, `share this`,
+     `related`, a bare `contact us` heading
+   - merchandising chrome: `featured products`, `limited-time offer`,
+     `% off`, `save \d+%`
+   - faceted-listing counts: `^\d[\d,]*\s*(products?|results?|items?)$`
+     and a bare number `^\d[\d,]*$`
+   - leaked CSS / script text: any value containing `{` or `}`
+
+   Apply this filter wherever `headings[]` / `ctas[]` text is reused
+   downstream as a label (module detection, section heads, card titles)
+   — not only for `heroHeadline`.
+
 6. **Landmark structure** — every `header`, `nav`, `main`, `aside`,
    `footer`, plus elements with `role="banner|navigation|main|complementary|contentinfo|region"`. For each: tag, role, id, class, child element count.
 7. **Visible text per landmark** — innerText in full, normalised
@@ -406,10 +471,31 @@ For each page, capture:
       `gap`, `margin-block`)
     - dominant border-radius (mode of non-zero values across direct
       children)
-11. **Media inventory** — for every `<img>`: src, srcset, alt,
-    naturalWidth, naturalHeight. For every inline SVG: serialized
-    markup hash + viewBox. For every `<video>` and `<iframe>`: src and
-    poster.
+11. **Media inventory** — for every `<img>`: `currentSrc || src`
+    captured **with its query string intact** (see § Source-URL
+    fidelity below), `srcset`, `alt`, `naturalWidth`, `naturalHeight`,
+    and a `resolves` boolean. For every inline SVG: serialized markup
+    hash + viewBox. For every `<video>` and `<iframe>`: src and poster.
+
+    **Source-URL fidelity (enterprise CDNs).** The #1 way migration
+    ships `<img src="about:error">` is re-using a source image URL that
+    doesn't actually resolve. Two capture-time rules prevent it:
+    - **Never truncate the URL, and prefer `currentSrc`.** Enterprise
+      DAM / CDN URLs carry load-bearing query strings
+      (`…/connect/<uuid>/file.jpg?MOD=AJPERES&CACHEID=…`); dropping the
+      query (or reading `src` instead of the resolved `currentSrc`)
+      yields a 404. An early reference that sliced `src` to a fixed
+      length produced exactly this on a 3m.com run.
+    - **Record a `resolves` flag.** After capture, issue a `HEAD`
+      (fall back to `GET`) for each `<img>` src and set
+      `resolves: true` only on a 2xx with an image `content-type`.
+      On a bot-managed origin issue it through the page context (the
+      in-page `fetch` / route-fulfiller path that carries the accepted
+      fingerprint, per § Bot-management fallback) **and** with a
+      browser `User-Agent` + `Referer: <page-url>` — bare requests are
+      frequently rejected by enterprise CDNs even when the asset
+      exists. `migrate` must omit or repair (never author) any image
+      whose `resolves` is `false`.
     For each cross-origin `<iframe>` (host different from page host),
     additionally capture: `boundingClientRect` after layout settles,
     `viewportCoveragePct` (its rect area divided by 1440×900), and


### PR DESCRIPTION
## Why

`stardust:extract`'s content/image heuristics are tuned for semantic / SSR sites and degrade on **JS-rendered enterprise CMSes** (React / SPA layers over WebSphere, AEM, Sitecore, and bespoke "SNAPS"/"FUZE"-style shells). A real 3m.com → EDS migration run surfaced two recurring, high-friction failure modes. This PR encodes the fixes directly in the capture recipe + per-page schema so agents don't re-derive them per run.

## What changed (docs/spec only — no runtime code)

**Content extraction**
- New resolved fields **`heroHeadline` / `heroLede`**, chosen by **font-size × hero-region** rather than document order (`headings[0]`), which on these sites grabs the wrong line.
- A shared **junk / hidden-state filter** — framework-injected hidden modal/error/promo/result-count nodes (`"Thank You!"`, `"Our Apologies…"`, `"629 products"`, `"Limited-time offer…"`) are dropped before a heading becomes the hero or a card title.
- A **clean meta-description fallback** when DOM hero copy is empty/junk (recovered ~half the bad pages in the dogfood run); `_provenance.heroSource` records `dom` vs `meta-fallback`.
- An **enterprise-CMS wait-mode caveat**: hydrating shells aren't empty HTML but still need `spec` + the scroll/reveal passes.

**Image capture**
- Capture **`currentSrc` with query strings intact** — enterprise DAM/CDN URLs carry load-bearing `?MOD=…&CACHEID=…`; stripping them 404s (the #1 source of shipped `about:error`).
- New **`resolves` flag** (HEAD/GET → 2xx + image content-type, issued through the accepted page fingerprint + browser UA/Referer) so `migrate` omits/repairs broken srcs instead of authoring `<img src="about:error">`.

## Files
- `plugins/stardust/skills/extract/SKILL.md` — Phase 2 capture summary
- `plugins/stardust/skills/extract/reference/playwright-recipe.md` — capture list 5-bis (hero headline + junk filter), 11 (source-URL fidelity), auto-detect caveat
- `plugins/stardust/skills/extract/reference/current-state-schema.md` — `§ Hero headline`, media `currentSrc`/`resolves`, `heroSource` provenance

Scoped to `extract` only. A companion set of `deploy` improvements (vanilla-EDS first-class path) was identified in the same run and is intentionally left for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)