### PR TITLE
docs(stardust): 0.14.4 — Tessl quality pass part 1 (extract + prepare-migration descriptions)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "stardust",
       "source": "./plugins/stardust",
       "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-      "version": "0.14.3",
+      "version": "0.14.4",
       "category": "design",
       "keywords": [
         "design",

--- a/plugins/stardust/.claude-plugin/plugin.json
+++ b/plugins/stardust/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stardust",
   "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "author": {
     "name": "Adobe"
   },

--- a/plugins/stardust/CHANGELOG.md
+++ b/plugins/stardust/CHANGELOG.md
@@ -4,6 +4,17 @@ This file starts at 0.14.0. Prior versions (0.3.0 – 0.13.1) are documented in
 git history only (plus the branch-scoped notes in
 `CHANGELOG-redesign-adobecom.md` and `CHANGELOG-delivery-media-fidelity.md`).
 
+## 0.14.4 — Tessl quality pass, part 1 (descriptions)
+
+Description rewrites for the two skills whose tessl-review drag included
+description criteria: `extract` (adds a "Use when…" clause + natural trigger
+terms — analyze/reverse-engineer/capture design tokens — and a "Not for"
+scraping disambiguation) and `prepare-migration` (plain-language framing of
+the prep cascade + trigger phrases + "Not for" migrate/deploy
+disambiguation). Body text untouched — zero behavioral surface; the
+conciseness/progressive-disclosure restructuring of extract/deploy is a
+separate follow-up with its own validation run.
+
 ## 0.14.3 — seventh-site validation harvest (stardust.style) + review fixes
 
 Learnings L1–L9 from the final validation run (full pipeline on

--- a/plugins/stardust/skills/extract/SKILL.md
+++ b/plugins/stardust/skills/extract/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: extract
-description: Crawl an existing website (capped, multi-page) and seed stardust/current/ with PRODUCT.md, DESIGN.md, DESIGN.json, a per-page inventory, and the consolidated brand surface.
+description: Crawl an existing website (capped, multi-page) and seed stardust/current/ with PRODUCT.md, DESIGN.md, DESIGN.json, a per-page inventory, and the consolidated brand surface — the captured design system, palette, typography, motifs, and voice of the live site. Use when the user wants to analyze an existing site's design, extract or reverse-engineer its design system or brand, capture design tokens from a live site, import a website as the starting point for a redesign, capture the current state before a migration, or invokes /stardust:extract. Trigger phrases include "analyze this site", "extract the design tokens", "capture the brand", "crawl the site", "reverse engineer the design". Not for scraping page data or content for its own sake (it captures design evidence, not datasets), and not for the redesign itself — extraction is descriptive; direction and prototyping happen downstream.
 license: Apache-2.0
 ---
 

--- a/plugins/stardust/skills/prepare-migration/SKILL.md
+++ b/plugins/stardust/skills/prepare-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prepare-migration
-description: Orchestrate the migrate-prep cascade — extract --prep → direct --prep → prototype --prep → assets prep — with confirmation gates between phases. Builds the data structure migrate consumes.
+description: Prepare a whole site for migration by orchestrating the prep cascade — a full-inventory crawl (extract --prep), page-type and module-catalog confirmation (direct --prep), archetype prototypes plus design canon (prototype --prep), and asset preparation — with confirmation gates between phases. Builds the typed page inventory, confirmed module catalog, and canon that stardust:migrate consumes. Use when the user wants to prepare or set up a full-site migration, run migration prep, confirm page types and modules before migrating a site, get a large site ready to migrate, or invokes /stardust:prepare-migration. Trigger phrases include "prepare the migration", "migration prep", "set up the migration data", "get the site ready to migrate". Not for running the migration itself (stardust:migrate) or converting a single page (stardust:deploy).
 license: Apache-2.0
 ---
 

--- a/plugins/stardust/tile.json
+++ b/plugins/stardust/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe/stardust",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "summary": "Redesign an existing website to make it better. Built on top of impeccable.",
   "skills": {
     "stardust": {


### PR DESCRIPTION
Part 1 of the tessl-review quality pass deferred from #232: description-only rewrites for the two skills whose sub-80 score included description criteria.

- **extract** (64%, trigger_term_quality 2/3 + completeness 2/3): adds a "Use when…" clause, natural trigger terms (analyze this site / extract the design tokens / capture the brand / reverse engineer the design), and a "Not for" clause disambiguating from data scraping.
- **prepare-migration** (71%, description subscore 42%: specificity 2/3 + trigger_term_quality 1/3 + completeness 2/3): plain-language framing of the prep cascade, trigger phrases (prepare the migration / migration prep / get the site ready to migrate), and "Not for" pointers to migrate/deploy.

**Zero behavioral surface** — frontmatter only; skill bodies untouched, so no design-generation risk. deploy/direct/prototype/uplift descriptions already score 3/3; their drag is body conciseness/progressive-disclosure, deferred to part 2 (SKILL.md split into reference files) which needs its own e2e validation run.

Versions aligned at 0.14.4 (plugin.json, tile.json, marketplace.json, CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)