### PR TITLE
fix(stardust): align marketplace.json version with plugin.json/tile.json (0.13.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "stardust",
       "source": "./plugins/stardust",
       "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "category": "design",
       "keywords": [
         "design",


### PR DESCRIPTION
## Summary
The stardust plugin version was bumped to `0.13.1` in `plugins/stardust/.claude-plugin/plugin.json` and `plugins/stardust/tile.json`, but the marketplace listing in `.claude-plugin/marketplace.json` was left at `0.13.0`, so the Claude Code plugin UI reports a stale version.

This aligns the marketplace entry to `0.13.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)