### PR TITLE
docs(stardust): 0.14.5 — Tessl quality pass part 2 (deploy/direct/prototype/uplift restructure, A/B-validated)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "stardust",
       "source": "./plugins/stardust",
       "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-      "version": "0.14.4",
+      "version": "0.14.5",
       "category": "design",
       "keywords": [
         "design",

--- a/plugins/stardust/.claude-plugin/plugin.json
+++ b/plugins/stardust/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stardust",
   "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "author": {
     "name": "Adobe"
   },

--- a/plugins/stardust/CHANGELOG.md
+++ b/plugins/stardust/CHANGELOG.md
@@ -4,6 +4,31 @@ This file starts at 0.14.0. Prior versions (0.3.0 – 0.13.1) are documented in
 git history only (plus the branch-scoped notes in
 `CHANGELOG-redesign-adobecom.md` and `CHANGELOG-delivery-media-fidelity.md`).
 
+## 0.14.5 — Tessl quality pass, part 2 (rules-inline / rationale-out restructure)
+
+The four remaining sub-80 SKILL.mds restructured under a strict contract:
+every rule, gate, discipline, and refusal condition stays inline (tersened);
+only rationale, historical narratives, worked examples, and flag-gated modal
+flows move to reference files, each wired with an imperative READ gate at its
+consumption point. Rule-preservation audited per skill (zero deletions;
+deploy's #NN set verified by comm).
+
+- deploy 892→475 (+5 refs: decode-disciplines, encode-contract, font-strategy,
+  anti-patterns, runtime-bootstrap) · direct 1596→398 (+prep-mode, add-variant,
+  mode-notes) · prototype 1486→1215 (+prep-mode, lessons — most conservative;
+  design-critical core stays inline) · uplift 593→430 (+output-templates).
+- Validated by A/B runs following the restructured docs as written: deploy
+  docs-page conversion 41/41 QA green, full baseline match (+1 focus-ring bug
+  caught that baseline missed); direct re-run structurally equivalent on every
+  load-bearing field (mode, pins, 4 seed dims, 4 inversions, improvements
+  F-ids, register, density).
+- A/B-evidenced additions: § Page templates (Template: metadata → body
+  <name>-template + template-vs-block specificity warning), harness-parity
+  notes, hardened collectNodes (mixed text+inline cells), Mode A research
+  sentence + craft in the roll list, dangling impeccable pointers
+  (teach.md/load-context.mjs) softened for current impeccable versions,
+  cross-refs to moved sections repaired.
+
 ## 0.14.4 — Tessl quality pass, part 1 (descriptions)
 
 Description rewrites for the two skills whose tessl-review drag included

--- a/plugins/stardust/skills/deploy/IMPROVEMENTS.md
+++ b/plugins/stardust/skills/deploy/IMPROVEMENTS.md
@@ -724,3 +724,26 @@ Implemented and smoke-tested in crawl.mjs.
 - [ ] #87 content-diff JOIN/SPLIT concat-matching (node-granularity false 🔴 → 🟡 advisory) — diff SKILL.md documents the limitation; code fix pending (stardust-style e2e, learning L8)
 - [x] #88 crawl.mjs: verbatim slash forms + key-dedupe + 404 slash-retry; reducedMotion emulation + settle; codeBlocks[] capture — extract (stardust-style e2e, learnings L1/L2/L3, smoke-tested live)
 - [x] #89 --no-save playwright installs pruned by later npm i → per-skill re-probe rule; token-hygiene check moved to first hands-off commit; partial-inventory broken-link carve-out; cinematic-pickup sentence corrected — extract/stardust/migrate/prototype SKILLs (learnings L7/L6/L4/L5)
+
+---
+
+## 2026-07 Tessl quality pass, part 2 — SKILL.md restructure (no findings changed)
+
+SKILL.md was restructured for conciseness/progressive disclosure (892 → 475 lines). **All
+numbered findings (#NN) keep their numbers and remain enforced**: every rule/gate/checklist
+item stays inline in SKILL.md as a terse one-liner; only rationale paragraphs, failure
+narratives, worked examples, and deep-dive recipes moved to `reference/`:
+
+- `reference/runtime-bootstrap.md` — port manifest, #4/#21 edit mechanics, lint list (#6).
+- `reference/font-strategy.md` — #11/#12/#22/#30/#65/#77/#80 recipes + #81 header-reservation
+  deep dive.
+- `reference/encode-contract.md` — section-head reabsorption, #2/#86 image procedures,
+  #25/#41 button narratives + worked CSS.
+- `reference/decode-disciplines.md` — full #42–#79 narratives + QA probes (#13/#19/#29).
+- `reference/anti-patterns.md` — the 17 anti-pattern narratives (incl. 1b/9b — #58, #44/#67,
+  #74, #37).
+
+Each reference is wired in with a mandatory read gate at its consumption point, and the
+Step 7 sub-agent brief template instructs dispatched block agents to READ
+`reference/decode-disciplines.md` and `reference/encode-contract.md` before writing code.
+The `stardust:diff` `eds` profile citations (#NN) resolve as before.

--- a/plugins/stardust/skills/deploy/SKILL.md
+++ b/plugins/stardust/skills/deploy/SKILL.md
@@ -8,87 +8,34 @@ license: Apache-2.0
 
 ## When to use
 
-The user has:
-1. **Per-page styled HTML prototypes** — one file per page, each carrying its own CSS. Accept any of these shapes:
-   - **Single-file with inline `<style>`** and `:root` tokens + semantic `<section class="…">` (e.g. stardust output, or claude-design "Stardust"/Mobirise/Relume-style pages). Easiest — convert directly.
-   - **External per-page `.css`** (the `<style>` lives in a sibling stylesheet). Read the linked CSS the same way you'd read an inline `<style>`.
-   - **`<x-dc>` document-content with everything inline-styled** (per-element `style="…"`). Harder — you must lift inline styles into a scoped block stylesheet.
-   - **React/JSX prototypes** (an HTML shell that mounts `.jsx` components at runtime). **Pre-render to static HTML first** (run it, or screenshot + read the JSX to reconstruct the DOM); you cannot decorate a shell that has no server-rendered `<main>`.
-   The prototypes typically live under `stardust/prototypes/**` or a `samples/<Name>/` folder — don't hard-code the path; discover them.
-2. An EDS project at the repo root — `blocks/`, `styles/`, `scripts/`, `head.html`, plus existing blocks (`fragment`, `section-metadata`). If the project is **vanilla `aem-boilerplate`** rather than the AuthorKit runtime this skill assumes, run the **Runtime bootstrap** below first.
-3. A goal to convert: prototypes → authorable EDS blocks + EDS content pages under `content/**`.
+The user has (1) **per-page styled HTML prototypes** — one file per page, each carrying its own CSS; (2) an EDS project at the repo root (`blocks/`, `styles/`, `scripts/`, `head.html`, `fragment`/`section-metadata` blocks — if it's **vanilla `aem-boilerplate`**, run Runtime bootstrap first); (3) a goal: prototypes → authorable EDS blocks + content pages under `content/**`. Accepted prototype shapes:
+- **Single-file with inline `<style>`** + `:root` tokens + semantic `<section class="…">` (stardust / claude-design / Mobirise / Relume). Convert directly.
+- **External per-page `.css`** — read the linked CSS as you would an inline `<style>`.
+- **`<x-dc>` document-content, per-element `style="…"`** — lift inline styles into a scoped block stylesheet.
+- **React/JSX prototypes** — pre-render to static HTML first (Step 1, #24); you cannot decorate a shell with no server-rendered `<main>`.
 
-If the user has prototypes but no EDS scaffolding, stop and ask whether to bootstrap. If they have EDS but no prototypes, this skill doesn't apply.
+Prototypes typically live under `stardust/prototypes/**` or `samples/<Name>/` — discover them, don't hard-code the path. Prototypes but no EDS scaffolding → stop and ask whether to bootstrap. EDS but no prototypes → this skill doesn't apply.
 
 ## Runtime bootstrap (vanilla aem-boilerplate targets)
 
-This skill's runtime is the **AuthorKit** runtime (`ak.js` page boot, `postlcp.js` static header/footer fragments, `body.session` font gating, `decorateSession()`). The conversion steps below assume those files exist. They are **NOT** in this skill folder — they live in the canonical AuthorKit repo (`github.com/aemsites/author-kit`). (The `sanitise.js` DA-write helper is bundled with this skill at `skills/deploy/scripts/sanitise.js`; it is not part of the ported runtime.)
+This skill assumes the **AuthorKit** runtime (`ak.js` page boot, `postlcp.js` static header/footer fragments, `body.session` font gating, `decorateSession()`), from `github.com/aemsites/author-kit`. (`sanitise.js` is bundled with this skill at `skills/deploy/scripts/sanitise.js`, not ported.) If the target has `scripts/aem.js` + `scripts/scripts.js` and `header`/`footer` blocks but no `ak.js`/`postlcp.js`, port the runtime before Step 1:
 
-If the target project is a **vanilla `aem-boilerplate`** (it has `scripts/aem.js` + `scripts/scripts.js` and `header`/`footer` blocks, but no `ak.js`/`postlcp.js`), port the runtime before Step 1.
+- **Automate it (#6):** `node skills/deploy/scripts/bootstrap-authorkit.mjs --target . [--from-sibling <dir> | --ref <gitref>]` — copies the port-in set, removes the boilerplate set, applies AND verifies both mandatory edits, patches the `body.appear` gate, writes `.eslintignore`.
+- **Prefer `--from-sibling <dir>`** when another site in the repo is already bootstrapped (offline, deterministic, parity with a known-good deployed runtime). Otherwise `--ref` with a **pinned** commit/tag — never a tracking branch (author-kit's runtime drifts; if it no longer matches the static-fragment model, pin an older ref or use `--from-sibling`).
+- **Two mandatory edits — do BOTH (halves of one change).** If bootstrapping manually, verify each; a miss is silent:
+  1. **`scripts/lazy.js` (#4):** delete the `import('./utils/footer.js')…` line — it `loadBlock(footer)`s against the static fragment and renders a visible "Error" box.
+  2. **`scripts/postlcp.js` (#21):** in `loadStaticFragment`, set `el.className = name;` BEFORE `el.innerHTML = html;` — otherwise `header.header`/`footer.footer` root selectors never match and fragment-root styling silently no-ops.
+- **Lint mismatch (#6):** treat the runtime as vendored — `.eslintignore` it (the bootstrap script writes the list); your blocks + `styles/styles.css` still lint clean under airbnb.
 
-**Automate it (#6):** run `node skills/deploy/scripts/bootstrap-authorkit.mjs --target . [--from-sibling <dir> | --ref <gitref>]`. The script does the entire port below — copies the PORT-IN set, removes the boilerplate set, applies AND verifies both mandatory edits (failing loud instead of the usual silent footer-error-box), patches the `body.appear` blank-render gate, and writes `.eslintignore`. Two source modes:
-- **`--from-sibling <dir>` (preferred in a multi-site repo):** copy the runtime from another EDS project in the workspace that is already bootstrapped (has `scripts/ak.js` with both edits). Offline, deterministic, and parity-safe with a known-good *deployed* runtime — no re-fetch, no re-patch risk per site. This is the right default when several sites share one repo (e.g. 8 subfolder sites).
-- **`--ref <gitref>`:** fetch a **pinned** author-kit ref tarball and port from it. Pin a real commit/tag (the script's `AUTHORKIT_REF` constant or `--ref`), **not** a tracking branch — author-kit's runtime has drifted (static-fragment → block-based header/footer), so an unpinned port can silently change what you get. If the fetched runtime no longer matches the static-fragment model the steps below describe (`loadStaticFragment`, `postlcp.js` injecting `fragments/{header,footer}.html` via `innerHTML`), pin an older known-good ref or use `--from-sibling`.
-
-The manual manifest (what the script does, for reference / hand-porting). Fetch the author-kit tarball and copy:
-
-**Port in (from author-kit):**
-```
-scripts/ak.js scripts/scripts.js scripts/postlcp.js scripts/lazy.js scripts/utils/*
-tools/**                      # da/da.js (+ sidekick, quick-edit, scheduler — keep so lazy.js/scripts.js imports resolve). sanitise.js is bundled with this skill, not ported.
-deps/**                       # rum.js + lit (head.html loads deps/rum.js)
-head.html                     # AuthorKit head: loads ak.js + scripts.js + styles.css + deps/rum.js
-blocks/fragment blocks/section-metadata
-.hlxignore
-```
-
-**Remove (boilerplate the AuthorKit runtime replaces):**
-```
-scripts/aem.js scripts/delayed.js          # replaced by ak.js + lazy.js
-blocks/header blocks/footer                 # replaced by static fragments/{header,footer}.html (Step 6)
-blocks/cards blocks/columns blocks/widget   # unused demo blocks (delete to avoid stale aem.js imports)
-styles/fonts.css styles/lazy-styles.css     # @font-face goes in styles.css; AuthorKit head loads only styles.css
-```
-
-**After porting, two runtime edits are mandatory (do BOTH — they're halves of one change):**
-1. **`scripts/lazy.js` (#4):** the stock AuthorKit `lazy.js` lazy-loads `utils/footer.js`, which does `loadBlock(footer)` and collides with the static footer fragment (renders a visible "Error" box, since there is no `blocks/footer`). **Delete the `import('./utils/footer.js')…` line.**
-2. **`scripts/postlcp.js` (#21):** deleting `utils/footer.js` also removed the only code that set the `<footer>`'s class. Without it, the fragment's own root selector (`footer.footer { background: … }`) never matches and any styling on the fragment ROOT (background/padding/color) silently no-ops. In `loadStaticFragment`, set the class before injecting:
-   ```js
-   const html = await resp.text();
-   el.className = name;          // so header.header / footer.footer match
-   el.innerHTML = html;
-   ```
-   This bug is invisible when the footer happens to match the body background; it bites the moment a fragment has its own background (e.g. a yellow footer).
-
-When starting a NEW conversion in a repo where a sibling site is already bootstrapped, port from that sibling (`bootstrap-authorkit.mjs --from-sibling <dir>`) — it already carries both edits and matches a known-good deployed runtime. Otherwise port from a **pinned** author-kit ref, not a tracking branch (the runtime drifts).
-
-**Lint mismatch (#6).** The AuthorKit runtime is authored for `@adobe/eslint-config-helix`; a boilerplate project lints with `airbnb-base`, so `npm run lint` will throw thousands of errors on the vendored runtime + minified `deps/`. Treat the runtime as vendored — add to `.eslintignore`:
-```
-deps/
-scripts/ak.js
-scripts/lazy.js
-scripts/postlcp.js
-scripts/scripts.js
-scripts/utils/
-tools/
-blocks/fragment/
-samples            # reference prototypes, not project code
-```
-Your generated blocks + `styles/styles.css` still lint clean under airbnb (expand any single-line multi-declaration CSS rules the prototype used). Alternatively, adopt the author-kit `eslint.config.js` (helix) wholesale.
+Hand-porting, or debugging a port? **READ `reference/runtime-bootstrap.md` first** — it carries the full PORT-IN/REMOVE manifest, the edit mechanics, the `.eslintignore` list, and the drift history.
 
 ## Playwright re-probe (run before anything that renders)
 
-`--no-save` playwright installs from earlier phases are pruned by any later
-real `npm i` — including this skill's own bootstrap adding a devDependency
-(extract SKILL.md § Setup → `--no-save` installs are ephemeral). Before the
-Local-QA harness, the computed-layout gate, or any probe below, verify
-`node -e "import('playwright').then(()=>process.exit(0))"` from the project
-root and re-install (`npm i -D playwright --no-save --legacy-peer-deps`) on
-failure.
+`--no-save` playwright installs from earlier phases are pruned by any later real `npm i`. Before the Local-QA harness, the computed-layout gate, or any probe: verify `node -e "import('playwright').then(()=>process.exit(0))"` from the project root; on failure → `npm i -D playwright --no-save --legacy-peer-deps`.
 
 ## Runtime-detection probe (run before Step 1 — write `stardust/runtime-contract.json`)
 
-Two EDS runtimes look identical from the content side but need different generated code, and a wrong assumption here is **silent and sitewide**. Before converting anything, inspect the repo — `scripts/ak.js` vs `scripts/aem.js`, how `loadBlock` wraps blocks, what the button decorator emits — and record the answers:
+Two EDS runtimes look identical from the content side but need different generated code; a wrong assumption is **silent and sitewide**. Inspect the repo (`scripts/ak.js` vs `scripts/aem.js`, how `loadBlock` wraps blocks, what the button decorator emits) and record:
 
 ```json
 {
@@ -100,554 +47,297 @@ Two EDS runtimes look identical from the content side but need different generat
 }
 ```
 
-Block CSS/JS generation and the Local-QA harness read this contract instead of assuming a runtime. The two costliest wrong guesses:
-- **`blockWrapperClass`** — AuthorKit's `loadBlock` (`ak.js`) only sets `data-block-name`; it **never adds a `.block` class** (blocks sit inside `.block-content` as `<div class="<name> <variant>">`). CSS must scope `.<name> …`, **never `.<name>.block`** — that selector silently never matches, grids fall back to `display: block`, and every grid section stacks single-column ("mobile layout on desktop") while typography still looks fine. Confirm by asserting a grid container computes `display: grid` in a headless render.
-- **`buttonClasses`** — the AuthorKit decorator emits `a.btn` / `.btn-primary` / `.btn-secondary` inside `p.btn-group`, NOT the stock EDS `.button` / `.button-container`. Style the wrong family and every CTA ships as a bare unstyled link.
-
-When `emptySectionCollapse` is true (the page-metadata block leaves an empty padded section after its content is consumed into `<head>`), add `main .section:empty { display: none }` to the foundation — or an empty ~88px band sits between the header and the first real section.
+Block CSS/JS generation and the Local-QA harness read this contract. The two costliest wrong guesses:
+- **`blockWrapperClass`** — AuthorKit's `loadBlock` never adds a `.block` class (only `data-block-name`; blocks sit inside `.block-content`). CSS must scope `.<name> …`, **never `.<name>.block`** — that selector silently never matches, every grid falls back to `display: block` and stacks single-column while typography still looks fine. Confirm by asserting a grid container computes `display: grid` in a headless render.
+- **`buttonClasses`** — the AuthorKit decorator emits `a.btn`/`.btn-primary`/`.btn-secondary` in `p.btn-group`, NOT stock `.button`/`.button-container`. Style the wrong family → every CTA ships as a bare link.
+- When `emptySectionCollapse` is true, add `main .section:empty { display: none }` to the foundation — or an empty ~88px band sits under the header.
 
 ## Deploy (DA Source API, from a local agent)
 
-**Steps 1–9 are the conversion methodology**; deploy is the one transport-specific step. From a local agent (Claude Code / CLI), each converted page deploys headlessly:
+**Steps 1–9 are the conversion methodology**; deploy is the one transport-specific step. Per page:
 
 | Stage | How |
 |---|---|
 | Code | `git push` the branch → AEM Code Sync builds it |
-| Sanitise | `skills/deploy/scripts/sanitise.js` — run it before the write (DA corrupts raw UTF-8) |
-| Content write | DA Source API: `PUT admin.da.live/source/<org>/<repo>/<path>.html` (multipart, field name **`data`**, `type=text/html`) |
+| Sanitise | `skills/deploy/scripts/sanitise.js` before every write (DA corrupts raw UTF-8) |
+| Content write | DA Source API: `PUT admin.da.live/source/<org>/<repo>/<path>.html` (multipart, field **`data`**, `type=text/html`) |
 | Make live | `POST admin.hlx.page/preview/<org>/<repo>/<branch>/<path>` (then optionally `/live/...`) |
 | Auth | IMS token (`DA_TOKEN`) — see the `da-content` / `da-auth` skills |
 
-The content payload is a **body fragment** (see Step 9). The deploy needs the **code branch pushed to GitHub** so the branch preview (`<branch>--<repo>--<org>.aem.page`) renders with your blocks. See `da-deploy-protocol.md` for the full curl contract.
+The content payload is a **body fragment** (Step 9); the code branch must be pushed so `<branch>--<repo>--<org>.aem.page` renders your blocks. Full curl contract: `da-deploy-protocol.md`.
 
-**For more than a few pages, use the bundled driver instead of a hand-rolled loop (#4).** `node skills/deploy/scripts/deploy-batch.mjs --org <org> --repo <repo> --branch <branch> --content content [--concurrency 4] [--no-publish]` runs `PUT → preview → live` across a content tree with bounded concurrency, a **persistent ledger** (`content/.deploy-ledger.json`) so a re-run **skips pages already live** and only re-drives FAILs, capped-backoff retries on `000/429/5xx`, an **append-only** log (survives a restart), and a delivered-`.plain.html` check before flipping a page to `live` (admin 200 ≠ delivered). It's idempotent — safe to Ctrl-C and re-run, which is the documented recovery for a transient-blip half-deploy. A serial hand-rolled bash loop that truncates its own log on restart is the anti-pattern this replaces.
-
-**Per-page atomic delivery contract.** A page is `deployed` only when the full chain passes, in order: sanitise-wrapped file (`scripts/sanitise.js`) → `PUT` (multipart field `data`, `type=text/html`) → `POST /preview/` → `POST /live/` → **GET the rendered `.plain.html` and assert**: HTTP 200, the `<body>` wrapper intact, exactly one `<h1>`, zero `about:error`, no `/img/` srcs — plus, when key facts are declared for the site (#86 — `DESIGN.json.extensions.metadata.keyFacts[]`, written by `direct`; skip the gate and note the skip when the field is absent), grep the RAW full-page HTML (not the rendered DOM) for each fact string on the pages that carry them. Only then flip the page's ledger entry to `deployed` — never on the POST codes (admin 200 ≠ delivered).
-
-**A `.plain.html` pass is NOT a layout pass — add one computed-style assertion (#the silent-failure guard).** The text-level asserts above are all satisfied while the page renders as a single stacked column, because the AuthorKit `.<name>.block` scoping bug (see `blockWrapperClass` in the runtime contract) makes every grid fall back to `display: block` *with the typography still correct*. This shipped green on a real e2e site. So the contract's final gate is a **headless computed-style check on the delivered live URL** (not `.plain.html`): load the page in a headless browser and assert, for the first page of each template, that every block whose CSS declares a grid/flex layout **computes `display: grid`/`flex` (not `block`)**, `main .section` count > 0, blocks are decorated (`data-block-name` present), zero `pageerror`, zero broken images. A block that should grid but computes `block` fails the page — do not flip it to `deployed`. This is the assertion `blockWrapperClass` in the runtime contract calls for; the atomic contract is where it must actually run, once per template. Two field-decodes worth pinning: a **burst of `PUT` 400s is a malformed path, not rate limiting** — lowercase every segment, never a double slash (`content//…` 400s the PUT while preview/live still 200), no trailing `-`/`_` on a segment; and **write long loops to a bash script file with absolute binary paths** (`/usr/bin/curl`, the full `node` path) — zsh drops PATH inside `while`/`for` in some contexts, and the resulting `command not found` burst mimics a transport failure.
-
-**Token hygiene (#16).** The IMS token typically lives in repo `.env` as `DA_TOKEN`. Before the first commit, make sure `.gitignore` excludes `.env`, `.env.*`, and `qa/` (the local QA harness) **on the branch you'll branch tests from** — otherwise every test subbranch re-exposes the token. Keep `samples/` out of commits too. Dev tokens last ~24h; a `401` with an empty body means expired → refresh and retry (the write is idempotent).
-
-**DA_TOKEN lifecycle — preflight and re-check, never fail pages on it.** At setup, preflight the token: decode the JWT `exp` claim when present (base64-decode the middle segment) and smoke-test ONE authenticated DA call before any batch. **Re-check before each long batch** — a token fresh at setup can expire mid-run. On a `401` mid-batch: checkpoint the ledger (the batch driver's persistent ledger already records per-page state), stop the batch, and halt with a single actionable instruction — "DA_TOKEN expired; refresh it in `.env` and re-run the same command (the ledger skips delivered pages)" — instead of letting every remaining page fail red. Token expiry is the one credential failure the agent cannot self-recover; it is a legitimate hard stop even in a hands-off run.
+- **More than a few pages → use the bundled driver, never a hand-rolled loop (#4):** `node skills/deploy/scripts/deploy-batch.mjs --org <org> --repo <repo> --branch <branch> --content content [--concurrency 4] [--no-publish]`. Persistent ledger (`content/.deploy-ledger.json`) skips already-live pages and re-drives only FAILs; capped-backoff retries on `000/429/5xx`; append-only log; delivered-`.plain.html` check before flipping `live`. Idempotent — Ctrl-C and re-run is the documented recovery for a half-deploy.
+- **Per-page atomic delivery contract.** A page is `deployed` only when the full chain passes in order: sanitise → `PUT` → `POST /preview/` → `POST /live/` → **GET the delivered `.plain.html` and assert** HTTP 200, `<body>` wrapper intact, exactly one `<h1>`, zero `about:error`, no `/img/` srcs. When `DESIGN.json.extensions.metadata.keyFacts[]` exists (#86, written by `direct`), also grep the RAW full-page HTML (not rendered DOM) for each fact on the pages that carry it; if the field is absent, skip the gate and note the skip. Only then flip the ledger entry — **never on the POST codes** (admin 200 ≠ delivered).
+- **A `.plain.html` pass is NOT a layout pass — run the computed-style gate (the silent-failure guard), once per template.** The `.<name>.block` scoping bug renders a green-text page as a single stacked column. On the delivered LIVE URL, headless-load the first page of each template and assert: every block whose CSS declares grid/flex **computes `display: grid`/`flex` (not `block`)**; `main .section` count > 0; blocks decorated (`data-block-name` present); zero `pageerror`; zero broken images. A should-grid block computing `block` fails the page → do not flip to `deployed`; fix the CSS scoping per the runtime contract.
+- **Field decodes:** a burst of `PUT` 400s is a **malformed path, not rate limiting** — lowercase every segment, never a double slash (`content//…`), no trailing `-`/`_`. Write long loops to a bash **script file** with absolute binary paths (`/usr/bin/curl`, full `node` path) — zsh drops PATH inside `while`/`for` in some contexts and the `command not found` burst mimics a transport failure.
+- **Token hygiene (#16).** `DA_TOKEN` lives in repo `.env`. Before the first commit, `.gitignore` must exclude `.env`, `.env.*`, `qa/` **on the branch you'll branch tests from** (or every subbranch re-exposes the token); keep `samples/` out of commits. Dev tokens last ~24h; `401` with empty body = expired → refresh and retry (the write is idempotent).
+- **DA_TOKEN lifecycle — preflight and re-check, never fail pages on it.** At setup: decode the JWT `exp` claim and smoke-test ONE authenticated DA call. Re-check before each long batch. On a mid-batch `401` → checkpoint the ledger, stop, and halt with one actionable instruction ("DA_TOKEN expired; refresh in `.env` and re-run the same command — the ledger skips delivered pages"). Token expiry is a legitimate hard stop even in a hands-off run.
 
 ## The one rule that drives everything else
 
-**One prototype `<section>` = one EDS block — as the SAFE DEFAULT.** Don't abstract speculatively, and don't extract "patterns" across prototypes unless sections are genuinely the same pattern. This default exists because each section's bespoke CSS can't be wrongly shared; violating it casually cost full resets (see ANTI-PATTERNS).
+**One prototype `<section>` = one EDS block — as the SAFE DEFAULT.** Don't abstract speculatively; don't extract "patterns" across prototypes unless sections are genuinely the same pattern. Violating this casually cost full resets (see Anti-patterns).
 
-**The one deliberate exception — collapse SAME-PATTERN sections into one block + VARIANT classes.** When two or more sections are the same content pattern (card grids, prose/CTA bands, quotes, accordions) differing only in skin, emit ONE canonical block (`cards`, `text`, `quote`, `accordion`) and put each section's look behind a variant class (`class="cards brands"`), brand styling in the variant CSS. The block JS stays generic (classify cells by content); only the CSS differs per variant. This is the David's-Model library win (small, reusable, variant-driven — not 20 bespoke names) and is proven to preserve fidelity. Keep genuinely-unique sections (a hero, a countdown widget) bespoke. Budget for it: variant CSS is careful work and some grids are count-specific.
+**The one deliberate exception — collapse SAME-PATTERN sections into one block + VARIANT classes.** When sections are the same content pattern (card grids, prose/CTA bands, quotes, accordions) differing only in skin, emit ONE canonical block (`cards`, `text`, `quote`, `accordion`) with each look behind a variant class (`class="cards brands"`); JS stays generic, only variant CSS differs. This is the David's-Model library win and is proven to preserve fidelity. Keep genuinely-unique sections (hero, countdown) bespoke. Budget for it: variant CSS is careful work and some grids are count-specific.
 
-The prototype is the visual spec. The block exists to AUTHOR its content — see **The ENCODE contract** below for what well-authored content looks like, and ANTI-PATTERNS for how a block must defensively PARSE it.
+The prototype is the visual spec. The block exists to AUTHOR its content — the ENCODE contract defines well-authored content; Step 8's disciplines define how a block defensively PARSES it.
 
 ## Output you will produce
 
-For a typical 5–10 page site:
-
-- **One block per distinct prototype section.** A 5-page site with 6 sections each → ~12–18 blocks (some are reused across pages, e.g. `closing`).
-- **One EDS content page per prototype page.** Same number of pages.
-- **Nav + footer fragments** at `content/fragments/{nav,footer}.html` (the navigation lives in `nav.html`, not `header.html`).
-- **Updated `styles/styles.css`** with brand tokens lifted from the prototype's `:root`, a reset, the EDS section scaffold, and a global button system (see "Lean on EDS button conventions" below). Nothing more.
-- **No shared utility modules.** No wave systems. No section-metadata style classes. No motion library. The prototype already encodes these per-section; keep them inside the owning block.
+For a typical 5–10 page site: **one block per distinct prototype section** (~12–18 blocks; some reused across pages, e.g. `closing`); **one EDS content page per prototype page**; **nav + footer fragments** at `content/fragments/{nav,footer}.html` (navigation lives in `nav.html`); **updated `styles/styles.css`** (brand tokens from the prototype's `:root`, a reset, the EDS section scaffold, the global button system — nothing more). **No shared utility modules, wave systems, section-metadata style classes, or motion libraries** — the prototype encodes these per-section; keep them inside the owning block.
 
 ## The ENCODE contract — what well-authored content looks like
 
-The ANTI-PATTERNS below are the **decode** side: a block must parse robustly whatever DA hands it. This is the **encode** side: what the content page should EMIT in the first place. One principle drives all of it:
+Step 8 is the **decode** side (parse robustly whatever DA hands you); this is what the content page should EMIT. One principle drives all of it:
 
 > **Decoration that must survive DA rides a semantic inline tag — never a class, never an invented delimiter.** DA strips `<span>` and author classes from block cells, but PRESERVES `<strong>`, `<em>`, `<code>`, `<a>`, `<picture>`/`<img>`.
 
-- **Accent / emphasis → `<em>`, never `<span class="em">`** — DA strips the span and the accent is silently lost. Ensure the block CSS targets BOTH `em` and `.em`.
-- **Key facts must live in SERVER-RENDERED content, never solely in chrome fragments (#86).** The static header/footer fragments are client-injected (`postlcp.js` `innerHTML` after first paint), so anything that exists only there — a trust fact line ("Open source · Apache 2.0 · built by X"), pricing, contact facts — is INVISIBLE to non-rendering crawlers and AI bots on every page. If a fact matters for SEO/LLM answerability, author it in page content (a fact panel, an install-section sentence, the metadata description); the fragment copy is presentation, not the crawlable source of truth. Verify by grepping the RAW served HTML (no JS) for the key-facts list — the rendered DOM check passes either way and hides the failure.
-- **Sub-fields → a leading preserved tag, never an in-band delimiter.** Don't invent `Step|Title`, `flag :: desc`, `name|tag` micro-syntax (authors must learn it). Lead the cell with the field's tag — kicker → `<strong>`, code/flag/path → `<code>` — and the block reads the leading tag as the term, the rest as the value. (A block MAY still parse a delimiter as a back-compat fallback — that's decode, not what you emit.)
-- **No raw presentational HTML in content.** No `<sup>` (move unit superscript into the block — split `185+` into number + generated `<sup>`); don't use `<br>` for layout (a deliberate editorial line break via Shift+Enter is fine — it's not "exposed code").
-- **Grouped item sets → one row per item.** A band of N similar units (metrics, stats, feature cards) is ONE row per unit, its parts as flat siblings in that cell — not one cell per atom (loses which label pairs with which number) and not all-in-one-cell. The block segments per row.
-- **Lists / FAQ → rows, not nested lists or one blob.** An accordion/FAQ is a head cell then one row per Q/A (question cell + answer cell). David's-Model #5.
-- **Section head → DEFAULT CONTENT, not a block row.** The eyebrow/heading/lede that sits *above* a repeating block (cards, metrics, FAQ, insights) is prose, not part of the block's structure — author it as **default content** in the section, before the block, so DA and `.plain.html` keep it out of the block table (David's #1). The block **reabsorbs** it at decorate time (see "Section heads" below), so this is a pure markup/authoring win with **zero pixel change**. (NOT for a genuine widget whose rows ARE its structure, e.g. countdown.)
-- **Buttons → one emphasis axis:** primary `<strong><a>`, secondary `<em><a>`; never `<strong><em><a>`. (See "Lean on EDS button conventions".)
-- **Headings → real outline, no level jumps:** one `<h1>`; section titles `<h2>`; card/sub titles `<h3>` (never skip to `<h4>`). Canonicalising a prototype's card `<h4>` to `<h3>` is correct.
+- **Accent/emphasis → `<em>`, never `<span class="em">`** (DA strips the span). Block CSS targets BOTH `em` and `.em`.
+- **Key facts live in SERVER-RENDERED content, never solely in chrome fragments (#86)** — fragments are client-injected, invisible to non-rendering crawlers/AI bots. Verify by grepping the RAW served HTML for the key-facts list (rationale in `reference/encode-contract.md`).
+- **Sub-fields → a leading preserved tag, never an in-band delimiter.** No `Step|Title` / `flag :: desc` micro-syntax; lead the cell with kicker → `<strong>`, code/flag/path → `<code>`. (Blocks MAY parse delimiters as decode fallback — never emit them.)
+- **No raw presentational HTML:** no `<sup>` (block generates it from `185+`); no layout `<br>` (a deliberate Shift+Enter editorial break is fine).
+- **Grouped item sets → one row per item**, its parts as flat siblings in that cell — never one cell per atom, never all-in-one-cell.
+- **Lists/FAQ → rows:** head cell, then one row per Q/A (David's #5) — not nested lists, not one blob.
+- **Section head → DEFAULT CONTENT, not block rows** (David's #1): the eyebrow/heading/lede above a repeating block is authored as section default content; the block **reabsorbs** it at decorate time — zero pixel change. (NOT for a widget whose rows ARE its structure, e.g. countdown.)
+- **Buttons → one emphasis axis:** primary `<strong><a>`, secondary `<em><a>`; never `<strong><em><a>` (Step 5).
+- **Headings → real outline, no level jumps:** one `<h1>`; section titles `<h2>`; card titles `<h3>` (canonicalise a prototype's `<h4>` card titles to `<h3>`).
 - **Metadata stays name/value** (config only — David's #14); never name/value for semantic content.
 
-### Section heads: default content the block reabsorbs (zero pixel change)
+**Images — editorial vs decorative:**
+- **Any meaning-carrying raster/brand image is EDITORIAL → authorable content**, including hero/feature/CTA-band backgrounds behind text+scrim. Upload the binary to DA (`PUT admin.da.live/source/{org}/{repo}/media/<scope>/<file>`, multipart field `data`), author one `<img src="https://content.da.live/…" alt="…">` per cell. **Never** repo-relative `/img/…` in content (→ `about:error`); **never** bake imagery into block JS by index (`CARD_IMAGES`) — not authorable.
+- The block renders the authored `<img>` into a background LAYER (`.hero-bg`/`.card-media`); scrim/gradient is CSS `::before` over it; keep a fixed CSS asset as no-image fallback.
+- **Decorative = CSS only**: image-less treatments (gradients/scrims/washes) and genuinely fixed brand assets as CSS backgrounds, root-relative `/img/<brand>/…` (browser-fetched, never ingested).
+- **Gate: after preview, grep the delivered `.plain.html` for the expected `<img>`+alt count** — "it renders" hides CSS-background images (absent from `.plain.html`, no alt, not authorable or AI/SEO-visible). Fails → reauthor as content `<img>`.
+- **Migration source URLs — verify BEFORE authoring, with the recorded fetch technique (#2):** read `_crawl-log.json#discovery.fetchTechnique`; when `headed-chrome`, verify via in-page fetch (a bare `curl` falsely reports bot-walled assets broken and would strip every real brand image). `403`/`401` = blocked-not-missing → **download-and-rehost to DA, never omit**; omit only on a true `404` after attempting the rendition/`?`-delimiter repairs; never substitute a generic logo. `content.da.live` URLs 401 to anonymous curl — that's normal; verify those post-preview only (`about:error` grep + img/alt count).
 
-A head-bearing block (one with a section eyebrow/heading/lede above repeating units) should NOT carry that head as block rows. Author the head as **default content** in the section, before the block; the block table holds only the repeating units. Then the block **reabsorbs** the head so the decorated DOM — and every pixel — is identical to the old in-table form:
-
-- On `decorate(block)`, read the section's leading default-content wrapper, build the SAME `.section-head` the block used to build from its first rows, and **remove the wrapper**. Result: identical decorated DOM; CSS untouched.
-- **The head wrapper is a sibling of the block's SECTION-LEVEL wrapper, not of the block, and its class varies by runtime.** Use `block.closest('.block-content')?.previousElementSibling` and match BOTH `.default-content` (AuthorKit runtime) **and** `.default-content-wrapper` (vanilla EDS). `block.previousElementSibling` alone is `null` (the block is nested in `.block-content`).
-- Keep the old in-table head (leading non-unit rows) as a **back-compat fallback**.
-- **Verify zero change:** diff the *decorated* block `outerHTML` (ids/`media_<hash>` normalised) old-vs-new — it must be byte-identical, with 0 default-content wrappers left after decorate.
-
-A FOUC is possible (head paints as default content, then reabsorbs); the final layout is identical — watch CLS only if default-content margins differ markedly from the head's.
-
-### Images: editorial → authored content, decorative → CSS only
-
-**Any raster/brand image that carries meaning is EDITORIAL and must be authorable content** — including hero / feature / CTA-band backgrounds that sit *behind* text and a scrim (the author swaps them per campaign; they're the page's most important visual). For editorial images:
-
-1. Upload the binary to DA: `PUT https://admin.da.live/source/{org}/{repo}/media/<scope>/<file>` (multipart, field name **`data`**, correct `Content-Type`; upload the JPG/PNG/webp source only — the pipeline generates responsive variants).
-2. Author a single `<img src="https://content.da.live/{org}/{repo}/media/<scope>/<file>" alt="…">` in the cell (branch-independent; the pipeline emits the responsive `<picture>`). **Never** a repo-relative `/img/…` in content (→ `<img src="about:error">`). **Never** bake imagery into block JS by index (`CARD_IMAGES`/`LOGOS`) — that isn't authorable.
-3. The block renders the authored `<img>` into a background LAYER (`.hero-bg` / `.card-media` / `.text-media`); the scrim/gradient is a CSS `::before` OVER it. Keep a fixed CSS asset as the no-image fallback.
-
-**Decorative = CSS only** applies to image-LESS treatments (gradients, scrims, textures, solid washes) and to genuinely fixed brand assets referenced as **CSS backgrounds** root-relative (`/img/<brand>/…` — browser-fetched, never ingested, so no `about:error` and no upload).
-
-**The check that catches the #1 mistake:** after preview, grep the delivered `.plain.html` for the expected `<img>`+alt count. "It renders" hides CSS-background images — they're absent from `.plain.html`, carry no alt, and are neither authorable nor AI/SEO-visible.
-
-**When the image src is a SOURCE/external URL (migration), verify it resolves BEFORE you author it.** Re-using an image straight off the source page is the most common way to ship `<img src="about:error">`: the preview ingester fetches the authored URL, and if that fetch fails the delivered image is `about:error` — silent, since the page still renders. So verify every authored `<img>` whose src points at the source/CDN — **but the verification fetch must match how extract reached the origin, and a failure is not automatically "omit".**
-
-**Verify with the recorded fetch technique, not a bare curl (#2 — bot-managed origins).** A large fraction of real migration targets sit behind Akamai / Cloudflare / Imperva / F5, which 403 a plain `curl` (and headless requests) while serving the same asset fine to a real browser. A blanket "curl it; if not 200, omit" therefore **strips every real brand image** off an entire bot-walled site — the exact failure the quality bar forbids. Instead: read `_crawl-log.json#discovery.fetchTechnique`. When it is `headed-chrome`, verify image URLs with an **in-page fetch from the open browser context** (`page.evaluate(async u => (await fetch(u)).status, url)`) — that inherits the JA3/H2 fingerprint and cookies (per `extract/reference/playwright-recipe.md` § Bot-management → Sub-resource fetches); a bare `curl`/`request` will falsely report the asset broken. Only when `fetchTechnique` is plain may a bare `curl -s -o /dev/null -w '%{http_code}' <url>` stand in.
-
-**Distinguish 403-bot-wall from 404-missing, and prefer rehost over omit.** A `403`/`401` from a CDN means *blocked-when-hotlinked*, NOT *missing* — and even if the URL would 200 to the ingester now, hotlinking the source CDN from the delivery host is fragile (it can 403 cross-origin at preview time, yielding `about:error`). So the default remediation for a `403`/blocked captured image is **download-and-rehost**, not omit: extract already saved a local copy under `stardust/current/assets/media/` via the in-page fetch — upload it to DA (`PUT …/source/{org}/{repo}/media/<scope>/<file>`) and author the `content.da.live` URL (see Images, above). **Omit only on a true `404` (asset genuinely gone) after attempting the rendition/delimiter repairs below** — and never substitute a generic logo/placeholder (`…-logo…`) as if it were editorial. Two real failure signatures where the asset exists — fix the URL, don't drop it: (1) **wrong rendition variant** — the page exposes only a derivative that 404s while a sibling resolves (e.g. a portrait's `…/4x3/768/…` 404 vs `…/original/768/…` 200) → rewrite to the resolver; (2) **missing query delimiter** — `…/<id>&wid=600&hei=…` with no `?` makes `<id>&wid=…` a bogus id → 403 → repair the first `&` after the id to `?`.
-
-**`content.da.live` media URLs are auth-gated — don't anon-curl them.** Once you've rehosted to DA, the recommended `https://content.da.live/{org}/{repo}/media/…` src returns **`401` to an anonymous `curl`** even though it is correct and the preview pipeline ingests it fine. Do not treat that `401` as "broken" and omit. The correct verification for an already-rehosted/DA-hosted image is **post-preview**: grep the delivered `.plain.html` for `about:error` (must be 0) and assert the expected `<img>`/alt count — see `da-deploy-protocol.md` step 3b. Exempt `content.da.live` (and `admin.da.live`) URLs from the pre-author 200-check entirely.
+**Before authoring any image cell or section head, READ `reference/encode-contract.md`** — it carries the upload/verification/repair procedures and the section-head reabsorption mechanics (`block.closest('.block-content')?.previousElementSibling`, match `.default-content` AND `.default-content-wrapper`, back-compat fallback, byte-identical outerHTML verification).
 
 ## Steps
 
 ### 1. Audit (light)
 
-**First, normalize the input to static HTML.** If a prototype is React/JSX (an HTML shell that mounts `.jsx` into `#root`), **pre-render it to static HTML** before auditing (#24). The reliable recipe:
-```bash
-# 1. serve the prototype's OWN folder with a plain static server (NOT file:// —
-#    babel-standalone XHRs the .jsx and file:// CORS-blocks it; the aem dev
-#    server CSP-blocks the inline scripts too).
-( cd samples/<proto> && python3 -m http.server 8765 & )
-# 2. load in Playwright (React/babel load from unpkg — needs internet), wait for
-#    mount, capture #root's innerHTML, save it for the block agents to read:
-#    page.goto('http://localhost:8765/<file>.html'); waitForTimeout(4000);
-#    fs.writeFileSync('samples/<proto>/_rendered.html', root.innerHTML)
-```
-From there it converts like an external-CSS prototype (semantic classes + the prototype's `.css`). If it's `<x-dc>` document-content, the sections are still `<section>`/`<div>` elements; just expect inline `style="…"` instead of a `<style>` block. The rest of this skill assumes a static `<main>` exists.
+**Normalize the input to static HTML first.**
+- **React/JSX (#24):** serve the prototype's OWN folder with a plain static server (`cd samples/<proto> && python3 -m http.server 8765` — NOT `file://`, babel-standalone CORS-blocks; NOT the aem dev server, CSP-blocks). Load in Playwright (React/babel come from unpkg — needs internet), wait for mount, save `#root.innerHTML` to `samples/<proto>/_rendered.html` for the block agents. Then treat as an external-CSS prototype.
+- **`<x-dc>` document-content:** sections are still `<section>`/`<div>`; expect inline `style="…"` instead of a `<style>` block.
+- **View behind routing/sign-in (#27):** seed persisted state before boot (`page.addInitScript(() => localStorage.setItem('<key>', JSON.stringify({page:'dashboard'})))`), or drive the UI / set the router hash — capture `#root` for the view you intend to convert.
 
-**View behind routing / sign-in (#27).** If the view you want is not the default render (e.g. a signed-in dashboard behind a sign-on flow), **seed the app's persisted state before it boots** rather than capturing the landing page. Many prototypes persist their route to `localStorage`: `page.addInitScript(() => localStorage.setItem('<key>', JSON.stringify({page:'dashboard', user:'Alex'})))` then navigate. Generic alternatives: drive the UI to the view (fill + submit the sign-on form, then capture) or set the router hash/URL. Capture `#root` for the view you actually intend to convert.
-
-Read every prototype's `<main>` markup (skip the `<style>` for now) and produce a per-page section list:
+Read every prototype's `<main>` (skip `<style>` for now) and produce a per-page section list:
 
 ```
 home: hero, work, approach, team, clients, closing
 approach: approach-hero, manifesto, tenets-detailed, cadence, closing
-team: team-hero, team-roster, work-style, recent, careers, closing
-…
 ```
 
-A useful pattern: dispatch the `Explore` subagent at thoroughness=quick with this exact ask. You don't need a 22-pattern punch list — you need filenames + section names. **Resist the urge to "find shared patterns."** Pattern reuse will emerge organically when two sections turn out to be byte-identical.
+Dispatching the `Explore` subagent at thoroughness=quick works well. You need filenames + section names, not a 22-pattern punch list. **Resist "finding shared patterns"** — reuse emerges when two sections turn out byte-identical.
 
 ### 2. Decide names + reuse — LOCK BEFORE WRITING ANY CODE
 
-Naming rules:
-- Block name = the prototype's `<section class="X">` value, kebab-cased (`hero`, `work`, `closing`, `approach`).
-- **Never name a block after a reserved EDS class** (#15). `section`, `default-content`, `block-content`, `wrap`, and `button` are used by the runtime's section/decoration DOM — a block named `section` collides with `<div class="section">` and breaks decoration. When the prototype's section class is generic/reserved (Festool uses `class="section"` twice), derive a semantic name from the section's `data-screen-label` / intent instead (`new-products`, `discover`) and carry any modifier like `tinted` as a block variant.
-- When the same section appears on multiple pages with identical visual treatment, build ONE block and use it everywhere. The classic example: `closing` CTA at the end of every page.
-- When a section appears on multiple pages but looks different (e.g. home `hero` vs case-study `case-hero` vs service `service-hero`), they are different blocks. Prefix with the page archetype.
-- When two sections within one prototype share the same visual treatment but different copy (e.g. case-study `discovery` and `decisions` are both 2-col prose with eyebrow + headline), it is fine to merge into one block (`case-prose-2col`) with a single text variant cell ("tinted" / "default"). Use your judgment.
-
-**Scale the naming ceremony to the number of pages.** For a **single-page** conversion where each `<section class="X">` has a self-evident, unique name (`hero`, `quick`, `used`, `stats`…), there are no cross-page reuse decisions to make — just lock `block name = section class` and proceed; don't pepper the user with questions. The questions below matter for **multi-page** sites, where the same-looking section recurs and you must decide reuse vs. archetype-prefixing.
-
-**Surface 3–5 naming questions to the user before writing any block code (multi-page sites):**
-- "What's the home hero called? `hero`?"
-- "Are the closing CTAs across all pages identical? Same `closing` block?"
-- "Should case-study discovery/decisions/solutions be one block or three?"
-- "Is the per-service hero distinct from the home hero? Build `service-hero` separately?"
-
-Lock the answers in writing (in `stardust/eds-conversion-log.md` or similar). This is the single highest-leverage step in the whole process.
+- Block name = the prototype's `<section class="X">` value, kebab-cased.
+- **Never name a block after a reserved EDS class (#15):** `section`, `default-content`, `block-content`, `wrap`, `button` collide with the runtime's decoration DOM. When the section class is generic/reserved, derive a semantic name from `data-screen-label`/intent (`new-products`, `discover`); carry modifiers like `tinted` as variants.
+- Same section, multiple pages, identical treatment → ONE block everywhere (classic: `closing`).
+- Same role, different look per archetype → different blocks, archetype-prefixed (`hero` / `case-hero` / `service-hero`).
+- Two sections in one prototype, same treatment, different copy → merging into one block with a variant cell is fine. Use judgment.
+- **Scale the ceremony to the page count.** Single-page with self-evident unique names → lock `block name = section class` and proceed; don't pepper the user. Multi-page → surface 3–5 naming questions first ("Are the closing CTAs identical across pages — same `closing` block?", "Case-study discovery/decisions/solutions: one block or three?").
+- **Lock the answers in writing** (`stardust/eds-conversion-log.md`). This is the single highest-leverage step; building before the lock is Anti-pattern 8.
 
 ### 3. Foundation
 
 Update `styles/styles.css` to the following — and ONLY the following:
-
-- Lift `:root` tokens verbatim from the prototype's `<style>` (colors, fonts, type scale, weights, tracking, layout, motion easing).
-- Document reset (box-sizing, margin reset, scroll-behavior, body font + bg, ::selection, img defaults, button reset). **The `img` reset MUST be `img { display: block; max-width: 100%; height: auto; }` (#36).** EDS's media pipeline emits `<img>` with `width`/`height` attributes; without `height: auto` a width constraint stretches the image vertically (a landscape 1920×1258 rendered 677×1258). The bug is invisible on the prototype (raw `<img>`, no attrs) — it only appears post-pipeline.
-- A minimal EDS section scaffold:
+- `:root` tokens lifted verbatim from the prototype (colors, fonts, type scale, weights, tracking, layout, motion easing).
+- Document reset. **The `img` reset MUST be `img { display: block; max-width: 100%; height: auto; }` (#36)** — EDS emits width/height attrs; without `height: auto` images stretch vertically (a landscape 1920×1258 rendered 677×1258; invisible on the prototype, appears post-pipeline).
+- The minimal EDS section scaffold:
   ```css
   main .section { display: block; }
   main .section > .default-content,
   main .section > .block-content { display: block; }
   main > div, .has-template, div[data-status] { display: none; }
   ```
-- A global button system (see next section). This is the one place per-block CSS does NOT own its paint — buttons are site-wide and convention-driven.
-- **Reserve the static header's height — or the late fragment injection shifts the first section → CLS (#81).** `postlcp.js` injects `fragments/header.html` AFTER first paint (it's a deferred fetch). In the common layout where the header sits in flow ABOVE the first section (full-bleed hero *below* the nav), the hero therefore renders at `y=0`, then jumps DOWN by the header's height the instant the fragment lands — a large layout shift the browser attributes to the hero block (a real page measured **CLS 0.143, ~0.13 of it the hero**; metric-matched fonts do NOT fix it because the cause is the header box appearing, not a font swap). Reserve the header's rendered height on the **bare `<header>` element** in `styles/styles.css` (it applies before the fragment loads — `decorateHeader()` sets the class early, but styling the bare element covers the pre-class sliver too), with responsive `min-height` matching the fragment per breakpoint and the chrome's own `background` so any reserve-vs-actual delta is invisible:
-  ```css
-  header { min-height: 98px; background: var(--brand-ground); }   /* desktop nav+banner height */
-  @media (width <= 767px) { header { min-height: 102px; } }
-  @media (width <= 480px) { header { min-height: 120px; } }       /* banner wraps to 2 lines */
-  ```
-  Make the header's height **deterministic** so the reserved value actually matches: keep the reservation breakpoints in sync with the fragment's, and avoid nav-link *wrap zones* (e.g. extend the burger/hamburger breakpoint so the inline links can't wrap to a second row at awkward widths). Reserve slightly OVER the natural height (a few px) so you never under-reserve and shift — on a dark/uniform ground the small gap is invisible; a `header:empty` page (`header: off`) removes the element so the reservation is moot. **The footer needs NO reservation** — it's below the fold, so its late injection shifts nothing above it. Verify with a CLS probe (Playwright `PerformanceObserver({type:'layout-shift'})`) that **delays the woff2/fragment fetches** to reproduce the slow-network swap PSI measures — a fast localhost load hides the shift.
+- The global button system (Step 5) — the one place per-block CSS does not own its paint.
+- **Reserve the static header's height on the bare `<header>` element (#81)** — `postlcp.js` injects the header fragment AFTER first paint; with the header in flow above the hero, the hero jumps down by the header height → CLS ~0.13 attributed to the hero (metric-matched fonts do NOT fix it). Responsive `min-height` per breakpoint matching the fragment (reserve a few px OVER), plus the chrome's own `background`; keep the header height deterministic (breakpoints in sync, no nav-link wrap zones). Footer needs NO reservation (below the fold). Verify with a fetch-delayed CLS probe (target < 0.1; fast localhost hides the shift). Full mechanics + CSS: `reference/font-strategy.md` § #81.
 
-That's it. No section-style classes. No motion primitives. No utility classes beyond the button system.
-
-`scripts/scripts.js` stays minimal — only the page boot. No reveal-on-scroll. No marquee init. No header scroll-state. Per-block animation is owned by per-block CSS.
+That's it. No section-style classes, no motion primitives, no utilities beyond buttons. `scripts/scripts.js` stays minimal — page boot only; per-block animation is owned by per-block CSS.
 
 ### 4. Self-host fonts and minimize CLS — never put font loads in `head.html`
 
-Four principles, applied in this order on every project:
+**Before writing any `@font-face`, READ `reference/font-strategy.md`** and apply every recipe that matches (fontsource fetch commands, opsz/static-weight variants, fonttools metric math, licensing-alert mechanics, width-probe verification). The inline rules:
 
-**0. Ship an `@font-face` for EVERY named family — not just the body face (#65).** Prototypes name a display face AND a body face (`--display: "Hebden Incised", …; --body: "Lekton", …`). If you self-host only the body font, every heading/numeral/title whose stack names the un-shipped display family silently falls back to `Times New Roman`/`Arial` (generic serif/sans) — **invisible to size/color checks** (the glyphs differ but the metrics match; only the `FONT MISMATCH` probe flag #66 or an eyeball catches it). Distinct from #11/#22 (wrong weight) and #30 (opsz): here the family is NAMED but NEVER SHIPPED. For each quoted family in `--display`/`--body`/any heading stack, self-host a matching `@font-face` (download + commit the woff2 under `styles/fonts/`, reference root-relative — never the prototype's brand-CDN origin, #44). **Checklist:** grep every quoted family in `styles.css`'s font stacks against the `@font-face { font-family }` names declared — any unmatched name is a silent fallback.
-
-Then four principles, applied in this order on every project:
-
-**1. Leave `head.html` untouched. No font lines, period.**
-No Google Fonts `<link>`. No CDN `<link rel="stylesheet">` for type. No `<style>` blocks declaring `@font-face`. **No `<link rel="preload" as="font">`** either — even self-hosted preloads belong out of `head.html`. The browser will fetch the woff2 it needs as soon as `styles/styles.css` parses; the `body { arial }` / `body.session { var(--font-body) }` split (principle 3) eliminates the CLS that preloading is normally meant to prevent. **All `@font-face` declarations live in `styles/styles.css`.**
-
-**2. Self-host EVERY brand face — including proprietary ones — and emit a licensing alert (#80).**
-Inspect the prototype to identify each font family and its license:
-- SIL OFL 1.1 (Inter, JetBrains Mono, Fraunces, Roboto, Open Sans, IBM Plex, Source Sans, etc.) → self-host. License permits redistribution, including embedding on the served domain.
-- Apache 2.0 (some Google Fonts) → self-host.
-- **Proprietary commercial (Pangram Pangram, Adobe Fonts / Typekit, Monotype, foundry-direct) → self-host anyway for fidelity, BUT raise a LICENSING ALERT (#80).** The DEFAULT is brand-faithful: a converted/presales page that silently degrades the brand display face to Arial reads as broken to the client (this is exactly what a stakeholder notices first). So lift the prototype's actual webfonts — if the prototype ships `.otf`/`.ttf` (claude-design/stardust prototypes usually do, under `assets/fonts/`), convert them to latin `woff2` with `fontTools` (`f.flavor='woff2'; f.save(...)`, ~30–60 KB each) and declare them in `styles/styles.css` exactly like an OFL face. Because they're proprietary you MUST surface the licensing obligation in THREE places so it can't ship unnoticed:
-  1. a banner comment at the top of `styles/styles.css` (`⚠️ FONT LICENSING REQUIRED BEFORE GOING LIVE` + foundry per family + "do not publish to `aem.live` until the webfont/embedding license is confirmed");
-  2. a `styles/fonts/LICENSING.md` file (table: file → family → foundry → status, plus the remove-and-fall-back instructions);
-  3. the conversion log, AND your hand-off message to the user.
-  Document the **remove path**: if licensing can't be confirmed, delete the `.woff2` + their `@font-face` rules and the stacks fall back to the metric-matched system fallback (principle 3/4). This is the inverse of the old "keep CDN / accept Arial" guidance — prefer fidelity + a loud alert over a silent generic fallback. (Only keep a CDN load when the prototype itself loads from an Adobe/Typekit CDN AND you cannot obtain the font files — then document the CDN coupling + CLS cost.)
-
-For OFL fonts, fetch latin-subset variable woff2 files. The fastest reliable source is jsDelivr's `@fontsource-variable/<name>` packages:
-
-```bash
-mkdir -p styles/fonts
-curl -sSL -o styles/fonts/<name>-variable.woff2 \
-  "https://cdn.jsdelivr.net/npm/@fontsource-variable/<name>@latest/files/<name>-latin-wght-normal.woff2"
-# italic, if used:
-curl -sSL -o styles/fonts/<name>-italic-variable.woff2 \
-  "https://cdn.jsdelivr.net/npm/@fontsource-variable/<name>@latest/files/<name>-latin-wght-italic.woff2"
-```
-
-Latin-only variable woff2 is typically 30–60 KB per file, weights 100–900 included.
-
-**Match the axes the prototype loads — incl. optical size (#30).** Check the prototype's Google Fonts `<link>` URL. If it requests an **`opsz`** (optical-size) axis — e.g. `Source+Serif+4:opsz,wght@8..60,400;…` — the default `@fontsource-variable/<name>` file (`<name>-latin-wght-normal.woff2`) is **wght-only** (one fixed optical master) and headings will render subtly off (heavier/different letterforms at large sizes). Fetch the **opsz** file instead (carries both `wght` + `opsz`, ~2× the bytes); `font-optical-sizing: auto` (the CSS default) then tracks the size:
-```bash
-curl -sSL -o styles/fonts/<name>-opsz.woff2 \
-  "https://cdn.jsdelivr.net/npm/@fontsource-variable/<name>@latest/files/<name>-latin-opsz-normal.woff2"
-```
-More generally: self-host the variant whose axes match what the prototype loaded (wght-only vs opsz; italic if used).
-
-**Non-variable fonts (#11).** Many Google fonts ship only as named static weights — no variable axis (e.g. **Barlow**, Barlow Condensed, Anton). For these, `@fontsource-variable/<name>` does NOT exist; use the **static** `@fontsource/<name>` package and fetch each weight you actually use:
-```bash
-curl -sSL -o styles/fonts/<name>-700.woff2 \
-  "https://cdn.jsdelivr.net/npm/@fontsource/<name>@latest/files/<name>-latin-700-normal.woff2"
-```
-Static `@fontsource` packages also do **not** publish a "Fallback" `@font-face`, so you must **compute** the metric-override values yourself (principle 3) from the woff2 with fonttools:
-```python
-from fontTools.ttLib import TTFont
-f = TTFont("styles/fonts/<name>-400.woff2"); upm=f['head'].unitsPerEm; hhea=f['hhea']; os2=f['OS/2']
-arial = dict(upm=2048, xavg=904)  # Arial reference (use Times metrics for a serif brand)
-size_adjust = (os2.xAvgCharWidth/upm) / (arial['xavg']/arial['upm'])
-adj = upm*size_adjust
-print(f"size-adjust:{size_adjust*100:.2f}% ascent-override:{hhea.ascent/adj*100:.2f}% "
-      f"descent-override:{abs(hhea.descent)/adj*100:.2f}% line-gap-override:{hhea.lineGap/adj*100:.2f}%")
-```
-Apply those to the system-font override `@font-face` (renamed `"Arial"` / `"Times New Roman"`) exactly as in principle 3.
-
-**3. Body.session pattern with a metric-matched fallback `@font-face`.**
-The brand font must NOT render at first paint. Default to a metric-matched system font; switch to the brand font once `decorateSession()` (in `scripts/ak.js`) adds `body.session`. The recipe:
-
-```css
-@font-face {
-  font-family: "<Brand>";
-  src: url("/styles/fonts/<brand>-variable.woff2") format("woff2");
-  font-weight: 100 900;
-  font-display: swap;
-}
-
-/* Override the system font's metrics so it renders with the brand font's
-   line box. Naming the @font-face after the system font (e.g. "Arial",
-   "Times New Roman") makes any reference to that family in a font stack
-   pick up the metric-adjusted version site-wide — no per-block changes. */
-@font-face {
-  font-family: "Arial";          /* "Times New Roman" for a serif brand */
-  src: local("Arial");           /* local("Times New Roman") for serif */
-  size-adjust: <X>%;
-  ascent-override: <Y>%;
-  descent-override: <Z>%;
-  line-gap-override: 0%;
-}
-
-:root {
-  --font-body: "<Brand>", arial, sans-serif;       /* serif: times, "Times New Roman", serif */
-}
-
-body { font-family: arial, sans-serif; }
-body.session { font-family: var(--font-body); }
-```
-
-**Keep `body` VISIBLE — never gate display on `body.appear` (#40).** The font gate is the `body` → `body.session` font swap above; `ak.js` adds `body.session`. Do NOT port the aem-boilerplate pattern `body { display: none } body.appear { display: block }` into the foundation: the static-chrome runtime never adds `appear`, so every OFF-pipeline render (the Local-QA harness, the `visual-diff` probe) stays permanently hidden/zero-height — and a blank page silently passes most checks. (The probe now emits a `BLANK RENDER` red flag as a backstop, but the foundation must not introduce the gate in the first place.)
-
-The metric-override values come from the `@fontsource-variable/<name>` package's published calibration — fetch their CSS:
-
-```bash
-curl -s "https://cdn.jsdelivr.net/npm/@fontsource-variable/<name>@latest/index.css" \
-  | grep -A 6 "Fallback"
-```
-
-Each fontsource package publishes a `<Name> Fallback` `@font-face` with `size-adjust`, `ascent-override`, and `descent-override` values. Lift those three numbers verbatim and apply them to a local-system `@font-face` renamed to the system font (`"Arial"`, `"Times New Roman"`, `"Courier New"`).
-
-The CLS chain that results:
-- **Initial paint**: `body { font-family: arial, sans-serif; }` — renders the metric-adjusted local Arial because the override `@font-face` named `"Arial"` wins over the OS Arial. Line box already matches the brand font's metrics.
-- **Session activates**: `body.session` switches to `var(--font-body)`. Brand woff2 is still loading; Arial renders in its place with matching metrics. **Zero shift.**
-- **Brand font loads**: swaps in. **Zero shift** because metrics already match.
-
-**4. Match the fallback family to the brand font's classification.**
-Use the SAME class of typeface for the fallback so visual rhythm is preserved during the load:
-- Sans-serif brand → fallback `arial, sans-serif`. Override `@font-face "Arial"` with `local("Arial")`.
-- Serif brand → fallback `times, "Times New Roman", serif`. Override `@font-face "Times New Roman"` with `local("Times New Roman")`.
-- Monospace brand → fallback `"Courier New", courier, monospace`. Override `@font-face "Courier New"` with `local("Courier New")`. (Note: skipping monospace metric-matching is acceptable when the mono font is only used in small eyebrows/labels — CLS impact is negligible. Document the choice in the conversion log.)
-
-Never substitute classifications (don't match a serif brand to Arial; don't match a sans brand to Times). Even with metric overrides, character widths and rhythm differ enough that the visible shift is jarring.
-
-**Classification includes WIDTH — a condensed/narrow display face needs a condensed fallback, never plain Arial (#80).** "Sans→Arial" is only right for a *normal-width* sans. A narrow/condensed display face (PP Formula Narrow, Bebas Neue, Oswald, Barlow/Archivo Condensed, Anton) falling back to plain Arial is a width-class mismatch: Arial runs **~15–20% wider** with different letterforms, so headings lose the condensed character and wrap differently — a silent divergence the eye catches even when sizes/weights/tracking match exactly (a CardValet pass shipped PP Formula→Arial; the width probe showed Arial 975 vs PP Formula 839 for the same H1 string). When the condensed brand face is self-hosted (principle 2, now the default) this only bites if the webfont is blocked, but the fallback must STILL preserve width: put a condensed system/free face ahead of `arial` in the stack — `"<Brand>", "Arial Narrow", arial, sans-serif` (system `Arial Narrow` is present on macOS/Windows but NOT Android/Linux, so for guaranteed coverage self-host a free OFL condensed analog — Oswald / Barlow Semi Condensed / Archivo Narrow). Same logic for an *extended/wide* brand face. Quick check during foundation: for every `--*-font-family` token whose first face is condensed, confirm the final non-`sans-serif` fallback is also condensed.
-
-**Self-host the prototype's INTENDED fallback, not its accidental system render — and verify with a width probe, never `document.fonts.check` (#77).** Prototypes routinely load **zero `@font-face`** and name a proprietary brand font first (`--display: "Bellfort", "Bebas Neue", system-ui`). On any machine missing the brand font the prototype silently renders **system-ui** — so its on-screen display face is an *accident of the viewing machine*, not the design intent. Do NOT match that accident (don't set EDS `--display` to system-ui because "that's what the proto shows"). The prototype's OWN stack documents the intent: self-host the first **redistributable** fallback (OFL/Apache — e.g. Bebas Neue) so EDS ships the condensed display face the design wants; keep proprietary families documented in the conversion log. **Verify what actually rendered with a width probe** — `document.fonts.check('24px "X"')` returns **true for any family name the page references**, installed or not, so it produces false "fonts match" reads. Instead measure: a span at `font-family:"X",monospace` whose width equals a known-absent name's width means X fell back (absent); a distinct width means X is really rendering. (A beermaker pass set `--display` to Bebas Neue via a `fonts.check` false-positive — the width probe later showed the proto actually renders system-ui, but Bebas Neue was still correct as the documented intended fallback.)
-
-**Multiple display families (#12).** A brand may use several families — e.g. Barlow (body) + Barlow Condensed + Barlow Semi Condensed (display). The `body.session` pattern only gates the **body** family; display families referenced directly by class (headings, eyebrows) load with `font-display: swap` and aren't fully CLS-eliminated. Define each as a `:root` token (`--font-cond`, `--font-semi`) and reference it per-block on the elements that use it. Fully metric-matching every display family is optional polish — for display text used sparingly (eyebrows, big condensed headings) the CLS impact is small; **document the trade-off** in the conversion log rather than over-engineering it. **But when a display family is used in an ABOVE-THE-FOLD heading (the hero `<h1>`, an LCP title), metric-match it too** — compute its `size-adjust`/`ascent-override`/`descent-override` from the woff2 (the same fonttools recipe as #11) and put a dedicated fallback `@font-face` SECOND in that family's stack: `--hero: "Lilita One", "Lilita One Fallback", …`. The fallback family MUST have its own name — do NOT reuse the renamed `"Arial"` face the body match already defines (#11), since that carries the *body* font's metrics, not the display font's. (Note: in practice the dominant first-section CLS is usually the late header box, #81, not the display-font swap — fix the header reservation first, then metric-match above-fold display faces to zero the remainder.)
-
-**Match the prototype's effective weight (#22).** A single-weight display font (e.g. **Anton**, ships only 400) often appears *bolder* in the prototype than its one weight: a bare `<h1>`/`<h2>` inherits the browser-default heading weight (700), and the browser **faux-bolds** the 400-only face. If your foundation sets `h1,h2,h3 { font-weight: 400 }`, headings render visibly lighter than the prototype. Set the weight the prototype actually shows (often 700) so the faux-bold matches — don't assume "one weight in the file ⇒ `font-weight: 400`".
+- **#65 — Ship an `@font-face` for EVERY named family, not just the body face.** An un-shipped display family silently falls back to Times/Arial, invisible to size/color checks. Gate: grep every quoted family in `styles.css` stacks against declared `@font-face { font-family }` names — any unmatched name fails.
+- **1. `head.html` untouched. No font lines, period** — no Google Fonts `<link>`, no CDN stylesheet, no `@font-face` `<style>`, **no `<link rel="preload" as="font">`**. All `@font-face` lives in `styles/styles.css`.
+- **2. Self-host EVERY brand face — proprietary included — and emit a licensing alert (#80).** OFL/Apache → self-host (fontsource latin woff2, 30–60 KB). Proprietary → self-host anyway for fidelity (convert the prototype's `.otf`/`.ttf` to woff2 with fontTools) BUT surface the licensing obligation in THREE places: `styles.css` banner comment, `styles/fonts/LICENSING.md`, conversion log + hand-off message; document the remove-and-fall-back path. Never a silent Arial degrade; keep a CDN load only when the files are unobtainable (document the coupling).
+  - **#30:** match the axes the prototype loads — an `opsz` axis needs the opsz fontsource file, or headings render subtly off.
+  - **#11:** non-variable families (Barlow, Anton…) → static `@fontsource/<name>` per weight, and **compute** the metric overrides from the woff2 with fonttools (no published Fallback face).
+- **3. `body.session` pattern with a metric-matched fallback `@font-face`.** The brand font must NOT render at first paint:
+  ```css
+  @font-face { font-family: "<Brand>"; src: url("/styles/fonts/<brand>-variable.woff2") format("woff2"); font-weight: 100 900; font-display: swap; }
+  /* System-font metrics overridden to the brand font's line box. Naming it after
+     the system font makes every stack reference pick it up site-wide. */
+  @font-face { font-family: "Arial"; src: local("Arial"); size-adjust: <X>%; ascent-override: <Y>%; descent-override: <Z>%; line-gap-override: 0%; }
+  :root { --font-body: "<Brand>", arial, sans-serif; }
+  body { font-family: arial, sans-serif; }
+  body.session { font-family: var(--font-body); }
+  ```
+  Lift `size-adjust`/`ascent-override`/`descent-override` verbatim from the fontsource package's published `<Name> Fallback` face (recipe in the reference). Result: zero shift at session-activate and at brand-font load.
+- **#40 — keep `body` VISIBLE; never port `body { display:none } body.appear { display:block }`** — the static-chrome runtime never adds `appear`, so every off-pipeline render (harness, visual-diff) stays blank and silently passes most checks.
+- **4. Match the fallback to the brand font's classification.** Sans → metric-overridden `"Arial"`; serif → `"Times New Roman"`; mono → `"Courier New"` (skipping mono metric-match is fine for small labels — document it). Never cross classifications.
+  - **#80 — classification includes WIDTH:** a condensed/narrow display face needs a condensed fallback (`"<Brand>", "Arial Narrow", arial, …`, or a self-hosted OFL condensed analog for Android/Linux coverage) — plain Arial runs ~15–20% wider and rewraps headings. Gate: every condensed `--*-font-family` token has a condensed non-generic fallback.
+  - **#77 — self-host the prototype's INTENDED fallback, not its accidental system render**, when the named brand font never loads anywhere (the proto's own stack documents intent — take its first redistributable face). **Verify rendered faces with a width probe, never `document.fonts.check`** (it returns true for any referenced name).
+  - **#12 — multiple display families:** define each as a `:root` token, reference per-block; metric-matching every display family is optional polish (document the trade-off) — **but metric-match any family used in an ABOVE-THE-FOLD heading**, with its own dedicated fallback name (never reuse the body's `"Arial"` face — wrong metrics).
+  - **#22 — match the prototype's EFFECTIVE weight:** a single-weight face (Anton, 400-only) is usually faux-bolded by the browser-default heading weight 700 — set the weight the prototype shows, don't assume `400`.
 
 ### 5. Lean on EDS button conventions — DO NOT manufacture button anchors in block JS
 
-The EDS link decorator in `scripts/ak.js` (`decorateButton()`) automatically applies button classes when authors wrap a link in inline emphasis. This runs during page boot, AFTER block JS. Block JS just needs to clone the cell anchor as-is.
-
-**Author markup → auto-applied class:**
+`decorateButton()` in `scripts/ak.js` applies button classes from the author's inline emphasis, AFTER block JS:
 
 | Author markup | Class applied | Visual |
 |---|---|---|
-| `<strong><a>` | `.btn.btn-primary` | wavelength fill, dark text |
+| `<strong><a>` | `.btn.btn-primary` | brand fill |
 | `<em><a>` | `.btn.btn-secondary` | transparent + outline (color-aware) |
 | `<em><strong><a>` | `.btn.btn-accent` | canvas fill on dark surfaces |
 | `<del><a>` | `.btn.btn-negative` | rare; destructive |
 | `+ <u>` inside any | adds `.btn-outline` | transparent variant |
 | 2+ buttons in same parent | parent gets `.btn-group` | flex with gap |
 
-**Add to `styles/styles.css`** (the project's brand button system):
+- **Add the brand button system to `styles/styles.css`** — before writing it, READ `reference/encode-contract.md` § Buttons for the worked CSS (base `a.btn`, primary/secondary, light-surface overrides, trailing arrow, `.btn-group`).
+- **Block JS just clones the cell** — never `cta.className = 'btn-loud'`, never inject custom SVG arrows:
+  ```js
+  const ctaCell = rows[N]?.firstElementChild;
+  if (ctaCell && ctaCell.querySelector('a')) {
+    const actions = document.createElement('div');
+    actions.className = 'actions';
+    [...ctaCell.childNodes].forEach((n) => actions.append(n.cloneNode(true)));
+    container.append(actions);
+  }
+  ```
+- **Block CSS overrides only what's actually different** (e.g. `.closing .actions a.btn-primary { padding: 22px 32px; }`) — target the global class, never a custom one.
+- **#41 — surface-aware variants scope to the BLOCK class, not just the section:** `main .section.hero a.btn-secondary` never matches post-conversion (the block class is one level below `.section`) → on-dark CTAs silently render dark-on-dark. Write `main .section.dark …, main .hero … { }` and eyeball-QA every dark-surface CTA for contrast.
+- **Not every link is a button:** styled text links, whole-card tile anchors, `tel:`/`mailto:` channel values stay plain `<a>` (no emphasis wrap); the owning block styles them.
+- **#25 — more variants than primary/secondary/accent?** Don't force emphasis: lift the prototype's full `.btn` + variant system into `styles/styles.css`, author plain `<a>`, and let each block apply its `btn btn--<variant>` class to the cloned anchor.
 
-```css
-a.btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 16px 26px;
-  font-size: 12px;
-  font-weight: var(--weight-bold);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  border: 1px solid transparent;
-  transition: background 0.25s var(--ease-out), color 0.25s var(--ease-out), border-color 0.25s var(--ease-out);
-}
+### Page templates (page-level CSS a block cannot own)
 
-a.btn-primary { background: var(--color-wavelength); color: var(--color-ink-rich); border-color: var(--color-wavelength); }
-a.btn-primary:hover { background: var(--color-canvas); border-color: var(--color-canvas); }
-
-a.btn-secondary { background: transparent; color: currentcolor; border-color: rgb(255 255 255 / 40%); }
-a.btn-secondary:hover { border-color: currentcolor; background: rgb(255 255 255 / 5%); }
-
-/* On light surfaces, secondary uses dark-tinted outline. List the dark sections explicitly. */
-main .section:not(.dark, .closing, .hero, .team) a.btn-secondary { border-color: var(--color-rule-strong); color: var(--color-ink-rich); }
-main .section:not(.dark, .closing, .hero, .team) a.btn-secondary:hover { border-color: var(--color-ink-rich); }
-
-/* Trailing arrow on primary/accent. */
-a.btn-primary::after, a.btn-accent::after { content: "→"; font-weight: 600; transition: transform 0.3s var(--ease-out); }
-a.btn-primary:hover::after, a.btn-accent:hover::after { transform: translateX(4px); }
-
-.btn-group { display: inline-flex; flex-wrap: wrap; gap: 16px; align-items: center; }
-```
-
-**Surface-aware variants: scope to the BLOCK class, not just the section (#41).** When a button/link/text treatment differs on dark vs light surfaces, the prototype's dark-surface cue (e.g. `.hero`, `.cta-dark`) becomes a **block class** after conversion — a `<div class="hero">` nested inside the `<div class="section">`. So an override written as `main .section.hero a.btn-secondary` never matches (the `.hero` is one level below `.section`), and the on-dark CTA silently renders dark-on-dark. Scope on-dark overrides to BOTH: `main .section.dark a.btn-secondary, main .hero a.btn-secondary { … }`. QA any block on a dark background for secondary/ghost-CTA contrast (light outline + light text) — the button "exists" in metrics, so only contrast/eyeball catches this.
-
-**Block JS pattern — just clone the cell:**
-
-```js
-// Get the cell that holds the CTAs
-const ctaCell = rows[N]?.firstElementChild;
-if (ctaCell && ctaCell.querySelector('a')) {
-  const actions = document.createElement('div');
-  actions.className = 'actions';
-  [...ctaCell.childNodes].forEach((n) => actions.append(n.cloneNode(true)));
-  container.append(actions);
-}
-```
-
-DO NOT manufacture anchors with `cta.className = 'btn-loud'` or inject custom SVG arrows. The global `::after` arrow + the convention's class system handle 95% of cases.
-
-**Block CSS pattern — only override what's actually different:**
-
-The `closing` block's CTA is slightly larger than the global default. That's a legitimate override:
-
-```css
-.closing .actions a.btn-primary { padding: 22px 32px; font-size: 13px; }
-```
-
-Three lines. Targets the global class, not a custom one. This is the entire "blocks slightly augment defaults" pattern.
-
-**When NOT to use the convention:**
-
-Some links are NOT buttons. Examples:
-- A wavelength-underlined text link in a section footer ("How we work →"). It's a styled text link, not a chip.
-- Whole-card anchors on tile grids (`<a class="tile">…</a>`). The whole tile is the click target.
-- Channel values in a closing CTA (`<a href="tel:…">801-363-0101</a>`). It's a value, not a CTA.
-- `mailto:` / `tel:` links inside prose.
-
-For these: the author leaves the `<a>` as a plain anchor in content (no `<strong>` / `<em>` wrap), and the owning block styles it with per-block CSS. The convention is for buttons; if it's not a button, don't apply it.
-
-**Multi-variant button systems (#25).** The strong/em convention only names three slots (primary / secondary / accent). When a prototype has **more** context-specific variants than that — e.g. JFK's `.btn--accent` (yellow), `.btn--primary` (blue), `.btn--ghost` (outline), `.btn--onblue` (white-on-blue) — author emphasis can't express them. Don't force it: **lift the prototype's full `.btn` + variant system into `styles/styles.css`**, author the CTAs as plain `<a>` in content, and have each block apply the right `btn btn--<variant>` class to the cloned anchor (the block knows its section's variant). This is the same "if it doesn't fit, style it" escape hatch, applied at the button-system level rather than per-link.
+Some page-level treatments — a per-page ground inversion (cream docs body on an
+ink site), a fixed-rail offset (`main { padding-left: 240px }`), chrome-state
+overrides — cannot live in a block (a block cannot restyle sibling sections)
+and must NOT go in `styles/styles.css` (foundation is site-wide). The home for
+them is a **template**: a metadata row `Template: <name>` in the content page →
+the pipeline emits `<meta name="template">` → AuthorKit `loadTemplate()` loads
+`/templates/<name>/<name>.css` and adds body class **`<name>-template`** (note
+the `-template` suffix — scope selectors to `body.<name>-template …`).
+Specificity warning: a template rule like `body.x-template :focus-visible`
+(0,2,1) silently outranks a block's `.block :focus-visible` (0,2,0) — scope
+template pseudo-class rules narrowly or blocks lose their focus styling
+(same silent-failure family as #41). Harness parity: `build-harness.mjs`
+strips the metadata block, so re-inject `<meta name="template" content="<name>">`
+into the harness head or the template CSS never loads and every ground/color
+assert reads wrong.
 
 ### 6. Static header + footer fragments
 
-Header and footer are **static fragments** — extracted verbatim from the prototype with their full DOM and styles intact. No EDS authoring, no block JS parsing. They are stored in `fragments/header.html` and `fragments/footer.html` at the repo root and committed to GitHub as code.
+Header and footer are **static fragments** — prototype DOM + styles verbatim, no EDS authoring, no block JS parsing — at repo-root `fragments/{header,footer}.html`, committed as code. Format: a `<style>` tag (scoped rules incl. all breakpoints) followed by the raw DOM. No `<!DOCTYPE>`/`<html>`/`<body>`. `scripts/postlcp.js` fetches them from the code origin and injects via `innerHTML`.
 
-**Fragment file format:**
+Extraction rules:
+1. Copy the header DOM (utility bar + topnav) and footer DOM from any prototype (shared across pages).
+2. Collect their CSS from `_tokens.css` + page `<style>` blocks, incl. responsive breakpoints, into the fragment's `<style>`.
+3. **Lift the chrome element's OWN box styles (#31)** — `margin`/`padding`/`border` on the prototype's `<header>`/`<footer>` element — onto `header.header`/`footer.footer`; the last-section↔footer gap comes entirely from the footer's own top margin, easy to miss.
+4. Rewrite relative asset paths to fully-qualified code-origin URLs (`https://main--<repo>--<owner>.aem.page/…`); rewrite relative link hrefs to root-relative (`/donate`). (On branch-hosted pages, relative fragment paths resolve to the branch automatically.)
 
-```html
-<style>
-  /* Scoped styles lifted from the prototype's _tokens.css and page <style> */
-  .utility { background: var(--color-ink); ... }
-  nav.topnav { position: sticky; ... }
-  .nav-inner { ... }
-  /* Include responsive breakpoints */
-  @media (max-width: 900px) { ... }
-</style>
-<!-- Full prototype DOM, copied verbatim -->
-<div class="utility">...</div>
-<nav class="topnav">...</nav>
-```
+**Fragments cannot run JavaScript** (`innerHTML` injection = inert `<script>`). Re-implement interactive chrome CSS-only, and document anything dropped in the conversion log:
+- Mobile menu/drawer → checkbox-hack (`<input type="checkbox" id="mnav-toggle">` + `<label for>` open/close/scrim + `#mnav-toggle:checked ~ #mnav { … }`).
+- Scroll-state shadow / sticky color change → drop (keep a static border) or CSS scroll-driven where supported. Never reattach JS.
+- **Forms / inline `on*` handlers (#20):** EDS's CSP (`strict-dynamic` makes `'unsafe-inline'` ignored) means inline handlers never fire and a real `<form>` submits+reloads. Render non-submitting: `<div>` wrapper (no `<form>`) + `<button type="button">`.
 
-No `<!DOCTYPE>`, no `<html>`, no `<body>` wrapper. Just the raw `<style>` + DOM. The EDS runtime injects it directly into the page's `<header>` or `<footer>` element via `innerHTML`.
-
-**Extraction rules:**
-
-1. Copy the header DOM (utility bar + topnav) from any prototype — it's shared across all pages.
-2. Copy the footer DOM from any prototype — also shared.
-3. For each fragment, collect the relevant CSS rules from the prototype's `_tokens.css` and any page `<style>` blocks. Include all responsive breakpoints.
-3b. **Lift the chrome element's OWN box styles (#31)** — `margin`, `padding`, `border` set on the prototype's `<header>`/`<footer>` element itself — onto `header.header` / `footer.footer`, not just the inner content styles. The fragment injects into the EDS `<header>`/`<footer>`, which sit OUTSIDE `<main>`, so the gap between the last section and the footer comes entirely from the footer's own top margin (e.g. `footer { margin-top: 72px }`). Easy to miss: the inner content looks right while the footer sits flush against the last block.
-4. Scope the CSS inside a `<style>` tag at the top of the fragment file.
-5. Rewrite relative asset paths (e.g. `../assets/logo.png`) to fully-qualified URLs on the code origin: `https://main--<repo>--<owner>.aem.page/path/to/asset`.
-6. Rewrite relative link hrefs (e.g. `donate.html`) to root-relative paths (e.g. `/donate`) matching how EDS serves pages.
-
-**Loading mechanism:** `scripts/postlcp.js` fetches `fragments/header.html` and `fragments/footer.html` from the code origin (`codeBase`) and injects via `innerHTML`. On branch-hosted pages (`<branch>--repo--org.aem.live`), relative paths resolve to the correct branch automatically.
-
-**Fragments cannot run JavaScript.** Because the fragment is injected via `innerHTML`, any `<script>` inside it is inert — the prototype's header JS (mobile-menu toggle, scroll-state shadow, dropdown logic) will NOT run. Re-implement interactive chrome as **CSS-only**:
-- **Mobile menu / drawer** → checkbox-hack: a visually-hidden `<input type="checkbox" id="mnav-toggle">` as the first element, `<label for="mnav-toggle">` for the open button and the close button and a full-screen scrim label, and CSS `#mnav-toggle:checked ~ #mnav { … }` to drive the open/close state and the panel transform.
-- **Scroll-state shadow / sticky color change** → drop it (keep a static border), or use a CSS scroll-driven approach where supported. Don't try to reattach JS to the fragment.
-- **Forms / inline `on*` handlers (#20)** → EDS's delivered CSP is `script-src 'nonce-…' 'strict-dynamic' 'unsafe-inline'`; with `strict-dynamic`, `'unsafe-inline'` is **ignored**, so inline `onsubmit`/`onclick` never fire. A real `<form>` would then submit and reload the page. Render such controls **non-submitting**: a `<div>` wrapper (no `<form>`) with `<button type="button">`. (Same root cause as the no-`<script>` rule — fragments are inert.)
-- Document anything you dropped in the conversion log.
-
-**Footer reconciliation (see #4).** The AuthorKit `lazy.js` also tries to load the footer as a *block* (`utils/footer.js` → `loadBlock(footer)`), which collides with the static footer fragment and renders an error box. Make sure the Runtime-bootstrap edit removing that import has been applied.
-
-**Fragment root class (#26).** `postlcp.js` sets the host element's class to `header` / `footer`. If the prototype's chrome styling is keyed to a *different* root class (e.g. JFK's `.utilnav` / `.site-footer`), wrap the fragment content in a `<div class="<that-class>">` so the lifted root selector matches — `header.header` / `footer.footer` is only the host. (Don't nest another `<header>`/`<footer>` inside the host element; use a `<div>`.)
-
-**`header: off` / `footer: off`:** To suppress header/footer on a specific page, add a metadata block with `header: off` or `footer: off`. The loader checks `getMetadata('header')` / `getMetadata('footer')` before fetching.
+More rules:
+- **Footer reconciliation (#4):** verify the Runtime-bootstrap edit removed `lazy.js`'s `utils/footer.js` import, or the footer double-loads as an error box.
+- **Fragment root class (#26):** `postlcp.js` sets the host class to `header`/`footer` only. Chrome styling keyed to a different root class (`.utilnav`, `.site-footer`) → wrap the fragment content in `<div class="<that-class>">` (never nest another `<header>`/`<footer>`).
+- **`header: off` / `footer: off`** in a page's metadata block suppresses chrome on that page (the loader checks `getMetadata()` before fetching).
 
 ### 7. Blocks (parallel agents)
 
-Dispatch one agent per page-archetype cluster (utility pages, services, case studies, etc.). Each agent owns a non-overlapping set of new blocks and content pages. Three to four parallel agents is the sweet spot.
+Dispatch one agent per page-archetype cluster (utility pages, services, case studies…), each owning a non-overlapping set of blocks + content pages. Three to four parallel agents is the sweet spot; they don't coordinate — the brief tells them what to reuse.
 
 The brief template:
 
-> Per the project's locked direction: each prototype `<section>` becomes its own EDS block. Lift the prototype's `<style>` for that section verbatim, scope it under the block class (`.block-name .x` instead of `section.x .y`), and rebuild the prototype's DOM through a `decorate(block)` function that consumes EDS table-block input.
+> Per the project's locked direction: each prototype `<section>` becomes its own EDS block. Lift the prototype's `<style>` for that section verbatim, scope it under the block class (`.block-name .x`, not `section.x .y`), and rebuild the prototype's DOM through a `decorate(block)` function that consumes EDS table-block input.
+>
+> **READ FIRST — mandatory, before writing any block code:** (1) `skills/deploy/reference/decode-disciplines.md` — apply EVERY discipline (#42–#79: query-don't-index, flatten-first collector, segmentation order, delimiter decode, idempotent markers, eyebrow buffering…); (2) `skills/deploy/reference/encode-contract.md` — authoring shapes, image handling, section-head reabsorption, button CSS; (3) SKILL.md § Step 8 (scaffold + canonical `collectNodes`) and § The ENCODE contract (the one-line rules you must satisfy).
 >
 > **You own**: prototypes [list], content pages [list], sections [list].
->
 > **Existing blocks — REUSE, do not recreate**: [list with one-line authoring shape per block].
->
 > **Brand tokens** are global in `styles/styles.css`; do not redefine.
->
-> **Section layout — reproduce the prototype's max-width container (#13)**: if the prototype section wraps its content in a centered max-width container (`<div class="wrap">` / `.container` / `.inner`), your block MUST recreate it — build the content into a `.wrap` div (`block.replaceChildren(wrap)`), so the colored/section background bleeds full-width but the **content** stays within the page max-width. Only render content edge-to-edge where the prototype section itself is full-bleed (no inner wrapper). Getting this wrong is invisible at ≤1440px and only shows at wide viewports.
->
-> **Images — `<image-slot>` placeholders (#2)**: claude-design prototypes use `<image-slot>` custom elements as image drop-targets; there are usually NO real image assets. Treat each image as an **optional** authored cell holding a `<picture>`/`<img>` (`const pic = cell.querySelector('picture, img'); if (pic) …`). When the cell is empty, fall back to the prototype's background treatment (e.g. dark `--ink`, or a placeholder rectangle) via the block CSS so the section still looks right with no image. Leave image cells EMPTY in the authoring snippet.
->
-> **Scroll-reveal / JS-hidden content (#14)**: if the prototype hides content behind a class an inline `<script>` toggles on scroll (`.reveal { opacity:0 }` + an IntersectionObserver that adds `.in`), do NOT lift the `opacity:0` — the prototype script does not run in EDS, so the content would be **permanently invisible**. Render it visible; drop the reveal (keep only hover/`:hover` transitions). Honor `prefers-reduced-motion`.
->
-> **Interactive / component-driven sections (#17)**: when a section is driven by a component (state, a list loop like `<sc-for>`, conditionals like `<sc-if>`, `{{ }}` bindings, a `data-count` counter, a tab/selector), split it: **data → authorable rows** (one row per list item, with the item's fields as cells) and **behavior → block JS**. Unlike static *fragments*, **block JS runs** — so `decorate()` is the right place to wire click handlers, an IntersectionObserver count-up, tab switching, etc. Render the default/active state in markup; drive the rest from JS-held local state. `{{ }}`/`<sc-for>`/`<sc-if>` are NOT EDS syntax — read them as "loop these rows" / "show one state".
->
-> **Buttons**: do NOT manufacture button anchors. Author CTAs as `<strong><a>` (primary) or `<em><a>` (secondary) in the content page; in block JS, clone the cell's child nodes into a `.actions` wrapper. Block CSS only overrides global button styles when something is genuinely different (e.g. larger size). Text links with flourish (wavelength underline) are NOT buttons — leave as plain `<a>` and style per-block.
->
-> **EDS block convention**: each block at `blocks/<name>/<name>.{js,css}`. JS exports `default async function decorate(block)`. Block input is `<div class="block-name"><div>row<div>cell</div></div>…</div>`. CSS scoped under `.block-name`. Inline SVG markup per-block (no shared utility). Honor `prefers-reduced-motion`.
->
-> **EDS content page format**: NO `<head>` element (project `head.html` is injected by EDS), empty `<header></header>`/`<footer></footer>`, each top-level `<div>` inside `<main>` is one section containing one block, no `<style>`/`<script>`/section-metadata, fully-qualified image URLs.
->
-> **Done criteria**: [list of paths]. Return a list of new blocks + one-line summary per page.
+> **Section layout (#13)**: if the prototype section wraps content in a centered max-width container (`.wrap`/`.container`/`.inner`), your block MUST recreate it (`block.replaceChildren(wrap)`) — background bleeds full-width, content stays constrained. Full-bleed content only where the prototype itself has no inner wrapper. Invisible ≤1440px — QA wide.
+> **Images (#2)**: claude-design prototypes use `<image-slot>` placeholders — usually NO real assets. Treat each image as an OPTIONAL authored cell (`cell.querySelector('picture, img')`); when empty, fall back to the prototype's background treatment via block CSS. Leave image cells EMPTY in the authoring snippet.
+> **Scroll-reveal (#14)**: never lift a JS-toggled `opacity:0` reveal — the prototype script doesn't run in EDS; content would be permanently invisible. Render visible; keep only `:hover` transitions; honor `prefers-reduced-motion`.
+> **Interactive sections (#17)**: component-driven sections (state, `<sc-for>`/`<sc-if>`/`{{ }}`, counters, tabs) split into data → authorable rows and behavior → block JS (block JS runs, unlike fragments). Render the default state in markup; drive the rest from JS-held local state.
+> **Buttons**: author CTAs as `<strong><a>` / `<em><a>`; clone cell child nodes into a `.actions` wrapper; never manufacture anchors. Text links with flourish are NOT buttons.
+> **EDS block convention**: `blocks/<name>/<name>.{js,css}`; JS exports `default async function decorate(block)`; input is `<div class="block-name"><div>row<div>cell</div></div>…</div>`; CSS scoped under `.block-name`; SVG inline per-block; honor `prefers-reduced-motion`.
+> **EDS content page format**: NO `<head>` (project `head.html` is injected), empty `<header></header>`/`<footer></footer>`, each top-level `<div>` in `<main>` is one section with one block, no `<style>`/`<script>`/section-metadata, fully-qualified image URLs.
+> **Done criteria**: [list of paths]. Return new blocks + one-line summary per page.
 
-Agents do not need to coordinate on shared blocks — the brief tells them which existing blocks to reuse.
+### 8. Block JS scaffold + decode disciplines
 
-### 8. Block JS scaffold
+**Before writing any block, READ `reference/decode-disciplines.md`** — each rule below is explained there with its failure signature and worked example. The one-liners here are the enforceable contract; violating any of them ships a silent 1-of-N/blank/scrambled render.
 
 ```js
 /**
  * <block-name> — <one-line description from prototype data-intent attribute>
- *
- * Authoring rows (positional):
- *   1. <picture> background image
- *   2. eyebrow text
- *   3. headline — render as a REAL heading element, never a bare <div>: the
- *      hero/lead block's headline becomes the page's single <h1>; every other
- *      section title becomes <h2> (sub-items <h3>). (use <strong> for emphasis)
- *   4. body paragraph
- *   5. CTA links — wrap primary in <strong>, secondary in <em>; the EDS link
- *      decorator applies .btn.btn-primary / .btn.btn-secondary
- *   6..N: card rows — cells: num | label | description
+ * Authoring rows (positional): 1. <picture> bg image · 2. eyebrow ·
+ *   3. headline — a REAL heading, never a bare <div>: hero/lead → the page's
+ *   single <h1>, other section titles <h2> (sub-items <h3>) · 4. body ·
+ *   5. CTAs (<strong><a> primary / <em><a> secondary; decorator applies classes) ·
+ *   6..N card rows — cells: num | label | description
  */
-
-function text(cell) { return cell ? cell.textContent.trim() : ''; }
-function pic(cell)  { return cell ? cell.querySelector('picture, img') : null; }
-
 export default async function decorate(block) {
   const rows = [...block.children];
   if (!rows.length) return;
-
-  // 1. Read content by QUERYING, not by hard row index, for lead/hero blocks (#42):
-  //    const h = block.querySelector('h1, h2');           // the heading
-  //    const ps = [...block.querySelectorAll('p')];
-  //    const lede = ps.find((p) => !p.querySelector('a')); // first link-free <p>
-  //    const ctaP = ps.find((p) => p.querySelector('a'));  // link-bearing <p>
-  //    const pic = block.querySelector('picture, img');
-  // 2. Build the prototype's DOM (with prototype-style class names)
-  // 3. For CTA rows, clone the cell's child nodes into a .actions wrapper —
-  //    do NOT manufacture button anchors with custom classes.
+  // 1. Read content by QUERYING/classifying (collectNodes below), not hard row indexes.
+  // 2. Build the prototype's DOM (prototype-style class names).
+  // 3. CTA rows: clone cell child nodes into a .actions wrapper (Step 5).
   // 4. block.replaceChildren(...newMarkup);
 }
 ```
 
-**Lead/hero blocks: query content, don't hard-index rows (#42).** A hero that reads `rows[3]=headline, rows[4]=lede, rows[5]=CTA` breaks the moment the content shape differs — and the mandatory-metadata / single-`<h1>` SEO rework (#34/#35) actively **consolidates** the headline + lede + CTAs into ONE cell, so the fixed indices come back `undefined` and the hero `.wrap` (the LCP element and the only `<h1>`) renders EMPTY with no error. Decorate lead blocks by querying (`block.querySelector('h1,h2')`; link-bearing `<p>` = CTAs; `picture` from anywhere) so they tolerate BOTH the rich multi-row shape and the consolidated single-cell shape. **Disambiguate eyebrow vs lede by ORDER/length, not "first `<p>`" (#51):** both are link-free `<p>`s, so "first link-free paragraph = lede" swaps them (the short eyebrow comes first). The canonical lead order is **eyebrow → heading → lede**: the eyebrow is the short/uppercase line *before* the heading; the lede is the sentence-length `<p>` *after* it. Local-QA check: after decoration, assert the hero's inner wrap is non-empty and contains the `<h1>`.
+The canonical CELL-LEVEL cascade collector (#62/#68/#71) — flatten-first is the DEFAULT:
 
-**When cloning a cell into your OWN heading element, UNWRAP the cell's heading first (#55).** If you build a live `<h1>` and clone a source cell's *childNodes* into it, and that cell wraps its text in its own `<h1>` (which #35/#42 actively encourage), you get `<h1><h1>…</h1></h1>` — a duplicate heading and a doubled font cascade. Always `const inner = cell.querySelector('h1,h2,h3,h4,h5,h6') || cell;` then clone `inner.childNodes`. Local-QA: exactly one `<h1>`, and 0 descendant headings inside the live headline.
-
-**Marker injection must be IDEMPOTENT (#70).** When `decorate()` PREPENDS a fixed decorative marker to authored heading/link text (a glyph `▶`, a badge, a `CH NN` number), first STRIP a matching leading occurrence from the cloned text node — `firstText.textContent = firstText.textContent.replace(/^\s*▶\s*/, '')` — because the author (or the #34/#35 SEO content rebuild) may already type it, so the marker doubles (`▶ ▶ Latest signal`). Apply the SAME strip at EVERY place the block injects that marker (section titles AND card links), not just some. (The visual-diff text-match catches a doubled glyph `X X …`.)
-
-**Carousel slide segmentation is HEADING-boundary driven and ORDER-AGNOSTIC (#69).** Segment slides ONLY on the heading boundary — one heading opens one slide (a leading `<picture>` before the first heading may open slide 0). Fold EVERYTHING between two headings into the open slide regardless of authored order (eyebrow/label may come AFTER the heading, not before): first non-link text run = eyebrow, links = CTAs, extra text = description. Never let a post-heading text node open a NEW slide (that steals the heading slot and the CTAs never attach — symptom: N+2 jumbled slides with 0 CTAs). Local-QA: rendered slide count == authored heading count AND each slide's CTA count == authored.
-
-**Split/photo-overlay segmentation: BUFFER the eyebrow that PRECEDES its heading (#76).** Heading-boundary segmentation (#52/#69/#73) opens a new group ON the heading — but in split panels and photo-overlay halves the eyebrow is the small label ABOVE the title, so it arrives BEFORE the heading and a "start collecting after the heading" loop drops it entirely. Worse, the body line after the heading then falls into the now-empty eyebrow slot (inheriting its accent/uppercase paint) and the next group's eyebrow bleeds into the prior group's teaser. Fix: keep a `pendingEyebrow` — any text seen before a heading is buffered and attached to the group that heading opens; once a group already has its body/CTA, further bare text re-buffers as the NEXT group's pending eyebrow (not this group's teaser). This complements #69 (carousel eyebrow may come AFTER the heading): don't hard-assume either order — buffer pre-heading text, classify post-heading text by what's already filled. The content is all in the DOM, so a count check passes while the render is scrambled — Local-QA: assert each group's eyebrow/heading/body/CTA land in their OWN slots (eyebrow text ≠ body text), not just that N groups exist. Hit on beermaker `the-people`.
-
-**Carousel/rotator lead: exactly ONE server `<h1>` across all slides (#57).** A rotating hero authors N slide headlines; if each is an `<h1>`, the delivered HTML has N `<h1>`s (the block may rotate a single live `<h1>` post-JS, but crawlers see all N). Author the **first/primary** slide's headline as the page `<h1>` and every other slide's headline as `<h2>` — the block reads them generically (`querySelector('h1,h2…')`) so the carousel still works, and the server HTML has one `<h1>` (#35). Local-QA: count `<h1>` in the *content* file = 1.
-
-**A multi-row head/intro must be collected whole, not just its first row (#56).** A block that takes "the first row with no image" as the head breaks when the head is authored as N separate single-cell rows (eyebrow / heading / CTA): only the eyebrow becomes the head and the section heading + CTA leak into the item grid as bogus cards (the section title then renders at card-title size). The head is **everything before the first content/image cell** — collect ALL leading no-image rows into the head. (Inverse of #52's flattening.) Local-QA: the item grid holds exactly the expected count, and the section heading renders at section-title size.
-
-**DEFAULT to the DA-flattened single-cell contract (#62 — the root cause of most decode bugs).** When block JS and the content page are generated in the same run, they MUST agree on the row shape — and DA delivers most blocks as ONE row with ONE cell holding all elements as flat siblings, NOT the rich multi-row layout the prototype implies. A block written to a multi-row index contract (`rows[0]=eyebrow, rows[1]=title, rows[2]=cards…`) then reads its whole cell as `rows[0]` and finds `rows[1..]` undefined — rendering 1-of-N (a jumbled hero, a card grid with one card) while passing lint. So make **flatten-first the default**, via a CELL-LEVEL cascade collector (#68/#71) — NOT a single selector and NOT a block-level fallback chain. The trap (#71): a block-level chain (try `:scope>div>div>*` on the whole block, else…) succeeds on the first tier whenever ANY cell has a child element, so in a block that MIXES element cells (`img`/`h1`/`a`) with text-only cells (eyebrow, lede, count, meta, date) it returns only the element cells and **silently drops every bare-text cell** — the most common one-element-per-row DA shape. The canonical collector iterates CELLS and recovers each:
 ```js
 function collectNodes(block) {
   const out = [];
   block.querySelectorAll(':scope > div > div').forEach((cell) => {
-    const kids = [...cell.children];
-    if (kids.length) out.push(...kids);
-    else if (cell.textContent.trim()) { const p = document.createElement('p'); p.textContent = cell.textContent.trim(); out.push(p); }
+    // walk childNodes, not children: a cell mixing bare text with inline
+    // elements (text + <strong>/<a> siblings) otherwise silently drops the
+    // text-node part (A/B-validation finding).
+    [...cell.childNodes].forEach((n) => {
+      if (n.nodeType === 1) out.push(n);
+      else if (n.textContent.trim()) { const p = document.createElement('p'); p.textContent = n.textContent.trim(); out.push(p); }
+    });
   });
   return out.length ? out : [...block.children]; // last-ditch: direct children
 }
 ```
-Then segment/classify the returned nodes by content; one-cell-per-row is a fallback. **Local-QA: assert every block's primary content container is non-empty post-decorate (childCount>0 / height>0)** — a 0-node selector mismatch otherwise renders a silent blank box (a blank hero only surfaces via a per-block height probe; testimonials surfaced as a CONTENT GAP). **Local-QA / Checklist assertion:** after `decorate()`, the rendered count must equal the authored count — the hero wrap is non-empty and has the `<h1>`; a card grid holds N cards (= N repeat-headings in source), never 1. Index-based contracts pass lint but silently render 1/N.
 
-**Card grids that alternate ground: reconstruct the rhythm by INDEX when no marker survives (#61).** A prototype encodes a grid's light/dark alternation structurally (the 2nd card has `--dark`), but that marker does NOT survive into DA content. A block that flips dark only on an explicit authored "dark" cell renders every card light — the dark card's white heading/CTA go invisible (caught by the #59 `SURFACE/GROUND MISMATCH` flag). Fallback to the positional pattern: `const dark = explicitMarker ?? (i % 2 === 1)`. Then scope on-dark button/text overrides to the resulting `.card.dark` block class (#41).
-
-**This applies to EVERY block, not just hero (#48).** The author's row/cell layout is rarely the contract the agent assumed — a block that hard-codes `rows[4] = <dl> data cell` silently drops content when the content authors one `dt|dd` pair per row instead, and a `[num]|[label]` two-cell assumption duplicates the eyebrow when the author wrote a single `"01 — Title"` cell. These are **silent**: the page still renders something, and the metrics-only diff (stretch/flush/blank) does NOT catch a dropped CTA, a duplicated eyebrow, or an empty data grid. Classify rows/cells by content — presence of a heading, a `<picture>`, a link, a number prefix (`/^\d+/`), a 2-cell `dt|dd` shape — never by `block.children[N]`. **When DA flattens content, it becomes "one line per row, delimiters carry structure" (#50) — so DECODE defensively.** (ENCODE is the opposite: when the generator controls authoring, do NOT invent delimiters — lead each sub-field with a preserved tag instead; see **The ENCODE contract**. A block parses delimiters only as a back-compat fallback.) DA/snowflake content rarely preserves the prototype's semantic `<dl>`/`<dt>`/`<dd>`/`<ol>`/`<ul>`/`<li>` — it flattens them to a sequence of single-cell `<p>` rows with INLINE delimiters: `Address: PLACEHOLDER · Brand team to supply` (key:value), `01 · Tabernacle · Imp. Stout · 6.5%` (`·`-delimited spec line), `Heber Valley · Utah · Est 1996` (a plain foot line). So a block that `querySelector('dl, dt')` or `'ol, ul, li'` finds NOTHING and silently drops the whole data table / spec list / menu. **Parse by delimiters, not tags:** split `Key: value` on the first colon into `dt`/`dd`; split `·`-delimited lines into spans; detect a list's start by its preceding heading (`On tap this week`), not an `<ol>`. (Even #48's "one `dt|dd` pair per row" misses this — the row is ONE cell, not two.) Checklist: for any table/spec-list/menu block, assert post-decorate that the data container has the expected non-zero row count.
-
-**Repeating card/tile grids: DA flattens N units into ONE cell — segment, don't iterate rows (#52).** A section that is a grid/band of N similar units (a 3-up card grid, a 2-up tile band, a logo row, a team grid) is very often collapsed by DA into a SINGLE cell of a SINGLE row, with each unit's elements (heading, picture, paragraphs, link) as flat siblings. A block written one-DOM-row-per-card then renders **0 cards** (the whole grid collapses into the section header) or **1** — silently dropping every other product/tile. Detect the flattened shape (`rows.length === 1` with multiple headings in the cell) and **segment the flat sibling list into one group per repeating heading**. The repeat-unit boundary is the **most frequent heading tag** in the cell (cards are `h3`; the lone section title is `h2` one level up) — segmenting on "any heading" turns the section title into a phantom first card. Support BOTH the flat-single-cell and the one-row-per-unit shapes. **Segmentation order (#63, #73):** (0) **one-row-per-card** — if ≥2 `:scope > div` ROWS each contain a card heading (`h3`/`h4`), build one group per ROW from `[...row.children]` in AUTHORED field order (treat leading non-card-heading rows as the section head); never assume a `tag → media → heading` field order — content authored `media → tag → heading` otherwise attributes each card's image to the PREVIOUS card and drops the first card's (a 1-of-N image shift that passes a card-COUNT check, #73); ELSE (1) per-card heading boundary if present; ELSE (2) **one card per delimited `<p>` line** — when the cards carry no per-card heading (only the section title), each card is a single `Name · meta · meta · Badge` line (the natural way to author a short card): split on the unit delimiter (`·`), first segment = name, a trailing keyword (`New`/`Limited`/`Sold out`…) = badge, the middle = meta; ELSE (3) one-row-per-unit. This unifies #50 (delimiter parsing) and #52 (card segmentation) for the headingless card/tile rail that falls between them (it silently renders 0 cards otherwise — the section heading still shows, so only the #49 CONTENT GAP / a card-count assert catches it). Local-QA: assert the grid count EVEN WHEN the block found no per-card headings (that's the case that returns 0), AND that each card's image src matches its OWN title (#73 — an image shifted by one passes a count-only check). **Never use `<picture>` as the PRIMARY card boundary (#64):** image-led prototypes tempt "the picture leads each card", but claude-design content is usually image-less (#2), so a picture-keyed split collapses N cards into 1. Segment on the per-card heading first; treat the picture only as a hint for which segment owns the media. (If a grid renders 1-of-N, suspect a picture-keyed boundary with no heading fallback.)
-
-**Classifiers must match the element ITSELF or a descendant (#53), and media must match `picture, img` (#72).** In the flattened shape the segmented "cells" are bare sibling elements (an `<img>`, an `<a>`, an `<h3>`), so `cell.querySelector('img')` returns null and the content silently vanishes. Classify with `el.matches(sel) || el.querySelector(sel)`. For MEDIA, always test `picture, img` (not just `picture`) — un-pipelined/harness content and pasted external URLs deliver a bare `<img>` with no `<picture>` wrapper: `const media = el.matches('picture, img') ? el : el.querySelector('picture, img')`. (Likewise A / `Hn`.)
-
-Always pair with a per-section screenshot eyeball (#23) and the `CONTENT GAP` probe flag (#49) — a heading/contentBox-count or main-height delta vs the proto means content was dropped or duplicated.
-
-**Headings — exactly one `<h1>` per page + a real outline (#35).** Prototype headlines are usually styled `<div>`/`<span>`s with no heading semantics. Promote them: the hero/lead block renders its headline as the page's **single `<h1>`**; every other section title renders as `<h2>` (sub-items `<h3>`). Never leave a headline as a bare `<div>` — the `<h1>` is the strongest on-page relevance signal, it's the source of the page `<title>` (#34), and the outline drives crawlers, AI answer engines, and screen readers (WCAG). This applies to **interactive blocks too**: a flow/quiz/dashboard renders its lead title as `<h1>` in its server-visible markup, not just after JS. (Symptom this prevents: a converted page with zero `<h*>` elements, or sibling `<h2>`s with no `<h1>`.)
-
-**Interactive blocks (#28).** When the prototype section is a stateful component (a selector, a filter, a form that mutates data, a multi-step flow), reproduce it as **one self-contained interactive block that owns the state** — block JS runs, so this is fully supported:
-- **Data → keyed authorable rows.** For heterogeneous data, key each row by its first cell (`account | id | name | …`, `txn | date | desc | …`) and parse by key. Homogeneous lists are just one row per item.
-- **Behavior → local state + targeted re-render.** Hold a mutable `state` object; write small `render*()` functions (e.g. `renderCards()`, `renderList()`) and re-invoke only the affected one on each interaction — the manual equivalent of a React re-render. A form that mutates data validates, updates `state`, re-renders the affected parts (cards, totals, `<option>`s), and shows a confirmation.
-- This mirrors lifting state to a parent in React: if several widgets share data, put them in **one** block rather than trying to sync state across blocks. (Cross-block coordination, if ever needed, is a DOM `CustomEvent`.)
-- **Sequential flow vs. addressable views — pick the right decomposition (#33).** A *sequential* flow whose views are entered from one starting point and are not independently addressable (search → results → seats → confirm; an onboarding wizard; a checkout) is **one block** with a `state.view` field and a `render()` dispatcher that `replaceChildren()`s the active view. This is the inverse of #29: *independently-addressable* views with **different chrome** become **multiple pages**. Rule of thumb — sequential-from-one-entry → one block; addressable-with-own-chrome → pages.
-- **QA the behavior, not just the paint** — see Local QA: drive each control and assert the state change. (When asserting computed style right after a click, move the pointer off the element and let CSS transitions settle first, or a mid-`transition`/`:hover` read gives a false negative.)
+Disciplines (terse; full narratives in the reference):
+- **#62/#68/#71 — DA delivers most blocks as ONE row/ONE cell of flat siblings.** Default to the collector above, then segment/classify by content; one-cell-per-row is the fallback. Never a block-level fallback chain (#71 — it silently drops every bare-text cell). QA: rendered count == authored count; every primary container non-empty post-decorate (childCount>0 / height>0).
+- **#42 — lead/hero blocks: query, don't hard-index rows** (`querySelector('h1,h2')`, link-bearing `<p>` = CTAs) — the #34/#35 SEO rework consolidates the head into one cell and fixed indexes render an EMPTY `<h1>`/LCP. QA: hero wrap non-empty, contains the `<h1>`.
+- **#51 — eyebrow vs lede by ORDER/length, not "first `<p>`":** eyebrow = short/uppercase line BEFORE the heading; lede = sentence-length `<p>` AFTER it.
+- **#55 — unwrap the cell's own heading before cloning into your live heading** (`cell.querySelector('h1,…,h6') || cell`) or you ship `<h1><h1>`. QA: one `<h1>`, 0 nested headings.
+- **#70 — marker injection is IDEMPOTENT:** strip a matching leading glyph/badge before prepending, at EVERY injection site — or authored markers double (`▶ ▶ …`).
+- **#69 — carousel slides segment on heading boundaries, ORDER-AGNOSTIC:** fold everything between headings into the open slide (eyebrow may come AFTER the heading); a post-heading text node must never open a new slide. QA: slide count == heading count; per-slide CTA count == authored.
+- **#76 — split/photo-overlay panels: BUFFER the pre-heading eyebrow** (`pendingEyebrow`) and attach it to the group its heading opens; once a group is filled, bare text re-buffers for the NEXT group. QA: each group's eyebrow/heading/body/CTA in their OWN slots, not just N groups.
+- **#57 — carousel lead: exactly ONE server `<h1>`** — first slide `<h1>`, others `<h2>`; block reads them generically. QA: `<h1>` count in the content file = 1.
+- **#56 — a multi-row head is EVERYTHING before the first content/image cell** — collect all leading no-image rows, or the section title leaks into the grid as a bogus card.
+- **#61 — alternating light/dark card rhythm: `explicitMarker ?? (i % 2 === 1)`** — the prototype's structural marker doesn't survive DA; scope on-dark overrides to the resulting `.card.dark` (#41).
+- **#48 — classify rows/cells by CONTENT on EVERY block** (heading / `<picture>` / link / `/^\d+/` / `dt|dd` shape), never `block.children[N]` — index contracts silently drop CTAs/duplicate eyebrows.
+- **#50 — DA flattens semantic lists to delimiter lines** (`Key: value`, `01 · Name · 6.5%`): parse by delimiters as decode fallback, never by `<dl>`/`<ol>` tags alone. QA: data containers have the expected non-zero row count.
+- **#52/#63/#73/#64 — card/tile grids: segment, don't iterate rows.** Boundary = the MOST FREQUENT heading tag (not "any heading"). Order: (0) one-row-per-card in AUTHORED field order (never assume `tag→media→heading` — #73's off-by-one image shift passes count checks); (1) per-card heading boundary; (2) one card per `·`-delimited `<p>` line (name / meta / trailing badge keyword); (3) one-row-per-unit. **Never `<picture>` as the PRIMARY boundary (#64)** — image-less content collapses N cards to 1. QA: grid count asserted even with no per-card headings; each card's image src matches its OWN title.
+- **#53/#72 — classifiers match the element ITSELF or a descendant** (`el.matches(sel) || el.querySelector(sel)`); media always tests `picture, img` (harness/pasted content delivers bare `<img>`).
+- **#79 — read plain-text fields by CELL/`textContent`, never `querySelectorAll('p')`** — the pipeline unwraps `<p>` in single-text cells; live drops what the harness shows. Assert each text field present (counts don't catch it).
+- **#35 — promote headlines to real headings:** one `<h1>` per page (hero/lead), `<h2>` sections, `<h3>` sub-items — interactive blocks included, in server-visible markup.
+- **#28 — interactive blocks: ONE self-contained block owns the state** — data as keyed authorable rows, behavior as local `state` + targeted `render*()`; shared data → one block, not cross-block sync. QA: drive each control and assert the state change.
+- **#33 — sequential-from-one-entry flow → one block** (`state.view` + `render()` dispatcher); independently-addressable views with different chrome → multiple pages (#29).
+- **#23/#49 — always pair with a per-section screenshot eyeball and the `CONTENT GAP` probe flag** — a heading/contentBox-count or main-height delta means dropped/duplicated content.
 
 ### 9. Content page scaffold
 
-**Every content page MUST begin with a `metadata` block (#34).** At minimum it carries a **Title** (~50–60 chars: brand + primary keyword/location, derived from the page's real `<h1>` — NEVER a block or section name) and a **Description** (~150–160 chars summarising the page). Skip it and EDS derives `<title>` from the first content cell — junk like `<title>Hero</title>` / `<title>Quiz</title>` — and emits no description; and because EDS **mirrors Title/Description into `og:`/`twitter:`**, that junk poisons social/AI share cards too. Authoring this one block resolves title, description, og:title, og:description, twitter:title and twitter:description at once. `header: off` / `footer: off` / `Robots` rows go in the same block when needed (the pipeline extracts the block wherever it sits in `<main>` — first or last). The static header/footer fragments still load automatically via `postlcp.js`; no other per-page configuration is required.
-
-**The content page is a DA *body fragment* (#7).** The DA Source API (the headless deploy path) requires the document to start at `<body>` — **no `<!DOCTYPE>`, no `<html>`, no `<head>`** (the pipeline injects head/scripts/styles from Code Bus). Emit exactly:
+- **Every page MUST begin with a `metadata` block (#34):** Title ~50–60 chars (brand + primary keyword/location, derived from the page's real `<h1>` — NEVER a block/section name) + Description ~150–160 chars. Skip it → EDS derives `<title>` from the first cell (`<title>Hero</title>`) and mirrors the junk into `og:`/`twitter:` cards. `header: off` / `footer: off` / `Robots` rows go in the same block (`<div><div>header</div><div>off</div></div>`; the pipeline finds the block anywhere in `<main>`).
+- **The page is a DA *body fragment* (#7)** — the Source API requires it to start at `<body>`: **no `<!DOCTYPE>`, no `<html>`, no `<head>`** (only the mount-based deploy tolerates a full document — it strips `<head>` on ingestion). Emit exactly:
 
 ```html
 <body>
@@ -666,227 +356,147 @@ Always pair with a per-section screenshot eyeball (#23) and the `CONTENT GAP` pr
         <div><div><strong><a href="/path">Primary CTA</a></strong> <em><a href="/path">Secondary CTA</a></em></div></div>
       </div>
     </div>
-    <div>
-      <!-- next section: its title decorates to <h2> -->
-    </div>
+    <div><!-- next section: its title decorates to <h2> --></div>
   </main>
   <footer></footer>
 </body>
 ```
 
-(Only the **mount-based** deploy tolerates a full `<!DOCTYPE html><html>…</html>` document — it strips `<head>` on ingestion. For the Source-API/`curl` path, emit the body fragment above. Before any DA write, run `node skills/deploy/scripts/sanitise.js <file>` to encode non-ASCII — `® · – —`, accents, emoji — to HTML entities, or DA corrupts them to U+FFFD.)
-
-To suppress header/footer on a specific page, add `header: off` and/or `footer: off` rows to that same `metadata` block:
-
-```html
-    <div>
-      <div class="metadata">
-        <div><div>header</div><div>off</div></div>
-      </div>
-    </div>
-```
-
-**Multi-view SPA → multiple pages (#29).** If the prototype is a single-page app with several views that have **different chrome** (e.g. a marketing home with a full nav vs. a signed-in dashboard with a minimal bar), convert **each view to its own EDS page** (pre-render each per #27) and link them with real hrefs. Since `postlcp.js` loads ONE shared `fragments/header.html` for the whole site, two different headers can't both be the fragment: keep the most representative header as the fragment, and on the other page set **`header: off`** (metadata above) and render that page's header as a **block** (`site-nav`) at the top of its content. Share the footer fragment if the footer is the same. (Harness caveat: the `metadata` block is consumed by the delivery pipeline into a `<head>` `<meta>`, but the local harness has no pipeline — so it won't apply `header: off` and will try to load `metadata` as a block, showing a stray error. Strip the `<header>` element from the harness to preview a header-off page; it's a non-issue live.)
-
-**Do NOT emit a `<head>` element.** EDS content pages are markdown-equivalent fragments: the document metadata (title, meta, stylesheets, scripts) lives in the project's `head.html`, which EDS injects at delivery time. A `<head>` block in a content page is dead weight at best and a duplication conflict at worst.
-
-When the prototype has **real** images, AUTHORED content `<img src>` URLs must point at a host the preview ingester can fetch — **prefer `https://content.da.live/{org}/{repo}/media/<scope>/<file>`** (branch-independent; upload the binary via the Source API first — see **The ENCODE contract → Images**). A fully-qualified `https://main--<repo>--<owner>.aem.page/…` also ingests but is branch-locked. **NEVER** a repo-relative `/img/…` in authored content — it delivers as `<img src="about:error">`. **This applies ONLY to authored content `<img>` — NOT to fixed assets referenced as CSS backgrounds from block JS/CSS (#67): those stay root-relative `/img/<brand>/…` (anti-pattern 9b), browser-fetched and never ingested.** When the prototype uses **`<image-slot>` placeholders** (no real assets — common for claude-design prototypes), leave the image cells EMPTY (`<div></div>`); the block CSS background fallback (Step 7) renders the section correctly without an image. The author drops real images in later.
+- **Before any DA write, run `node skills/deploy/scripts/sanitise.js <file>`** — non-ASCII (`® · – —`, accents, emoji) → HTML entities, or DA corrupts them to U+FFFD.
+- **Never emit a `<head>` element** — document metadata lives in the project `head.html`, injected at delivery; a content `<head>` is dead weight or a duplication conflict.
+- **Multi-view SPA → multiple pages (#29):** views with **different chrome** each become their own page (pre-render each per #27), linked with real hrefs. One shared `fragments/header.html` can't be two headers: keep the representative one as the fragment; the other page sets `header: off` and renders its header as a block (`site-nav`) at the top of its content. (Harness caveat for `header: off`: see `reference/decode-disciplines.md` § #29.)
+- **Real images:** authored `<img src>` must be ingester-fetchable — **prefer `https://content.da.live/{org}/{repo}/media/<scope>/<file>`** (branch-independent; upload the binary first — ENCODE contract § Images). A `main--<repo>--<owner>.aem.page` URL ingests but is branch-locked. **NEVER repo-relative `/img/…` in authored content** (→ `about:error`). **#67 — this rule is ONLY for authored content `<img>`:** fixed assets in block JS/CSS backgrounds stay root-relative `/img/<brand>/…` (anti-pattern 9b), browser-fetched, never ingested. `<image-slot>` prototypes → leave image cells EMPTY (`<div></div>`); the block's CSS fallback renders the section; the author drops real images later.
 
 ## Local QA before deploy (no DA)
 
-`aem up --html-folder content` is **not** a reliable way to preview new pages: it serves repo files statically and only renders a path through the full pipeline if that path is already in the remote routing index — brand-new paths 404 on the rendered route. To verify decoration locally, build a **self-contained harness** and open it through the dev server (which serves repo code at its real paths):
+`aem up --html-folder content` is NOT a reliable preview — brand-new paths 404 on the rendered route (only paths already in the remote routing index render through the pipeline). Build the harness instead:
 
 ```bash
-# 1. dev server (serves /scripts, /styles, /blocks, /fragments at their real paths)
+# 1. dev server (serves /scripts /styles /blocks /fragments at real paths)
 npx -y @adobe/aem-cli up --no-open &
-
-# 2. harness — use the committed helper (do NOT hand-roll the metadata strip, #46):
-#    it removes the metadata block by balanced tag-counting and rewrites absolute
-#    /img/ URLs to root-relative (#43), then emits the full harness doc.
-node skills/deploy/scripts/build-harness.mjs content/<path>.html qa/page.html   # qa/ is gitignored
+# 2. harness — use the committed helper; do NOT hand-roll the metadata strip (#46).
+#    It also rewrites absolute /img/ URLs to root-relative (#43). qa/ is gitignored.
+node skills/deploy/scripts/build-harness.mjs content/<path>.html qa/page.html
+#    (mkdir -p qa first — the helper does not create the output dir; the harness
+#    also emits no <header>/<footer> elements and strips the metadata block, so
+#    patch those back in when QA'ing fragments or a Template: page — see
+#    § Page templates. Programmatic .focus() does not match :focus-visible; use
+#    keyboard Tab when asserting focus styles.)
 ```
 
-Open `http://localhost:3000/qa/page.html` — `scripts.js` runs `loadArea()`, blocks load from the code origin, fragments inject via `postlcp.js`. Screenshot / inspect with headless Chrome (`--virtual-time-budget=9000 --screenshot` / `--dump-dom`) or Playwright.
+Open `http://localhost:3000/qa/page.html` (`loadArea()` runs, blocks load, fragments inject); screenshot/inspect with headless Chrome (`--virtual-time-budget=9000 --screenshot` / `--dump-dom`) or Playwright. Then run every gate; a failure loops back to the owning step:
 
-**Capture at a real viewport and scroll — not one giant window (#19).** A `min-height:100vh` hero becomes *window-tall* under a huge capture window (e.g. 7800px), pushing its centered content far down and off the top crop — it looks like the hero text vanished. Instead, use Playwright at a normal viewport (e.g. 1440×900) and `scrollIntoView()` each section before each screenshot.
-
-**Visually diff each section against the prototype (#23).** Programmatic checks (width, decoration counts, interactivity) pass things the eye catches — header alignment, intentional line breaks (`<br>`), heading **weight**, and a section root's **background/color** (e.g. a footer that should be a brand color but renders on the body background). Open the prototype itself (`<x-dc>`/JSX prototypes self-render from their file via their `support.js`/bundle) and the harness at the **same viewport, section by section**, and compare.
-
-**Drive interactive blocks and assert state changes (#28).** For any interactive block, don't stop at the static render — Playwright-drive each control and assert the result: click a selector/tab → expect the active item / filtered count to change; submit an invalid form → expect the error text; submit a valid one → assert the visible state changed (e.g. a balance went `$4,862.13 → $3,862.13`, a confirmation appeared). Run the same drive against the **deployed** preview too — block JS that worked in the harness can still trip on CSP or a missing dependency live.
-
-**Wide-viewport layout check (#13).** Always QA at a **wide** viewport (≥1600px), not just 1440 — a missing max-width container is invisible where the 1320 max ≈ the viewport. Measure each block's inner content width and flag anything spanning full width that shouldn't:
-
-```js
-// Playwright, viewport 1600: for each block, is the content constrained?
-for (const n of ['hero','quick','used','stats','service','offers','brands','locations']) {
-  const w = await page.evaluate((sel) => {
-    const inner = document.querySelector(`.${sel} .wrap`) || document.querySelector(`.${sel}`).firstElementChild;
-    return Math.round(inner.getBoundingClientRect().width);
-  }, n);
-  console.log(n, w, w > 1340 ? '<== FULL-WIDTH (check against prototype)' : '');
-}
-```
-
-Cross-check each flag against the prototype: full-bleed is correct only where the prototype section has no inner max-width wrapper.
+- **#19 — capture at a real viewport (e.g. 1440×900) and `scrollIntoView()` each section** — a giant capture window makes a `100vh` hero window-tall and its content looks vanished.
+- **#23 — visually diff each section against the prototype at the SAME viewport** (the prototype self-renders from its file). Programmatic checks miss header alignment, intentional `<br>`s, heading weight, and a section root's background/color. Mismatch → fix the owning block's CSS.
+- **#28 — drive every interactive block and assert state changes** (click tab → active item changes; invalid submit → error text; valid submit → visible state change). Re-run the same drive against the **deployed** preview — harness-green JS can still trip on CSP live. Let transitions settle before computed-style asserts.
+- **#13 — wide-viewport check at ≥1600px (not just 1440):** measure each block's inner content width; anything spanning full width that the prototype constrains is a dropped wrap → restore it. Probe snippet: `reference/decode-disciplines.md` § QA probes.
+- Per-block content asserts from Step 8 (counts, non-empty containers, single `<h1>`).
 
 ## Step 10 — Visual + structural diff & reconcile (optional, recommended)
 
-After deploy, reconcile the EDS page against the source prototype with **two complementary probes — run BOTH** (#78). They catch disjoint failure classes; either alone gives a false "looks fine":
+After deploy, reconcile against the prototype with **two complementary probes — run BOTH (#78)**; either alone gives a false "looks fine". Neither is a pixel diff (computed-style/geometry only; pixels are noise):
 
-1. **`skills/diff/scripts/visual-diff.mjs` — the PIXEL/layout probe.** Reasons about rendered geometry: stretched images (#36), dropped max-width wraps (#37), blank renders (#40), surface/ground colour flips (#59). Good at "this looks broken." STRUCTURALLY BLIND to "the right text is in the wrong slot" or "one CTA is gone" — those keep full pixels and plausible colours, so no flag fires.
-2. **`skills/diff/scripts/content-diff.mjs` — the STRUCTURAL content+type probe.** Extracts an ordered, role-classified inventory ({heading, eyebrow, cta+href, body}) from each `<main>` — classifying by computed style + tag so the prototype's `.ds-*` DOM and the EDS block DOM compare symmetrically — and DIFFS them: `MISSING CTA/HEADING/EYEBROW` (🔴 dropped content — caught the `the-place` CTA), `ROLE SWAP` (🔴 same text, wrong slot — caught the `the-people` eyebrow↔body scramble #76), `MISSING BODY`/`EXTRA` (🟡 placeholder→real-copy or invented prose), and `FONT FORK` (🟠 a matched line whose rendered FACE differs, by **width probe** not `document.fonts.check` — the #77 method, grouped into one advisory). This is the layer the pixel probe can't see.
-
-Neither is a pixel diff — both use computed-style/geometry measurements; pixels are noise (fonts, animation, dynamic mock data).
+1. **`skills/diff/scripts/visual-diff.mjs` — PIXEL/layout probe:** stretched images (#36), dropped wraps (#37), blank renders (#40), colour flips (#59). Structurally blind to wrong-slot text or a missing CTA.
+2. **`skills/diff/scripts/content-diff.mjs` — STRUCTURAL content+type probe:** ordered role-classified inventory ({heading, eyebrow, cta+href, body}) from each `<main>`, diffed — the layer the pixel probe can't see.
 
 ```bash
-# Prereq: a RENDERABLE prototype. Static → serve from its own dir so relative
-# ../assets resolve. JSX → pre-render first (#24/#27).
+# Prereq: a RENDERABLE prototype (serve its own dir; JSX → pre-render first, #24/#27).
 ( cd <prototype-dir> && python3 -m http.server 8791 & )
-
-node skills/diff/scripts/visual-diff.mjs \
-  "http://localhost:8791/<prototype>.html" \
-  "https://<branch>--<repo>--<owner>.aem.page/<path>" \
-  --profile eds --sections ".hero,.feature-tabs,.compare"   # optional per-section shots
-
-# Structural content + typography diff (same two URLs). Use the LIVE/harness EDS
-# URL so blocks are decorated; a raw content .plain.html has no roles to classify.
-node skills/diff/scripts/content-diff.mjs \
-  "http://localhost:8791/<prototype>.html" \
-  "https://<branch>--<repo>--<owner>.aem.page/<path>" \
-  --profile eds   # --json to dump both inventories
+node skills/diff/scripts/visual-diff.mjs "http://localhost:8791/<p>.html" \
+  "https://<branch>--<repo>--<owner>.aem.page/<path>" --profile eds --sections ".hero,.compare"
+node skills/diff/scripts/content-diff.mjs "http://localhost:8791/<p>.html" \
+  "https://<branch>--<repo>--<owner>.aem.page/<path>" --profile eds   # live URL, not .plain.html (--json dumps both inventories)
 ```
 
-Both probes are owned by the **`stardust:diff`** skill and share
-`skills/diff/scripts/diff-profiles.mjs`. The `--profile eds` flag supplies the EDS/DA remediation
-language used in the flag messages below; the comparison engines are stack-agnostic
-(`--profile generic` for non-EDS builds).
+Both probes are owned by the **`stardust:diff`** skill (`--profile generic` for non-EDS builds). Read the output — each flag names its fix:
 
-Read the output:
-- **Red flags (advisory)** — `BLANK RENDER` (hidden/empty page → #40, a `body{display:none}` gate or harness load failure — fix before trusting anything else); `IMAGE DID NOT LOAD` (rendered box, natural 0×0 → #43, the harness `<img>` 404'd); `STRETCHED IMAGE` (raster aspect ≠ natural → #36, add `height:auto`); `FLUSH-LEFT TEXT` (a left-anchored heading/para at left≈0 → #37, the owning block dropped its max-width wrap). A clean page prints "none".
-- **Harness images (#43):** when building the off-pipeline qa harness, rewrite absolute `…aem.page/img/...` `<img src>` to root-relative `/img/...` (the asset is committed locally) — otherwise the image 404s, natural dims are 0×0, and the stretch check silently skips.
-- **Metrics JSON** — compare `proto` vs `eds`: `eyebrows`/`headings` colors (catches #38 — a primitive styled in the prototype but dropped in one block), `images` dims, and `contentBoxes` (each block's content width + left offset; a wrapped block sits at left ≈ (viewport−maxw)/2 + padding, a dropped-wrap block at left ≈ 0).
-- **Screenshots** in the `--out` dir (default `qa/`): open the full-page pair and any per-section shots and confirm fidelity.
+- `BLANK RENDER` → #40 (`body{display:none}` gate or harness load failure) — fix before trusting anything else.
+- `IMAGE DID NOT LOAD` → #43: the harness `<img>` 404'd — rewrite absolute `…aem.page/img/...` srcs to root-relative `/img/...` in the harness or the stretch check silently skips.
+- `STRETCHED IMAGE` → #36 (add `height:auto`). **#45 — justified, leave the CSS, when** (a) it's an intentional `object-fit: cover` full-bleed, or (b) the SAME flag fires proto-side (a faithful lift); a real defect only when the proto renders natural AR and the EDS doesn't.
+- `FLUSH-LEFT TEXT` → #37: the owning block dropped its max-width wrap.
+- **Metrics JSON:** compare `proto` vs `eds` — eyebrow/heading colors (#38: a primitive styled in the proto, dropped in one block), image dims, `contentBoxes` (dropped-wrap blocks sit at left ≈ 0). Screenshots land in `--out` (default `qa/`) — eyeball them.
+- **#44 — pre-deploy URL gate:** `grep -rn "http://localhost\|aem\.page/img\|aem\.live/img" blocks/` MUST be empty (absolute origins pass local QA, 404 everywhere real).
+- `FONT MISMATCH` → #66: a family that loaded proto-side but not EDS-side = missing `@font-face` (#65) — ship the woff2 self-hosted.
+- `SURFACE/GROUND MISMATCH` → #59: heading luminance flipped dark↔light = a band on the wrong ground (#58) — check the owning block's section background.
+- **#54 — GAP flags are WHOLE-PAGE**, independent of `--sections`: `IMAGERY GAP` (#47) / `CONTENT GAP` (#49) may point at a different block than the one you scoped. Never dismiss as "outside my section" → re-run an UNSCOPED diff and locate the dropped/duplicated content.
 
-- **Justified vs defect `STRETCHED IMAGE` (#45):** a stretch flag is JUSTIFIED — leave the CSS — when (a) the image is an `object-fit: cover` intentional full-bleed background/watermark, OR (b) the SAME flag appears on the proto side of the diff (a faithful lift of the prototype's own `height:Npx; padding; box-sizing:border-box` rule). "Fixing" a faithful flag only makes the EDS diverge. Treat it as a real defect ONLY when the proto renders the image at its natural AR but the EDS does not.
-- **Pre-deploy URL gate (#44):** `grep -rn "http://localhost\|aem\.page/img\|aem\.live/img" blocks/` MUST be empty. Block JS that injects fixed imagery (logos/icons/watermarks) must reference assets root-relative `/img/...`; an absolute origin baked into block JS passes local QA (the dev server is localhost:3000) but 404s in every real environment.
+Reading `content-diff` (#78):
+- `MISSING CTA/HEADING/EYEBROW` 🔴 — real dropped content, BLOCKING (missing eyebrow → usually #76; missing CTA → the link cell never rendered).
+- `ROLE SWAP` 🔴 — same text, wrong slot (#76 mis-classification) → fix the block's segmentation.
+- `MISSING BODY` / `EXTRA` 🟡 — usually a placeholder→real-copy rewrite; CONFIRM intended, not lost/hallucinated prose.
+- `FONT FORK` 🟠 — matched line, different rendered face (width probe). `proto X→sys` with EDS shipping the intended fallback is CORRECT (#77); EDS falling back → ship the missing `@font-face`.
+- The per-role summary counts are a fast dropped-section signal before reading flags.
 
-- **`FONT MISMATCH` (#66):** a heading whose named display/body family loaded in the proto but NOT in the EDS = a missing `@font-face` falling back to serif/sans (#65). Ship the woff2 self-hosted + root-relative.
-- **`SURFACE/GROUND MISMATCH` (#59):** a heading that matches the proto by text but renders a materially different color (luminance flipped dark↔light) means its band rendered on the wrong ground (e.g. a light intro band fused into a dark scene, #58). Check the owning block's section background.
-- **GAP flags are WHOLE-PAGE, independent of `--sections` (#54):** `IMAGERY GAP` (#47) and `CONTENT GAP` (#49) are computed page-wide; `--sections` only chooses which per-section *screenshots* are saved. So a focused `--sections .hero` run whose hero looks perfect can STILL fire a GAP pointing at a defect in a *different* block (e.g. services dropping 3/4 cards). Never dismiss a GAP flag as "outside my section" — when either fires, run an UNSCOPED full-page diff (or a per-section diff on the suspect block) and locate the dropped/duplicated content before trusting the focused pass.
-
-**Reading `content-diff` (#78):**
-- **`MISSING CTA/HEADING/EYEBROW` (🔴):** real dropped content — FIX. A missing eyebrow is most often a segmentation drop (#76, the eyebrow precedes its heading); a missing CTA means the block never authored/rendered the link cell. These are the failures the pixel probe cannot see (full pixels, plausible colours) — treat 🔴 as blocking.
-- **`ROLE SWAP` (🔴):** the same text rendered under a different role (body painted as eyebrow, eyebrow folded into a teaser) — the #76 mis-classification class. FIX the owning block's node segmentation.
-- **`MISSING BODY` / `EXTRA` (🟡):** body prose dropped, or EDS copy with no proto source. Usually fine — a prototype placeholder ("two paragraphs of prose live here…") legitimately becomes real authored copy. CONFIRM it's an intended rewrite, not lost/hallucinated prose.
-- **`FONT FORK` (🟠):** matched lines whose rendered FACE differs (width probe). A `proto X→sys` means the prototype named font X but never loaded it and fell back to system — EDS self-hosting the intended fallback is then CORRECT (#77), not a bug. Confirm the fork is intended; if instead EDS is the one falling back, ship the missing `@font-face`. The probe groups all forked lines into ONE advisory (a proprietary→fallback swap fires on every display line).
-- The summary line counts nodes per role on each side — a large `headings`/`cta` count delta is itself a fast dropped-section signal before reading individual flags.
-
-Fix the flagged few, then re-run BOTH probes until visual red flags are "none" (or justified) and content-diff shows **0 structural 🔴** (🟡/🟠 confirmed intended). The flag lists double as a regression checklist — seeded from the findings above, so a new silent regression is worth adding both a fix AND a probe signal.
+**Exit criteria:** re-run BOTH probes until visual red flags are "none" (or justified per #45) and content-diff shows **0 structural 🔴** (🟡/🟠 confirmed intended). The flag lists double as a regression checklist — a new silent regression deserves a fix AND a probe signal.
 
 ## Anti-patterns (lessons paid for the hard way)
 
-These look reasonable. They will cost a full reset.
+These look reasonable; each cost a full reset. **Before Step 2 naming, and before merging or abstracting ANY sections, READ `reference/anti-patterns.md`** for the full failure narratives. The contract:
 
-**1. Abstracting prototype sections into "blocks with variants."**
-Building one `hero` block with five class-variant treatments (`dark` / `light` / `image` / `full-bleed` / `with-wave`) seems DRY. In practice the variants don't share enough markup or CSS to compress; the JS forks too many ways; CSS gets brittle. **Build one block per distinct prototype section.** Reuse only when sections are byte-identical.
-
-**1b. Merging two prototype bands that have different `data-ground`/surfaces (#58).**
-A cinematic/editorial prototype often alternates ground bands — a light `data-ground="dust"` intro (dark heading) followed by a dark `data-ground="ink"` scene (light heading). Fusing them into one block rendered on a single ground silently **inverts** the lost band (its heading flips dark↔light, the design beat vanishes) — lint passes, all content present, only an eyeball or the `SURFACE/GROUND MISMATCH` probe flag (#59) catches it. If one block must span >1 ground, reproduce EACH ground as a distinct full-bleed sub-band inside it (a `.loop-head` light sub-band + the dark scene), never collapse to one. Audit cue: note each section's `data-ground` before merging; a cross-ground merge must preserve both.
-
-**2. Section-metadata style classes that parallel block variants.**
-Defining `.section.dark`, `.section.prose-2col`, `.section.eyebrow`, etc. and applying them via section-metadata adds a second styling system that overlaps with block CSS. Authors don't know whether to set `dark` on the section or on the block. Pick one path: **per-block CSS that paints the entire section.** No section-style classes.
-
-**3. Shared utility modules (waves, animation primitives).**
-A wave SVG that all blocks import seems reusable. But each prototype section uses its wave differently (different dimensions, colors, animation). Inlining the SVG inside the owning block is more code on paper but eliminates a coupling and makes each block self-contained.
-
-**4. Manually creating button anchors in block JS.**
-Code like `cta.className = 'btn-loud'; cta.innerHTML = '<span>…</span>' + ARROW_SVG;` duplicates the EDS button decorator's job, fights its class-application order, and ties block JS to specific button classes. **Clone the cell anchor; let `decorateButton()` apply the class.** Block CSS overrides the global button style only when something is actually different (size, hover variant).
-
-**5. Building complex block JS to parse and rebuild header/footer.**
-The old pattern (fetch flat DA fragment → parse structurally → rebuild DOM) is fragile and lossy. Static fragments (`fragments/header.html`, `fragments/footer.html`) are injected verbatim — no parsing, no rebuild. If you find yourself writing block JS for header/footer, stop. Extract the prototype's header/footer as-is.
-
-**6. `.default-content-wrapper` (or any guess about EDS's section DOM).**
-The actual EDS shape is `<div class="section"><div class="default-content">…</div><div class="block-content">…</div></div>`. Confirm by inspecting a rendered page in the browser before designing CSS that relies on the wrapping shape.
-
-**7. Doing the audit in too much depth.**
-A 22-pattern audit produces abstractions. You only need a per-page section list. Pattern reuse emerges organically when you find two byte-identical sections.
-
-**8. Building before locking decisions.**
-Naming + reuse decisions look small but ripple through every block and content page. **Surface 3–5 naming questions to the user up front.** Lock answers in writing before any block code.
-
-**9. Generic placeholder image paths.**
-`/img/case-studies/foo.jpg` will 404 unless those images are uploaded. Use the prototype host URL so what you author renders correctly in EDS preview from day one.
-
-**9b. Absolute-origin URLs baked into block CODE — JS string literals AND CSS `background-image: url(...)` (#44, #67).**
-ANY fixed brand asset referenced from block code — a JS string literal (logo/icon/watermark/fallback) OR a CSS `background-image: url("…")` (a full-bleed section wash) — must be root-relative `/img/<brand>/x.png`, NEVER an absolute origin (`http://localhost:3000/img/...`, a branch `--…aem.page/img/...` host). An absolute origin passes local QA (the dev server *is* localhost:3000, so it loads) but 404s on every real environment. **This directly overrides anti-pattern #9 / the Step-9 "fully-qualified host URL" rule for fixed block assets (#67):** that rule applies ONLY to AUTHORED content `<img src>` for *uploaded/Media-Bus* assets — fixed imagery in block CSS/JS (section backgrounds, watermarks, CSS fallbacks) is always root-relative. (Cinematic prototypes lean on CSS background washes, so this is common.) Gate before deploy: `grep -rn "http://localhost\|aem\.page/img\|aem\.live/img" blocks/` must be empty (it scans CSS too).
-
-**10. Touching `head.html` for fonts (preload included).**
-Google Fonts `<link>` tags, Adobe Fonts script tags, any CDN-hosted stylesheet, AND `<link rel="preload" as="font">` lines all belong out of `head.html`. The first three add DNS/handshake hops and external coupling; the preload looks helpful but it's not — the metric-matched `body.session` pattern (principle 3) makes preload irrelevant for CLS, and adding it splits font discovery between two files. Declare `@font-face` in `styles/styles.css` only. Self-host proprietary brand faces too (for fidelity) and raise the licensing alert (#80) — only keep a CDN load when you genuinely cannot obtain the font files, and then document the CDN coupling + CLS trade-off.
-
-**11. Skipping the metric-matched fallback `@font-face`.**
-Without `size-adjust` + `ascent-override` + `descent-override` on a system-font fallback, the swap from system font → brand font shifts every line of text on the page when the woff2 lands. For a variable brand, lift the calibration from the matching `@fontsource-variable/<name>` package; for a **non-variable** brand (static weights only, no published Fallback face), compute it from the woff2 with fonttools (Step 4, #11). Rename the override `@font-face` after the system font (`"Arial"`, `"Times New Roman"`) so any reference to that family in a font stack picks up the adjusted metrics automatically.
-
-**12. Over-applying the button convention.**
-Not every link is a button. Whole-card tile anchors, tel:/mailto: channel values, and styled text links (e.g. wavelength-underlined "How we work →") are NOT buttons. Authors leave these as plain `<a>`; per-block CSS styles them. **The convention is for chips with a clickable boundary; if it's not that, don't apply it.**
-
-**13. Dropping the prototype's max-width container.**
-The prototype wraps section content in a centered max-width container (`.wrap` / `.container`) while the section background bleeds full-width. If your block appends content straight to the block root, the content runs edge-to-edge at wide viewports. **Recreate the container** (`block.replaceChildren(wrap)`, or a CSS `max-width: var(--maxw); margin: 0 auto; padding: 0 24px` on the content). This is the easiest bug to miss because it's invisible at ≤1440px — QA wide (see Local QA). Parallel block agents are especially prone to this: state the rule in each brief. **The trap is worst on plain-background sections (#37):** agents reliably keep the wrap on full-bleed *banded* blocks (the colored background makes the edge obvious) but drop it on sections whose background is the page background — there the missing constraint is invisible until you measure. EVERY block constrains content to `--maxw`; the only thing that stays full-bleed is a section *background* (e.g. keep the wrap on the inner grid so a hero's wash background still spans the viewport). **And the wrapper must be STYLED, not just emitted (#74):** a block whose JS writes `class="wrap"` but whose CSS never defines `.{block} .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 24px }` flushes left exactly the same — the markup looks right, the rule is just absent (it only shows when no inner card supplies its own padding). Gate: for every block whose JS emits a `.wrap`/container class, grep its CSS for the matching rule.
-
-**14. Forgetting `<image-slot>` placeholders have no real assets.**
-Claude-design prototypes use `<image-slot>` drop-targets, not `<img>` with real `src`. Don't hard-code a prototype image URL (it 404s) and don't ship a broken `<img>`. Treat the image as an **optional** cell and give the block a CSS background fallback so the empty state still looks right.
-
-**15. Loading the footer twice (block + static fragment).**
-The AuthorKit `lazy.js` lazy-loads `utils/footer.js` → `loadBlock(footer)`. With static chrome fragments (this skill) and no `blocks/footer`, that throws and renders a visible "Error" box between the last section and the footer. Remove the `utils/footer.js` import from `lazy.js` during Runtime bootstrap.
-
-**16. Lifting a JS-toggled `opacity:0` reveal.**
-Prototypes often hide sections with `.reveal { opacity:0 }` and reveal them via an inline-`<script>` IntersectionObserver. That script doesn't run in EDS, so the lifted `opacity:0` makes the content **permanently invisible** — and it looks fine in the prototype, so it's easy to miss. Render content visible; drop the reveal. (Same root cause as anti-pattern 5 and the fragment-JS rule: prototype `<script>` never executes after conversion.)
-
-**17. Injecting a `<main>` element from block JS.**
-A block that builds its own layout/view wrapper (common for interactive blocks that swap views, #33) must NOT use `<main>` — or a bare top-level `<div>` that the foundation reset matches. The reset hides undecorated sections with `main > div { display:none }`; an injected `<main>` makes its child `<div>`s direct children of *a* `main`, so they get `display:none` and the view renders **blank/partial**. It's **silent** — lint passes, no console error; only the missing content shows it. Use a `<section>` (or keep injected nodes scoped under the block element, which never trips `main > div`). Don't port a prototype's `<main>` wrapper literally into block-injected DOM.
+1. Never abstract sections into "blocks with variants" speculatively — one block per distinct section; reuse only byte-identical ones.
+   1b. Never merge two prototype bands with different `data-ground`/surfaces (#58) — the lost band's heading silently inverts; reproduce EACH ground as a sub-band or don't merge.
+2. No section-metadata style classes paralleling block variants — per-block CSS paints the entire section; one styling system.
+3. No shared utility modules (waves, animation primitives) — inline the SVG in the owning block.
+4. Never manually create button anchors in block JS — clone the cell anchor; `decorateButton()` applies classes.
+5. Never write block JS to parse/rebuild header/footer — static fragments are injected verbatim.
+6. Never guess EDS's section DOM (`.default-content-wrapper`…) — inspect a rendered page; the shape is `.section > .default-content` + `.block-content`.
+7. Don't over-audit — a per-page section list, not a 22-pattern punch list.
+8. Don't build before locking naming/reuse decisions in writing (Step 2).
+9. No generic placeholder image paths (`/img/case-studies/foo.jpg` 404s) — author URLs that render in preview from day one.
+   9b. No absolute-origin URLs in block CODE — JS literals AND CSS `background-image` (#44, #67): fixed assets are root-relative `/img/<brand>/…`; absolute origins pass local QA and 404 everywhere real. Gate: the #44 grep.
+10. Never touch `head.html` for fonts — preload included; all `@font-face` in `styles/styles.css` (Step 4).
+11. Never skip the metric-matched fallback `@font-face` — fontsource calibration for variable brands, fonttools-computed for static ones (#11).
+12. Don't over-apply the button convention — tile anchors, `tel:`/`mailto:` values, styled text links are NOT buttons.
+13. Never drop the prototype's max-width container — worst on plain-background sections (#37); and the emitted `.wrap` must be STYLED in CSS (#74). Gate: JS emits a wrap class → grep its CSS for the matching rule.
+14. `<image-slot>` placeholders have no real assets — optional cells + CSS background fallback, never a hard-coded prototype URL.
+15. Never load the footer twice (block + static fragment) — remove `lazy.js`'s `utils/footer.js` import (#4).
+16. Never lift a JS-toggled `opacity:0` reveal — the prototype script doesn't run; content goes permanently invisible.
+17. Never inject a `<main>` element from block JS — the foundation reset hides `main > div`; use `<section>` or stay inside the block element.
 
 ## Checklist (per page)
 
-- [ ] Each section in the prototype `<main>` has a corresponding block call in the content page.
-- [ ] **Content page is a body fragment** for the Source-API deploy: starts at `<body>`, **no `<!DOCTYPE>`/`<html>`/`<head>`** — EDS injects the project `head.html` at delivery. (Only the mount deploy tolerates a full doc.)
-- [ ] Ran `node skills/deploy/scripts/sanitise.js` on the content before any DA write (non-ASCII → entities).
-- [ ] `<header></header>` and `<footer></footer>` are EMPTY (static fragments load automatically via `postlcp.js`).
-- [ ] **Page begins with a `metadata` block** (#34): real Title (≤60 chars, from the `<h1>`, never a block name) + Description (~155 chars). `header: off` / `footer: off` / `Robots` rows go in the same block when needed.
-- [ ] **Exactly one `<h1>` per page** (#35): the hero/lead headline is `<h1>`; section titles are `<h2>`/`<h3>`; no headline left as a bare `<div>` (interactive blocks included — the lead title is `<h1>` in server-visible markup).
-- [ ] **Editorial images are authorable content** — uploaded to DA `/media`, authored as `content.da.live` `<img>` with `alt` (NOT repo-relative `/img/`, NOT baked into block JS by index). Hero/feature/CTA-band backgrounds count as editorial. Decorative image-less treatments (gradients/scrims/washes) and fixed brand assets stay CSS background. **Verify: the delivered `.plain.html` carries the expected `<img>`+alt count** (CSS-background images are absent from it). `<image-slot>` placeholders → empty cells with a CSS background fallback.
-- [ ] **ENCODE shapes (see The ENCODE contract):** grouped bands = one row per item; FAQ/accordion = head cell + Q/A rows; sub-fields carried by a leading `<strong>`/`<code>` tag, **not** an invented `::`/`|` delimiter; accents `<em>` not `<span class="em">`; no `<sup>`/layout-`<br>` in content.
-- [ ] **Section heads are DEFAULT CONTENT, not block rows** — the eyebrow/heading/lede above a repeating block is authored as section default content; the block reabsorbs it (`block.closest('.block-content').previousElementSibling`; match `.default-content`/`.default-content-wrapper`) so the decorated DOM is byte-identical (verify: 0 wrappers left, decorated outerHTML unchanged).
-- [ ] **Same-pattern sections share ONE block + variant classes** (`cards`/`text`/…); only genuinely-unique sections are bespoke (see "The one rule").
+- [ ] Each prototype section has a corresponding block call in the content page.
+- [ ] Content page is a **body fragment**: starts at `<body>`, no `<!DOCTYPE>`/`<html>`/`<head>` (#7).
+- [ ] `sanitise.js` run before any DA write (non-ASCII → entities).
+- [ ] `<header></header>` / `<footer></footer>` EMPTY (fragments load via `postlcp.js`).
+- [ ] Page begins with a `metadata` block (#34): real Title ≤60 chars from the `<h1>` + ~155-char Description; `header: off` / `Robots` rows in the same block when needed.
+- [ ] Exactly one `<h1>` (#35); section titles `<h2>`/`<h3>`; no headline left as a bare `<div>` (interactive blocks included).
+- [ ] Editorial images are authorable content — uploaded to DA `/media`, authored as `content.da.live` `<img>` with `alt`; hero/CTA-band backgrounds count. Decorative/fixed → CSS background. Verify: delivered `.plain.html` has the expected `<img>`+alt count. `<image-slot>` → empty cells + CSS fallback.
+- [ ] ENCODE shapes: one row per grouped item; FAQ = head + Q/A rows; sub-fields via leading `<strong>`/`<code>`, no invented delimiters; accents `<em>` not `<span class="em">`; no `<sup>`/layout-`<br>`.
+- [ ] Section heads authored as DEFAULT CONTENT; block reabsorbs (0 wrappers left, decorated outerHTML byte-identical — `reference/encode-contract.md`).
+- [ ] Same-pattern sections share ONE block + variants; only genuinely-unique sections bespoke.
 - [ ] Heading outline has no level jumps (`h2 → h3`, never `h2 → h4`).
-- [ ] Each block reproduces the prototype's max-width container — **including plain-background sections** (#37); **no unintended full-width content at a wide (≥1600px) viewport**.
-- [ ] Global `img` reset is `display: block; max-width: 100%; height: auto;` (#36) — EDS adds width/height attrs; without `height: auto` images stretch vertically.
-- [ ] When the header sits in flow above the first section, the bare `<header>` has a reserved responsive `min-height` matching the fragment (#81) — the late `postlcp.js` fragment injection must NOT push the hero down (verify CLS with a fetch-delayed probe; target < 0.1).
-- [ ] Any styling that depends on a `<span>`/class INSIDE a block cell is re-created in `decorate()` (#39) — EDS strips `<span>` in block cells (e.g. wrap a `.stars` run in JS, don't author it).
-- [ ] Every block reads plain-text fields by CELL/`textContent`, NOT `querySelectorAll('p')` (#79) — the pipeline unwraps the `<p>` in single-text cells, so a `p`-based read drops eyebrow/subhead/lede/tag/body on live while the raw-`<p>` harness still shows them. Verify against the decorated live/preview render or a `<p>`-stripping harness, and assert each text field is present (counts alone don't catch it).
-- [ ] No `<style>` or `<script>` tags in the content page.
-- [ ] No section-metadata blocks.
+- [ ] Every block reproduces the prototype's max-width container — plain-background sections included (#37); no unintended full-width content at ≥1600px (#13); emitted wrap classes are styled (#74).
+- [ ] Global `img` reset is `display: block; max-width: 100%; height: auto;` (#36).
+- [ ] Bare `<header>` has a reserved responsive `min-height` matching the fragment when the header sits above the first section (#81); CLS verified with a fetch-delayed probe, target < 0.1.
+- [ ] Any styling depending on a `<span>`/class INSIDE a block cell is re-created in `decorate()` (#39) — EDS strips spans in cells (e.g. wrap a `.stars` run in JS).
+- [ ] Blocks read plain-text fields by CELL/`textContent`, not `querySelectorAll('p')` (#79); each text field asserted present against a decorated render.
+- [ ] No `<style>`/`<script>` in the content page; no section-metadata blocks.
 - [ ] Closing CTA reuses the shared `closing` block.
-- [ ] CTA links are wrapped in `<strong>` (primary) or `<em>` (secondary). Text links and tile-card anchors are plain `<a>`.
-- [ ] Block JS exports `default async function decorate(block)` with JSDoc describing rows and noting any button conventions.
-- [ ] Block CSS is scoped under `.block-name`.
-- [ ] Block CSS does NOT redefine global tokens.
-- [ ] Block CSS does NOT redefine global button classes (only legitimate overrides like size or hover variant).
-- [ ] SVG markup is inline in the block JS (no shared waves utility).
-- [ ] Block JS does NOT manufacture button anchors with custom classes.
+- [ ] CTAs wrapped `<strong>`/`<em>`; text links and tile anchors plain `<a>`.
+- [ ] Block JS exports `default async function decorate(block)` with row-describing JSDoc.
+- [ ] Block CSS scoped under `.block-name`; no global-token or global-button redefinition (size/hover overrides only).
+- [ ] SVG inline in block JS (no shared utility); no manufactured button anchors.
 - [ ] `prefers-reduced-motion: reduce` honored on any animation.
-- [ ] No JS-toggled `opacity:0` reveal lifted from the prototype — content renders visible (prototype scroll-reveal script doesn't run in EDS).
-- [ ] No block named after a reserved EDS class (`section`, `default-content`, `block-content`, `wrap`, `button`).
-- [ ] `head.html` is untouched. No font `<link>`, `<script>`, `<style>`, or `<link rel="preload" as="font">` lines added. All `@font-face` declarations live in `styles/styles.css`. Brand woff2(s) live in `styles/fonts/`.
-- [ ] EVERY named brand face is self-hosted — including proprietary ones (#80); proprietary `.otf`/`.ttf` from the prototype were converted to woff2 with fontTools. If any proprietary face is shipped, the **licensing alert** exists in all three places (styles.css banner + `styles/fonts/LICENSING.md` + conversion log) and the hand-off message flags "license required before `aem.live`".
-- [ ] Condensed/narrow display faces fall back to a **condensed** face, not plain Arial (#80): `"<Brand>", "Arial Narrow", arial, …` (or a self-hosted free condensed analog). Width-class is part of classification.
-- [ ] Body defaults to a metric-matched system fallback (`arial, sans-serif` for sans brand, `times, "Times New Roman", serif` for serif). `body.session` switches to the brand stack via `var(--font-body)`.
-- [ ] An override `@font-face` named after the system font (e.g. `"Arial"`) declares `size-adjust` / `ascent-override` / `descent-override`. For variable brands, lift the calibration from `@fontsource-variable/<name>`; for non-variable brands, **compute** it from the woff2 with fonttools. Result: zero CLS on font swap.
-- [ ] No per-block `font-family: var(--font-body)` or `var(--font-display)` declarations. Brand font flows from `body.session` via inheritance. Only mono and serif (Fraunces / Times) families are explicitly set per-block.
+- [ ] No lifted JS-toggled `opacity:0` reveal — content renders visible.
+- [ ] No block named after a reserved EDS class (#15).
+- [ ] `head.html` untouched; all `@font-face` in `styles/styles.css`; woff2s in `styles/fonts/`.
+- [ ] EVERY named brand face self-hosted, proprietary included (#80/#65); licensing alert in all three places when proprietary shipped; hand-off flags "license required before `aem.live`".
+- [ ] Condensed/narrow faces fall back to a condensed face, never plain Arial (#80).
+- [ ] Body defaults to a metric-matched system fallback; `body.session` switches to the brand stack.
+- [ ] Override `@font-face` named after the system font declares `size-adjust`/`ascent-override`/`descent-override` (fontsource calibration or fonttools-computed, #11) — zero CLS on swap.
+- [ ] No per-block `font-family: var(--font-body)`/`var(--font-display)` — brand font flows from `body.session` by inheritance; only mono/serif families set per-block.
 
 ## When you finish
 
-Update `stardust/eds-conversion-log.md` (or create one) with: final block inventory, decisions locked, anti-patterns avoided this run, anything site-specific the next person should know. The log is the running history of "why does this look the way it does."
+Update `stardust/eds-conversion-log.md` (or create it): final block inventory, decisions locked, anti-patterns avoided this run, anything site-specific the next person should know. The log is the running history of "why does this look the way it does."
 
 ## References
 
 - `da-deploy-protocol.md` — the curl-based DA Source API deploy contract (auth, source PUT, preview/publish, asset-before-preview ordering).
-- `IMPROVEMENTS.md` — running log of friction/gaps and the numbered findings (#NN) that the `stardust:diff` `eds` profile cites.
+- `reference/runtime-bootstrap.md` — port manifest, mandatory-edit mechanics, lint list (read before hand-porting).
+- `reference/font-strategy.md` — font recipes, metric math, licensing mechanics, #81 header-reservation deep dive (read before Step 4).
+- `reference/encode-contract.md` — section-head reabsorption, image upload/verify/repair, worked button CSS (read before authoring images/heads and before Step 5 CSS).
+- `reference/decode-disciplines.md` — full #42–#79 narratives + QA probes (read before Step 8 and named in every Step 7 brief).
+- `reference/anti-patterns.md` — the full failure narratives behind the numbered list.
+- `IMPROVEMENTS.md` — running log of friction/gaps and the numbered findings (#NN) the `stardust:diff` `eds` profile cites.

--- a/plugins/stardust/skills/deploy/reference/anti-patterns.md
+++ b/plugins/stardust/skills/deploy/reference/anti-patterns.md
@@ -1,0 +1,153 @@
+# Anti-patterns — full narratives (lessons paid for the hard way)
+
+Companion to SKILL.md § Anti-patterns. The numbered one-line list inline in SKILL.md is the
+contract; this file carries the full story behind each entry. These look reasonable. They
+will cost a full reset.
+
+**1. Abstracting prototype sections into "blocks with variants."**
+Building one `hero` block with five class-variant treatments (`dark` / `light` / `image` /
+`full-bleed` / `with-wave`) seems DRY. In practice the variants don't share enough markup or
+CSS to compress; the JS forks too many ways; CSS gets brittle. **Build one block per distinct
+prototype section.** Reuse only when sections are byte-identical.
+
+**1b. Merging two prototype bands that have different `data-ground`/surfaces (#58).**
+A cinematic/editorial prototype often alternates ground bands — a light `data-ground="dust"`
+intro (dark heading) followed by a dark `data-ground="ink"` scene (light heading). Fusing
+them into one block rendered on a single ground silently **inverts** the lost band (its
+heading flips dark↔light, the design beat vanishes) — lint passes, all content present, only
+an eyeball or the `SURFACE/GROUND MISMATCH` probe flag (#59) catches it. If one block must
+span >1 ground, reproduce EACH ground as a distinct full-bleed sub-band inside it (a
+`.loop-head` light sub-band + the dark scene), never collapse to one. Audit cue: note each
+section's `data-ground` before merging; a cross-ground merge must preserve both.
+
+**2. Section-metadata style classes that parallel block variants.**
+Defining `.section.dark`, `.section.prose-2col`, `.section.eyebrow`, etc. and applying them
+via section-metadata adds a second styling system that overlaps with block CSS. Authors don't
+know whether to set `dark` on the section or on the block. Pick one path: **per-block CSS
+that paints the entire section.** No section-style classes.
+
+**3. Shared utility modules (waves, animation primitives).**
+A wave SVG that all blocks import seems reusable. But each prototype section uses its wave
+differently (different dimensions, colors, animation). Inlining the SVG inside the owning
+block is more code on paper but eliminates a coupling and makes each block self-contained.
+
+**4. Manually creating button anchors in block JS.**
+Code like `cta.className = 'btn-loud'; cta.innerHTML = '<span>…</span>' + ARROW_SVG;`
+duplicates the EDS button decorator's job, fights its class-application order, and ties block
+JS to specific button classes. **Clone the cell anchor; let `decorateButton()` apply the
+class.** Block CSS overrides the global button style only when something is actually
+different (size, hover variant).
+
+**5. Building complex block JS to parse and rebuild header/footer.**
+The old pattern (fetch flat DA fragment → parse structurally → rebuild DOM) is fragile and
+lossy. Static fragments (`fragments/header.html`, `fragments/footer.html`) are injected
+verbatim — no parsing, no rebuild. If you find yourself writing block JS for header/footer,
+stop. Extract the prototype's header/footer as-is.
+
+**6. `.default-content-wrapper` (or any guess about EDS's section DOM).**
+The actual EDS shape is `<div class="section"><div class="default-content">…</div><div
+class="block-content">…</div></div>`. Confirm by inspecting a rendered page in the browser
+before designing CSS that relies on the wrapping shape.
+
+**7. Doing the audit in too much depth.**
+A 22-pattern audit produces abstractions. You only need a per-page section list. Pattern
+reuse emerges organically when you find two byte-identical sections.
+
+**8. Building before locking decisions.**
+Naming + reuse decisions look small but ripple through every block and content page.
+**Surface 3–5 naming questions to the user up front.** Lock answers in writing before any
+block code.
+
+**9. Generic placeholder image paths.**
+`/img/case-studies/foo.jpg` will 404 unless those images are uploaded. Use the prototype host
+URL so what you author renders correctly in EDS preview from day one.
+
+**9b. Absolute-origin URLs baked into block CODE — JS string literals AND CSS
+`background-image: url(...)` (#44, #67).**
+ANY fixed brand asset referenced from block code — a JS string literal
+(logo/icon/watermark/fallback) OR a CSS `background-image: url("…")` (a full-bleed section
+wash) — must be root-relative `/img/<brand>/x.png`, NEVER an absolute origin
+(`http://localhost:3000/img/...`, a branch `--…aem.page/img/...` host). An absolute origin
+passes local QA (the dev server *is* localhost:3000, so it loads) but 404s on every real
+environment. **This directly overrides anti-pattern #9 / the Step-9 "fully-qualified host
+URL" rule for fixed block assets (#67):** that rule applies ONLY to AUTHORED content
+`<img src>` for *uploaded/Media-Bus* assets — fixed imagery in block CSS/JS (section
+backgrounds, watermarks, CSS fallbacks) is always root-relative. (Cinematic prototypes lean
+on CSS background washes, so this is common.) Gate before deploy:
+`grep -rn "http://localhost\|aem\.page/img\|aem\.live/img" blocks/` must be empty (it scans
+CSS too).
+
+**10. Touching `head.html` for fonts (preload included).**
+Google Fonts `<link>` tags, Adobe Fonts script tags, any CDN-hosted stylesheet, AND
+`<link rel="preload" as="font">` lines all belong out of `head.html`. The first three add
+DNS/handshake hops and external coupling; the preload looks helpful but it's not — the
+metric-matched `body.session` pattern makes preload irrelevant for CLS, and adding it splits
+font discovery between two files. Declare `@font-face` in `styles/styles.css` only. Self-host
+proprietary brand faces too (for fidelity) and raise the licensing alert (#80) — only keep a
+CDN load when you genuinely cannot obtain the font files, and then document the CDN coupling
++ CLS trade-off.
+
+**11. Skipping the metric-matched fallback `@font-face`.**
+Without `size-adjust` + `ascent-override` + `descent-override` on a system-font fallback, the
+swap from system font → brand font shifts every line of text on the page when the woff2
+lands. For a variable brand, lift the calibration from the matching
+`@fontsource-variable/<name>` package; for a **non-variable** brand (static weights only, no
+published Fallback face), compute it from the woff2 with fonttools (see
+reference/font-strategy.md, #11). Rename the override `@font-face` after the system font
+(`"Arial"`, `"Times New Roman"`) so any reference to that family in a font stack picks up the
+adjusted metrics automatically.
+
+**12. Over-applying the button convention.**
+Not every link is a button. Whole-card tile anchors, tel:/mailto: channel values, and styled
+text links (e.g. wavelength-underlined "How we work →") are NOT buttons. Authors leave these
+as plain `<a>`; per-block CSS styles them. **The convention is for chips with a clickable
+boundary; if it's not that, don't apply it.**
+
+**13. Dropping the prototype's max-width container.**
+The prototype wraps section content in a centered max-width container (`.wrap` /
+`.container`) while the section background bleeds full-width. If your block appends content
+straight to the block root, the content runs edge-to-edge at wide viewports. **Recreate the
+container** (`block.replaceChildren(wrap)`, or a CSS `max-width: var(--maxw); margin: 0 auto;
+padding: 0 24px` on the content). This is the easiest bug to miss because it's invisible at
+≤1440px — QA wide. Parallel block agents are especially prone to this: state the rule in each
+brief. **The trap is worst on plain-background sections (#37):** agents reliably keep the
+wrap on full-bleed *banded* blocks (the colored background makes the edge obvious) but drop
+it on sections whose background is the page background — there the missing constraint is
+invisible until you measure. EVERY block constrains content to `--maxw`; the only thing that
+stays full-bleed is a section *background* (e.g. keep the wrap on the inner grid so a hero's
+wash background still spans the viewport). **And the wrapper must be STYLED, not just emitted
+(#74):** a block whose JS writes `class="wrap"` but whose CSS never defines
+`.{block} .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 24px }` flushes left
+exactly the same — the markup looks right, the rule is just absent (it only shows when no
+inner card supplies its own padding). Gate: for every block whose JS emits a
+`.wrap`/container class, grep its CSS for the matching rule.
+
+**14. Forgetting `<image-slot>` placeholders have no real assets.**
+Claude-design prototypes use `<image-slot>` drop-targets, not `<img>` with real `src`. Don't
+hard-code a prototype image URL (it 404s) and don't ship a broken `<img>`. Treat the image as
+an **optional** cell and give the block a CSS background fallback so the empty state still
+looks right.
+
+**15. Loading the footer twice (block + static fragment).**
+The AuthorKit `lazy.js` lazy-loads `utils/footer.js` → `loadBlock(footer)`. With static
+chrome fragments (this skill) and no `blocks/footer`, that throws and renders a visible
+"Error" box between the last section and the footer. Remove the `utils/footer.js` import from
+`lazy.js` during Runtime bootstrap.
+
+**16. Lifting a JS-toggled `opacity:0` reveal.**
+Prototypes often hide sections with `.reveal { opacity:0 }` and reveal them via an
+inline-`<script>` IntersectionObserver. That script doesn't run in EDS, so the lifted
+`opacity:0` makes the content **permanently invisible** — and it looks fine in the prototype,
+so it's easy to miss. Render content visible; drop the reveal. (Same root cause as
+anti-pattern 5 and the fragment-JS rule: prototype `<script>` never executes after
+conversion.)
+
+**17. Injecting a `<main>` element from block JS.**
+A block that builds its own layout/view wrapper (common for interactive blocks that swap
+views, #33) must NOT use `<main>` — or a bare top-level `<div>` that the foundation reset
+matches. The reset hides undecorated sections with `main > div { display:none }`; an injected
+`<main>` makes its child `<div>`s direct children of *a* `main`, so they get `display:none`
+and the view renders **blank/partial**. It's **silent** — lint passes, no console error; only
+the missing content shows it. Use a `<section>` (or keep injected nodes scoped under the
+block element, which never trips `main > div`). Don't port a prototype's `<main>` wrapper
+literally into block-injected DOM.

--- a/plugins/stardust/skills/deploy/reference/decode-disciplines.md
+++ b/plugins/stardust/skills/deploy/reference/decode-disciplines.md
@@ -1,0 +1,284 @@
+# Decode disciplines — deep dive (#42–#79)
+
+Companion to SKILL.md § Step 8. The one-line rules inline in SKILL.md are the enforceable
+contract; this file carries each discipline's full explanation, failure signature, and worked
+example. Every block author (including dispatched sub-agents) must read this before writing
+`decorate()` code.
+
+## #42 — Lead/hero blocks: query content, don't hard-index rows
+
+A hero that reads `rows[3]=headline, rows[4]=lede, rows[5]=CTA` breaks the moment the content
+shape differs — and the mandatory-metadata / single-`<h1>` SEO rework (#34/#35) actively
+**consolidates** the headline + lede + CTAs into ONE cell, so the fixed indices come back
+`undefined` and the hero `.wrap` (the LCP element and the only `<h1>`) renders EMPTY with no
+error. Decorate lead blocks by querying (`block.querySelector('h1,h2')`; link-bearing `<p>` =
+CTAs; `picture` from anywhere) so they tolerate BOTH the rich multi-row shape and the
+consolidated single-cell shape. Local-QA check: after decoration, assert the hero's inner
+wrap is non-empty and contains the `<h1>`.
+
+## #51 — Disambiguate eyebrow vs lede by ORDER/length, not "first `<p>`"
+
+Both are link-free `<p>`s, so "first link-free paragraph = lede" swaps them (the short
+eyebrow comes first). The canonical lead order is **eyebrow → heading → lede**: the eyebrow
+is the short/uppercase line *before* the heading; the lede is the sentence-length `<p>`
+*after* it.
+
+## #55 — Unwrap the cell's heading before cloning into your OWN heading element
+
+If you build a live `<h1>` and clone a source cell's *childNodes* into it, and that cell
+wraps its text in its own `<h1>` (which #35/#42 actively encourage), you get
+`<h1><h1>…</h1></h1>` — a duplicate heading and a doubled font cascade. Always
+`const inner = cell.querySelector('h1,h2,h3,h4,h5,h6') || cell;` then clone
+`inner.childNodes`. Local-QA: exactly one `<h1>`, and 0 descendant headings inside the live
+headline.
+
+## #70 — Marker injection must be IDEMPOTENT
+
+When `decorate()` PREPENDS a fixed decorative marker to authored heading/link text (a glyph
+`▶`, a badge, a `CH NN` number), first STRIP a matching leading occurrence from the cloned
+text node — `firstText.textContent = firstText.textContent.replace(/^\s*▶\s*/, '')` — because
+the author (or the #34/#35 SEO content rebuild) may already type it, so the marker doubles
+(`▶ ▶ Latest signal`). Apply the SAME strip at EVERY place the block injects that marker
+(section titles AND card links), not just some. (The visual-diff text-match catches a doubled
+glyph `X X …`.)
+
+## #69 — Carousel slide segmentation: heading-boundary driven and ORDER-AGNOSTIC
+
+Segment slides ONLY on the heading boundary — one heading opens one slide (a leading
+`<picture>` before the first heading may open slide 0). Fold EVERYTHING between two headings
+into the open slide regardless of authored order (eyebrow/label may come AFTER the heading,
+not before): first non-link text run = eyebrow, links = CTAs, extra text = description. Never
+let a post-heading text node open a NEW slide (that steals the heading slot and the CTAs
+never attach — symptom: N+2 jumbled slides with 0 CTAs). Local-QA: rendered slide count ==
+authored heading count AND each slide's CTA count == authored.
+
+## #76 — Split/photo-overlay segmentation: BUFFER the eyebrow that PRECEDES its heading
+
+Heading-boundary segmentation (#52/#69/#73) opens a new group ON the heading — but in split
+panels and photo-overlay halves the eyebrow is the small label ABOVE the title, so it arrives
+BEFORE the heading and a "start collecting after the heading" loop drops it entirely. Worse,
+the body line after the heading then falls into the now-empty eyebrow slot (inheriting its
+accent/uppercase paint) and the next group's eyebrow bleeds into the prior group's teaser.
+Fix: keep a `pendingEyebrow` — any text seen before a heading is buffered and attached to the
+group that heading opens; once a group already has its body/CTA, further bare text re-buffers
+as the NEXT group's pending eyebrow (not this group's teaser). This complements #69 (carousel
+eyebrow may come AFTER the heading): don't hard-assume either order — buffer pre-heading
+text, classify post-heading text by what's already filled. The content is all in the DOM, so
+a count check passes while the render is scrambled — Local-QA: assert each group's
+eyebrow/heading/body/CTA land in their OWN slots (eyebrow text ≠ body text), not just that N
+groups exist. Hit on beermaker `the-people`.
+
+## #57 — Carousel/rotator lead: exactly ONE server `<h1>` across all slides
+
+A rotating hero authors N slide headlines; if each is an `<h1>`, the delivered HTML has N
+`<h1>`s (the block may rotate a single live `<h1>` post-JS, but crawlers see all N). Author
+the **first/primary** slide's headline as the page `<h1>` and every other slide's headline as
+`<h2>` — the block reads them generically (`querySelector('h1,h2…')`) so the carousel still
+works, and the server HTML has one `<h1>` (#35). Local-QA: count `<h1>` in the *content* file
+= 1.
+
+## #56 — A multi-row head/intro must be collected whole, not just its first row
+
+A block that takes "the first row with no image" as the head breaks when the head is authored
+as N separate single-cell rows (eyebrow / heading / CTA): only the eyebrow becomes the head
+and the section heading + CTA leak into the item grid as bogus cards (the section title then
+renders at card-title size). The head is **everything before the first content/image cell** —
+collect ALL leading no-image rows into the head. (Inverse of #52's flattening.) Local-QA: the
+item grid holds exactly the expected count, and the section heading renders at section-title
+size.
+
+## #62 / #68 / #71 — DEFAULT to the DA-flattened single-cell contract (the root cause of most decode bugs)
+
+When block JS and the content page are generated in the same run, they MUST agree on the row
+shape — and DA delivers most blocks as ONE row with ONE cell holding all elements as flat
+siblings, NOT the rich multi-row layout the prototype implies. A block written to a multi-row
+index contract (`rows[0]=eyebrow, rows[1]=title, rows[2]=cards…`) then reads its whole cell
+as `rows[0]` and finds `rows[1..]` undefined — rendering 1-of-N (a jumbled hero, a card grid
+with one card) while passing lint.
+
+So make **flatten-first the default**, via a CELL-LEVEL cascade collector (#68/#71) — NOT a
+single selector and NOT a block-level fallback chain. The trap (#71): a block-level chain
+(try `:scope>div>div>*` on the whole block, else…) succeeds on the first tier whenever ANY
+cell has a child element, so in a block that MIXES element cells (`img`/`h1`/`a`) with
+text-only cells (eyebrow, lede, count, meta, date) it returns only the element cells and
+**silently drops every bare-text cell** — the most common one-element-per-row DA shape. The
+canonical `collectNodes` collector (inline in SKILL.md Step 8) iterates CELLS and recovers
+each. Then segment/classify the returned nodes by content; one-cell-per-row is a fallback.
+
+**Local-QA: assert every block's primary content container is non-empty post-decorate
+(childCount>0 / height>0)** — a 0-node selector mismatch otherwise renders a silent blank box
+(a blank hero only surfaces via a per-block height probe; testimonials surfaced as a CONTENT
+GAP). And assert the rendered count equals the authored count — the hero wrap is non-empty
+and has the `<h1>`; a card grid holds N cards (= N repeat-headings in source), never 1.
+Index-based contracts pass lint but silently render 1/N.
+
+## #61 — Card grids that alternate ground: reconstruct the rhythm by INDEX when no marker survives
+
+A prototype encodes a grid's light/dark alternation structurally (the 2nd card has `--dark`),
+but that marker does NOT survive into DA content. A block that flips dark only on an explicit
+authored "dark" cell renders every card light — the dark card's white heading/CTA go
+invisible (caught by the #59 `SURFACE/GROUND MISMATCH` flag). Fallback to the positional
+pattern: `const dark = explicitMarker ?? (i % 2 === 1)`. Then scope on-dark button/text
+overrides to the resulting `.card.dark` block class (#41).
+
+## #48 — Content-classification applies to EVERY block, not just hero
+
+The author's row/cell layout is rarely the contract the agent assumed — a block that
+hard-codes `rows[4] = <dl> data cell` silently drops content when the content authors one
+`dt|dd` pair per row instead, and a `[num]|[label]` two-cell assumption duplicates the
+eyebrow when the author wrote a single `"01 — Title"` cell. These are **silent**: the page
+still renders something, and the metrics-only diff (stretch/flush/blank) does NOT catch a
+dropped CTA, a duplicated eyebrow, or an empty data grid. Classify rows/cells by content —
+presence of a heading, a `<picture>`, a link, a number prefix (`/^\d+/`), a 2-cell `dt|dd`
+shape — never by `block.children[N]`.
+
+## #50 — When DA flattens content, delimiters carry structure — DECODE defensively
+
+(ENCODE is the opposite: when the generator controls authoring, do NOT invent delimiters —
+lead each sub-field with a preserved tag instead; see the ENCODE contract. A block parses
+delimiters only as a back-compat fallback.) DA/snowflake content rarely preserves the
+prototype's semantic `<dl>`/`<dt>`/`<dd>`/`<ol>`/`<ul>`/`<li>` — it flattens them to a
+sequence of single-cell `<p>` rows with INLINE delimiters: `Address: PLACEHOLDER · Brand team
+to supply` (key:value), `01 · Tabernacle · Imp. Stout · 6.5%` (`·`-delimited spec line),
+`Heber Valley · Utah · Est 1996` (a plain foot line). So a block that `querySelector('dl,
+dt')` or `'ol, ul, li'` finds NOTHING and silently drops the whole data table / spec list /
+menu. **Parse by delimiters, not tags:** split `Key: value` on the first colon into
+`dt`/`dd`; split `·`-delimited lines into spans; detect a list's start by its preceding
+heading (`On tap this week`), not an `<ol>`. (Even #48's "one `dt|dd` pair per row" misses
+this — the row is ONE cell, not two.) Checklist: for any table/spec-list/menu block, assert
+post-decorate that the data container has the expected non-zero row count.
+
+## #52 / #63 / #73 / #64 — Repeating card/tile grids: segment, don't iterate rows
+
+A section that is a grid/band of N similar units (a 3-up card grid, a 2-up tile band, a logo
+row, a team grid) is very often collapsed by DA into a SINGLE cell of a SINGLE row, with each
+unit's elements (heading, picture, paragraphs, link) as flat siblings. A block written
+one-DOM-row-per-card then renders **0 cards** (the whole grid collapses into the section
+header) or **1** — silently dropping every other product/tile. Detect the flattened shape
+(`rows.length === 1` with multiple headings in the cell) and **segment the flat sibling list
+into one group per repeating heading**. The repeat-unit boundary is the **most frequent
+heading tag** in the cell (cards are `h3`; the lone section title is `h2` one level up) —
+segmenting on "any heading" turns the section title into a phantom first card. Support BOTH
+the flat-single-cell and the one-row-per-unit shapes.
+
+**Segmentation order (#63, #73):**
+0. **one-row-per-card** — if ≥2 `:scope > div` ROWS each contain a card heading (`h3`/`h4`),
+   build one group per ROW from `[...row.children]` in AUTHORED field order (treat leading
+   non-card-heading rows as the section head); never assume a `tag → media → heading` field
+   order — content authored `media → tag → heading` otherwise attributes each card's image to
+   the PREVIOUS card and drops the first card's (a 1-of-N image shift that passes a
+   card-COUNT check, #73); ELSE
+1. per-card heading boundary if present; ELSE
+2. **one card per delimited `<p>` line** — when the cards carry no per-card heading (only the
+   section title), each card is a single `Name · meta · meta · Badge` line (the natural way
+   to author a short card): split on the unit delimiter (`·`), first segment = name, a
+   trailing keyword (`New`/`Limited`/`Sold out`…) = badge, the middle = meta; ELSE
+3. one-row-per-unit.
+
+This unifies #50 (delimiter parsing) and #52 (card segmentation) for the headingless
+card/tile rail that falls between them (it silently renders 0 cards otherwise — the section
+heading still shows, so only the #49 CONTENT GAP / a card-count assert catches it). Local-QA:
+assert the grid count EVEN WHEN the block found no per-card headings (that's the case that
+returns 0), AND that each card's image src matches its OWN title (#73 — an image shifted by
+one passes a count-only check).
+
+**#64 — Never use `<picture>` as the PRIMARY card boundary:** image-led prototypes tempt "the
+picture leads each card", but claude-design content is usually image-less (#2), so a
+picture-keyed split collapses N cards into 1. Segment on the per-card heading first; treat
+the picture only as a hint for which segment owns the media. (If a grid renders 1-of-N,
+suspect a picture-keyed boundary with no heading fallback.)
+
+## #53 / #72 — Classifiers must match the element ITSELF or a descendant; media = `picture, img`
+
+In the flattened shape the segmented "cells" are bare sibling elements (an `<img>`, an `<a>`,
+an `<h3>`), so `cell.querySelector('img')` returns null and the content silently vanishes.
+Classify with `el.matches(sel) || el.querySelector(sel)`. For MEDIA, always test
+`picture, img` (not just `picture`) — un-pipelined/harness content and pasted external URLs
+deliver a bare `<img>` with no `<picture>` wrapper:
+`const media = el.matches('picture, img') ? el : el.querySelector('picture, img')`.
+(Likewise `a` / `Hn`.)
+
+Always pair with a per-section screenshot eyeball (#23) and the `CONTENT GAP` probe flag
+(#49) — a heading/contentBox-count or main-height delta vs the proto means content was
+dropped or duplicated.
+
+## #79 — Read plain-text fields by CELL/`textContent`, not `querySelectorAll('p')`
+
+The pipeline unwraps the `<p>` in single-text cells, so a `p`-based read drops
+eyebrow/subhead/lede/tag/body on live while the raw-`<p>` harness still shows them. Verify
+against the decorated live/preview render or a `<p>`-stripping harness, and assert each text
+field is present (counts alone don't catch it).
+
+## #35 — Headings: exactly one `<h1>` per page + a real outline
+
+Prototype headlines are usually styled `<div>`/`<span>`s with no heading semantics. Promote
+them: the hero/lead block renders its headline as the page's **single `<h1>`**; every other
+section title renders as `<h2>` (sub-items `<h3>`). Never leave a headline as a bare `<div>`
+— the `<h1>` is the strongest on-page relevance signal, it's the source of the page `<title>`
+(#34), and the outline drives crawlers, AI answer engines, and screen readers (WCAG). This
+applies to **interactive blocks too**: a flow/quiz/dashboard renders its lead title as `<h1>`
+in its server-visible markup, not just after JS. (Symptom this prevents: a converted page
+with zero `<h*>` elements, or sibling `<h2>`s with no `<h1>`.)
+
+## #28 — Interactive blocks (stateful components)
+
+When the prototype section is a stateful component (a selector, a filter, a form that mutates
+data, a multi-step flow), reproduce it as **one self-contained interactive block that owns
+the state** — block JS runs, so this is fully supported:
+
+- **Data → keyed authorable rows.** For heterogeneous data, key each row by its first cell
+  (`account | id | name | …`, `txn | date | desc | …`) and parse by key. Homogeneous lists
+  are just one row per item.
+- **Behavior → local state + targeted re-render.** Hold a mutable `state` object; write small
+  `render*()` functions (e.g. `renderCards()`, `renderList()`) and re-invoke only the
+  affected one on each interaction — the manual equivalent of a React re-render. A form that
+  mutates data validates, updates `state`, re-renders the affected parts (cards, totals,
+  `<option>`s), and shows a confirmation.
+- This mirrors lifting state to a parent in React: if several widgets share data, put them in
+  **one** block rather than trying to sync state across blocks. (Cross-block coordination, if
+  ever needed, is a DOM `CustomEvent`.)
+- **QA the behavior, not just the paint** — drive each control and assert the state change.
+  (When asserting computed style right after a click, move the pointer off the element and
+  let CSS transitions settle first, or a mid-`transition`/`:hover` read gives a false
+  negative.)
+
+## #33 — Sequential flow vs. addressable views: pick the right decomposition
+
+A *sequential* flow whose views are entered from one starting point and are not independently
+addressable (search → results → seats → confirm; an onboarding wizard; a checkout) is **one
+block** with a `state.view` field and a `render()` dispatcher that `replaceChildren()`s the
+active view. This is the inverse of #29: *independently-addressable* views with **different
+chrome** become **multiple pages**. Rule of thumb — sequential-from-one-entry → one block;
+addressable-with-own-chrome → pages.
+
+## QA probes referenced from Local QA
+
+### #13 — Wide-viewport content-width probe
+
+```js
+// Playwright, viewport 1600: for each block, is the content constrained?
+for (const n of ['hero','quick','used','stats','service','offers','brands','locations']) {
+  const w = await page.evaluate((sel) => {
+    const inner = document.querySelector(`.${sel} .wrap`) || document.querySelector(`.${sel}`).firstElementChild;
+    return Math.round(inner.getBoundingClientRect().width);
+  }, n);
+  console.log(n, w, w > 1340 ? '<== FULL-WIDTH (check against prototype)' : '');
+}
+```
+
+Cross-check each flag against the prototype: full-bleed is correct only where the prototype
+section has no inner max-width wrapper.
+
+### #19 — Capture at a real viewport
+
+A `min-height:100vh` hero becomes *window-tall* under a huge capture window (e.g. 7800px),
+pushing its centered content far down and off the top crop — it looks like the hero text
+vanished. Use Playwright at a normal viewport (e.g. 1440×900) and `scrollIntoView()` each
+section before each screenshot.
+
+### #29 — Multi-view SPA harness caveat
+
+The `metadata` block is consumed by the delivery pipeline into a `<head>` `<meta>`, but the
+local harness has no pipeline — so it won't apply `header: off` and will try to load
+`metadata` as a block, showing a stray error. Strip the `<header>` element from the harness
+to preview a header-off page; it's a non-issue live.

--- a/plugins/stardust/skills/deploy/reference/encode-contract.md
+++ b/plugins/stardust/skills/deploy/reference/encode-contract.md
@@ -1,0 +1,197 @@
+# ENCODE contract — deep dive (section heads, images, buttons)
+
+Companion to SKILL.md § The ENCODE contract and § Step 5. The contract rules are inline in
+SKILL.md; this file carries the mechanics: section-head reabsorption, the image
+upload/verification/repair procedures, and the worked button-system CSS.
+
+## Section heads: default content the block reabsorbs (zero pixel change)
+
+A head-bearing block (one with a section eyebrow/heading/lede above repeating units) should
+NOT carry that head as block rows. Author the head as **default content** in the section,
+before the block; the block table holds only the repeating units. Then the block
+**reabsorbs** the head so the decorated DOM — and every pixel — is identical to the old
+in-table form:
+
+- On `decorate(block)`, read the section's leading default-content wrapper, build the SAME
+  `.section-head` the block used to build from its first rows, and **remove the wrapper**.
+  Result: identical decorated DOM; CSS untouched.
+- **The head wrapper is a sibling of the block's SECTION-LEVEL wrapper, not of the block, and
+  its class varies by runtime.** Use
+  `block.closest('.block-content')?.previousElementSibling` and match BOTH `.default-content`
+  (AuthorKit runtime) **and** `.default-content-wrapper` (vanilla EDS).
+  `block.previousElementSibling` alone is `null` (the block is nested in `.block-content`).
+- Keep the old in-table head (leading non-unit rows) as a **back-compat fallback**.
+- **Verify zero change:** diff the *decorated* block `outerHTML` (ids/`media_<hash>`
+  normalised) old-vs-new — it must be byte-identical, with 0 default-content wrappers left
+  after decorate.
+
+A FOUC is possible (head paints as default content, then reabsorbs); the final layout is
+identical — watch CLS only if default-content margins differ markedly from the head's.
+
+This is NOT for a genuine widget whose rows ARE its structure (e.g. countdown) — those keep
+their rows.
+
+## #86 — Key facts must be server-rendered (rationale)
+
+The static header/footer fragments are client-injected (`postlcp.js` `innerHTML` after first
+paint), so anything that exists only there — a trust fact line ("Open source · Apache 2.0 ·
+built by X"), pricing, contact facts — is INVISIBLE to non-rendering crawlers and AI bots on
+every page. If a fact matters for SEO/LLM answerability, author it in page content (a fact
+panel, an install-section sentence, the metadata description); the fragment copy is
+presentation, not the crawlable source of truth. Verify by grepping the RAW served HTML (no
+JS) for the key-facts list — the rendered DOM check passes either way and hides the failure.
+
+## Images: editorial → authored content, decorative → CSS only
+
+**Any raster/brand image that carries meaning is EDITORIAL and must be authorable content** —
+including hero / feature / CTA-band backgrounds that sit *behind* text and a scrim (the
+author swaps them per campaign; they're the page's most important visual). For editorial
+images:
+
+1. Upload the binary to DA: `PUT https://admin.da.live/source/{org}/{repo}/media/<scope>/<file>`
+   (multipart, field name **`data`**, correct `Content-Type`; upload the JPG/PNG/webp source
+   only — the pipeline generates responsive variants).
+2. Author a single `<img src="https://content.da.live/{org}/{repo}/media/<scope>/<file>"
+   alt="…">` in the cell (branch-independent; the pipeline emits the responsive `<picture>`).
+   **Never** a repo-relative `/img/…` in content (→ `<img src="about:error">`). **Never** bake
+   imagery into block JS by index (`CARD_IMAGES`/`LOGOS`) — that isn't authorable.
+3. The block renders the authored `<img>` into a background LAYER (`.hero-bg` / `.card-media`
+   / `.text-media`); the scrim/gradient is a CSS `::before` OVER it. Keep a fixed CSS asset as
+   the no-image fallback.
+
+**Decorative = CSS only** applies to image-LESS treatments (gradients, scrims, textures,
+solid washes) and to genuinely fixed brand assets referenced as **CSS backgrounds**
+root-relative (`/img/<brand>/…` — browser-fetched, never ingested, so no `about:error` and no
+upload).
+
+**The check that catches the #1 mistake:** after preview, grep the delivered `.plain.html`
+for the expected `<img>`+alt count. "It renders" hides CSS-background images — they're absent
+from `.plain.html`, carry no alt, and are neither authorable nor AI/SEO-visible.
+
+### Source/external image URLs (migration): verify BEFORE authoring
+
+Re-using an image straight off the source page is the most common way to ship
+`<img src="about:error">`: the preview ingester fetches the authored URL, and if that fetch
+fails the delivered image is `about:error` — silent, since the page still renders. So verify
+every authored `<img>` whose src points at the source/CDN — **but the verification fetch must
+match how extract reached the origin, and a failure is not automatically "omit".**
+
+**Verify with the recorded fetch technique, not a bare curl (#2 — bot-managed origins).** A
+large fraction of real migration targets sit behind Akamai / Cloudflare / Imperva / F5, which
+403 a plain `curl` (and headless requests) while serving the same asset fine to a real
+browser. A blanket "curl it; if not 200, omit" therefore **strips every real brand image**
+off an entire bot-walled site — the exact failure the quality bar forbids. Instead: read
+`_crawl-log.json#discovery.fetchTechnique`. When it is `headed-chrome`, verify image URLs
+with an **in-page fetch from the open browser context**
+(`page.evaluate(async u => (await fetch(u)).status, url)`) — that inherits the JA3/H2
+fingerprint and cookies (per `extract/reference/playwright-recipe.md` § Bot-management →
+Sub-resource fetches); a bare `curl`/`request` will falsely report the asset broken. Only
+when `fetchTechnique` is plain may a bare
+`curl -s -o /dev/null -w '%{http_code}' <url>` stand in.
+
+**Distinguish 403-bot-wall from 404-missing, and prefer rehost over omit.** A `403`/`401`
+from a CDN means *blocked-when-hotlinked*, NOT *missing* — and even if the URL would 200 to
+the ingester now, hotlinking the source CDN from the delivery host is fragile (it can 403
+cross-origin at preview time, yielding `about:error`). So the default remediation for a
+`403`/blocked captured image is **download-and-rehost**, not omit: extract already saved a
+local copy under `stardust/current/assets/media/` via the in-page fetch — upload it to DA
+(`PUT …/source/{org}/{repo}/media/<scope>/<file>`) and author the `content.da.live` URL.
+**Omit only on a true `404` (asset genuinely gone) after attempting the rendition/delimiter
+repairs below** — and never substitute a generic logo/placeholder (`…-logo…`) as if it were
+editorial. Two real failure signatures where the asset exists — fix the URL, don't drop it:
+1. **wrong rendition variant** — the page exposes only a derivative that 404s while a sibling
+   resolves (e.g. a portrait's `…/4x3/768/…` 404 vs `…/original/768/…` 200) → rewrite to the
+   resolver;
+2. **missing query delimiter** — `…/<id>&wid=600&hei=…` with no `?` makes `<id>&wid=…` a
+   bogus id → 403 → repair the first `&` after the id to `?`.
+
+**`content.da.live` media URLs are auth-gated — don't anon-curl them.** Once you've rehosted
+to DA, the recommended `https://content.da.live/{org}/{repo}/media/…` src returns **`401` to
+an anonymous `curl`** even though it is correct and the preview pipeline ingests it fine. Do
+not treat that `401` as "broken" and omit. The correct verification for an already-rehosted/
+DA-hosted image is **post-preview**: grep the delivered `.plain.html` for `about:error` (must
+be 0) and assert the expected `<img>`/alt count — see `da-deploy-protocol.md` step 3b. Exempt
+`content.da.live` (and `admin.da.live`) URLs from the pre-author 200-check entirely.
+
+## Buttons — worked global button system (Step 5)
+
+Add to `styles/styles.css` (adapt tokens to the project's brand):
+
+```css
+a.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 26px;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+  transition: background 0.25s var(--ease-out), color 0.25s var(--ease-out), border-color 0.25s var(--ease-out);
+}
+
+a.btn-primary { background: var(--color-wavelength); color: var(--color-ink-rich); border-color: var(--color-wavelength); }
+a.btn-primary:hover { background: var(--color-canvas); border-color: var(--color-canvas); }
+
+a.btn-secondary { background: transparent; color: currentcolor; border-color: rgb(255 255 255 / 40%); }
+a.btn-secondary:hover { border-color: currentcolor; background: rgb(255 255 255 / 5%); }
+
+/* On light surfaces, secondary uses dark-tinted outline. List the dark sections explicitly. */
+main .section:not(.dark, .closing, .hero, .team) a.btn-secondary { border-color: var(--color-rule-strong); color: var(--color-ink-rich); }
+main .section:not(.dark, .closing, .hero, .team) a.btn-secondary:hover { border-color: var(--color-ink-rich); }
+
+/* Trailing arrow on primary/accent. */
+a.btn-primary::after, a.btn-accent::after { content: "→"; font-weight: 600; transition: transform 0.3s var(--ease-out); }
+a.btn-primary:hover::after, a.btn-accent:hover::after { transform: translateX(4px); }
+
+.btn-group { display: inline-flex; flex-wrap: wrap; gap: 16px; align-items: center; }
+```
+
+### #41 — Surface-aware variants: scope to the BLOCK class, not just the section
+
+When a button/link/text treatment differs on dark vs light surfaces, the prototype's
+dark-surface cue (e.g. `.hero`, `.cta-dark`) becomes a **block class** after conversion — a
+`<div class="hero">` nested inside the `<div class="section">`. So an override written as
+`main .section.hero a.btn-secondary` never matches (the `.hero` is one level below
+`.section`), and the on-dark CTA silently renders dark-on-dark. Scope on-dark overrides to
+BOTH: `main .section.dark a.btn-secondary, main .hero a.btn-secondary { … }`. QA any block on
+a dark background for secondary/ghost-CTA contrast (light outline + light text) — the button
+"exists" in metrics, so only contrast/eyeball catches this.
+
+### Per-block overrides: only what's actually different
+
+The `closing` block's CTA is slightly larger than the global default — a legitimate override:
+
+```css
+.closing .actions a.btn-primary { padding: 22px 32px; font-size: 13px; }
+```
+
+Three lines. Targets the global class, not a custom one. This is the entire "blocks slightly
+augment defaults" pattern.
+
+### When NOT to use the convention — examples
+
+Some links are NOT buttons:
+- A wavelength-underlined text link in a section footer ("How we work →"). It's a styled text
+  link, not a chip.
+- Whole-card anchors on tile grids (`<a class="tile">…</a>`). The whole tile is the click
+  target.
+- Channel values in a closing CTA (`<a href="tel:…">801-363-0101</a>`). It's a value, not a
+  CTA.
+- `mailto:` / `tel:` links inside prose.
+
+For these: the author leaves the `<a>` as a plain anchor in content (no `<strong>` / `<em>`
+wrap), and the owning block styles it with per-block CSS. The convention is for buttons; if
+it's not a button, don't apply it.
+
+### #25 — Multi-variant button systems
+
+The strong/em convention only names three slots (primary / secondary / accent). When a
+prototype has **more** context-specific variants than that — e.g. JFK's `.btn--accent`
+(yellow), `.btn--primary` (blue), `.btn--ghost` (outline), `.btn--onblue` (white-on-blue) —
+author emphasis can't express them. Don't force it: **lift the prototype's full `.btn` +
+variant system into `styles/styles.css`**, author the CTAs as plain `<a>` in content, and
+have each block apply the right `btn btn--<variant>` class to the cloned anchor (the block
+knows its section's variant). This is the same "if it doesn't fit, style it" escape hatch,
+applied at the button-system level rather than per-link.

--- a/plugins/stardust/skills/deploy/reference/font-strategy.md
+++ b/plugins/stardust/skills/deploy/reference/font-strategy.md
@@ -1,0 +1,246 @@
+# Font strategy & CLS — deep dive
+
+Companion to SKILL.md § Step 3 (#81 header reservation) and § Step 4 (fonts). The rules are
+inline in SKILL.md as one-liners; this file carries the recipes, the metric math, the
+licensing-alert mechanics, and the failure narratives. Apply every recipe that matches your
+project.
+
+## #65 — Ship an `@font-face` for EVERY named family
+
+Prototypes name a display face AND a body face (`--display: "Hebden Incised", …;
+--body: "Lekton", …`). If you self-host only the body font, every heading/numeral/title whose
+stack names the un-shipped display family silently falls back to `Times New Roman`/`Arial`
+(generic serif/sans) — **invisible to size/color checks** (the glyphs differ but the metrics
+match; only the `FONT MISMATCH` probe flag #66 or an eyeball catches it). Distinct from
+#11/#22 (wrong weight) and #30 (opsz): here the family is NAMED but NEVER SHIPPED. For each
+quoted family in `--display`/`--body`/any heading stack, self-host a matching `@font-face`
+(download + commit the woff2 under `styles/fonts/`, reference root-relative — never the
+prototype's brand-CDN origin, #44). **Checklist:** grep every quoted family in `styles.css`'s
+font stacks against the `@font-face { font-family }` names declared — any unmatched name is a
+silent fallback.
+
+## Principle 2 mechanics — self-hosting sources and licensing (#80)
+
+License triage:
+- SIL OFL 1.1 (Inter, JetBrains Mono, Fraunces, Roboto, Open Sans, IBM Plex, Source Sans,
+  etc.) → self-host. License permits redistribution, including embedding on the served domain.
+- Apache 2.0 (some Google Fonts) → self-host.
+- **Proprietary commercial (Pangram Pangram, Adobe Fonts / Typekit, Monotype, foundry-direct)
+  → self-host anyway for fidelity, BUT raise a LICENSING ALERT (#80).** The DEFAULT is
+  brand-faithful: a converted/presales page that silently degrades the brand display face to
+  Arial reads as broken to the client (this is exactly what a stakeholder notices first). Lift
+  the prototype's actual webfonts — if the prototype ships `.otf`/`.ttf` (claude-design/
+  stardust prototypes usually do, under `assets/fonts/`), convert them to latin `woff2` with
+  `fontTools` (`f.flavor='woff2'; f.save(...)`, ~30–60 KB each) and declare them in
+  `styles/styles.css` exactly like an OFL face.
+
+**The licensing alert must appear in THREE places** so it can't ship unnoticed:
+1. a banner comment at the top of `styles/styles.css` (`⚠️ FONT LICENSING REQUIRED BEFORE
+   GOING LIVE` + foundry per family + "do not publish to `aem.live` until the
+   webfont/embedding license is confirmed");
+2. a `styles/fonts/LICENSING.md` file (table: file → family → foundry → status, plus the
+   remove-and-fall-back instructions);
+3. the conversion log, AND your hand-off message to the user.
+
+Document the **remove path**: if licensing can't be confirmed, delete the `.woff2` + their
+`@font-face` rules and the stacks fall back to the metric-matched system fallback. This is
+the inverse of the old "keep CDN / accept Arial" guidance — prefer fidelity + a loud alert
+over a silent generic fallback. (Only keep a CDN load when the prototype itself loads from an
+Adobe/Typekit CDN AND you cannot obtain the font files — then document the CDN coupling + CLS
+cost.)
+
+### Fetching OFL fonts (fontsource via jsDelivr)
+
+Latin-only variable woff2 is typically 30–60 KB per file, weights 100–900 included:
+
+```bash
+mkdir -p styles/fonts
+curl -sSL -o styles/fonts/<name>-variable.woff2 \
+  "https://cdn.jsdelivr.net/npm/@fontsource-variable/<name>@latest/files/<name>-latin-wght-normal.woff2"
+# italic, if used:
+curl -sSL -o styles/fonts/<name>-italic-variable.woff2 \
+  "https://cdn.jsdelivr.net/npm/@fontsource-variable/<name>@latest/files/<name>-latin-wght-italic.woff2"
+```
+
+### #30 — Match the axes the prototype loads, incl. optical size
+
+Check the prototype's Google Fonts `<link>` URL. If it requests an **`opsz`** (optical-size)
+axis — e.g. `Source+Serif+4:opsz,wght@8..60,400;…` — the default `@fontsource-variable/<name>`
+file (`<name>-latin-wght-normal.woff2`) is **wght-only** (one fixed optical master) and
+headings will render subtly off (heavier/different letterforms at large sizes). Fetch the
+**opsz** file instead (carries both `wght` + `opsz`, ~2× the bytes); `font-optical-sizing:
+auto` (the CSS default) then tracks the size:
+
+```bash
+curl -sSL -o styles/fonts/<name>-opsz.woff2 \
+  "https://cdn.jsdelivr.net/npm/@fontsource-variable/<name>@latest/files/<name>-latin-opsz-normal.woff2"
+```
+
+More generally: self-host the variant whose axes match what the prototype loaded (wght-only
+vs opsz; italic if used).
+
+### #11 — Non-variable fonts (static weights)
+
+Many Google fonts ship only as named static weights — no variable axis (e.g. **Barlow**,
+Barlow Condensed, Anton). For these, `@fontsource-variable/<name>` does NOT exist; use the
+**static** `@fontsource/<name>` package and fetch each weight you actually use:
+
+```bash
+curl -sSL -o styles/fonts/<name>-700.woff2 \
+  "https://cdn.jsdelivr.net/npm/@fontsource/<name>@latest/files/<name>-latin-700-normal.woff2"
+```
+
+Static `@fontsource` packages also do **not** publish a "Fallback" `@font-face`, so you must
+**compute** the metric-override values yourself from the woff2 with fonttools:
+
+```python
+from fontTools.ttLib import TTFont
+f = TTFont("styles/fonts/<name>-400.woff2"); upm=f['head'].unitsPerEm; hhea=f['hhea']; os2=f['OS/2']
+arial = dict(upm=2048, xavg=904)  # Arial reference (use Times metrics for a serif brand)
+size_adjust = (os2.xAvgCharWidth/upm) / (arial['xavg']/arial['upm'])
+adj = upm*size_adjust
+print(f"size-adjust:{size_adjust*100:.2f}% ascent-override:{hhea.ascent/adj*100:.2f}% "
+      f"descent-override:{abs(hhea.descent)/adj*100:.2f}% line-gap-override:{hhea.lineGap/adj*100:.2f}%")
+```
+
+Apply those to the system-font override `@font-face` (renamed `"Arial"` / `"Times New Roman"`)
+exactly as in SKILL.md's body.session recipe.
+
+## Principle 3 mechanics — metric calibration and the CLS chain
+
+The metric-override values for variable fonts come from the `@fontsource-variable/<name>`
+package's published calibration — fetch their CSS:
+
+```bash
+curl -s "https://cdn.jsdelivr.net/npm/@fontsource-variable/<name>@latest/index.css" \
+  | grep -A 6 "Fallback"
+```
+
+Each fontsource package publishes a `<Name> Fallback` `@font-face` with `size-adjust`,
+`ascent-override`, and `descent-override` values. Lift those three numbers verbatim and apply
+them to a local-system `@font-face` renamed to the system font (`"Arial"`,
+`"Times New Roman"`, `"Courier New"`).
+
+The CLS chain that results:
+- **Initial paint**: `body { font-family: arial, sans-serif; }` — renders the metric-adjusted
+  local Arial because the override `@font-face` named `"Arial"` wins over the OS Arial. Line
+  box already matches the brand font's metrics.
+- **Session activates**: `body.session` switches to `var(--font-body)`. Brand woff2 is still
+  loading; Arial renders in its place with matching metrics. **Zero shift.**
+- **Brand font loads**: swaps in. **Zero shift** because metrics already match.
+
+## Principle 4 mechanics — fallback classification
+
+Use the SAME class of typeface for the fallback so visual rhythm is preserved during load:
+- Sans-serif brand → fallback `arial, sans-serif`. Override `@font-face "Arial"` with
+  `local("Arial")`.
+- Serif brand → fallback `times, "Times New Roman", serif`. Override `@font-face
+  "Times New Roman"` with `local("Times New Roman")`.
+- Monospace brand → fallback `"Courier New", courier, monospace`. Override `@font-face
+  "Courier New"` with `local("Courier New")`. (Skipping monospace metric-matching is
+  acceptable when the mono font is only used in small eyebrows/labels — CLS impact is
+  negligible. Document the choice in the conversion log.)
+
+Never substitute classifications (don't match a serif brand to Arial; don't match a sans
+brand to Times). Even with metric overrides, character widths and rhythm differ enough that
+the visible shift is jarring.
+
+### #80 — Classification includes WIDTH (condensed fallbacks)
+
+"Sans→Arial" is only right for a *normal-width* sans. A narrow/condensed display face
+(PP Formula Narrow, Bebas Neue, Oswald, Barlow/Archivo Condensed, Anton) falling back to
+plain Arial is a width-class mismatch: Arial runs **~15–20% wider** with different
+letterforms, so headings lose the condensed character and wrap differently — a silent
+divergence the eye catches even when sizes/weights/tracking match exactly (a CardValet pass
+shipped PP Formula→Arial; the width probe showed Arial 975 vs PP Formula 839 for the same H1
+string). When the condensed brand face is self-hosted (the default) this only bites if the
+webfont is blocked, but the fallback must STILL preserve width: put a condensed system/free
+face ahead of `arial` in the stack — `"<Brand>", "Arial Narrow", arial, sans-serif` (system
+`Arial Narrow` is present on macOS/Windows but NOT Android/Linux, so for guaranteed coverage
+self-host a free OFL condensed analog — Oswald / Barlow Semi Condensed / Archivo Narrow).
+Same logic for an *extended/wide* brand face. Quick check during foundation: for every
+`--*-font-family` token whose first face is condensed, confirm the final non-`sans-serif`
+fallback is also condensed.
+
+### #77 — Self-host the INTENDED fallback; verify with a width probe
+
+Prototypes routinely load **zero `@font-face`** and name a proprietary brand font first
+(`--display: "Bellfort", "Bebas Neue", system-ui`). On any machine missing the brand font the
+prototype silently renders **system-ui** — so its on-screen display face is an *accident of
+the viewing machine*, not the design intent. Do NOT match that accident (don't set EDS
+`--display` to system-ui because "that's what the proto shows"). The prototype's OWN stack
+documents the intent: self-host the first **redistributable** fallback (OFL/Apache — e.g.
+Bebas Neue) so EDS ships the condensed display face the design wants; keep proprietary
+families documented in the conversion log.
+
+**Verify what actually rendered with a width probe** — `document.fonts.check('24px "X"')`
+returns **true for any family name the page references**, installed or not, so it produces
+false "fonts match" reads. Instead measure: a span at `font-family:"X",monospace` whose width
+equals a known-absent name's width means X fell back (absent); a distinct width means X is
+really rendering. (A beermaker pass set `--display` to Bebas Neue via a `fonts.check`
+false-positive — the width probe later showed the proto actually renders system-ui, but Bebas
+Neue was still correct as the documented intended fallback.)
+
+### #12 — Multiple display families
+
+A brand may use several families — e.g. Barlow (body) + Barlow Condensed + Barlow Semi
+Condensed (display). The `body.session` pattern only gates the **body** family; display
+families referenced directly by class (headings, eyebrows) load with `font-display: swap` and
+aren't fully CLS-eliminated. Define each as a `:root` token (`--font-cond`, `--font-semi`)
+and reference it per-block on the elements that use it. Fully metric-matching every display
+family is optional polish — for display text used sparingly (eyebrows, big condensed
+headings) the CLS impact is small; **document the trade-off** in the conversion log rather
+than over-engineering it.
+
+**But when a display family is used in an ABOVE-THE-FOLD heading (the hero `<h1>`, an LCP
+title), metric-match it too** — compute its `size-adjust`/`ascent-override`/`descent-override`
+from the woff2 (the same fonttools recipe as #11) and put a dedicated fallback `@font-face`
+SECOND in that family's stack: `--hero: "Lilita One", "Lilita One Fallback", …`. The fallback
+family MUST have its own name — do NOT reuse the renamed `"Arial"` face the body match
+already defines (#11), since that carries the *body* font's metrics, not the display font's.
+(In practice the dominant first-section CLS is usually the late header box, #81, not the
+display-font swap — fix the header reservation first, then metric-match above-fold display
+faces to zero the remainder.)
+
+### #22 — Match the prototype's effective weight
+
+A single-weight display font (e.g. **Anton**, ships only 400) often appears *bolder* in the
+prototype than its one weight: a bare `<h1>`/`<h2>` inherits the browser-default heading
+weight (700), and the browser **faux-bolds** the 400-only face. If your foundation sets
+`h1,h2,h3 { font-weight: 400 }`, headings render visibly lighter than the prototype. Set the
+weight the prototype actually shows (often 700) so the faux-bold matches — don't assume "one
+weight in the file ⇒ `font-weight: 400`".
+
+## #81 — Reserve the static header's height (the dominant first-section CLS)
+
+`postlcp.js` injects `fragments/header.html` AFTER first paint (it's a deferred fetch). In
+the common layout where the header sits in flow ABOVE the first section (full-bleed hero
+*below* the nav), the hero therefore renders at `y=0`, then jumps DOWN by the header's height
+the instant the fragment lands — a large layout shift the browser attributes to the hero
+block (a real page measured **CLS 0.143, ~0.13 of it the hero**; metric-matched fonts do NOT
+fix it because the cause is the header box appearing, not a font swap).
+
+Reserve the header's rendered height on the **bare `<header>` element** in
+`styles/styles.css` (it applies before the fragment loads — `decorateHeader()` sets the class
+early, but styling the bare element covers the pre-class sliver too), with responsive
+`min-height` matching the fragment per breakpoint and the chrome's own `background` so any
+reserve-vs-actual delta is invisible:
+
+```css
+header { min-height: 98px; background: var(--brand-ground); }   /* desktop nav+banner height */
+@media (width <= 767px) { header { min-height: 102px; } }
+@media (width <= 480px) { header { min-height: 120px; } }       /* banner wraps to 2 lines */
+```
+
+Make the header's height **deterministic** so the reserved value actually matches: keep the
+reservation breakpoints in sync with the fragment's, and avoid nav-link *wrap zones* (e.g.
+extend the burger/hamburger breakpoint so the inline links can't wrap to a second row at
+awkward widths). Reserve slightly OVER the natural height (a few px) so you never
+under-reserve and shift — on a dark/uniform ground the small gap is invisible; a
+`header:empty` page (`header: off`) removes the element so the reservation is moot. **The
+footer needs NO reservation** — it's below the fold, so its late injection shifts nothing
+above it.
+
+Verify with a CLS probe (Playwright `PerformanceObserver({type:'layout-shift'})`) that
+**delays the woff2/fragment fetches** to reproduce the slow-network swap PSI measures — a
+fast localhost load hides the shift. Target < 0.1.

--- a/plugins/stardust/skills/deploy/reference/runtime-bootstrap.md
+++ b/plugins/stardust/skills/deploy/reference/runtime-bootstrap.md
@@ -1,0 +1,92 @@
+# Runtime bootstrap — deep dive (vanilla aem-boilerplate → AuthorKit)
+
+Companion to SKILL.md § Runtime bootstrap. The rules live inline in SKILL.md; this file
+carries the full port manifest, the mechanics of the two mandatory edits, the lint list,
+and the drift history. Read this before hand-porting or debugging a port.
+
+## Source modes for `bootstrap-authorkit.mjs` (#6)
+
+- **`--from-sibling <dir>` (preferred in a multi-site repo):** copy the runtime from another
+  EDS project in the workspace that is already bootstrapped (has `scripts/ak.js` with both
+  edits). Offline, deterministic, and parity-safe with a known-good *deployed* runtime — no
+  re-fetch, no re-patch risk per site. This is the right default when several sites share one
+  repo (e.g. 8 subfolder sites).
+- **`--ref <gitref>`:** fetch a **pinned** author-kit ref tarball and port from it. Pin a real
+  commit/tag (the script's `AUTHORKIT_REF` constant or `--ref`), **not** a tracking branch —
+  author-kit's runtime has drifted (static-fragment → block-based header/footer), so an
+  unpinned port can silently change what you get. If the fetched runtime no longer matches the
+  static-fragment model this skill describes (`loadStaticFragment`, `postlcp.js` injecting
+  `fragments/{header,footer}.html` via `innerHTML`), pin an older known-good ref or use
+  `--from-sibling`.
+
+The script does the entire port — copies the PORT-IN set, removes the boilerplate set,
+applies AND verifies both mandatory edits (failing loud instead of the usual silent
+footer-error-box), patches the `body.appear` blank-render gate, and writes `.eslintignore`.
+
+## Manual manifest (what the script does, for hand-porting)
+
+Fetch the author-kit tarball and copy:
+
+**Port in (from author-kit):**
+```
+scripts/ak.js scripts/scripts.js scripts/postlcp.js scripts/lazy.js scripts/utils/*
+tools/**                      # da/da.js (+ sidekick, quick-edit, scheduler — keep so lazy.js/scripts.js imports resolve). sanitise.js is bundled with this skill, not ported.
+deps/**                       # rum.js + lit (head.html loads deps/rum.js)
+head.html                     # AuthorKit head: loads ak.js + scripts.js + styles.css + deps/rum.js
+blocks/fragment blocks/section-metadata
+.hlxignore
+```
+
+**Remove (boilerplate the AuthorKit runtime replaces):**
+```
+scripts/aem.js scripts/delayed.js          # replaced by ak.js + lazy.js
+blocks/header blocks/footer                 # replaced by static fragments/{header,footer}.html (Step 6)
+blocks/cards blocks/columns blocks/widget   # unused demo blocks (delete to avoid stale aem.js imports)
+styles/fonts.css styles/lazy-styles.css     # @font-face goes in styles.css; AuthorKit head loads only styles.css
+```
+
+## The two mandatory edits — full mechanics (halves of one change)
+
+1. **`scripts/lazy.js` (#4):** the stock AuthorKit `lazy.js` lazy-loads `utils/footer.js`,
+   which does `loadBlock(footer)` and collides with the static footer fragment (renders a
+   visible "Error" box, since there is no `blocks/footer`). **Delete the
+   `import('./utils/footer.js')…` line.**
+2. **`scripts/postlcp.js` (#21):** deleting `utils/footer.js` also removed the only code that
+   set the `<footer>`'s class. Without it, the fragment's own root selector
+   (`footer.footer { background: … }`) never matches and any styling on the fragment ROOT
+   (background/padding/color) silently no-ops. In `loadStaticFragment`, set the class before
+   injecting:
+   ```js
+   const html = await resp.text();
+   el.className = name;          // so header.header / footer.footer match
+   el.innerHTML = html;
+   ```
+   This bug is invisible when the footer happens to match the body background; it bites the
+   moment a fragment has its own background (e.g. a yellow footer).
+
+When starting a NEW conversion in a repo where a sibling site is already bootstrapped, port
+from that sibling (`bootstrap-authorkit.mjs --from-sibling <dir>`) — it already carries both
+edits and matches a known-good deployed runtime. Otherwise port from a **pinned** author-kit
+ref, not a tracking branch (the runtime drifts).
+
+## Lint mismatch (#6)
+
+The AuthorKit runtime is authored for `@adobe/eslint-config-helix`; a boilerplate project
+lints with `airbnb-base`, so `npm run lint` will throw thousands of errors on the vendored
+runtime + minified `deps/`. Treat the runtime as vendored — add to `.eslintignore`:
+
+```
+deps/
+scripts/ak.js
+scripts/lazy.js
+scripts/postlcp.js
+scripts/scripts.js
+scripts/utils/
+tools/
+blocks/fragment/
+samples            # reference prototypes, not project code
+```
+
+Your generated blocks + `styles/styles.css` still lint clean under airbnb (expand any
+single-line multi-declaration CSS rules the prototype used). Alternatively, adopt the
+author-kit `eslint.config.js` (helix) wholesale.

--- a/plugins/stardust/skills/direct/SKILL.md
+++ b/plugins/stardust/skills/direct/SKILL.md
@@ -6,1591 +6,396 @@ license: Apache-2.0
 
 # stardust:direct
 
-Resolve the user's freeform redesign intent into a complete **target
-specification**: project-root `PRODUCT.md` and `DESIGN.md` (impeccable
-format), a `DESIGN.json` sidecar with the divergence audit trail, and a
-`stardust/direction.md` with the full reasoning trace.
-
-`direct` produces the spec against which `prototype` and `migrate`
-operate. It never writes prototypes or migrates pages — those are
-downstream sub-commands.
+Resolve the user's freeform redesign intent into a complete **target specification**: project-root `PRODUCT.md` and `DESIGN.md` (impeccable format), a `DESIGN.json` sidecar with the divergence audit trail, and `stardust/direction.md` with the full reasoning trace. `direct` produces the spec `prototype` and `migrate` operate against; it never writes prototypes or migrates pages.
 
 ## Inputs
 
-- `<phrase>` — optional positional. The user's freeform intent
-  ("make it better", "more Linear less Salesforce", "feel more premium
-  on a small screen"). If omitted, ask the user for one.
-- `--re-direct` — optional. Replace the current direction with a new
-  one. Triggers stale-flagging on prototyped / approved / migrated
-  pages per `skills/stardust/reference/state-machine.md`. Default
-  behaviour without the flag is additive: if a direction already
-  exists, the agent asks before replacing.
-- `--rebrand` — optional. Force rebrand mode (full divergence-seed
-  roll, no Mode A inheritance) regardless of whether the captured
-  brand surface has signal. The default mode is brand-faithful
-  whenever `_brand-extraction.json` is `signal-strong` (see § Setup
-  step 5 and Phase 2 § Mode-detection precedence); pass `--rebrand`
-  to opt out explicitly when the user's phrase is ambiguous about
-  whether they want a refresh or a clean-slate redesign.
-- `--prep` — optional. Run in **migrate-prep mode**: confirm the
-  type catalog, finalize the module catalog, capture color
-  reservations and brand-level metadata defaults, re-evaluate
-  direction against the wider crawl. See § Prep mode below.
-  Typically invoked via the `prepare-migration` orchestrator.
-- `--add-variant <name>` — optional. Add a new variant against
-  the existing direction without re-running intent reasoning or
-  mode detection. Writes `DESIGN-<name>.{md,json}` at the
-  project root and appends a per-variant section to
-  `stardust/direction.md`. The previous direction stays
-  authoritative; existing prototypes are **not** stale-flagged.
-  Used when variants are spec'd incrementally — typical
-  workflow: render variant A, review, then ask for B and C as
-  "the alternatives we discussed earlier." See § Add-variant
-  mode below for the per-field inheritance rules.
+- `<phrase>` — optional positional freeform intent ("make it better", "more Linear less Salesforce"). If omitted, ask the user for one.
+- `--re-direct` — replace the current direction. Stale-flags prototyped / approved / migrated pages per `skills/stardust/reference/state-machine.md`. Without the flag, behaviour is additive: if a direction exists, ask before replacing.
+- `--rebrand` — force rebrand mode (full divergence-seed roll, no Mode A inheritance). Default is brand-faithful whenever `_brand-extraction.json` is `signal-strong` (§ Setup step 6, § Mode-detection precedence); pass `--rebrand` to opt out when the phrase is ambiguous between refresh and clean-slate redesign.
+- `--prep` — migrate-prep mode. **When `--prep` is passed, READ `skills/direct/reference/prep-mode.md` and follow it end-to-end** on top of the standard procedure (type catalog, module catalog, color reservations, metadata defaults, wider re-evaluation). Typically invoked via the `prepare-migration` orchestrator.
+- `--add-variant <name>` — add a variant against the existing direction without re-running intent reasoning or mode detection. **When `--add-variant` is passed, READ `skills/direct/reference/add-variant.md` and follow it end-to-end** (procedure, parentage, per-field inheritance, its failure modes). Writes `DESIGN-<name>.{md,json}`, appends a per-variant section to `stardust/direction.md`; the previous direction stays authoritative and existing prototypes are **not** stale-flagged.
 
 ## Setup
 
-1. Run the master skill's setup
-   (`skills/stardust/SKILL.md` § Setup) — hard impeccable dep check,
-   context loader, state read.
-2. Verify `stardust/state.json` exists and contains at least one
-   `extracted` page. If not, stop and recommend
-   `$stardust extract <url>` first.
-3. Read `stardust/current/_brand-extraction.json`. If absent, stop —
-   extract did not complete brand-surface extraction; re-run extract.
-3b. **Cross-site brand inputs** (when present). Two extract-written
-   signals widen the brand surface beyond the primary origin:
-   - `state.json.designSource` — design-donor mode (extract ran with
-     `--design-source <url>`). The donor's derived system at
-     `stardust/canon-source/DESIGN.{md,json}` becomes the **target**
-     the Mode A pins bind to: palette and type pin to the *donor*
-     surface while content, IA priorities, and per-page evidence stay
-     with the primary origin. Surface in the plan: *"Design-donor
-     mode — target system inherited from <donor-url>."*
-   - `_brand-extraction.json.origins[]` — sibling-property evidence
-     captured via `--brand-source`. Traits captured on a sibling
-     origin count as **captured evidence** for trait amplification
-     (variant B/C briefs, improvements items) exactly like
-     primary-origin evidence; cite the origin in the evidence
-     citation. Under Mode A the *pins* still come from the primary
-     origin unless designSource says otherwise — sibling evidence
-     widens what can be amplified, not what is pinned.
-4. Read `stardust/direction.md` if present. If a prior direction
-   exists and `--re-direct` was not passed, ask whether the user wants
-   to refine the existing direction or replace it.
-5. **Validate provenance on every in-scope page** (prep mode only).
-   When `--prep` is active, call
-   `validateProvenance(page)` per
-   `skills/stardust/reference/state-machine.md` § Provenance
-   validation on every `extracted` page in `state.json` before
-   typing or module detection. Abort with the helper's error
-   when any page lacks live-render evidence. Surface
-   `Provenance OK on N pages` in the prep summary. Discovery-
-   mode `direct` does not validate (it operates on a 5-page
-   sample for which extract's own write-time refusal is
-   sufficient).
-6. **Classify the captured brand signal.** Read
-   `_brand-extraction.json` and stamp one of:
-   - `signal-strong` — palette has ≥ 3 distinct colors (after
-     near-duplicate clustering and excluding pure black/white if they
-     are the only entries) **AND** at least one captured type family
-     is named in `type.headingFamily.name` or `type.bodyFamily.name`.
-     This is the common case for any extracted commercial site.
-   - `signal-thin` — palette has 2 colors OR no captured type family
-     OR `type.scaleAudit.kind === "ad-hoc"` with fewer than 3
-     distinct heading sizes. The brand exists but cannot fully
-     anchor a refresh.
-   - `signal-absent` — palette has 1 color or 0, or
-     `_brand-extraction.json._provenance.notes` flags the extraction
-     as failed / login-walled / iframe-dominated.
-   The classification feeds the Mode-detection precedence in Phase 2.
-   Surface the classification in the plan when it would change the
-   default mode.
+1. Run the master skill's setup (`skills/stardust/SKILL.md` § Setup): hard impeccable dep check, context loader, state read.
+2. Verify `stardust/state.json` exists with ≥ 1 `extracted` page. If not → stop; recommend `$stardust extract <url>` first.
+3. Read `stardust/current/_brand-extraction.json`. If absent → stop; extract did not complete brand-surface extraction; re-run extract.
+3b. **Cross-site brand inputs** (when present):
+   - `state.json.designSource` — design-donor mode. The donor's derived system at `stardust/canon-source/DESIGN.{md,json}` is the **target** the Mode A pins bind to: palette and type pin to the *donor* surface; content, IA priorities, and per-page evidence stay with the primary origin. Surface in the plan: *"Design-donor mode — target system inherited from <donor-url>."*
+   - `_brand-extraction.json.origins[]` — sibling-property evidence (`--brand-source`). Sibling-origin traits count as **captured evidence** for trait amplification (variant B/C briefs, improvements items) exactly like primary-origin evidence; cite the origin. Under Mode A the *pins* still come from the primary origin unless designSource says otherwise — sibling evidence widens what can be amplified, not what is pinned.
+4. Read `stardust/direction.md` if present. Prior direction exists and no `--re-direct` → ask whether to refine or replace.
+5. **Prep mode only:** call `validateProvenance(page)` (per `skills/stardust/reference/state-machine.md` § Provenance validation) on every `extracted` page before typing or module detection. Any page lacking live-render evidence → abort with the helper's error. Surface `Provenance OK on N pages` in the prep summary. Discovery-mode runs do not validate (5-page sample; extract's write-time refusal suffices).
+6. **Classify the captured brand signal** from `_brand-extraction.json`; stamp one of:
+   - `signal-strong` — palette has ≥ 3 distinct colors (after near-duplicate clustering, excluding pure black/white if they are the only entries) **AND** ≥ 1 named type family in `type.headingFamily.name` or `type.bodyFamily.name`.
+   - `signal-thin` — palette has 2 colors OR no captured type family OR `type.scaleAudit.kind === "ad-hoc"` with < 3 distinct heading sizes.
+   - `signal-absent` — palette has ≤ 1 color, or `_provenance.notes` flags the extraction as failed / login-walled / iframe-dominated.
+
+   The stamp feeds § Mode-detection precedence. Surface it in the plan when it would change the default mode.
 
 ## Procedure
 
 ### Phase 1 — Reasoning
 
-Run the full intent-reasoning procedure from
-`skills/stardust/reference/intent-reasoning.md`. Steps 1-6: restate
-the phrase in dimensional vocabulary, identify movement, identify
-gaps, ask **at most two** clarifying questions, map to an impeccable
-command sequence, show the plan to the user.
+Run the full intent-reasoning procedure from `skills/stardust/reference/intent-reasoning.md`, steps 1-6: restate the phrase in dimensional vocabulary, identify movement, identify gaps, ask **at most two** clarifying questions (hard ceiling, per turn, no exceptions), map to an impeccable command sequence, show the plan. Worked examples: `skills/stardust/reference/intent-examples.md`.
 
-Worked examples in
-`skills/stardust/reference/intent-examples.md` calibrate the style.
-Hard ceiling on questions: two per turn, no exceptions.
-
-**Hands-off mode** (per `skills/stardust/SKILL.md` § Hands-off mode,
-`state.json.handsOff: true`): ask nothing and wait for nothing.
-Derive every answer the questions would have collected from the
-captured evidence — density and ia-fidelity from their documented
-defaults and trigger conditions, audience and register from the
-captured surface — and record each as a named assumption in
-`direction.md` § Movements (e.g. `density: balanced (hands-off
-default — multi-audience floor fired)`). The plan is still written;
-execution proceeds without the confirmation gate. Question budgets
-and gates below that say "ask the user" resolve the same way: derive,
-stamp the assumption, proceed.
+**Hands-off mode** (`state.json.handsOff: true`, per `skills/stardust/SKILL.md` § Hands-off mode): ask nothing, wait for nothing. Derive every answer from captured evidence — density and ia-fidelity from their documented defaults and triggers, audience and register from the captured surface — and record each as a named assumption in `direction.md` § Movements (e.g. `density: balanced (hands-off default — multi-audience floor fired)`). The plan is still written; execution proceeds without the confirmation gate. Every "ask the user" below resolves the same way: derive, stamp the assumption, proceed.
 
 #### Density tuning (one-shot, only when unmoved)
 
-When the user's phrase does **not** move the `density` axis (per
-`reference/intent-dimensions.md` § 4), and the resolved register is
-`brand`, ask one short follow-up — count it within the two-question
-ceiling:
+When the phrase does **not** move `density` (`reference/intent-dimensions.md` § 4) and the resolved register is `brand`, ask one follow-up (counts within the two-question ceiling):
 
-> Density tuning — (a) airy (NYT-Opinion-tier breathing, ~96px
-> section padding), (b) balanced (calm but compact, ~64–72px),
-> (c) packed (data-dense, ~40–48px). Default for brand-register
-> sites with multi-audience IA is **(b) balanced**; pick (a) only
-> when the page is editorial-led with deep per-section density.
+> Density tuning — (a) airy (NYT-Opinion-tier breathing, ~96px section padding), (b) balanced (calm but compact, ~64–72px), (c) packed (data-dense, ~40–48px). Default for brand-register sites with multi-audience IA is **(b) balanced**; pick (a) only when the page is editorial-led with deep per-section density.
 
-If the user answers, stamp the chosen tier in `direction.md` §
-Movements as `density: <tier>`. If unanswered, default to
-**balanced** (not airy) for brand register and stamp
-`density: balanced (default)`.
+Answered → stamp `density: <tier>` in `direction.md` § Movements. Unanswered → default **balanced** (not airy) for brand register, stamp `density: balanced (default)`.
 
-Skip this question entirely when:
-- The user's phrase already moved `density` (any of "make it
-  denser", "more breathing room", "compact", "tight", "spacious"
-  count as movement).
-- The register is `product` (default `packed` per § 4).
-- The register is `ambiguous` and resolving it earlier in the
-  reasoning is the higher-value question — defer density to the
-  next turn rather than burning a question slot.
+Skip the question entirely when:
+- The phrase already moved `density` ("denser", "more breathing room", "compact", "tight", "spacious" all count as movement).
+- Register is `product` (default `packed` per § 4).
+- Register is `ambiguous` and resolving it is the higher-value question — defer density to the next turn rather than burning a question slot.
 
-The tier propagates to `DESIGN.md`'s `spacing.sectionPadding`
-deterministically per `intent-dimensions.md` § 4: airy = 96px,
-balanced = 64px, packed = 48px. Phase 4 picks the value from this
-stamp without re-asking.
+The tier propagates deterministically to `DESIGN.md spacing.sectionPadding` (intent-dimensions § 4): airy = 96px, balanced = 64px, packed = 48px. Phase 4 reads the stamp; it never re-asks.
 
 #### IA-fidelity tuning (one-shot, only when unmoved)
 
-When the user's phrase does **not** auto-pin `ia-fidelity` (per
-`reference/intent-dimensions.md` § 9 — i.e. none of *"verbatim"*,
-*"same IA"*, *"keep the structure"*, *"swap the surface"*,
-*"don't rethink the IA"* and none of *"reimagine"*, *"rethink"*,
-*"deeper redesign"*, *"what if"* appear), ask one short follow-up
-— count it within the two-question ceiling:
+When the phrase does **not** auto-pin `ia-fidelity` (intent-dimensions § 9 — none of *"verbatim"*, *"same IA"*, *"keep the structure"*, *"swap the surface"*, *"don't rethink the IA"* [→ verbatim] and none of *"reimagine"*, *"rethink"*, *"deeper redesign"*, *"what if"* [→ reimagined]), ask one follow-up (counts within the ceiling):
 
-> IA fidelity — (a) verbatim (same section sequence, same content
-> beats; variants explore surface only: color, type, density,
-> motion), or (b) reimagined (variants may demote / promote / drop
-> sections, move IA priorities, take "what if" positions on the
-> spine of the page).
-> Default (b) for the typical refresh; pick (a) when the customer
-> asked to keep their site structurally identical and only swap
-> the surface.
+> IA fidelity — (a) verbatim (same section sequence, same content beats; variants explore surface only: color, type, density, motion), or (b) reimagined (variants may demote / promote / drop sections, move IA priorities, take "what if" positions on the spine of the page). Default (b) for the typical refresh; pick (a) when the customer asked to keep the structure and only swap the surface.
 
-If the user answers, stamp the chosen tier in `direction.md` §
-Movements as `ia-fidelity: <tier>`. If unanswered, default to
-**reimagined** and stamp `ia-fidelity: reimagined (default)`.
+Answered → stamp `ia-fidelity: <tier>`. Unanswered → default **reimagined**, stamp `ia-fidelity: reimagined (default)`.
 
-Skip this question entirely when:
-- The user's phrase already auto-pinned the axis (any trigger phrase
-  in § 9 — *"same IA, swap the surface"* → verbatim;
-  *"what if we rethought the home page"* → reimagined).
-- An existing `direction.md` is being refined (the active tier holds
-  unless the user explicitly re-pins).
+Skip entirely when: the phrase already auto-pinned the axis, or an existing `direction.md` is being refined (active tier holds unless the user re-pins).
 
-The tier propagates to `DESIGN.json.extensions.iaPriorities[].mutability`:
-`locked` under verbatim, `movable` under reimagined. Phase 4 stamps
-the field; downstream `prototype` reads it.
+Propagates to `DESIGN.json.extensions.iaPriorities[].mutability`: `locked` under verbatim, `movable` under reimagined (stamped in Phase 4; `prototype` reads it).
 
-Pair this question with the density-tuning question when both are
-unmoved — *"two things to pin before we resolve: (1) density …, (2)
-IA fidelity …"* — to stay within the two-question ceiling. If
-resolving register (brand vs product) is also outstanding, prioritise
-register first; defer one of density / ia-fidelity to the next turn.
+**Pairing:** when both density and ia-fidelity are unmoved, ask them as one paired question to stay within the ceiling. If register (brand vs product) is also outstanding, resolve register first and defer one of density / ia-fidelity to the next turn.
 
-Wait for the user's confirmation (`"go"`, or a correction to the
-plan) before moving on.
+**Gate:** wait for the user's confirmation (`"go"` or a correction) before Phase 2. If the phrase is still too vague after two questions → § Failure modes (vague phrase): persist partial reasoning, do not write specs.
 
 ### Phase 2 — Resolve the divergence inputs
 
-Once the plan is confirmed, resolve the divergence-toolkit inputs
-from `skills/stardust/reference/divergence-toolkit.md`. Before
-rolling the seed, run the mode-detection precedence below to decide
-whether the seed needs rolling at all.
+Resolve the divergence-toolkit inputs (`skills/stardust/reference/divergence-toolkit.md`) — but first run mode detection to decide whether the seed needs rolling at all.
 
 #### Mode-detection precedence (run first)
 
-The default mode for `direct` is determined by whether an extracted
-brand surface exists with usable signal — **not** by the user's
-freeform phrase alone. Stardust's primary use case is migrating an
-existing site with a design refresh; "make it modern" / "stunning new
-version" / "design fatigue cure" are migration-shaped asks. Treating
-those phrases as rebrand triggers (rolling a fresh divergence seed)
-produces output that is recognisably a different brand from the one
-that asked for the refresh — a published failure mode. The
-precedence below catches the common case as the default and reserves
-divergence-seed rolls for explicit rebrand requests.
+The default mode is determined by whether an extracted brand surface exists with usable signal — **not** by the user's phrase alone. The precedence is asymmetric on purpose: the safer Mode A catches ambiguous phrases; rebrand requires the user to name it. (Rationale and the 2026-04-29 default-flip provenance: `reference/mode-notes.md`.)
 
-The precedence is asymmetric on purpose: the safer mode (Mode A —
-brand-faithful) catches ambiguous phrases, and the riskier mode
-(rebrand / full divergence-seed) requires the user to name it.
+1. **Site migration / refresh — DEFAULT.** When the Setup-6 stamp is `signal-strong`, Mode A is active by default. The phrase moves *expressive*, *distinctiveness*, *tone*, and *density* inside Mode A — but palette and type are pinned to the captured surface and the image-reuse contract holds. **Signature preservation also holds:** a captured signature hero medium (background video / canvas / Lottie / scroll-motion, elevated as `_brand-extraction.json#voice.heroMedium`) or a site-wide motif is reproduced, not flattened — per intent-dimensions § 8b, exempt from the `surprise` budget. Surface in the plan: *"Brand-faithful mode active — palette and type pinned to the captured brand surface. Pass `--rebrand` to override."*
+2. **Rebrand — explicit opt-in.** Mode A is overridden when **any** fires:
+   - Phrase contains an explicit rebrand signal: `rebrand`, `new brand`, `clean slate`, `start over`, `from scratch`, `replace the brand`, `not brand-faithful`, `editorial reimagination`, `completely new`, `redo the brand`.
+   - `--rebrand` passed.
+   - Signal is `signal-absent` (no usable inheritance) — surface as an automatic switch with reason; the user can correct.
 
-1. **Site migration / refresh — DEFAULT.** When the captured brand
-   signal stamped in § Setup step 6 is `signal-strong`, Mode A is
-   active by default. The user's phrase moves *expressive*,
-   *distinctiveness*, *tone*, and *density* axes inside Mode A — but
-   palette and type are pinned to the captured surface, and the
-   image-reuse contract (below) holds. **Signature preservation also
-   holds:** a captured signature hero medium (background video /
-   canvas / Lottie / scroll-motion, elevated as
-   `_brand-extraction.json#voice.heroMedium`) or a site-wide motif is
-   reproduced, not flattened — per `skills/stardust/reference/
-   intent-dimensions.md` § 8b, and exempt from the `surprise` budget.
-   Surface in the plan:
-   *"Brand-faithful mode active — palette and type pinned to the
-   captured brand surface. Pass `--rebrand` to override."*
+   Run the divergence-seed roll per § Default mode. Surface: *"Rebrand mode active — full divergence-seed roll. Mode A bypassed because <reason>."*
+3. **Brand-faithful + targeted exploration.** User requests N variants while Mode A is active → the § Multi-variant fork contract applies. Variant A is locked to **strict Mode A** (palette/type pinned, IA preserved, every improvements item applied). Variants B+ may amplify one **captured** trait but cannot: introduce a font outside the captured surface, introduce a color outside the captured palette, or shift the register from PRODUCT.md.
+4. **Signal-thin fallback.** `signal-thin` → Mode A activates but warns: *"Captured brand surface is thin — {reason}. Variants will inherit what is available; some dimensions will be filled by the divergence toolkit."* Offer: re-run extract with a wider crawl (`--cap 25`) or proceed with reduced fidelity.
 
-2. **Rebrand — explicit opt-in.** Mode A is overridden when **any**
-   of the following triggers fire:
-   - The user's phrase contains an explicit rebrand signal: any of
-     `rebrand`, `new brand`, `clean slate`, `start over`,
-     `from scratch`, `replace the brand`, `not brand-faithful`,
-     `editorial reimagination`, `completely new`, `redo the brand`.
-   - The `--rebrand` flag is passed.
-   - Captured signal is `signal-absent` (no usable inheritance).
-     Surface this case as an automatic switch with reason; the user
-     can correct.
-
-   In rebrand mode, run the standard divergence-seed roll per
-   "Default mode (no constraints)" below. Surface in the plan:
-   *"Rebrand mode active — full divergence-seed roll. Mode A
-   bypassed because <reason>."*
-
-3. **Brand-faithful + targeted exploration.** When the user requests
-   N variants (e.g. *"3 variants"*, *"4 directions"*) and Mode A is
-   active, the variant role contract in § Multi-variant fork
-   applies. Variant A is locked to **strict Mode A** (palette and
-   type pinned, IA preserved, every improvements-list item applied).
-   Variants B+ may amplify one **captured** trait (a motif, a photo
-   treatment, an IA priority the current site underplays) but
-   cannot:
-   - introduce a font outside the captured surface,
-   - introduce a color outside the captured palette,
-   - shift the register from PRODUCT.md.
-
-4. **Signal-thin fallback.** When captured signal is `signal-thin`,
-   Mode A activates but warns: *"Captured brand surface is thin —
-   {reason}. Variants will inherit what is available; some
-   dimensions will need to be filled by the divergence toolkit."*
-   The user may either re-run extract with a wider crawl
-   (`--cap 25`) or proceed with reduced fidelity.
-
-After mode-detection completes, run the existing mode definitions
-below (Mode A procedure, Mode B anchor-reference precedence, Mode C
-ground-family override) as applicable.
+Then apply the mode definitions below as applicable.
 
 #### Mode A — Brand-faithful mode
 
-Triggered automatically when the captured brand signal is
-`signal-strong` and no rebrand-mode override fired (see
-§ Mode-detection precedence above), OR when the user pinned **both**
-type and palette (via explicit phrase: "keep typography and palette",
-"preserve the existing brand", "brand-faithful redesign"; or via
-constraints listing both as anchors).
+Triggered automatically by precedence step 1, OR explicitly when the user pinned **both** type and palette (phrase: "keep typography and palette", "preserve the existing brand", "brand-faithful redesign"; or a constraints list with `brand-faithful` + explicit type + palette anchors). Always surface "Brand-faithful mode active" in the plan so the user can correct (e.g. "actually rebrand it") before it locks. Do **not** roll type or palette — they are locked (why: `reference/mode-notes.md`).
 
-In this mode, direct does **not** roll the type or palette
-dimensions of the seed — they are already locked. Going through
-the motions of font-deck and palette picks would be ceremony,
-producing `picked_by = "user-constraint"` records that don't
-reflect any real choice.
+1. Record `font_deck.name = "brand-inherited"`, `font_deck.picked_by = "user-constraint"`. Do not invoke `reference/palette-picker.md`.
+2. Record `palette.source = "inherited from _brand-extraction.json"`, `palette.picked_by = "user-constraint"`. Apply role-renaming per toolkit § 4 if inherited names violate the brand-native rule (renaming is presentational, not a divergence choice).
+3. **Still roll** the seed for non-locked dimensions (decade, craft, register, ground-family per Mode C) — era and visual register can shift even with type/palette pinned.
+4. Auto-emit `brand_faithful_inversions[]` in `extensions.divergence` per `reference/direction-format.md` § Brand-faithful inversions (canonical patterns there).
+5. Surface in the user report which dimensions had teeth and which were inert (rolled vs inherited, per dimension).
+6. **Image-reuse contract.** Captured images are reused via their public URLs (or local copies in `stardust/current/assets/media/`) **at the same semantic position** as on the source site: hero stays hero, story-tile portrait stays story-tile portrait, program-card image stays program-card image, background motif stays background motif. (Why this is brand-faithful inheritance, not a content rule: `reference/mode-notes.md`.) The only legitimate deviations:
+   - the captured image is broken (404, `referrer-policy` blocked, CORS-walled, or `localPath: null` with a `downloadError`);
+   - the brand-review surfaced the image as a tension (e.g. `T-stock-photography` — obviously templated stock the brand team would replace anyway);
+   - the improvements list (Phase 2.5) explicitly notes a crop or positioning fix — then the **same image** is reused at the corrected crop/position.
 
-The mode procedure:
+   Synthesised placeholders are **forbidden** under Mode A. When a captured image cannot be reused, the shape brief declares the gap and the prototype shows a placeholder-with-signature element — reviewers see the gap, never a fabricated photo.
 
-1. Record `font_deck.name = "brand-inherited"` and
-   `font_deck.picked_by = "user-constraint"`. Do not invoke
-   `reference/palette-picker.md`.
-2. Record `palette.source = "inherited from _brand-extraction.json"`
-   and `palette.picked_by = "user-constraint"`. Apply role-renaming
-   per toolkit § 4 if the inherited names violate the brand-native
-   rule (this is still useful — role renaming is presentational,
-   not a divergence choice).
-3. **Still roll** the seed for the **non-locked** dimensions
-   (decade, register, ground-family-as-applicable per Mode C
-   below). These dimensions still drive divergence — the visual
-   register and the era can shift even when type and palette are
-   pinned.
-4. Auto-emit the `brand_faithful_inversions[]` block in
-   `extensions.divergence` per
-   `reference/direction-format.md` § Brand-faithful inversions.
-   The list is mostly mechanical (see § Brand-faithful inversions
-   in direction-format.md for the canonical patterns).
-5. Surface in the user report which dimensions had teeth and
-   which were inert:
 
-   ```
-   Divergence (brand-faithful mode):
-     decade           ✓ rolled    → 2025-now
-     craft            ✓ rolled    → Riso print
-     register         ✓ rolled    → Memoir-adjacent
-     ground-family    inherited   → stark-white (brand-native)
-     font deck        inherited   → existing site stack
-     palette          inherited   → existing 5-color set
-   ```
-
-6. **Image-reuse contract.** Captured images are reused via their
-   public URLs (or the local copies in
-   `stardust/current/assets/media/` written by extract Phase 2)
-   **at the same semantic position** as on the source site. Hero
-   stays hero. Story-tile portrait stays story-tile portrait.
-   Program-card image stays program-card image. Background-motif
-   image stays background motif.
-
-   This is part of brand-faithful inheritance, not a separate
-   content rule. A variant that swaps a captured subject portrait
-   for a gradient placeholder, or moves the captured hero photo to
-   a card thumbnail, erases the brand's most load-bearing trust
-   signal — the named-people stories that almost every nonprofit /
-   service-led site has spent years building.
-
-   The only legitimate ways to deviate from semantic
-   position-preservation under Mode A:
-
-   - The captured image is broken (404, blocked by `referrer-policy`,
-     CORS-walled, or recorded with `localPath: null` and a
-     `downloadError`).
-   - The brand-review surfaced the image as a tension (e.g.
-     `T-stock-photography` when added — flagging the captured
-     image as obviously templated stock that the brand team would
-     replace anyway).
-   - The improvements list (Phase 2.5) explicitly notes a crop or
-     positioning fix for that image — in which case the same
-     image is reused at the corrected crop or position.
-
-   Synthesised placeholders are forbidden under Mode A. When a
-   captured image cannot be reused, the prototype shape brief
-   declares the gap explicitly and the rendered prototype shows a
-   placeholder-with-signature element so reviewers see the gap
-   rather than a fabricated photo.
-
-Mode A is the default whenever § Mode-detection precedence step 1
-applies (captured signal is `signal-strong` and no rebrand override
-fires). It also activates explicitly when the resolved direction's
-constraints list contains `brand-faithful` AND explicit type AND
-palette anchors, OR when the user's phrase contains "keep
-typography" / "preserve the palette" / equivalent. The agent
-surfaces "Brand-faithful mode active" in the plan it shows the
-user before executing — the user can correct (e.g. "actually let
-me move the palette" or "actually rebrand it") before it locks.
+Reference research (`skills/stardust/reference/reference-research.md`) still runs under Mode A for the **non-locked** dimensions — researched anchors may imply decade/craft/register exactly as in Mode B; only type and palette are pinned.
 
 #### Mode A+ — Brand-adjacent refinement (bounded, evidence-gated)
 
-The middle tier between Mode A's hard pins and `--rebrand`. It exists
-because the median redesign candidate is a site whose brand is right
-but whose *execution* of that brand is part of the problem — a
-generic system body face, a palette whose only accent fails contrast
-on half its surfaces. Strict Mode A reproduces those weaknesses;
-rebrand throws away the brand. Mode A+ authorizes **bounded
-upgrades**, each gated on evidence:
+The middle tier between Mode A pins and `--rebrand` (rationale: `reference/mode-notes.md`). Authorizes exactly two bounded upgrades, each gated on evidence:
 
-- **Same-classification type upgrade.** When the improvements list
-  (Phase 2.5) names the captured *body or system* face as a weakness
-  with evidence (illegibility at captured sizes, a generic system
-  stack where the brand deserves a voice, missing weights/axes the
-  layout needs), the body face may be upgraded to a
-  same-classification, deliverable face (humanist sans → humanist
-  sans; grotesque → grotesque). **The display face stays pinned** —
-  it carries the brand's recognition.
-- **Single-role palette recolor.** When a specific captured color
-  fails contrast or hierarchy *as evidenced* (computed ratio cited,
-  or a `T-color-imbalance` tension), that one role may be re-derived
-  (deepened, re-weighted) while every other role stays pinned. New
-  hues from outside the captured family remain forbidden.
+- **Same-classification type upgrade.** Only when the improvements list names the captured *body or system* face as a weakness with evidence (illegibility at captured sizes, generic system stack where the brand deserves a voice, missing weights/axes the layout needs): upgrade the body face to a same-classification, deliverable face (humanist sans → humanist sans; grotesque → grotesque). **The display face stays pinned** — it carries brand recognition.
+- **Single-role palette recolor.** Only when a specific captured color fails contrast or hierarchy *as evidenced* (computed ratio cited, or a `T-color-imbalance` tension): re-derive that one role (deepen, re-weight); every other role stays pinned. New hues from outside the captured family remain forbidden.
 
-Contract: each refinement is recorded in
-`DESIGN.json.extensions.divergence.brand_adjacent_refinements[]` as
-`{ kind, captured, replacement, evidence, improvementsItem }` — an
-inversion-style audit entry citing the improvements-list item that
-authorizes it. No evidence citation → no refinement. Mode A+ never
-activates by default: it requires the qualifying improvements-list
-item, and the plan surfaces each refinement explicitly (*"body face
-upgraded Arial → Hanken Grotesk per improvements #3; display face
-pinned"*) so the user (or the hands-off record) sees exactly what
-moved. Refinements do not run through reference research — their
-justification is the captured weakness, not an external anchor.
+Contract: record each refinement in `DESIGN.json.extensions.divergence.brand_adjacent_refinements[]` as `{ kind, captured, replacement, evidence, improvementsItem }` — an inversion-style audit entry citing the improvements-list item that authorizes it. No evidence citation → no refinement. Mode A+ never activates by default: it requires the qualifying improvements-list item, and the plan surfaces each refinement explicitly (*"body face upgraded Arial → Hanken Grotesk per improvements #3; display face pinned"*) so the user (or the hands-off record) sees exactly what moved. Refinements do not run through reference research — their justification is the captured weakness, not an external anchor.
 
 #### Mode B — Anchor-reference precedence
 
-When the user provides anchor references (Q1/Q2 answers like
-"Pentagram nonprofits, This American Life, NYT Opinion longform"),
-those references **already imply** seed dimensions. Pentagram
-implies decade `2025-now` editorial. This American Life implies
-register `Memoir`-adjacent. Rolling those dimensions
-deterministically and getting an accidental alignment is fragile —
-the agent then has to retro-justify the alignment in
-`direction.md`.
+User-provided anchor references (Q1/Q2 answers like "Pentagram nonprofits, This American Life, NYT Opinion longform") **already imply** seed dimensions; rolling those dimensions and retro-justifying an accidental alignment is fragile.
 
-**Agent-sourced anchors (default when the user provides none).**
-Mode B no longer waits for the user to name references: run the
-reference-research procedure
-(`skills/stardust/reference/reference-research.md`) to source 3–5
-real-world anchors matched to the brand's category, register, and the
-resolved direction movement. Researched anchors carry the same
-implied-dimension weight as user-provided ones and are recorded as
-`picked_by: "reasoned: <anchor>"` with the full citation in
-`extensions.divergence.references_used[]`. User-provided references
-always outrank researched ones on conflict. When research is
-unavailable (ladder exhausted per reference-research.md § 1), Mode B
-degrades to the deterministic roll for the un-implied dimensions.
+**Agent-sourced anchors (default when the user provides none).** Run `skills/stardust/reference/reference-research.md` to source 3–5 real-world anchors matched to the brand's category, register, and the resolved movement. Researched anchors carry the same implied-dimension weight, recorded as `picked_by: "reasoned: <anchor>"` with full citation in `extensions.divergence.references_used[]`. User-provided references always outrank researched ones on conflict. Research unavailable (ladder exhausted per reference-research § 1) → degrade to the deterministic roll for un-implied dimensions.
 
 Precedence rule:
-
-1. If anchor references are present, extract their implied
-   dimensions:
-   - **Decade** from era of the references (Pentagram → 2025-now;
-     vintage Penguin → 1960s).
-   - **Craft** from medium of the references (TAL → audio editorial
-     ≠ a craft per se, but Bandcamp → web-print hybrid; Riso-print
-     anthology → Riso).
-   - **Register** from cultural reference set (Memoir, Tabloid,
-     Catalogue, etc.).
-   - **Ground-family** from typical ground of those references
-     (NYT Opinion → cream/parchment; Pentagram nonprofit →
-     stark-white or monochrome-tint).
-2. Mark each implied dimension as
-   `picked_by = "anchor-reference: <ref-name>"`.
+1. Extract implied dimensions from anchors: **decade** from era (Pentagram → 2025-now; vintage Penguin → 1960s); **craft** from medium (Bandcamp → web-print hybrid; Riso anthology → Riso); **register** from cultural reference set (Memoir, Tabloid, Catalogue, …); **ground-family** from typical ground (NYT Opinion → cream/parchment; Pentagram nonprofit → stark-white or monochrome-tint).
+2. Mark each implied dimension `picked_by = "anchor-reference: <ref-name>"`.
 3. Roll the seed only for **un-implied** dimensions.
-4. Record the anchor → dimension mapping in
-   `extensions.divergence.seed.anchors[]`.
+4. Record the anchor → dimension mapping in `extensions.divergence.seed.anchors[]`.
 
-Mode B can compose with Mode A: anchor-references narrow the seed,
-brand-faithful constraints lock type/palette, the remaining roll
-is whatever the anchors didn't already imply.
+Mode B composes with Mode A: anchors narrow the seed, brand-faithful constraints lock type/palette, the roll covers whatever the anchors didn't imply.
 
 #### Mode C — Brand-faithful ground-family override
 
-When Mode A is active **and** the seed's `ground_family` roll
-disagrees with the brand's existing ground (e.g. seed rolled
-`monochrome-tint` but the brand's captured background is
-`#ffffff` stark-white), the brand's ground wins. The seed roll is
-not discarded — it informs the **alt-section surface** instead
-(per `divergence-toolkit.md` § 4 Color roles). Record the override
-in `extensions.divergence.seed.ground_family.override` with one
-of three reasons:
+When Mode A is active **and** the seed's `ground_family` roll disagrees with the brand's captured ground (e.g. seed rolled `monochrome-tint`, brand ground is `#ffffff` stark-white), the brand's ground wins. The seed roll is not discarded — it informs the **alt-section surface** (toolkit § 4 Color roles). Record `extensions.divergence.seed.ground_family.override` with exactly one of three mutually exclusive reasons, surfaced in the user report:
 
-- `brand-faithful` — Mode A active and brand has a fixed ground.
-- `print-paper` — manual override for print/paper categories
-  (existing toolkit rule).
+- `brand-faithful` — Mode A active, brand has a fixed ground.
+- `print-paper` — manual override for print/paper categories (existing toolkit rule).
 - `direction-driven` — seed wins (default; no override).
-
-The three reasons are mutually exclusive; surface the chosen one
-in the user report.
 
 #### Default mode (no constraints)
 
-When neither Mode A nor Mode B applies (rebrand or thin-signal runs
-with no user anchors), the procedure is **research-first, roll as
-fallback**:
+Rebrand or thin-signal runs with no user anchors: **research-first, roll as fallback**.
 
-- **Reference research first.** Run
-  `skills/stardust/reference/reference-research.md` to source
-  anchors for the brand's category and the resolved direction, and
-  derive the dimensions they imply (`picked_by: "reasoned: <basis>"`).
-  This is Mode B's machinery applied to agent-sourced anchors — see
-  § Mode B above.
-- **Seed as fallback + tiebreaker.** Roll the 4-dimension seed
-  (decade × craft × register × ground-family) per § 2 of the toolkit
-  **only** for dimensions research left un-implied, or entirely when
-  research is unavailable. The roll also remains available as a
-  deliberate convergence-breaker when the self-audit catches the
-  model reproducing its defaults despite research. Record
-  `picked_by` per dimension.
-- **Font deck.** Pick from the 10 named decks per § 3, letting the
-  researched anchors inform the pick the same way a seed implication
-  would (e.g. an editorial-serif anchor set → `serif-luxury`). When
-  neither research nor seed implies a deck, pick deterministically
-  from the hash.
-- **Palette.** If the resolved direction moves the color-energy
-  axis or names the existing palette as part of the problem: derive
-  a full role-ramped palette (text, grounds, borders, accents,
-  states) from the primary researched anchor or a library candidate
-  — the library (`skills/direct/reference/palette-picker.md`) is an
-  **anchor bank**, not a closed menu; the model designs the ramp and
-  validates every text-on-ground pair for WCAG AA before it lands
-  in tokens (deterministic where it matters — math — not where it
-  hurts — taste). Record the derivation basis in
-  `extensions.divergence.palette_source`. Otherwise inherit
-  the existing palette from
-  `stardust/current/_brand-extraction.json`, applying role-renaming
-  per toolkit § 4 if the inherited names violate the brand-native
-  rule.
+- **Reference research first.** Run `skills/stardust/reference/reference-research.md`; derive the dimensions the anchors imply (`picked_by: "reasoned: <basis>"`) — Mode B's machinery applied to agent-sourced anchors.
+- **Seed as fallback + tiebreaker.** Roll the 4-dimension seed (decade × craft × register × ground-family) per toolkit § 2 **only** for dimensions research left un-implied, or entirely when research is unavailable. The roll also remains a deliberate convergence-breaker when the self-audit catches the model reproducing its defaults despite research. Record `picked_by` per dimension.
+- **Font deck.** Pick from the 10 named decks per toolkit § 3, letting researched anchors inform the pick as a seed implication would (editorial-serif anchors → `serif-luxury`). Neither research nor seed implies a deck → pick deterministically from the hash.
+- **Palette.** If the direction moves color-energy or names the existing palette as part of the problem: derive a full role-ramped palette (text, grounds, borders, accents, states) from the primary researched anchor or a library candidate — `reference/palette-picker.md` is an **anchor bank**, not a closed menu; the model designs the ramp and validates every text-on-ground pair for WCAG AA before it lands in tokens (deterministic where it matters — math — not where it hurts — taste). Record the basis in `extensions.divergence.palette_source`. Otherwise inherit the palette from `_brand-extraction.json`, role-renaming per toolkit § 4 where inherited names violate the brand-native rule.
 
 #### Always run
 
-- **Anti-toolbox audit.** Regardless of mode, run the self-audit
-  (toolkit § 1 Enforcement + Self-audit) on the resolved direction.
-  Each anti-toolbox hit needs a brand-specific justification or it
-  is removed.
+- **Anti-toolbox audit** (toolkit § 1 Enforcement + Self-audit) on the resolved direction, regardless of mode. Each anti-toolbox hit needs a brand-specific justification or it is removed. If the audit strips so much the direction collapses to defaults → § Failure modes (audit collapse).
 
-Record every resolution in `DESIGN.json.extensions.divergence` per
-the v2 storage shape at the bottom of `divergence-toolkit.md`.
+Record every resolution in `DESIGN.json.extensions.divergence` per the v2 storage shape at the bottom of `divergence-toolkit.md`.
 
 ### Phase 2.5 — Improvements list (Mode A only)
 
-Before any variant is rendered downstream, write
-`stardust/prototypes/<slug>-improvements.md` listing **3–5 specific
-weaknesses** observed in the captured site. This is the load-bearing
-artifact for variant A: without it, *"make it better"* has no claim
-the agent can defend, and each variant ends up inventing its own
-"better" — producing rebrand-shaped output even with Mode A active.
+Before any variant renders downstream, write `stardust/prototypes/<slug>-improvements.md` listing **3–5 specific weaknesses** of the captured site. This is the load-bearing brief variant A renders against (why: `reference/mode-notes.md`): it is descriptive of the gap to a competent 2026 execution of the same brand, never prescriptive of visual targets. Variant A closes the gap; variants B+ honor the list as a floor (may go further, may not contradict it).
 
-The improvements list is the brief variant A renders against. It is
-**not** prescriptive (it does not declare visual targets); it is
-**descriptive of the gap** between the existing site and a competent
-2026 execution of the same brand. Variant A's job is to close the
-gap; variants B+ honor the list as a floor (they may go further but
-not contradict it).
+**Skip this phase** when the resolved mode is rebrand — the list assumes brand-faithful inheritance; a rebrand replaces the site rather than fixing it.
 
-Skip this phase when the resolved mode is rebrand — the improvements
-list assumes brand-faithful inheritance, and a rebrand replaces the
-site rather than fixing it.
+**Audit reuse.** When `stardust/audit/<domain-slug>/audit.json` exists for this origin (written by `stardust:audit`), consume its design findings as candidate improvements instead of re-deriving; carry finding IDs into each item's evidence citation. The specificity bar still applies to every carried item.
 
-**Audit reuse.** When `stardust/audit/<domain-slug>/audit.json`
-exists for this origin (written by `stardust:audit`), consume its
-design findings as candidate improvements instead of re-deriving from
-scratch — carry the finding IDs into each item's evidence citation.
-The specificity bar below still applies to every carried item.
+**Five categories** (items must be citable by number from a prototype shape brief):
+1. **Dated patterns** the design world has moved past — named pattern + vintage, e.g. *"centered hero with stock photo + double CTA in primary blue is the SaaS template circa 2019"*, not *"the hero feels dated"*.
+2. **Cluttered IA / unclear hierarchy / weak CTAs / redundant sections** — e.g. *"4 donor CTAs with 4 different verbs (DONATE / GIVE / SUPPORT / CONTRIBUTE) fragment the conversion funnel"*.
+3. **Contrast failures, accessibility gaps, density issues** — pull from `brand-review.html` Tensions when present (`T-color-imbalance`, `T-img-alt-empty`, …), with computed ratios (e.g. teal passes AA at 4.6:1 on white but drops to 3.1:1 on light-grey cards).
+4. **Cliché conventions** the brand could move past while staying recognisably itself — e.g. all-caps-via-CSS headings where the voice survives mixed-case and mixed-case reads as more current.
+5. **Missed opportunities** the site doesn't capitalise on — e.g. excellent named-participant photography rendered as 280×180 slider thumbnails when it supports full-bleed editorial treatment that would carry the trust signal.
 
-#### What goes in the list
+**Specificity bar.** An item passes only when it cites all three:
+- a measurable observation (size, ratio, contrast value, count, or named tension ID) from the per-page JSON, brand-review, or brand-extraction;
+- the design pattern at fault, named (e.g. "centered hero + dual CTA");
+- one concrete fix the variant-A brief will apply.
 
-The list draws from five categories. Items should be specific enough
-that a downstream `prototype` shape brief can cite them by number.
+*"The hero needs work"* fails all three. *"Hero photo is cropped to 280×180 in a 1440-wide viewport when the captured source supports 16:9 full-bleed at 1440×810; fix: render full-bleed, headline in a left-anchored two-column overlay"* passes all three.
 
-1. **Dated patterns the design world has moved past.** Specific:
-   *"centered hero with stock photo + double CTA in primary blue
-   is the SaaS template circa 2019"* — not *"the hero feels dated."*
-2. **Cluttered IA, unclear hierarchy, weak CTAs, redundant sections.**
-   E.g. *"home page has 4 different donor CTAs, each with a different
-   verb (DONATE / GIVE / SUPPORT / CONTRIBUTE), fragmenting the
-   conversion funnel."*
-3. **Contrast failures, accessibility gaps, density issues.** Pull
-   from `brand-review.html` Tensions when present (`T-color-imbalance`,
-   `T-img-alt-empty`, etc.). E.g. *"Primary CTA `#008192` on white
-   passes AA at 4.6:1 but the same teal on light-grey card surfaces
-   drops to 3.1:1 — fails AA on those instances."*
-4. **Cliché conventions the brand could move past while staying
-   recognisably itself.** E.g. *"All headings render uppercase via
-   CSS — the brand voice survives mixed-case headlines, and mixed-case
-   reads as more current without changing identity."*
-5. **Missed opportunities the existing site doesn't capitalise on.**
-   E.g. *"The captured photography of named program participants is
-   excellent but the home page renders all 6 portraits as 280×180
-   thumbnails in a slick-slider; the photographs support full-bleed
-   editorial treatment that would carry the trust signal far more
-   effectively."*
-
-#### Specificity bar
-
-A weakness is specific enough when it cites:
-- a measurable observation (size, ratio, contrast value, count, or
-  named tension ID) drawn from the per-page JSON, the brand-review,
-  or the brand-extraction;
-- the design pattern at fault (named, e.g. "centered hero + dual CTA");
-- one concrete fix the variant A brief will apply.
-
-*"The hero needs work"* fails all three. *"Hero photo is cropped to
-280×180 in a 1440-wide viewport when the captured source supports
-16:9 full-bleed at 1440×810; variant A fix: render at full-bleed and
-move the headline to a left-anchored two-column overlay"* passes all
-three.
-
-#### Format
-
-Markdown, with a `_provenance` frontmatter block per the artifact-map
-convention. Each item is a numbered list entry with a category tag, a
-weakness statement, and a one-line fix. Example:
+**Format.** Markdown with a `_provenance` frontmatter block per the artifact-map convention (writtenBy, writtenAt, readArtifacts, stardustVersion). Each item: numbered entry with a bracketed category tag, a weakness statement, and a one-line `*Fix:*`. Example item:
 
 ```markdown
-<!--
-_provenance:
-  writtenBy: stardust:direct
-  writtenAt: 2026-04-29T11:00:00Z
-  readArtifacts:
-    - stardust/current/_brand-extraction.json
-    - stardust/current/brand-review.html
-    - stardust/current/pages/<slug>.json
-  stardustVersion: 0.10.x
--->
-
-# Improvements — <slug>
-
-1. **[dated-pattern]** Centered hero with double CTA pair (DONATE +
-   LEARN MORE) is the 2019 nonprofit-template silhouette.
-   *Fix:* Replace with a left-anchored editorial composition; one
-   primary CTA, one secondary text-link.
-
-2. **[ia-clutter]** 4 distinct donor verbs across the home page
-   (DONATE, GIVE, SUPPORT, CONTRIBUTE) fragment the funnel.
-   *Fix:* Pick one canonical verb (DONATE, per the CTA frequency
-   table); other instances become secondary "see all ways to give"
-   links.
-
-3. **[contrast]** Brand teal on light-grey card surfaces resolves to
-   3.1:1 — fails WCAG AA. (See `T-color-imbalance` in brand-review.)
-   *Fix:* Reserve teal for white-ground only; use deepened teal
-   (#005a68) on grey surfaces.
-
-4. **[cliché]** All headings render uppercase via CSS, including
-   long-form section openers ("OFFICIAL FOUR STAR CHARITY"). The
-   shout reads as urgency at first heading and as fatigue by the
-   third.
-   *Fix:* Mixed-case for headings ≥3 words; preserve uppercase only
-   for short imperative CTAs and eyebrow labels.
-
-5. **[missed-opportunity]** Six named-participant portraits render
-   as 280×180 thumbnails in a slick-slider; the captured source
-   supports editorial-scale treatment.
-   *Fix:* Replace carousel with a 3-column grid; portraits at 4:5
-   aspect, 1:1 minimum 480px wide.
+3. **[contrast]** Brand teal on light-grey card surfaces resolves to 3.1:1 — fails
+   WCAG AA. (See `T-color-imbalance` in brand-review.)
+   *Fix:* Reserve teal for white-ground only; use deepened teal (#005a68) on grey surfaces.
 ```
 
-#### Stopping condition
-
-If after reading the brand-review, the per-page JSON, and the
-brand-extraction the agent **cannot name 3 specific weaknesses**
-that meet the specificity bar, stop. Variant A has no brief; the
-"better" claim fails. See § Failure modes (d).
-
-The agent should not rationalise — *"the hero is dated"* is not an
-item, *"the typography could be more modern"* is not an item.
-Genuine empty-list cases occur when the captured site is already at
-a high execution level on observable dimensions. In that case the
-honest answer is to surface the empty list and propose reduced
-scope (density-and-contrast adjustments only, or pivot to a single
-exploratory variant rather than three).
+**Stopping condition.** If, after reading the brand-review, per-page JSON, and brand-extraction, you cannot name **3 weaknesses meeting the bar** → stop; variant A has no brief and the "better" claim fails (§ Failure modes (d)). Do not rationalise — *"the hero is dated"* / *"the typography could be more modern"* are not items. Genuine empty lists mean the site is already executing well on observable dimensions: surface the empty list honestly and propose reduced scope (density + contrast adjustments only, or one exploratory variant instead of three).
 
 ### Phase 2.6 — Multi-variant fork (when N > 1)
 
-When the user requests N variants (phrase contains *"3 variants"*,
-*"4 directions"*, or equivalent), variant slots are
-**role-differentiated**, not seed-differentiated. Each slot serves a
-distinct decision the customer is making — variants exist to
-de-risk a brand decision, not to fan out into N rebrand
-explorations.
-
-The previous default behavior (each variant rolls a fresh divergence
-seed with anchor references picked per slot) produced what the
-internal review called *"three rebrands"* output: each variant was
-defensible standalone but none felt like the same brand. The
-variant role contract below addresses this directly.
+When the user requests N variants (*"3 variants"*, *"4 directions"*), slots are **role-differentiated, not seed-differentiated** — each slot de-risks a distinct brand decision; variants are not N rebrand explorations (why the per-slot seed roll was retired: `reference/mode-notes.md`).
 
 #### Branch on `ia-fidelity` first
 
-The variant role contract is **`ia-fidelity`-aware**. Read the tier
-stamped in Phase 1 (per `reference/intent-dimensions.md` § 9 and the
-IA-fidelity tuning step above), and branch:
+Read the Phase 1 stamp and branch:
 
-**Under `ia-fidelity: verbatim` — surface-tuning forks (A1/A2/A3).**
-
-Variant slots are A1 / A2 / A3 (or A1…An for N > 3), all
-surface-tuning forks of A's role. Each must differ from the others by
-**≥ 2 surface changes** drawn from:
-
+**Under `ia-fidelity: verbatim` — surface-tuning forks (A1/A2/A3).** Slots are A1…An, all surface forks of A's role ("different tunings of the same role", not different roles). N=1 → just A. Each pair must differ by **≥ 2 surface changes** drawn from:
 - type-weight choice (e.g. 400 vs 600 vs 800 display)
 - type-scale ratio (e.g. 1.2 vs 1.333 vs 1.5)
-- density tier (within the multi-audience floor in § 4)
+- density tier (within the § 4 multi-audience floor)
 - motion energy (still vs gentle vs animated)
-- color-temperature move within the captured palette (warm-leaning
-  vs cool-leaning vs neutral-balanced)
+- color-temperature within the captured palette (warm-leaning vs cool-leaning vs neutral-balanced)
 - spacing rhythm (compact vs even vs generous within the floor)
 
-**Forbidden differentiation axes** under verbatim:
+**Forbidden differentiation axes** under verbatim: section sequence, section presence/absence, IA priority, layout strategy of a major section. All of A1/A2/A3 apply **every** item from `<slug>-improvements.md`; they differ only in surface treatment of the same applied fixes. The convergence detector (`prototype/SKILL.md` Discipline 10) becomes its inverse: structural deltas **forbidden**, surface-only deltas **required**. The variant role contract below does **not** apply under verbatim.
 
-- section sequence
-- section presence / absence
-- IA priority
-- layout strategy of a major section
-
-A1 / A2 / A3 names indicate "different tunings of the same role,"
-not different roles. When the user asks for *"3 variants"* while
-`ia-fidelity` is verbatim, the fork produces A1 / A2 / A3
-automatically; for N=1, just A.
-
-The improvements list (Phase 2.5) still anchors variant A's role —
-A1/A2/A3 all apply every item from `<slug>-improvements.md`. They
-differ only in surface treatment of the same applied fixes.
-
-The convergence detector in `prototype/SKILL.md` Discipline 10
-becomes its inverse under verbatim: structural deltas
-(section-sequence / presence / IA priority / layout strategy) are
-**forbidden**, surface-only deltas are **required**.
-
-**Under `ia-fidelity: reimagined` — A + B + C role-differentiated.**
-
-Variant slots are A + B + C (or A + B + C + D…) per the variant role
-contract below. The contract is unchanged from the prior behavior:
-faithful + improvements / one captured trait amplified / different
-captured trait amplified.
-
-The remainder of this Phase 2.6 (variant role contract, variant
-differentiation contract, C-cliff failure mode) applies as written
-under `reimagined`. Under `verbatim`, only the surface-fork rules
-above apply; the variant role contract below does not.
+**Under `ia-fidelity: reimagined` — A + B + C role-differentiated.** Slots follow the variant role contract; everything below applies as written.
 
 #### Variant role contract
 
 | Slot | Role | Brief |
 |---|---|---|
-| **A** | **Faithful + improvements** — *"this is what your site should be tomorrow."* | Same IA. Same section sequence. Same composition strategy. Apply every item from `<slug>-improvements.md` exactly — no extras, no embellishment, no creative reach. The brand team should react *"yes, that's us, with the obvious fixes."* This is the variant a risk-averse stakeholder green-lights. |
-| **B** | **One captured trait amplified** — *"what if we leaned into X?"* | Pick one specific trait already in the captured brand surface — a motif underused in current execution, a photographic treatment the site doesn't fully exploit, an IA priority the current site underplays, a tonal register that survives in copy but not in layout. Justify in one sentence in the variant's shape brief: *"This variant amplifies <captured trait> in service of <brand personality move from PRODUCT.md>."* |
-| **C+** | **Different captured trait amplified** — *"what if we leaned into Y?"* | Different from B by definition. Different captured trait. Different brand-personality move. Forbidden definitions: *"B but more"*, *"bolder fonts"*, *"more empty space"*, *"more brutalist"*, *"more editorial"*. Each subsequent variant must be a defensible standalone proposition. |
+| **A** | **Faithful + improvements** — *"this is what your site should be tomorrow."* | Same IA, same section sequence, same composition strategy. Apply every item from `<slug>-improvements.md` exactly — no extras, no embellishment, no creative reach. The brand team reacts *"yes, that's us, with the obvious fixes."* The variant a risk-averse stakeholder green-lights. |
+| **B** | **One captured trait amplified** — *"what if we leaned into X?"* | Pick one trait already in the captured surface — an underused motif, an unexploited photographic treatment, an underplayed IA priority, a tonal register alive in copy but not layout. Justify in one sentence in the shape brief: *"This variant amplifies <captured trait> in service of <brand personality move from PRODUCT.md>."* |
+| **C+** | **Different captured trait amplified** — *"what if we leaned into Y?"* | Different trait than B by definition, different brand-personality move. Forbidden definitions: *"B but more"*, *"bolder fonts"*, *"more empty space"*, *"more brutalist"*, *"more editorial"*. Each C+ must be a defensible standalone proposition. Variants beyond C (D, E, …) follow the same contract, each amplifying a distinct captured trait declared in the shape brief. |
 
-Variants beyond C (D, E, …) follow the C+ contract — each amplifies
-a distinct captured trait, declared in the shape brief.
+#### Surface forks of role-differentiated variants (B1/B2/B3, …)
 
-#### Surface forks of role-differentiated variants (B1/B2/B3, C1/C2/C3…)
+Under reimagined, a role variant may spawn **surface forks** — tunings of the *same role* across the same six surface axes as A1/A2/A3 (e.g. B = "scroll cinema amplified"; B1/B2/B3 all amplify scroll cinema, varying type-weight / type-scale / density / motion-energy / color-temperature / spacing-rhythm). The role contract binds the captured trait being amplified; the surface-fork delta governs how it reads in chrome.
 
-Under `ia-fidelity: reimagined`, a variant's role (A, B, C, …) may
-spawn **surface forks** — tunings of the *same role* across the
-same surface axes that A1/A2/A3 use under verbatim. The pattern:
+Surface forks are **opt-in, not default** (the default fork under reimagined is still A + B + C). They appear only via:
+1. explicit user request (*"design 5 variant directions for B"* → render B1…B5, each amplifying B's trait with distinct surface tunings); or
+2. `--add-variant <name>` with a parent inferred from the letter prefix (`B3` → parent `B`) — see `reference/add-variant.md` § Variant parentage.
 
-- `B` is "scroll cinema amplified" (the role).
-- `B1`, `B2`, `B3` are surface tunings of B that all amplify scroll
-  cinema, but vary along type-weight, type-scale, density,
-  motion-energy, color-temperature, or spacing-rhythm.
-
-This composes the verbatim-mode surface-fork machinery with the
-reimagined-mode role differentiation: the **role contract** binds
-the captured trait being amplified; the **surface-fork delta**
-governs how that trait reads in chrome.
-
-Surface forks of role-differentiated variants are **opt-in, not
-default**. The default fork under reimagined is still A + B + C.
-Surface forks appear in two ways:
-
-1. **Explicit user request**: *"design 5 variant directions for B"*
-   — the user asks for surface tunings of an existing role-
-   differentiated variant. Render B1 / B2 / B3 / B4 / B5, each
-   amplifying B's captured trait but with distinct surface tunings.
-2. **Via `--add-variant <name>` with a parent declared**: e.g.,
-   `--add-variant B3` after B exists. The parent inferred from the
-   slot name's letter prefix (`B3` → parent `B`). See § Add-variant
-   mode → Per-field inheritance rules for the inheritance chain.
-
-Surface forks of role-differentiated variants follow the **same
-≥ 2 surface-changes contract** as A1/A2/A3 — the per-pair
-differentiation is surface-only (type-weight / type-scale / density
-/ motion-energy / color-temperature / spacing-rhythm), with the
-**captured trait being amplified held constant** across the fork.
-Structural differentiation (section sequence / presence / IA
-priority / layout strategy) is forbidden between B and its surface
-forks B1/B2/B3 — the role IS the captured trait, and changing
-structure changes the role.
-
-The variant-convergence detector in `prototype/SKILL.md`
-Discipline 10 reads the variant's parent slot: when comparing
-B vs B3 (parent–child surface fork), it applies the verbatim-style
-inverse rule (surface deltas required, structural deltas
-forbidden); when comparing B vs C (sibling role-differentiated
-variants), it applies the reimagined-style rule (structural deltas
-required).
-
-The cap on motion-energy and other amplified surface axes is the
-parent role's cap — a B3 that amplifies motion-energy beyond B's
-ceiling must declare a **cap override** in its DESIGN.json
-extensions with a one-sentence rationale (e.g. *"B3 raises B's
-motion choreography count from ≤ 3 to ≤ 5 to accommodate the loud-
-register tuning of scroll cinema"*). The override must cite a
-captured-source basis or it refuses; cap overrides without a
-captured-source rationale produce surface drift instead of trait
-amplification.
+Rules: same **≥ 2 surface-changes** contract per pair; the amplified captured trait is **held constant** across the fork; structural differentiation (section sequence / presence / IA priority / layout strategy) between a parent and its surface forks is **forbidden** — the role IS the captured trait, and changing structure changes the role. The convergence detector reads the variant's parent slot: parent–child pairs (B vs B3) get the verbatim-style inverse rule (surface deltas required, structural forbidden); sibling role variants (B vs C) get the reimagined rule (structural deltas required). Amplified surface axes are capped at the parent role's cap; a fork exceeding it must declare a **cap override** in its DESIGN.json extensions with a one-sentence rationale citing a captured-source basis (e.g. *"B3 raises B's motion choreography count from ≤ 3 to ≤ 5 to accommodate the loud-register tuning of scroll cinema"*) — no captured-source rationale → refuse the override (it would be surface drift, not trait amplification).
 
 #### Variant differentiation contract
 
-Each pair of variants must differ by **≥ 2 substantive changes**
-drawn from this set:
-
+Each pair of role-differentiated variants must differ by **≥ 2 substantive changes** drawn from:
 - section sequence (which sections appear in which order),
-- section presence / absence (a section in one variant, not in another),
-- layout strategy of a major section (e.g. hero is split-half vs.
-  full-bleed-photo vs. type-led),
-- IA priority (which audience leads the home — donor vs. recipient
-  vs. volunteer for nonprofits; product vs. story for commerce).
+- section presence / absence,
+- layout strategy of a major section (hero split-half vs full-bleed-photo vs type-led),
+- IA priority (which audience leads the home — donor vs recipient vs volunteer; product vs story).
 
-Variants that fail the ≥ 2 changes test are rendered as the same
-variant under different chrome — *"variants are barely different"*
-is the published failure mode and is grounds for refusing render.
-See § Failure modes (b) — when only 1–2 captured traits are
-distinct enough to amplify, the agent surfaces this and proposes
-1 or 2 variants rather than producing 3 weak ones.
+Pairs failing the test are the same variant under different chrome — the published *"variants are barely different"* failure — and are grounds for **refusing render**. When only 1–2 captured traits are distinct enough to amplify, surface it and propose 1 or 2 variants instead of 3 weak ones (§ Failure modes (b)).
 
-#### The C-cliff failure mode
+#### The C-cliff: render-refusal conditions
 
-When defining variant C+, the following definitions are
-**render-refusal conditions**:
+These C+ definitions are **render-refusal conditions** (name origin: `reference/mode-notes.md`):
+- *"Everything from B but more"* — B+more is not a direction.
+- *"120pt+ display fonts"* — size-as-personality is not a captured trait.
+- *"96px+ section padding everywhere"* — padding-as-personality is not a captured trait, and conflicts with the intent-dimensions § 4 density floor.
+- *"Extreme airy"* / *"extreme dense"* / *"extreme [axis]"* — slider positions pushed past the prior variant are not directions.
+- Editorial-register vocabulary (*atelier*, *the studio*, *mise-en-place*, *the journal*) when the brand register is product / commerce / direct-services (toolkit § 1 → Voice-rule moves → `Editorial-register vocabulary applied to non-editorial brands`).
 
-- *"Everything from B but more"* (B+more is not a direction).
-- *"120pt+ display fonts"* (size-as-personality is not a captured
-  trait).
-- *"96px+ section padding everywhere"* (padding-as-personality is
-  not a captured trait — and conflicts with the density floor in
-  `intent-dimensions.md` § 4 anyway).
-- *"Extreme airy"* / *"extreme dense"* / *"extreme [axis]"* — slider
-  positions pushed past the prior variant are not directions.
-- Editorial-register vocabulary (*atelier*, *the studio*,
-  *mise-en-place*, *the journal*) when the brand register is
-  product / commerce / direct-services. See
-  `divergence-toolkit.md` § 1 → *Voice-rule moves* →
-  `Editorial-register vocabulary applied to non-editorial brands`.
-
-C+ must answer *"what if we leaned into Y?"* with a specific Y
-from the captured surface, not a slider position pushed past B.
-
-The C-cliff name comes from the observed pattern where a
-3-variant fork has A defensible, B defensible, and C reading as
-*"unprofessional"* rather than *"a third proposition."* The fix is
-not to soften C — it is to define C against a captured trait
-instead of against B.
+C+ must answer *"what if we leaned into Y?"* with a specific Y from the captured surface, not a slider pushed past B. The fix for a weak C is never to soften it — it is to define it against a captured trait instead of against B.
 
 ### Phase 3 — Author target PRODUCT.md
 
-Write `PRODUCT.md` at the project root using impeccable's
-`reference/teach.md` as the **format spec** (not as a runtime command
-to invoke). Direct authoring is intentional: by the time `direct`
-runs, every answer impeccable's interview would surface has already
-been resolved through stardust's intent-reasoning + divergence
-resolution above.
+Write `PRODUCT.md` at the project root using impeccable's `reference/teach.md (current impeccable versions ship the same format spec in `reference/init.md`; use whichever exists)` as the **format spec** (not a runtime command to invoke — by now every answer impeccable's interview would surface has been resolved). Populate:
 
-Sections to populate:
+- **Register** — from the resolved `register` axis.
+- **Users** — resolved audience tuple + tone signals from the extracted brand surface.
+- **Product Purpose** — user's phrase + extracted hero copy + resolved tone; one-line value statement, then one-line scope.
+- **Brand Personality** — resolved expressive axis + tone + reference set. Weight axes the user explicitly moved over inherited values.
+- **Anti-references** — the user's stated anti-refs **plus** anti-toolbox guardrails relevant to the direction (e.g. "modernise" triggers the Generic-2026-SaaS silhouette guardrail; list it explicitly so prototype and polish enforce it).
+- **Design Principles** — 3-5, each mapping to a specific axis movement; one verb-led principle + one-line elaboration.
+- **Accessibility & Inclusion** — populated when constraints include `a11y-first`, `RTL-required`, or similar; otherwise inherit impeccable's defaults.
 
-- **Register** — from the resolved direction's `register` axis.
-- **Users** — from the resolved audience tuple plus tone signals from
-  the extracted brand surface.
-- **Product Purpose** — from the user's phrase + extracted hero copy
-  + resolved tone, written as a one-line value statement followed by
-  one-line scope.
-- **Brand Personality** — derived from resolved expressive axis +
-  tone + reference set. Weight axes the user explicitly moved over
-  inherited values.
-- **Anti-references** — the user's stated anti-refs **plus** any
-  anti-toolbox guardrails relevant to the resolved direction
-  (e.g. "modernise" triggers the Generic-2026-SaaS silhouette
-  guardrail; list it explicitly so prototype and polish enforce it).
-- **Design Principles** — 3-5, each mapping to a specific axis
-  movement. Format: one verb-led principle, one-line elaboration.
-- **Accessibility & Inclusion** — populated when the constraint set
-  includes `a11y-first`, `RTL-required`, or similar. Otherwise
-  inherit impeccable's defaults.
-
-Where a section cannot be populated with confidence from inputs,
-mark it `<!-- _provenance: inferred -->` with a one-line basis
-sentence. Never invent strategy.
+A section that cannot be populated with confidence gets `<!-- _provenance: inferred -->` + a one-line basis sentence. Never invent strategy.
 
 ### Phase 4 — Author target DESIGN.md and DESIGN.json (site-level only)
 
-Write `DESIGN.md` at the project root using impeccable's
-`reference/document.md` as the format spec — Stitch YAML frontmatter
-plus the 6 canonical sections in fixed order.
+Write `DESIGN.md` at the project root using impeccable's `reference/document.md` as format spec — Stitch YAML frontmatter + the 6 canonical sections in fixed order.
 
-**Site-level only.** `direct` authors the design **system**, not
-page-level deployments. Page-specific composition decisions live
-in `stardust/prototypes/<slug>-shape.md` written by `prototype`
-Phase 1 — see `skills/prototype/reference/page-shape-brief.md`.
-
-The boundary is **abstract role vs literal deployment**:
+**Site-level only.** `direct` authors the design **system**; page-level deployments live in `stardust/prototypes/<slug>-shape.md` (written by `prototype` Phase 1, per `skills/prototype/reference/page-shape-brief.md`). The boundary is **abstract role vs literal deployment**:
 
 | In DESIGN.md / DESIGN.json (site system) | In `<slug>-shape.md` (page deployment) |
 |---|---|
 | Token vocabulary (colors, typography, spacing, radii) | Per-page section list and order |
-| Voice rules ("Mixed-Case-Headlines"), anti-refs | Literal copy per section (sourced from current/pages/<slug>.json) |
-| Anti-toolbox audit, divergence trace | Page-specific layout decisions ("hero is 5/3 split on home") |
-| Abstract component vocabulary: `button-primary`, `button-secondary`, `card`, `input`, `badge`, `link` (default treatment, density, sizing — NO page-specific dimensions or content) | Section-level component dimensions (`the211Panel` at 320×260 with dock points per viewport) |
-| Named system-component **roles** (a `header` exists, a `footer` exists, a `cta-band` pattern exists) | System-component **deployment** (literal tile labels in fixed order, link targets, copy variants) |
-| Default visual treatment for each abstract component | Per-page composition (statRow with literal "100 YEARS · 18,400 PEOPLE HOUSED · …") |
+| Voice rules ("Mixed-Case-Headlines"), anti-refs, anti-toolbox audit, divergence trace | Literal copy per section (from `current/pages/<slug>.json`); page-specific layout decisions ("hero is 5/3 split on home") |
+| Abstract component vocabulary (`button-primary`, `button-secondary`, `card`, `input`, `badge`, `link`): default treatment, density, sizing — NO page-specific dimensions or content | Section-level component dimensions (e.g. `the211Panel` at 320×260 with dock points per viewport) |
+| Named system-component **roles** (a `header` exists, a `footer` exists, a `cta-band` pattern exists) + default visual treatment per component | System-component **deployment**: literal tile labels in fixed order, link targets, copy variants; per-page composition (statRow with literal "100 YEARS · 18,400 PEOPLE HOUSED · …") |
 | Voice samples (do/don't, tone exemplars) | Per-page interaction model and key states |
 
-Concrete examples of items that **must not** appear in DESIGN.md /
-DESIGN.json:
-
-- Literal tile labels for any system-component pattern.
-- Section-level pixel dimensions, dock points, breakpoint-specific
-  widths.
-- Stat numbers, addresses, quotes, named-person references.
-- "On home, the hero is X" — that's a home-page deployment.
-- Per-page copy variants ("on the donate page the CTA reads Y").
-
-If a redesign demands a section-level dimension or a literal label
-that feels site-wide ("every page has a 211 panel docked at the
-bottom-right"), encode it as an **abstract role** in DESIGN.json
-(e.g. `extensions.systemComponentRoles.persistent-help` with
-purpose / position-class but no literal copy or dimensions) and let
-each page's shape brief specify the deployment.
+**Must not appear** in DESIGN.md / DESIGN.json: literal tile labels for system-component patterns; section-level pixel dimensions, dock points, breakpoint-specific widths; stat numbers, addresses, quotes, named-person references; "on home, the hero is X" (a home-page deployment); per-page copy variants ("on the donate page the CTA reads Y"). If a section-level dimension or literal label feels site-wide ("every page has a 211 panel docked bottom-right"), encode an **abstract role** in `DESIGN.json extensions.systemComponentRoles` (e.g. `persistent-help` with purpose / position-class but no literal copy or dimensions) and let each page's shape brief specify the deployment.
 
 Token sources:
 
-- **`colors`** — from the picked palette (palette-picker.md output)
-  or the inherited palette with role-renaming. Role names must
-  satisfy toolkit § 4 (brand-native, no `Primary` / `Secondary` /
-  `Alarm` etc. as sole role names).
-- **`typography`** — from the chosen font deck. Sizes scaled by the
-  resolved expressive axis (drenched → ratio ≥ 1.333; committed →
-  ratio 1.25; restrained → ratio 1.125-1.2). Heading vs body
-  assignments inherit from the deck.
-- **`rounded`** — derived from extracted brand-surface
-  `borderRadius.primary` mode, unless the direction moves
-  distinctiveness toward `singular` (in which case re-derive from the
-  font deck's tonal cousins).
-- **`spacing`** — 4pt base scale; `sectionPadding` propagated from
-  the density tier stamped in Phase 1 (`reference/intent-dimensions.md`
-  § 4):
-  - `airy` → `sectionPadding.desktop: 96px`, `tablet: 72px`, `mobile: 48px`
-  - `balanced` → `sectionPadding.desktop: 64px`, `tablet: 48px`, `mobile: 32px`  ← brand-register default
-  - `packed` → `sectionPadding.desktop: 48px`, `tablet: 36px`, `mobile: 24px`  ← product-register default
+- **`colors`** — the picked palette (palette-picker output) or the inherited palette with role-renaming. Role names must satisfy toolkit § 4 (brand-native; no `Primary` / `Secondary` / `Alarm` etc. as sole role names).
+- **`typography`** — the chosen font deck. Sizes scaled by the resolved expressive axis: drenched → ratio ≥ 1.333; committed → 1.25; restrained → 1.125-1.2. Heading vs body assignments inherit from the deck.
+- **`rounded`** — from extracted brand-surface `borderRadius.primary` mode, unless the direction moves distinctiveness toward `singular` (then re-derive from the font deck's tonal cousins).
+- **`spacing`** — 4pt base scale; `sectionPadding` picked deterministically from the Phase 1 density stamp — never re-ask here:
+  - `airy` → desktop 96px / tablet 72px / mobile 48px
+  - `balanced` → 64 / 48 / 32  ← brand-register default
+  - `packed` → 48 / 36 / 24  ← product-register default
 
-  The agent does **not** re-ask the density question here — the tier
-  was resolved in Phase 1 (asked once when the phrase didn't move
-  the axis, defaulted to balanced for brand register if unanswered).
-  Pick the value deterministically from the stamp.
+  **Hard floor enforcement.** When the captured page inventory shows > 5 sections OR > 2 audience tracks (intent-dimensions § 4 → "Hard floor for brand-register multi-audience sites"), `sectionPadding.desktop` is bounded to ≤ 64px and ≥ 40px on **every** variant including the highest-divergence one. If Phase 1 stamped `airy` despite the trigger firing → surface the conflict before writing tokens: *"density tier `airy` was selected but the captured inventory triggers the multi-audience hard floor; pick (a) override floor (`density: airy (user-pinned)` in direction.md) or (b) accept the floor (sectionPadding capped at 64px)."* No answer → default (b).
+- **`components`** — 4-6 canonical components (`button-primary`, `button-secondary`, `card`, `input`, `badge`, `link`) populated from extracted brand-surface `componentStyle`, adjusted for direction movements.
 
-  **Hard floor enforcement.** When the captured page inventory shows
-  >5 sections OR >2 audience tracks (per
-  `reference/intent-dimensions.md` § 4 → "Hard floor for
-  brand-register multi-audience sites"), the resolved
-  `sectionPadding.desktop` is bounded at ≤ 64px and ≥ 40px on every
-  variant including the highest-divergence one. If Phase 1 stamped
-  `airy` despite the trigger conditions firing, surface the conflict
-  before writing tokens — *"density tier `airy` was selected but the
-  captured inventory triggers the multi-audience hard floor; pick (a)
-  override floor (`density: airy (user-pinned)` in direction.md) or
-  (b) accept the floor (sectionPadding capped at 64px)."* Default to
-  (b) when the user does not respond.
-- **`components`** — 4-6 canonical components (`button-primary`,
-  `button-secondary`, `card`, `input`, `badge`, `link`) populated
-  from extracted brand-surface `componentStyle`, with values
-  adjusted for direction movements.
+Every component HTML/CSS snippet in `components[]` must be self-contained, use `ds-` class prefixes, and respect impeccable's hard rules (OKLCH only, no pure black/white, no glassmorphism, no side stripes, no gradient text, ≥ 1.25 type ratio for brand register).
 
 Write `DESIGN.json` (schemaVersion 2) with:
 
-- `extensions.colorMeta`, `typographyMeta`, `shadows`, `motion`,
-  `breakpoints` — filled from the same sources as DESIGN.md. The
-  `motion` block carries the **register selection** (when
-  cinematic motion may be applied at prototype time):
+- `extensions.colorMeta`, `typographyMeta`, `shadows`, `motion`, `breakpoints` — filled from the same sources as DESIGN.md. The `motion` block carries the **register selection** (whether cinematic motion may apply at prototype time):
 
   ```json
   "motion": {
     "register": "arrival | kinetic-display | live-systems | editorial | kinetic-grid",
-    "registerRationale": "<one-line citation back to PRODUCT.md Brand Personality trait that selected this register>",
+    "registerRationale": "<one-line citation to the PRODUCT.md Brand Personality trait that selected it>",
     "easings":   { "entrance": "...", "transition": "...", "expo": "..." },
     "durations": { "enter": <ms>, "stagger": <ms> },
     "parallax":  { "translate": <vh>, "fade": <0-1>, "rangeStart": <%>, "range": <%> }
   }
   ```
 
-  Picked per the **register selection heuristic** in
-  `skills/prototype/reference/motion-registers.md` § Selection
-  heuristic, reading the resolved `PRODUCT.md` § Brand Personality:
+  Pick the register per `skills/prototype/reference/motion-registers.md` § Selection heuristic, reading the resolved PRODUCT.md § Brand Personality:
 
-  | Personality traits (any match)                                            | Register          |
-  |---------------------------------------------------------------------------|-------------------|
-  | `civic-formal` + (`institutional` OR `place-led`)                         | `arrival`         |
-  | `signage-led` OR `wayfinding-first` OR `display-typography-signature`     | `kinetic-display` |
-  | `operationally-transparent` OR `data-led` OR `dashboard-register`         | `live-systems`    |
-  | `editorial` OR `slow-paced` OR `publication-register`                     | `editorial`       |
-  | `product` OR `SaaS` OR `transactional` OR `modular-catalogue`             | `kinetic-grid`    |
-  | (ambiguous / no clear match)                                              | `arrival`         |
+  | Personality traits (any match) | Register |
+  |---|---|
+  | `civic-formal` + (`institutional` OR `place-led`) | `arrival` |
+  | `signage-led` OR `wayfinding-first` OR `display-typography-signature` | `kinetic-display` |
+  | `operationally-transparent` OR `data-led` OR `dashboard-register` | `live-systems` |
+  | `editorial` OR `slow-paced` OR `publication-register` | `editorial` |
+  | `product` OR `SaaS` OR `transactional` OR `modular-catalogue` | `kinetic-grid` |
+  | (ambiguous / no clear match) | `arrival` |
 
-  Token defaults per register are sourced from
-  `skills/prototype/reference/motion-registers.md` § The five
-  registers; `direct` copies them verbatim into the `motion`
-  block unless the user has provided overrides during intent
-  reasoning. The `registerRationale` field records the one-line
-  justification so reviewers can audit the choice. **`direct`
-  does not apply the motion** — that happens at prototype time
-  under `--cinematic`. `direct` only **selects** the register.
-  Pages whose redesign does not need motion can leave
-  `register` absent; cinematic prototype will then either ask or
-  pick from the heuristic at render time.
+  Copy the register's token defaults verbatim from motion-registers.md § The five registers unless the user provided overrides during intent reasoning. `registerRationale` records the one-line justification so reviewers can audit the choice. **`direct` selects the register; it never applies motion** — that happens at prototype time under `--cinematic`. Pages whose redesign needs no motion leave `register` absent; cinematic prototype then asks or picks from the heuristic at render time. When the intent phrase contains explicit motion direction ("make it cinematic", "feel alive", "move like signage"), pick the register and set `registerRationale: "user-phrase: <verbatim>"`.
 
-  **Per-variant placement (when N > 1 variants).** For
-  multi-variant runs, the `motion` block goes into the
-  variant-specific `DESIGN-<id>.json` files (see § Multi-variant
-  DESIGN files below), not into the site-level `DESIGN.json`.
-  Variants that should render static omit the block entirely;
-  variants that should engage cinematic motion declare a
-  `register`. This is what lets one variant (typically C) be
-  cinematic while siblings stay static — `prototype` Phase 2.4
-  reads `DESIGN-<id>.json.extensions.motion.register` per
-  variant and fires only where present.
-
-  When the user's intent phrase contains explicit motion direction
-  ("make it cinematic", "feel alive", "move like signage"),
-  `direct` picks the register and notes the source in
-  `registerRationale` as `"user-phrase: <verbatim>"`.
-- `extensions.divergence` — full audit trail per the v2 storage shape
-  in `divergence-toolkit.md`. Includes the brand-faithful inversion
-  log (per `reference/direction-format.md` § Divergence inputs)
-  capturing pure-color or hex-format retentions.
-- `extensions.componentStyle` — the **abstract** v1 fields
-  (`buttons`, `cards`, `inputs`, `dualCTAPattern`). **Default**
-  treatment per component, no per-page dimensions or literal copy.
-- `extensions.systemComponentRoles` — the **abstract roles** for
-  named cross-page patterns (e.g. `persistent-help`, `cta-band`,
-  `header`, `footer`). Each role carries purpose, position class,
-  and any site-wide constraint — **not** literal copy, dimensions,
-  or per-viewport dock points (those are page-deployment, in
-  `<slug>-shape.md`).
-- `extensions.voice` — sampled DOs and DON'Ts derived from
-  `_brand-extraction.json` voice samples + the resolved tone.
-- `narrative.northStar`, `overview`, `keyCharacteristics`, `rules`,
-  `dos`, `donts` — derived from the resolved direction. Toolkit § 7
-  Optional House Standards land here in `narrative.rules[]`.
-
-Every component HTML/CSS snippet in `components[]` must be
-self-contained, use `ds-` class prefixes, and respect impeccable's
-hard rules (OKLCH only, no pure black/white, no glassmorphism, no
-side stripes, no gradient text, ≥ 1.25 type ratio for brand
-register).
+  **Per-variant placement (N > 1):** the `motion` block goes into the variant-specific `DESIGN-<id>.json` files (§ Multi-variant DESIGN files), not the site-level `DESIGN.json`. Static variants omit the block entirely; cinematic variants declare a `register` — this is what lets one variant (typically C) be cinematic while siblings stay static (`prototype` Phase 2.4 reads `DESIGN-<id>.json.extensions.motion.register` per variant and fires only where present).
+- `extensions.divergence` — full audit trail per the v2 shape in `divergence-toolkit.md`, including the brand-faithful inversion log (per `reference/direction-format.md` § Divergence inputs) capturing pure-color or hex-format retentions.
+- `extensions.componentStyle` — the **abstract** v1 fields (`buttons`, `cards`, `inputs`, `dualCTAPattern`): default treatment per component, no per-page dimensions or literal copy.
+- `extensions.systemComponentRoles` — abstract roles for named cross-page patterns (`persistent-help`, `cta-band`, `header`, `footer`): purpose, position class, site-wide constraints — **not** literal copy, dimensions, or per-viewport dock points (page-deployment, in `<slug>-shape.md`).
+- `extensions.voice` — sampled DOs and DON'Ts from `_brand-extraction.json` voice samples + the resolved tone.
+- `narrative.northStar`, `overview`, `keyCharacteristics`, `rules`, `dos`, `donts` — from the resolved direction. Toolkit § 7 Optional House Standards land in `narrative.rules[]`.
 
 #### IA-priority preservation audit (Mode A)
 
-After tokens are drafted but before they land in the variant DESIGN
-files, run the IA-priority preservation audit per
-`reference/intent-dimensions.md` § 8. For each captured signal that
-fires a trigger condition (commercial conversion, search-led IA,
-donation funnel, crisis affordance, audience routing), record an
-`extensions.iaPriorities[]` entry in `DESIGN.json`:
+After tokens are drafted but **before** they land in the variant DESIGN files, run the audit per intent-dimensions § 8. For each captured signal that fires a trigger condition (commercial conversion, search-led IA, donation funnel, crisis affordance, audience routing), record an `extensions.iaPriorities[]` entry:
 
 ```json
-[
-  {
-    "signal": "crisis-affordance",
-    "evidence": "pages/home.json#landmarks[hero] contains heading 'Looking for immediate shelter?' + phone 801-990-9999",
-    "preserveAs": "first-viewport",
-    "scope": "site-wide",
-    "mutability": "movable"
-  }
-]
+{ "signal": "crisis-affordance",
+  "evidence": "pages/home.json#landmarks[hero] contains heading 'Looking for immediate shelter?' + phone 801-990-9999",
+  "preserveAs": "first-viewport", "scope": "site-wide", "mutability": "movable" }
 ```
 
-Each entry is a constraint that downstream `prototype` and `migrate`
-must honor — a variant whose home shape brief omits the crisis
-affordance from the first viewport fails the audit and is rejected.
-The audit is the structural enforcement of § 8; without it, IA-
-priority preservation is a guideline rather than a contract.
-
-The `mutability` field reflects the `ia-fidelity` stamp from Phase 1
-(per `reference/intent-dimensions.md` § 9): `locked` under verbatim
-(variants may not move the priority at all — A1/A2/A3 are surface
-forks), `movable` under reimagined (variants may demote / promote /
-re-shape the priority's deployment, but the § 8 floor still fires).
-The field is stamped once at Phase 4 and is the source of truth
-prototype reads.
+Each entry is a constraint `prototype` and `migrate` must honor — a variant whose home shape brief omits the crisis affordance from the first viewport **fails the audit and is rejected**. The audit is the structural enforcement of § 8; without it, IA-priority preservation is a guideline rather than a contract. `mutability` comes from the Phase 1 `ia-fidelity` stamp (§ 9): `locked` under verbatim (variants may not move the priority at all — A1/A2/A3 are surface forks), `movable` under reimagined (variants may demote / promote / re-shape the deployment, but the § 8 floor still fires). Stamped once here; prototype reads it as source of truth.
 
 #### Multi-variant DESIGN files (when N > 1)
 
-When the user requested N variants (Phase 2.6 active), Phase 4
-writes per-variant design files at the project root instead of a
-single pair:
+Phase 2.6 active → write per-variant files at the project root instead of a single pair:
 
 ```
-PRODUCT.md                  ← shared across variants (strategy doesn't change)
+PRODUCT.md                  ← shared (audience, register, content strategy are per-brand, not per-variant)
 DESIGN-A.md / DESIGN-A.json ← variant A (faithful + improvements)
 DESIGN-B.md / DESIGN-B.json ← variant B (one captured trait amplified)
 DESIGN-C.md / DESIGN-C.json ← variant C (different captured trait amplified)
 ```
 
-`PRODUCT.md` is shared because audience, register, and content
-strategy are per-brand, not per-variant. Each variant's DESIGN
-files inherit the shared `extensions.iaPriorities[]` audit from the
-above step — variants cannot opt out of IA-priority preservation
-within Mode A.
-
-When the resolved mode is rebrand (`--rebrand` or rebrand-trigger
-phrase), the multi-variant fork still writes per-variant DESIGN
-files but PRODUCT.md may also vary — rebrand permits the strategy
-to shift, not just the visual treatment.
+Each variant's files inherit the shared `extensions.iaPriorities[]` audit — variants cannot opt out of IA-priority preservation under Mode A. Under rebrand mode (`--rebrand` or trigger phrase) the fork still writes per-variant DESIGN files but PRODUCT.md may also vary — rebrand permits the strategy to shift, not just the visual treatment.
 
 ### Phase 5 — Write direction.md and update state
 
-Write `stardust/direction.md` per
-`skills/direct/reference/direction-format.md`. The full reasoning
-trace: phrase, restatement, movements, gaps, questions and answers,
-resolved axes, divergence inputs, command sequence proposed, user
-confirmation, every assumption that defaulted in. Re-directs append
-to the file as a new section; prior direction stays as history.
+Write `stardust/direction.md` per `skills/direct/reference/direction-format.md` — the full reasoning trace: phrase, restatement, movements, gaps, questions and answers, resolved axes, divergence inputs, command sequence proposed, user confirmation, every assumption that defaulted in. Re-directs **append** a new section; prior direction stays as history.
 
 Update `stardust/state.json`:
+- `direction.resolvedAt` = now; `direction.phrase` = the user's verbatim phrase; `direction.directionFile` = `"stardust/direction.md"`.
+- Each in-scope page: `status` `extracted` → `directed`.
+- On `--re-direct`, each page already `prototyped` / `approved` / `migrated`: set `stale: true`, `staleReason: "direction changed at <ts>"`. Do **not** change the status itself — the on-disk artifact is still valid, just out of step.
 
-- `direction.resolvedAt` = now
-- `direction.phrase` = the user's verbatim phrase
-- `direction.directionFile` = `"stardust/direction.md"`
-- For each page in scope: `status` `extracted` → `directed`
-- On `--re-direct`, for each page already in `prototyped` /
-  `approved` / `migrated`: set `stale: true` and
-  `staleReason: "direction changed at <ts>"`. Do not change the
-  status itself; the on-disk artifact is still valid, just out of
-  step.
-
-Print a one-screen summary report and recommend the next step:
-
-```
-direction resolved
-==================
-
-Phrase:    "make it more expressive for a young audience"
-Audience:  Gen Z college / first-job (resolved via Q1)
-Register:  brand (inherited from current/PRODUCT.md)
-
-Movements:
-  expressive axis    restrained -> committed
-  distinctiveness    familiar  -> distinctive
-  tone               serious   -> playful
-  density            (unchanged)
-  audience           (resolved: Gen Z college / first-job)
-
-Divergence:
-  seed         1970s x Riso print x zine x monochrome-tint
-  font deck    zine-maximalist
-  palette      "Brutalist Dawn" (picked from library)
-
-Wrote:
-  PRODUCT.md, DESIGN.md, DESIGN.json
-  stardust/direction.md
-
-State:
-  25 pages: extracted -> directed
-  0 stale prototypes (none exist yet)
-
-Next: $stardust prototype  (defaults to home page)
-```
+Print a one-screen summary and recommend the next step — phrase, audience, register, per-axis movements (moved / unchanged / resolved), divergence resolutions (seed, font deck, palette), files written, state changes (N pages `extracted → directed`, stale-prototype count), then `Next: $stardust prototype` (defaults to home page).
 
 ## Outputs
 
-| Path                                  | Purpose                                            |
-|---------------------------------------|----------------------------------------------------|
-| `PRODUCT.md`                          | Target strategy (impeccable format). Shared across variants when N > 1 under Mode A. |
-| `DESIGN.md`                           | Target visual system (Stitch frontmatter + 6 sections). Single-variant runs only. |
-| `DESIGN.json`                         | Sidecar with extensions (divergence, componentStyle, voice, iaPriorities) and narrative. Single-variant runs only. |
-| `DESIGN-{A,B,C,…}.md`                 | Per-variant DESIGN files when the user requested N > 1 variants (Phase 2.6 active). |
-| `DESIGN-{A,B,C,…}.json`               | Per-variant DESIGN sidecars matching the .md files. |
-| `stardust/prototypes/<slug>-improvements.md` | Improvements list (Mode A only, written in Phase 2.5). The load-bearing artifact for variant A. |
-| `stardust/direction.md`               | Resolved direction + full reasoning trace + per-variant resolutions when N > 1. |
-| `stardust/state.json`                 | Updated with direction + per-page status changes + `direction.variantMode` + `direction.variants[]` when N > 1. |
+| Path | Purpose |
+|---|---|
+| `PRODUCT.md` | Target strategy (impeccable format). Shared across variants when N > 1 under Mode A. |
+| `DESIGN.md` / `DESIGN.json` | Target visual system (Stitch frontmatter + 6 sections) + sidecar with extensions (divergence, componentStyle, voice, iaPriorities) and narrative. Single-variant runs only. |
+| `DESIGN-{A,B,C,…}.md` / `.json` | Per-variant DESIGN files + sidecars when N > 1 (Phase 2.6 active). |
+| `stardust/prototypes/<slug>-improvements.md` | Improvements list (Mode A only, Phase 2.5). Load-bearing artifact for variant A. |
+| `stardust/direction.md` | Resolved direction + full reasoning trace + per-variant resolutions when N > 1. |
+| `stardust/state.json` | Direction block + per-page status changes + `direction.variantMode` + `direction.variants[]` when N > 1. |
 
 ## Failure modes
 
-- **No extracted state.** Abort and recommend `$stardust extract`.
-- **Phrase too vague even after two questions.** Persist the partial
-  reasoning to `stardust/direction.md` under a `# Pending` section,
-  ask the user to refine further, do **not** write `PRODUCT.md` /
-  `DESIGN.md` / `DESIGN.json` from incomplete reasoning.
-- **Re-direct with prior approved or migrated pages.** Always confirm
-  before stale-flagging. The flag is visible to the user and
-  reversible (clearing happens automatically on successful re-run of
-  prototype or migrate), but a re-direct invalidates work the user
-  may have signed off on.
-- **Anti-toolbox audit removes too many moves.** If the resolved
-  direction collapses to defaults after the audit strips
-  unjustifiable hits, surface this to the user and re-prompt for
-  reference anchors before writing tokens.
-- **(b) Insufficient brand signal for N variants.** When the
-  captured brand surface has fewer than 3 distinct moves to
-  amplify (e.g., monochrome palette, single type face, no
-  distinctive motifs, or `signal-thin` per § Setup step 6), refuse
-  to render N ≥ 3 variants under Mode A. Surface honestly:
-  *"the captured surface has 2 distinct traits to amplify; producing
-  3 variants would force one to invent moves not present in the
-  brand."* Propose 1 or 2 variants and let the user choose, or
-  recommend extract with a wider crawl. Better one strong variant
-  than three weak ones.
-- **(c) Hard rule conflict.** When Mode A is active *and* the
-  user's phrase requires violating a Mode A pin (e.g., the user
-  asks for *"a completely different palette"* while migration mode
-  is active and `--rebrand` was not passed), stop. Name the
-  conflict explicitly: *"You asked to keep the brand and to change
-  the palette — those are not compatible. Did you mean (a) keep the
-  current palette and only refresh execution, (b) rebrand
-  (`--rebrand`) and roll a new palette, or (c) Mode A with a
-  targeted palette move (single role recolored, rest pinned)?"*
-  Wait for explicit answer.
-- **(d) Empty improvements list.** When Phase 2.5 produces fewer
-  than 3 weaknesses meeting the specificity bar, stop before
-  rendering any variant. Variant A's brief depends on the list;
-  without it, the *"better"* claim fails. Surface honestly:
-  *"the captured site is already at a competent execution level on
-  observable dimensions — variant A would reduce to spacing and
-  contrast adjustments only."* Ask the user whether to (a) proceed
-  with reduced scope (density + contrast only), (b) extract
-  additional pages (`extract --cap 25` or higher) to surface more
-  weaknesses, or (c) pivot to rebrand mode (`--rebrand`) where the
-  brand-fidelity floor doesn't apply.
+- **No extracted state.** → Abort; recommend `$stardust extract`.
+- **Phrase too vague after two questions.** → Persist the partial reasoning to `stardust/direction.md` under a `# Pending` section, ask the user to refine; do **not** write PRODUCT.md / DESIGN.md / DESIGN.json from incomplete reasoning.
+- **Re-direct with prior approved or migrated pages.** → Always confirm before stale-flagging: the flag is visible and reversible (cleared automatically on successful re-run of prototype or migrate), but a re-direct invalidates work the user may have signed off on.
+- **Anti-toolbox audit collapse.** Direction collapses to defaults after the audit strips unjustifiable hits → surface it and re-prompt for reference anchors before writing tokens.
+- **(b) Insufficient brand signal for N variants.** Fewer than 3 distinct captured traits to amplify (monochrome palette, single type face, no distinctive motifs, or `signal-thin` per Setup 6) → refuse to render N ≥ 3 variants under Mode A. Say so plainly: *"the captured surface has 2 distinct traits to amplify; producing 3 variants would force one to invent moves not present in the brand."* Propose 1–2 variants and let the user choose, or recommend extract with a wider crawl. One strong variant beats three weak ones.
+- **(c) Hard rule conflict.** Mode A active *and* the phrase requires violating a pin (e.g. *"a completely different palette"* without `--rebrand`) → stop and name the conflict: *"You asked to keep the brand and to change the palette — those are not compatible. Did you mean (a) keep the current palette and only refresh execution, (b) rebrand (`--rebrand`) and roll a new palette, or (c) Mode A with a targeted palette move (single role recolored, rest pinned)?"* Wait for an explicit answer.
+- **(d) Empty improvements list.** Phase 2.5 yields < 3 weaknesses meeting the specificity bar → stop before rendering any variant (A has no brief; the *"better"* claim fails). Surface honestly (*"the captured site is already at a competent execution level on observable dimensions — variant A would reduce to spacing and contrast adjustments only"*) and offer: (a) reduced scope (density + contrast only), (b) `extract --cap 25` or higher to surface more weaknesses, (c) pivot to `--rebrand` where the brand-fidelity floor doesn't apply.
 
-## Prep mode (--prep)
-
-When invoked with `--prep`, direct runs an extended pass that
-finalizes the inventory data structures migrate consumes.
-Discovery-mode runs are unchanged: intent reasoning, divergence-
-toolkit resolution, target-spec authoring.
-
-`--prep` adds five things on top of the standard procedure:
-
-### 1. Type catalog confirmation
-
-Surface the page-type catalog inferred by `extract --prep` (in
-`state.json.pages[].type`). Show counts per type and a sample of
-slugs per type:
-
-```
-Page types from extract:
-  landing  1   (home)
-  article  84  (news/post-2026-04-15-housing-summit, news/post-2026-04-08-..., ...)
-  listing  6   (news, programs, events, ...)
-  program  12  (programs/shelter, programs/case-management, ...)
-  form     3   (donate, contact, volunteer)
-  static   18  (about, team, financials, ...)
-  unique   3   (404, search, faq)
-
-Confirm catalog (yes / refine "<phrase>")?
-```
-
-User can confirm or refine. Refinements: rename a type, split a
-type into finer-grained ones (e.g., `article-feature` vs.
-`article-press`), merge two types, mark specific pages as
-`unique`. Updates land in `state.json.pages[].type`.
-
-### 2. Module catalog finalization
-
-Surface the module candidates proposed by `extract --prep`
-(`DESIGN.json.extensions.modules[]` with `status: candidate`).
-For each candidate:
-
-```
-hotline-211 (5 instances)
-  Slot candidates: phone, hours, headline, cta-label
-  Found in: home, get-help, donate, news, programs
-
-  Confirm? (name "<id>" / promote / prune / refine slots)
-```
-
-User actions per candidate:
-
-- **Confirm.** Promote `status: candidate → confirmed`. Module
-  ID, slots, defaults are accepted as-is.
-- **Rename.** Change the auto-generated ID to a brand-native name.
-- **Prune.** Remove from the catalog (the candidate was a
-  spurious match; instances will render as inline content).
-- **Refine slots.** Mark slots required, set defaults, add or
-  remove slots, adjust types.
-
-Confirmed modules become the catalog migrate consumes.
-
-### 3. Color reservations
-
-If the resolved direction reserves any color to a specific
-module/lockup (e.g., centennial-red `#DC323D` reserved to the
-`trh-100-lockup` module), capture in
-`DESIGN.json.extensions.colorReservations[]`:
-
-```json
-[
-  { "color": "#DC323D", "reservedFor": ["module:trh-100-lockup"] }
-]
-```
-
-Migrate validates that reserved colors appear only in their
-declared contexts; violations refuse the page.
-
-### 4. Wider direction re-evaluation
-
-Discovery mode resolved direction against a 5-page sample. Prep
-mode has the full inventory. Re-read the broader content surface
-and check:
-
-- Does the resolved register still hold? (e.g., did discovery
-  miss a service-led section that pulls toward a different
-  register?)
-- Are there new tensions surfaced by the wider crawl that affect
-  direction?
-- Do any anti-references need updating?
-
-If the re-evaluation surfaces a meaningful divergence from the
-discovery-mode direction, surface to the user. If the user wants
-to re-direct, they run `$stardust direct --re-direct` separately;
-the prep run itself is non-destructive.
-
-### 5. Site-level metadata defaults
-
-Capture brand-level metadata defaults in
-`DESIGN.json.extensions.metadata`:
-
-- `siteName` — brand name (typically from `<title>` patterns or
-  `og:site_name`)
-- `defaultOgImage` — default OG image when a page doesn't have
-  its own
-- `themeColor` — typically already in DESIGN.md
-- `organization` — `Organization` JSON-LD entry (name, url,
-  logo, sameAs)
-- `locale` — default locale
-- `keyFacts` — optional: the short list of crawlable fact strings
-  the brand must expose in server-rendered content (price, license,
-  maker, requirement). Consumed by deploy's atomic-contract raw-HTML
-  grep (deploy SKILL.md #86); omit when the direction names none.
-
-These are composed with per-page metadata at migrate time. See
-`skills/migrate/reference/metadata-and-jsonld.md` for the
-composition rules.
-
-### Prep summary
-
-```
-direct --prep complete
-======================
-
-Type catalog:        confirmed (7 types, 127 pages)
-Module catalog:      confirmed (8 modules, slot vocabularies set)
-Color reservations:  1 (#DC323D reserved to trh-100-lockup)
-Brand metadata:      set (siteName, defaultOgImage, themeColor, organization, locale)
-Direction:           no change (wider crawl confirmed)
-
-Next: $stardust prototype --prep  (fill template gaps, write canon)
-```
-
-Default mode is unchanged.
-
-## Add-variant mode (--add-variant)
-
-When the user has already approved (or rendered) variant A and
-asks for B / C / etc. as alternatives, `--re-direct` is too
-heavy: it replaces the active direction, re-runs Phase 1
-reasoning, and stale-flags every approved or migrated page
-against the prior direction. The user is **not** changing
-direction — they are extending it with additional variant
-expressions of the same direction. `--add-variant <name>` is the
-incremental-extension flow.
-
-The flow surfaced on the 2026-05-04 ups.com session: variant A
-shipped, the user later asked for B and C as the directional
-alternatives that had been surfaced in the initial menu but not
-committed to. Without an additive flag, the agent had to author
-B and C as page-shape briefs + proposed HTML only (skipping
-`DESIGN-B.{md,json}` / `DESIGN-C.{md,json}`), embedding their
-system-level deviations inline in per-variant CSS. Migrate then
-had no machine-readable source to re-derive B / C from.
-
-### Procedure
-
-When `--add-variant <name>` is passed:
-
-1. **Setup** runs as normal (impeccable dep check, state read,
-   brand-extraction read, brand-signal classification).
-   Validation step 5 (provenance) is **skipped** — add-variant
-   does not consume per-page extracted JSON; it consumes the
-   already-resolved direction. The brand-signal stamp stays
-   useful for the inheritance rules below.
-2. **Skip Phase 1 (Reasoning).** The user's intent is *"add
-   another variant against the existing direction,"* not "resolve
-   a fresh direction." If the existing `direction.md` Active
-   section is missing, refuse — there is no direction to extend.
-3. **Skip Phase 2 (Mode detection + divergence).** Mode is
-   inherited from the existing direction (typically Mode A
-   given the brand-faithful default). The seed, font deck,
-   palette, and ground family are all inherited as-is.
-4. **Run Phase 2.5 (Improvements list)** **only if** the
-   existing direction is Mode A and a variant-A improvements
-   list does not yet exist for the slug being prototyped later.
-   The improvements list is shared across all Mode A variants
-   per `direct/SKILL.md` § Phase 2.5; if it already exists, the
-   add-variant pass reads it as input and does not regenerate.
-5. **Run Phase 2.6 (Multi-variant fork)** only enough to
-   resolve the **new variant's** role per the variant role
-   contract (faithful + improvements / one captured trait
-   amplified / different captured trait amplified). Surface the
-   role choice to the user before proceeding. Do not re-run the
-   role contract for variants that already exist — their roles
-   are stamped in `direction.md`.
-6. **Run Phase 4 against the new variant only.** Derive the
-   variant's system-level deviations (font-weight changes,
-   surface-color additions, motif amplifications, etc.) and
-   write:
-   - `DESIGN-<name>.md` — Stitch frontmatter + 6 canonical
-     sections, **inheriting** every token that doesn't change
-     for this variant.
-   - `DESIGN-<name>.json` — sidecar with extensions
-     (`divergence`, `componentStyle`, `voice`, `iaPriorities`).
-   When variant A has been written as the unsuffixed
-   `DESIGN.{md,json}` (single-variant flow), upgrade A's files
-   to the suffixed form (`DESIGN-A.{md,json}`) and **leave the
-   unsuffixed files in place as backward-compatible aliases
-   pointing at A** — `migrate` and `prototype` continue to
-   resolve the unsuffixed form to A.
-7. **Append a section to `direction.md`** under the existing
-   Active section, titled `## Variant <name>`, recording: the
-   variant's role (faithful / amplified-trait), the captured
-   trait being amplified (when applicable), the system-level
-   deviations from variant A, the IA-priority audit (must
-   match A's audit — variants cannot opt out of preservation
-   under Mode A), and a one-line thesis.
-8. **Skip Phase 5 update of state.json's `direction.*` block**.
-   The active direction has not changed; the direction file's
-   resolvedAt / phrase / directionFile fields stay untouched.
-   Pages already in `prototyped` / `approved` / `migrated`
-   states are **not** stale-flagged — adding a variant is
-   additive, not a re-direction. State.json gains a
-   `direction.variants[].<name>` entry (per
-   `state-machine.md`'s multi-variant additions) recording the
-   new variant's id and DESIGN files.
-
-### Variant parentage and inheritance chain
-
-`--add-variant <name>` infers a **parent** from the slot name:
-
-- Slot name is a single letter (`A`, `B`, `C`, ...): parent is the
-  *active direction* (the resolved direction in `direction.md`).
-  The variant inherits from the active direction's resolved seed.
-- Slot name is a letter + digits (`A1`, `A2`, `B3`, `C2`...):
-  parent is the variant whose id is the letter prefix (`A1` → `A`,
-  `B3` → `B`). The variant is a **surface fork** of its parent
-  per § Surface forks of role-differentiated variants. The
-  parent must already exist; if not, refuse and recommend adding
-  the parent first (`--add-variant B` before `--add-variant B3`).
-
-Inheritance chains under reimagined mode:
-
-- `A → active-direction` — A inherits from the resolved direction.
-- `B → active-direction` — B inherits from the resolved direction;
-  its captured trait is declared in its shape brief.
-- `B3 → B → active-direction` — B3 inherits from B (parent surface
-  fork); B's captured trait + role propagate, B3 declares its
-  surface tuning.
-
-Record the chain in `direction.md`'s per-variant section as
-`Inheritance chain: <child> → <parent> → <root>`. Stardust
-`state.json` records the parent in
-`direction.variants[].parentVariant` (per
-`stardust/reference/state-machine.md` § Variants block).
-
-### Per-field inheritance rules
-
-When writing `DESIGN-<name>.{md,json}`, fields fall into three
-categories:
-
-| inherit-as-is | inherit-then-extend | variant-local |
-|---|---|---|
-| `colors` (palette) — Mode A pin | `componentStyle` — base treatment from A; variant adds variant-local component overrides keyed by `data-variant="<name>"` | `narrative.northStar` — per-variant thesis |
-| `typography` family / scale — Mode A pin | `extensions.divergence.brand_faithful_inversions[]` — A's list is the floor; variant may add inversions that follow from its amplified trait | `narrative.overview`, `narrative.keyCharacteristics` — written against the variant's role |
-| `rounded`, `spacing` — site-wide tokens | `extensions.iaPriorities[]` — same audit as A; cannot opt out under Mode A | `voice.examples.do/dont` — variant may amplify a captured voice register A didn't lean on |
-| `extensions.colorMeta`, `typographyMeta`, `breakpoints` | `narrative.rules[]` — A's house standards inherit; variant adds its own | `extensions.divergence.seed.anchors[]` — variant may add a captured trait as the anchor for its amplified-trait role |
-| `extensions.systemComponentRoles` (abstract roles) | | The variant-id stamp in `_provenance` |
-
-Variants **cannot**:
-
-- Introduce a font outside the captured surface (Mode A pin).
-- Introduce a color outside the captured palette (Mode A pin).
-- Shift the register from PRODUCT.md (per-brand strategy is
-  variant-invariant under Mode A).
-- Skip the IA-priority audit (variants are visual expressions,
-  not strategic re-shapings).
-
-**Surface-fork-specific rules (when parent is a letter-prefix
-variant like B → B3):**
-
-- The captured trait being amplified is **inherited from the parent
-  variant**. The surface fork cannot change which trait is amplified
-  (changing it changes the role, which is a sibling variant, not a
-  surface fork).
-- The role narrative (B's "scroll cinema amplified" thesis) is
-  inherited; the surface fork's narrative extends it with its
-  per-axis tuning ("B3 amplifies the same captured trait in a loud
-  register: weight 700 body H3s, perfect-fifth type scale, packed
-  density").
-- The parent's caps (motion-energy ≤ N, color-temperature within
-  range, etc.) inherit. Cap overrides are permitted but must be
-  declared in the surface fork's DESIGN.json `extensions.capOverrides[]`
-  with a one-sentence rationale citing a captured-source basis.
-- Structural fields (IA priority order, section sequence, layout
-  strategy of major sections) inherit verbatim from the parent —
-  changing them produces a sibling variant, not a surface fork.
-
-When the user's add-variant request would violate one of the
-forbidden rules, refuse with the same § Failure modes (c) hard
-rule conflict pattern: name the conflict, propose targeted
-alternatives (rebrand mode via `--rebrand`, or a Mode A
-expression that fits within the pins).
-
-### Add-variant summary
-
-```
-direct --add-variant B complete
-==============================
-
-Variant role:         one captured trait amplified — editorial confidence
-Captured trait:       caption-band typography + named-driver portraits
-Inheritance:          palette, typography, rounded, spacing inherited from A
-Variant-local:        narrative.northStar, voice DOs (eyebrow voice expanded),
-                      componentStyle.heroOverlay (variant override)
-IA-priority audit:    matches A — commercial-conversion + crisis-affordance preserved
-
-Wrote:
-  DESIGN-B.md, DESIGN-B.json (alongside DESIGN-A.{md,json})
-  stardust/direction.md  (appended ## Variant B section)
-
-State:
-  pages unchanged (no stale flags — add-variant is additive)
-  direction.variants[]:  A + B
-
-Next: $stardust prototype <slug> --variant B
-```
-
-### Failure modes specific to add-variant
-
-- **No active direction.** Refuse — there is nothing to extend.
-  Recommend `$stardust direct` first.
-- **Variant `<name>` already exists.** Refuse — pass `--re-direct`
-  and re-resolve the variant explicitly if a refresh is wanted,
-  or pick a different name (variants are case-sensitive; B and b
-  are distinct entries but discouraged for clarity).
-- **Mode A constraint violation.** Per § Per-field inheritance
-  rules above; surface the conflict and propose targeted
-  alternatives.
-- **Existing direction is rebrand mode.** Add-variant is allowed,
-  but the inheritance rules relax — rebrand permits a different
-  PRODUCT.md per variant. Surface the relaxed contract to the
-  user before writing.
+Add-variant-specific failure modes: `reference/add-variant.md` § Failure modes.
 
 ## References
 
-- `skills/stardust/reference/intent-dimensions.md` — the 8 axes
-  (the 7 axes plus § 8 IA-priority preservation, the Mode A
-  constraint that fires on captured commercial-conversion / crisis /
-  audience-routing signals).
-- `skills/stardust/reference/intent-reasoning.md` — the procedure.
-- `skills/stardust/reference/intent-examples.md` — worked examples.
-- `skills/stardust/reference/impeccable-command-map.md` — when to
-  reach for each impeccable command (used when building the plan).
-- `skills/stardust/reference/reference-research.md` — the
-  research-first anchor procedure (refero MCP → WebSearch → seed
-  fallback) consumed by Mode B and Default mode; evidence shape and
-  budgets.
-- `skills/stardust/reference/divergence-toolkit.md` — anti-mediocrity
-  inputs and the v2 storage shape for the audit trail. Contains the
-  anti-toolbox additions for multi-variant moves
-  (`C-cliff overshoot`, `Anonymous middle variant`, `Variant
-  homogeneity`) and universal hardening (`Fabricated content`,
-  `Hero text on photographic background without contrast scrim`,
-  `Editorial-register vocabulary applied to non-editorial brands`).
+- `skills/stardust/reference/intent-dimensions.md` — the 8 axes (7 axes + § 8 IA-priority preservation, § 8b signature preservation, § 9 ia-fidelity).
+- `skills/stardust/reference/intent-reasoning.md` — the Phase 1 procedure. Worked examples: `intent-examples.md`.
+- `skills/stardust/reference/impeccable-command-map.md` — when to reach for each impeccable command (used when building the plan).
+- `skills/stardust/reference/reference-research.md` — research-first anchor procedure (refero MCP → WebSearch → seed fallback) for Mode B and Default mode; evidence shape and budgets.
+- `skills/stardust/reference/divergence-toolkit.md` — anti-mediocrity inputs, v2 audit-trail storage shape, anti-toolbox additions for multi-variant moves (`C-cliff overshoot`, `Anonymous middle variant`, `Variant homogeneity`) and universal hardening (`Fabricated content`, `Hero text on photographic background without contrast scrim`, `Editorial-register vocabulary applied to non-editorial brands`).
 - `skills/stardust/reference/artifact-map.md` — provenance shape.
 - `reference/direction-format.md` — schema for `stardust/direction.md`.
 - `reference/palette-picker.md` — palette resolution procedure.
-
-## Default-mode-flip note (2026-04-29)
-
-This skill changed its default behavior in 2026-04-29 to make Mode A
-(brand-faithful) the default whenever the captured brand surface is
-`signal-strong`, rather than activating only on explicit user
-signals. (The rationale: dogfood runs showed ambiguous refresh
-phrases rolling full divergence seeds and shipping rebrand-shaped
-output to brand owners who asked for a refresh.) Behavior summary:
-
-- Before: ambiguous phrases like *"make it more modern"* rolled the
-  full divergence seed and produced rebrand-shaped output.
-- After: ambiguous phrases default to Mode A; rebrand requires
-  explicit phrase signal or `--rebrand` flag.
-
-The flip was driven by dogfood evidence that the typical stardust
-use case (presales refresh of an existing site for a brand owner
-with design fatigue) was getting the wrong default.
+- `reference/prep-mode.md` — `--prep` modal flow (read gate at § Inputs).
+- `reference/add-variant.md` — `--add-variant` modal flow: procedure, parentage/inheritance tables, failure modes (read gate at § Inputs).
+- `reference/mode-notes.md` — rationale and provenance for mode defaults (2026-04-29 default flip, C-cliff origin, role-contract history). No rules live there.

--- a/plugins/stardust/skills/direct/reference/add-variant.md
+++ b/plugins/stardust/skills/direct/reference/add-variant.md
@@ -1,0 +1,203 @@
+# Add-variant mode (`--add-variant <name>`)
+
+Read and executed by `direct` when — and only when — the
+`--add-variant <name>` flag is passed. Default runs never read this
+file.
+
+When the user has already approved (or rendered) variant A and
+asks for B / C / etc. as alternatives, `--re-direct` is too
+heavy: it replaces the active direction, re-runs Phase 1
+reasoning, and stale-flags every approved or migrated page
+against the prior direction. The user is **not** changing
+direction — they are extending it with additional variant
+expressions of the same direction. `--add-variant <name>` is the
+incremental-extension flow.
+
+The flow surfaced on the 2026-05-04 ups.com session: variant A
+shipped, the user later asked for B and C as the directional
+alternatives that had been surfaced in the initial menu but not
+committed to. Without an additive flag, the agent had to author
+B and C as page-shape briefs + proposed HTML only (skipping
+`DESIGN-B.{md,json}` / `DESIGN-C.{md,json}`), embedding their
+system-level deviations inline in per-variant CSS. Migrate then
+had no machine-readable source to re-derive B / C from.
+
+## Procedure
+
+When `--add-variant <name>` is passed:
+
+1. **Setup** runs as normal (impeccable dep check, state read,
+   brand-extraction read, brand-signal classification).
+   Validation step 5 (provenance) is **skipped** — add-variant
+   does not consume per-page extracted JSON; it consumes the
+   already-resolved direction. The brand-signal stamp stays
+   useful for the inheritance rules below.
+2. **Skip Phase 1 (Reasoning).** The user's intent is *"add
+   another variant against the existing direction,"* not "resolve
+   a fresh direction." If the existing `direction.md` Active
+   section is missing, refuse — there is no direction to extend.
+3. **Skip Phase 2 (Mode detection + divergence).** Mode is
+   inherited from the existing direction (typically Mode A
+   given the brand-faithful default). The seed, font deck,
+   palette, and ground family are all inherited as-is.
+4. **Run Phase 2.5 (Improvements list)** **only if** the
+   existing direction is Mode A and a variant-A improvements
+   list does not yet exist for the slug being prototyped later.
+   The improvements list is shared across all Mode A variants
+   per `direct/SKILL.md` § Phase 2.5; if it already exists, the
+   add-variant pass reads it as input and does not regenerate.
+5. **Run Phase 2.6 (Multi-variant fork)** only enough to
+   resolve the **new variant's** role per the variant role
+   contract (faithful + improvements / one captured trait
+   amplified / different captured trait amplified). Surface the
+   role choice to the user before proceeding. Do not re-run the
+   role contract for variants that already exist — their roles
+   are stamped in `direction.md`.
+6. **Run Phase 4 against the new variant only.** Derive the
+   variant's system-level deviations (font-weight changes,
+   surface-color additions, motif amplifications, etc.) and
+   write:
+   - `DESIGN-<name>.md` — Stitch frontmatter + 6 canonical
+     sections, **inheriting** every token that doesn't change
+     for this variant.
+   - `DESIGN-<name>.json` — sidecar with extensions
+     (`divergence`, `componentStyle`, `voice`, `iaPriorities`).
+   When variant A has been written as the unsuffixed
+   `DESIGN.{md,json}` (single-variant flow), upgrade A's files
+   to the suffixed form (`DESIGN-A.{md,json}`) and **leave the
+   unsuffixed files in place as backward-compatible aliases
+   pointing at A** — `migrate` and `prototype` continue to
+   resolve the unsuffixed form to A.
+7. **Append a section to `direction.md`** under the existing
+   Active section, titled `## Variant <name>`, recording: the
+   variant's role (faithful / amplified-trait), the captured
+   trait being amplified (when applicable), the system-level
+   deviations from variant A, the IA-priority audit (must
+   match A's audit — variants cannot opt out of preservation
+   under Mode A), and a one-line thesis.
+8. **Skip Phase 5 update of state.json's `direction.*` block**.
+   The active direction has not changed; the direction file's
+   resolvedAt / phrase / directionFile fields stay untouched.
+   Pages already in `prototyped` / `approved` / `migrated`
+   states are **not** stale-flagged — adding a variant is
+   additive, not a re-direction. State.json gains a
+   `direction.variants[].<name>` entry (per
+   `state-machine.md`'s multi-variant additions) recording the
+   new variant's id and DESIGN files.
+
+## Variant parentage and inheritance chain
+
+`--add-variant <name>` infers a **parent** from the slot name:
+
+- Slot name is a single letter (`A`, `B`, `C`, ...): parent is the
+  *active direction* (the resolved direction in `direction.md`).
+  The variant inherits from the active direction's resolved seed.
+- Slot name is a letter + digits (`A1`, `A2`, `B3`, `C2`...):
+  parent is the variant whose id is the letter prefix (`A1` → `A`,
+  `B3` → `B`). The variant is a **surface fork** of its parent
+  per SKILL.md § Surface forks of role-differentiated variants. The
+  parent must already exist; if not, refuse and recommend adding
+  the parent first (`--add-variant B` before `--add-variant B3`).
+
+Inheritance chains under reimagined mode:
+
+- `A → active-direction` — A inherits from the resolved direction.
+- `B → active-direction` — B inherits from the resolved direction;
+  its captured trait is declared in its shape brief.
+- `B3 → B → active-direction` — B3 inherits from B (parent surface
+  fork); B's captured trait + role propagate, B3 declares its
+  surface tuning.
+
+Record the chain in `direction.md`'s per-variant section as
+`Inheritance chain: <child> → <parent> → <root>`. Stardust
+`state.json` records the parent in
+`direction.variants[].parentVariant` (per
+`stardust/reference/state-machine.md` § Variants block).
+
+## Per-field inheritance rules
+
+When writing `DESIGN-<name>.{md,json}`, fields fall into three
+categories:
+
+| inherit-as-is | inherit-then-extend | variant-local |
+|---|---|---|
+| `colors` (palette) — Mode A pin | `componentStyle` — base treatment from A; variant adds variant-local component overrides keyed by `data-variant="<name>"` | `narrative.northStar` — per-variant thesis |
+| `typography` family / scale — Mode A pin | `extensions.divergence.brand_faithful_inversions[]` — A's list is the floor; variant may add inversions that follow from its amplified trait | `narrative.overview`, `narrative.keyCharacteristics` — written against the variant's role |
+| `rounded`, `spacing` — site-wide tokens | `extensions.iaPriorities[]` — same audit as A; cannot opt out under Mode A | `voice.examples.do/dont` — variant may amplify a captured voice register A didn't lean on |
+| `extensions.colorMeta`, `typographyMeta`, `breakpoints` | `narrative.rules[]` — A's house standards inherit; variant adds its own | `extensions.divergence.seed.anchors[]` — variant may add a captured trait as the anchor for its amplified-trait role |
+| `extensions.systemComponentRoles` (abstract roles) | | The variant-id stamp in `_provenance` |
+
+Variants **cannot**:
+
+- Introduce a font outside the captured surface (Mode A pin).
+- Introduce a color outside the captured palette (Mode A pin).
+- Shift the register from PRODUCT.md (per-brand strategy is
+  variant-invariant under Mode A).
+- Skip the IA-priority audit (variants are visual expressions,
+  not strategic re-shapings).
+
+**Surface-fork-specific rules (when parent is a letter-prefix
+variant like B → B3):**
+
+- The captured trait being amplified is **inherited from the parent
+  variant**. The surface fork cannot change which trait is amplified
+  (changing it changes the role, which is a sibling variant, not a
+  surface fork).
+- The role narrative (B's "scroll cinema amplified" thesis) is
+  inherited; the surface fork's narrative extends it with its
+  per-axis tuning ("B3 amplifies the same captured trait in a loud
+  register: weight 700 body H3s, perfect-fifth type scale, packed
+  density").
+- The parent's caps (motion-energy ≤ N, color-temperature within
+  range, etc.) inherit. Cap overrides are permitted but must be
+  declared in the surface fork's DESIGN.json `extensions.capOverrides[]`
+  with a one-sentence rationale citing a captured-source basis.
+- Structural fields (IA priority order, section sequence, layout
+  strategy of major sections) inherit verbatim from the parent —
+  changing them produces a sibling variant, not a surface fork.
+
+When the user's add-variant request would violate one of the
+forbidden rules, refuse with the same SKILL.md § Failure modes (c)
+hard rule conflict pattern: name the conflict, propose targeted
+alternatives (rebrand mode via `--rebrand`, or a Mode A
+expression that fits within the pins).
+
+## Add-variant summary
+
+```
+direct --add-variant B complete
+==============================
+
+Variant role:         one captured trait amplified — editorial confidence
+Captured trait:       caption-band typography + named-driver portraits
+Inheritance:          palette, typography, rounded, spacing inherited from A
+Variant-local:        narrative.northStar, voice DOs (eyebrow voice expanded),
+                      componentStyle.heroOverlay (variant override)
+IA-priority audit:    matches A — commercial-conversion + crisis-affordance preserved
+
+Wrote:
+  DESIGN-B.md, DESIGN-B.json (alongside DESIGN-A.{md,json})
+  stardust/direction.md  (appended ## Variant B section)
+
+State:
+  pages unchanged (no stale flags — add-variant is additive)
+  direction.variants[]:  A + B
+
+Next: $stardust prototype <slug> --variant B
+```
+
+## Failure modes specific to add-variant
+
+- **No active direction.** Refuse — there is nothing to extend.
+  Recommend `$stardust direct` first.
+- **Variant `<name>` already exists.** Refuse — pass `--re-direct`
+  and re-resolve the variant explicitly if a refresh is wanted,
+  or pick a different name (variants are case-sensitive; B and b
+  are distinct entries but discouraged for clarity).
+- **Mode A constraint violation.** Per § Per-field inheritance
+  rules above; surface the conflict and propose targeted
+  alternatives.
+- **Existing direction is rebrand mode.** Add-variant is allowed,
+  but the inheritance rules relax — rebrand permits a different
+  PRODUCT.md per variant. Surface the relaxed contract to the
+  user before writing.

--- a/plugins/stardust/skills/direct/reference/mode-notes.md
+++ b/plugins/stardust/skills/direct/reference/mode-notes.md
@@ -1,0 +1,88 @@
+# Mode notes — rationale and provenance
+
+Background for rules that live in `direct/SKILL.md`. Nothing here is
+a rule; every rule these notes justify is stated inline in SKILL.md.
+Read when you need the "why" behind a mode default or a refusal
+condition (e.g. when a user challenges one).
+
+## Default-mode-flip note (2026-04-29)
+
+The skill changed its default behavior on 2026-04-29 to make Mode A
+(brand-faithful) the default whenever the captured brand surface is
+`signal-strong`, rather than activating only on explicit user
+signals. Behavior summary:
+
+- Before: ambiguous phrases like *"make it more modern"* rolled the
+  full divergence seed and produced rebrand-shaped output.
+- After: ambiguous phrases default to Mode A; rebrand requires
+  explicit phrase signal or `--rebrand` flag.
+
+The flip was driven by dogfood evidence that the typical stardust
+use case (presales refresh of an existing site for a brand owner
+with design fatigue) was getting the wrong default.
+
+## Why the mode-detection precedence is asymmetric
+
+Stardust's primary use case is migrating an existing site with a
+design refresh; "make it modern" / "stunning new version" / "design
+fatigue cure" are migration-shaped asks. Treating those phrases as
+rebrand triggers (rolling a fresh divergence seed) produces output
+that is recognisably a different brand from the one that asked for
+the refresh — a published failure mode. The precedence catches the
+common case as the default and reserves divergence-seed rolls for
+explicit rebrand requests: the safer mode (Mode A — brand-faithful)
+catches ambiguous phrases, and the riskier mode (rebrand / full
+divergence-seed) requires the user to name it.
+
+## Why Mode A skips the type/palette roll
+
+Going through the motions of font-deck and palette picks when both
+are already locked would be ceremony, producing
+`picked_by = "user-constraint"` records that don't reflect any real
+choice.
+
+## Why Mode A+ exists
+
+The median redesign candidate is a site whose brand is right but
+whose *execution* of that brand is part of the problem — a generic
+system body face, a palette whose only accent fails contrast on half
+its surfaces. Strict Mode A reproduces those weaknesses; rebrand
+throws away the brand. Mode A+ authorizes bounded, evidence-gated
+upgrades between the two.
+
+## Why the image-reuse contract is part of Mode A
+
+A variant that swaps a captured subject portrait for a gradient
+placeholder, or moves the captured hero photo to a card thumbnail,
+erases the brand's most load-bearing trust signal — the named-people
+stories that almost every nonprofit / service-led site has spent
+years building. Semantic position-preservation is therefore part of
+brand-faithful inheritance, not a separate content rule.
+
+## Why the improvements list is load-bearing (Phase 2.5)
+
+Without a written improvements list, *"make it better"* has no claim
+the agent can defend, and each variant ends up inventing its own
+"better" — producing rebrand-shaped output even with Mode A active.
+The list is descriptive of the gap between the existing site and a
+competent 2026 execution of the same brand, not prescriptive of
+visual targets. Genuine empty-list cases occur when the captured
+site is already at a high execution level on observable dimensions —
+the honest answer is a reduced-scope proposal, not rationalised
+filler items.
+
+## Why the variant role contract replaced per-slot seed rolls
+
+The previous multi-variant default (each variant rolls a fresh
+divergence seed with anchor references picked per slot) produced
+what the internal review called *"three rebrands"* output: each
+variant was defensible standalone but none felt like the same brand.
+Role differentiation (faithful + improvements / trait X amplified /
+trait Y amplified) binds every variant to the captured surface.
+
+## Where the C-cliff name comes from
+
+The observed pattern where a 3-variant fork has A defensible, B
+defensible, and C reading as *"unprofessional"* rather than *"a
+third proposition."* The fix is not to soften C — it is to define C
+against a captured trait instead of against B.

--- a/plugins/stardust/skills/direct/reference/prep-mode.md
+++ b/plugins/stardust/skills/direct/reference/prep-mode.md
@@ -1,0 +1,134 @@
+# Prep mode (`--prep`)
+
+Read and executed by `direct` when — and only when — the `--prep` flag
+is passed (typically via the `prepare-migration` orchestrator).
+Default (discovery-mode) runs never read this file and are unchanged:
+intent reasoning, divergence-toolkit resolution, target-spec authoring.
+
+When invoked with `--prep`, direct runs an extended pass that
+finalizes the inventory data structures migrate consumes.
+
+`--prep` adds five things on top of the standard procedure:
+
+## 1. Type catalog confirmation
+
+Surface the page-type catalog inferred by `extract --prep` (in
+`state.json.pages[].type`). Show counts per type and a sample of
+slugs per type:
+
+```
+Page types from extract:
+  landing  1   (home)
+  article  84  (news/post-2026-04-15-housing-summit, news/post-2026-04-08-..., ...)
+  listing  6   (news, programs, events, ...)
+  program  12  (programs/shelter, programs/case-management, ...)
+  form     3   (donate, contact, volunteer)
+  static   18  (about, team, financials, ...)
+  unique   3   (404, search, faq)
+
+Confirm catalog (yes / refine "<phrase>")?
+```
+
+User can confirm or refine. Refinements: rename a type, split a
+type into finer-grained ones (e.g., `article-feature` vs.
+`article-press`), merge two types, mark specific pages as
+`unique`. Updates land in `state.json.pages[].type`.
+
+## 2. Module catalog finalization
+
+Surface the module candidates proposed by `extract --prep`
+(`DESIGN.json.extensions.modules[]` with `status: candidate`).
+For each candidate:
+
+```
+hotline-211 (5 instances)
+  Slot candidates: phone, hours, headline, cta-label
+  Found in: home, get-help, donate, news, programs
+
+  Confirm? (name "<id>" / promote / prune / refine slots)
+```
+
+User actions per candidate:
+
+- **Confirm.** Promote `status: candidate → confirmed`. Module
+  ID, slots, defaults are accepted as-is.
+- **Rename.** Change the auto-generated ID to a brand-native name.
+- **Prune.** Remove from the catalog (the candidate was a
+  spurious match; instances will render as inline content).
+- **Refine slots.** Mark slots required, set defaults, add or
+  remove slots, adjust types.
+
+Confirmed modules become the catalog migrate consumes.
+
+## 3. Color reservations
+
+If the resolved direction reserves any color to a specific
+module/lockup (e.g., centennial-red `#DC323D` reserved to the
+`trh-100-lockup` module), capture in
+`DESIGN.json.extensions.colorReservations[]`:
+
+```json
+[
+  { "color": "#DC323D", "reservedFor": ["module:trh-100-lockup"] }
+]
+```
+
+Migrate validates that reserved colors appear only in their
+declared contexts; violations refuse the page.
+
+## 4. Wider direction re-evaluation
+
+Discovery mode resolved direction against a 5-page sample. Prep
+mode has the full inventory. Re-read the broader content surface
+and check:
+
+- Does the resolved register still hold? (e.g., did discovery
+  miss a service-led section that pulls toward a different
+  register?)
+- Are there new tensions surfaced by the wider crawl that affect
+  direction?
+- Do any anti-references need updating?
+
+If the re-evaluation surfaces a meaningful divergence from the
+discovery-mode direction, surface to the user. If the user wants
+to re-direct, they run `$stardust direct --re-direct` separately;
+the prep run itself is non-destructive.
+
+## 5. Site-level metadata defaults
+
+Capture brand-level metadata defaults in
+`DESIGN.json.extensions.metadata`:
+
+- `siteName` — brand name (typically from `<title>` patterns or
+  `og:site_name`)
+- `defaultOgImage` — default OG image when a page doesn't have
+  its own
+- `themeColor` — typically already in DESIGN.md
+- `organization` — `Organization` JSON-LD entry (name, url,
+  logo, sameAs)
+- `locale` — default locale
+- `keyFacts` — optional: the short list of crawlable fact strings
+  the brand must expose in server-rendered content (price, license,
+  maker, requirement). Consumed by deploy's atomic-contract raw-HTML
+  grep (deploy SKILL.md #86); omit when the direction names none.
+
+These are composed with per-page metadata at migrate time. See
+`skills/migrate/reference/metadata-and-jsonld.md` for the
+composition rules.
+
+## Prep summary
+
+```
+direct --prep complete
+======================
+
+Type catalog:        confirmed (7 types, 127 pages)
+Module catalog:      confirmed (8 modules, slot vocabularies set)
+Color reservations:  1 (#DC323D reserved to trh-100-lockup)
+Brand metadata:      set (siteName, defaultOgImage, themeColor, organization, locale)
+Direction:           no change (wider crawl confirmed)
+
+Next: $stardust prototype --prep  (fill template gaps, write canon)
+```
+
+Default mode is unchanged.

--- a/plugins/stardust/skills/migrate/reference/metadata-and-jsonld.md
+++ b/plugins/stardust/skills/migrate/reference/metadata-and-jsonld.md
@@ -249,7 +249,7 @@ Soft (log):
   render path selection (where this metadata gets emitted)
 - `skills/migrate/reference/content-preservation.md` — content
   rules (this doc handles head; that doc handles body)
-- `skills/direct/SKILL.md` § Prep mode — where brand-level
+- `skills/direct/reference/prep-mode.md` (direct prep mode) — where brand-level
   metadata is captured
 - `skills/stardust/reference/state-machine.md` — `deployUrl`
   configuration on `state.json.site`

--- a/plugins/stardust/skills/prepare-migration/SKILL.md
+++ b/plugins/stardust/skills/prepare-migration/SKILL.md
@@ -17,7 +17,7 @@ duplicate logic from the underlying skills; it invokes them and
 brokers the per-phase summaries. The substantive work lives in:
 
 - `skills/extract/SKILL.md` § Prep mode
-- `skills/direct/SKILL.md` § Prep mode
+- `skills/direct/reference/prep-mode.md` (direct prep mode)
 - `skills/prototype/SKILL.md` § Prep mode +
   `reference/canon-extraction.md`
 
@@ -363,7 +363,7 @@ canon-author prototype was re-iterated, etc.).
 ## References
 
 - `skills/extract/SKILL.md` § Prep mode
-- `skills/direct/SKILL.md` § Prep mode
+- `skills/direct/reference/prep-mode.md` (direct prep mode)
 - `skills/prototype/SKILL.md` § Prep mode
 - `skills/prototype/reference/canon-extraction.md` — the
   five-step extraction procedure prototype --prep performs on

--- a/plugins/stardust/skills/prototype/SKILL.md
+++ b/plugins/stardust/skills/prototype/SKILL.md
@@ -8,84 +8,79 @@ license: Apache-2.0
 
 For each `directed` page, render a **proposed redesign** as a
 self-contained static HTML file at
-`stardust/prototypes/<slug>-proposed.html`. Open the file in the
-browser; iterate via chat-driven impeccable commands ("make the
-hero bolder", "tighten the cup-note grid"). Mark `approved` once
-the user signs off in the conversation.
+`stardust/prototypes/<slug>-proposed.html`. Open it in the browser;
+iterate via chat-driven impeccable commands ("make the hero bolder",
+"tighten the cup-note grid"); mark `approved` once the user signs
+off in the conversation.
 
 `prototype` is not a renderer of its own design — it composes the
 target spec written by `direct` (`PRODUCT.md`, `DESIGN.md`,
-`DESIGN.json`, `stardust/direction.md`) onto the page content captured
-by `extract` (`stardust/current/pages/<slug>.json`). Visual creativity
-is delegated to `$impeccable craft` and the iteration commands
-(`bolder`, `quieter`, `distill`, `polish`, `colorize`, `typeset`,
-`layout`, `adapt`, `animate`, `delight`, `overdrive`, `impeccable`).
+`DESIGN.json`, `stardust/direction.md`) onto the page content
+captured by `extract` (`stardust/current/pages/<slug>.json`). Visual
+creativity is delegated to `$impeccable craft` and the iteration
+commands (`bolder`, `quieter`, `distill`, `polish`, `colorize`,
+`typeset`, `layout`, `adapt`, `animate`, `delight`, `overdrive`,
+`impeccable`).
 
 ## Inputs
 
 - `<slug>` — optional positional. Prototype just this page. Without
   it, prototype every `directed` page that is not `stale`.
 - `--all` — prototype every `directed` page including stale ones.
-- `--prep` — optional. Run in **migrate-prep mode**: fill page-type
-  gaps (prototype one representative archetype per type) and, on
-  approval, write canon back to `stardust/canon/` and
-  `DESIGN.json.extensions.canon`. See § Prep mode below and
-  `reference/canon-extraction.md`. Typically invoked via the
-  `prepare-migration` orchestrator.
-- `--canon-from <slug>` — optional. Override the default canon-
-  author (which is the first approved prototype, typically `home`).
-  Used when a different page should establish the design canon.
-- `--publish-sample <slug>` — submit the named slug to the
-  stardust showcase. Triggers the publish-sample sub-flow
-  documented in `reference/publish-sample.md`: eligibility checks,
+- `--prep` — run in **migrate-prep mode**: fill page-type gaps (one
+  representative archetype per type) and, on approval, write canon
+  back to `stardust/canon/` and `DESIGN.json.extensions.canon`.
+  **When `--prep` is passed, READ `reference/prep-mode.md`** before
+  proceeding — it carries the gap-fill procedure, canon write-back
+  rules, and prep summary. See also `reference/canon-extraction.md`.
+  Typically invoked via the `prepare-migration` orchestrator.
+- `--canon-from <slug>` — override the default canon-author (the
+  first approved prototype, typically `home`).
+- `--publish-sample <slug>` — submit the named slug to the stardust
+  showcase per `reference/publish-sample.md`: eligibility checks,
   file staging, PR creation against the upstream stardust repo.
   Requires `gh` installed and authenticated. The showcase is a
-  visual demonstration, not a deployable site — placeholder
-  content is allowed and recorded in the PR body's § Unsourced
-  content section. Design-quality gates stay strict: refuses on
-  unjustified anti-toolbox hits, `:root` token contract failure,
+  visual demonstration, not a deployable site — placeholder content
+  is allowed and recorded in the PR body's § Unsourced content
+  section. Design-quality gates stay strict: refuses on unjustified
+  anti-toolbox hits, `:root` token contract failure,
   data-attributes contract failure, or impeccable hard-rule
   violations. P0/P1 critique findings warn but don't refuse.
-  The showcase publishes via GitHub Pages on merge.
-- `--cinematic` — optional. Layer a cinematic motion register
-  on top of the static prototype. The register is read from
+  Publishes via GitHub Pages on merge.
+- `--cinematic` — layer a cinematic motion register on top of the
+  static prototype. The register is read from
   `DESIGN.json.extensions.motion.register` (written by `direct`);
-  if absent, the prototype phase picks one using the same
-  heuristic per `reference/motion-registers.md` § Selection
-  heuristic. Output filename is `<slug>-cinematic.html`
-  (alongside the static `<slug>-proposed.html`, never replacing
-  it). Triggers the cinematic gates in motion validation
-  (`reference/motion-validation.md` § Pass 6).
-- `--cinematic=<register>` — optional. Same as `--cinematic` but
-  forces a specific register (`arrival`, `kinetic-display`,
-  `live-systems`, `editorial`, `kinetic-grid`). The override is
-  recorded in `_provenance.motion.registerSource = "user-override"`
-  so reviewers can spot when direction's heuristic was bypassed.
+  if absent, pick one per `reference/motion-registers.md`
+  § Selection heuristic. Output is `<slug>-cinematic.html`
+  alongside the static `<slug>-proposed.html` — never replacing it.
+  Triggers the cinematic gates in `reference/motion-validation.md`
+  § Pass 6.
+- `--cinematic=<register>` — same, forcing a register (`arrival`,
+  `kinetic-display`, `live-systems`, `editorial`, `kinetic-grid`).
+  Record `_provenance.motion.registerSource = "user-override"` so
+  reviewers can spot when direction's heuristic was bypassed.
 
 ### No opt-outs
 
 `prototype` does not carry `--no-*` or `--skip-*` flags. The
 quality gates (critique, audit, mobile-adapt audit, anti-toolbox
-audit, content-sourcing scan) are the product — they're not
-optional. If a gate refuses a file, the remediation is to fix
-the file or override the gate by editing the file directly, not
-to pass a flag that silently lowers the bar. Manual chat
+audit, content-sourcing scan) are the product — not optional. If a
+gate refuses a file, the remediation is to fix the file or edit it
+directly, never a flag that silently lowers the bar. Manual chat
 overrides ("ship as-is", "accept the P1 findings") are still
-available; the agent records the override verbatim in
-`_provenance` so downstream consumers see the explicit
-acknowledgement.
+available; the agent records the override verbatim in `_provenance`
+so downstream consumers see the explicit acknowledgement.
 
 ## Setup
 
-0. **Playwright re-probe (mandatory first step).** `--no-save` playwright
-   installs from earlier phases are pruned by any later real `npm i`
-   (extract SKILL.md § Setup → `--no-save` installs are ephemeral). Before
-   any rendering step, probe
-   `node -e "import('playwright').then(()=>process.exit(0))"` from the
-   project root and re-install (`npm i -D playwright --no-save
-   --legacy-peer-deps`) on failure.
-1. Run the master skill's setup
-   (`skills/stardust/SKILL.md` § Setup).
+0. **Playwright re-probe (mandatory first step).** `--no-save`
+   playwright installs from earlier phases are pruned by any later
+   real `npm i` (extract SKILL.md § Setup). Before any rendering
+   step, probe
+   `node -e "import('playwright').then(()=>process.exit(0))"` from
+   the project root; on failure re-install
+   `npm i -D playwright --no-save --legacy-peer-deps`.
+1. Run the master skill's setup (`skills/stardust/SKILL.md` § Setup).
 2. Verify `stardust/state.json` exists and contains at least one
    `directed` page. If not, recommend `$stardust direct` and stop.
 3. Verify the project-root `DESIGN.md` and `DESIGN.json` exist. If
@@ -96,36 +91,33 @@ acknowledgement.
 5. **Validate provenance on every page in scope.** Call
    `validateProvenance(page)` per
    `skills/stardust/reference/state-machine.md` § Provenance
-   validation for every page that this run will render (the
-   single `<slug>` argument when present, otherwise every
-   non-stale `directed`/`prototyped`/`approved` page). Abort with
-   the helper's error when any page lacks live-render evidence
-   — re-running `prototype` against a synthesized page record
-   silently propagates the synthesis into the rendered prototype.
-   Surface `Provenance OK on N pages` once the check passes.
-6. Read `stardust/current/DESIGN.md` (the descriptive snapshot of the
-   existing site, used as a fallback reference during render when the
-   proposed file needs to mirror an aspect of the captured surface).
+   validation for every page this run will render (the single
+   `<slug>` when present, otherwise every non-stale
+   `directed`/`prototyped`/`approved` page). Abort with the helper's
+   error when any page lacks live-render evidence — re-running
+   `prototype` against a synthesized page record silently propagates
+   the synthesis into the rendered prototype. Surface
+   `Provenance OK on N pages` once the check passes.
+6. Read `stardust/current/DESIGN.md` (descriptive snapshot of the
+   existing site; fallback reference when the proposed file must
+   mirror an aspect of the captured surface).
 
 ## Delegation mechanic
 
 `prototype` does **not** author `<slug>-proposed.html` directly. The
 heavy creative lift is delegated to `$impeccable craft`, and (when
-needed) the structural plan to `$impeccable shape`. Spelling out the
-mechanic matters because the carve-out documented in
-`skills/stardust/reference/artifact-map.md` (where stardust authors
+needed) the structural plan to `$impeccable shape`. The carve-out in
+`skills/stardust/reference/artifact-map.md` — where stardust authors
 `PRODUCT.md`, `DESIGN.md`, `DESIGN.json`, `current/PRODUCT.md`,
 `current/DESIGN.md` directly, treating impeccable's references as
-*format specs*, not runtime commands) is **load-bearing for those
-five files only**. It does NOT extend to:
+*format specs* — is **load-bearing for those five files only**. It
+does NOT extend to:
 
-- `stardust/prototypes/<slug>-proposed.html` — must be authored by
-  `$impeccable craft`, not by stardust direct authoring.
-- Iteration on the proposed file — must be driven through a
-  chat-driven invocation of an explicit impeccable command (per
-  the iteration paths section).
-- Structural planning when a page is complex enough to need it —
-  `$impeccable shape`.
+- `stardust/prototypes/<slug>-proposed.html` — authored by
+  `$impeccable craft`, never by stardust direct authoring.
+- Iteration on the proposed file — driven through a chat-driven
+  invocation of an explicit impeccable command (§ Iteration paths).
+- Structural planning when a page needs it — `$impeccable shape`.
 
 The proximate cause of past content fabrication was the agent
 over-generalizing the direct-authoring carve-out to the proposed
@@ -133,10 +125,9 @@ HTML. Don't.
 
 ### Invoking impeccable
 
-When stardust runs in a Claude Code skill context (impeccable
-exposed as the `impeccable:impeccable` Skill, not as a CLI), invoke
-impeccable via the Skill tool with the sub-command and its args
-mirroring the slash-command form:
+In a Claude Code skill context (impeccable exposed as the
+`impeccable:impeccable` Skill, not a CLI), invoke via the Skill tool
+with the sub-command and args mirroring the slash-command form:
 
 ```
 Skill {
@@ -145,19 +136,19 @@ Skill {
 }
 ```
 
-Sub-commands referenced from this skill are all routed through the
-same Skill: `craft`, `shape`, plus the iteration commands
-(`bolder`, `quieter`, `distill`, `polish`, `colorize`, `typeset`,
-`layout`, `adapt`, `animate`, `delight`, `overdrive`, `impeccable`).
+All sub-commands route through the same Skill: `craft`, `shape`,
+plus the iteration commands (`bolder`, `quieter`, `distill`,
+`polish`, `colorize`, `typeset`, `layout`, `adapt`, `animate`,
+`delight`, `overdrive`, `impeccable`).
 
-When impeccable is **not** available (CLI-only environments,
-plugin uninstalled, sandbox without skill access), stop and tell
-the user impeccable is required for prototype rendering. Recommend
-installing the impeccable plugin. Do not fall back to direct
-authoring of `<slug>-proposed.html` — the validation contract
-craft enforces (anti-toolbox audit, divergence rules, type ratios,
-content sourcing hierarchy) is not reproducible by direct
-authoring, and falling back silently ships unverified output.
+When impeccable is **not** available (CLI-only environment, plugin
+uninstalled, sandbox without skill access), stop and tell the user
+impeccable is required; recommend installing the plugin. Do not
+fall back to direct authoring of `<slug>-proposed.html` — the
+validation contract craft enforces (anti-toolbox audit, divergence
+rules, type ratios, content sourcing hierarchy) is not reproducible
+by direct authoring, and falling back silently ships unverified
+output.
 
 Stardust's job inside Phase 2 is therefore:
 
@@ -169,8 +160,8 @@ Stardust's job inside Phase 2 is therefore:
 - Invoke craft via the Skill tool.
 - Validate the result against the contract (`:root` block, data
   attributes, divergence audit, impeccable hard rules, content
-  sourcing). If validation fails, refuse to write — never paper over
-  craft output the agent thinks is "close enough."
+  sourcing). If validation fails, refuse to write — never paper
+  over craft output that looks "close enough."
 
 The proposed file is whatever craft writes plus the validation
 report; it is not stardust's authored artifact.
@@ -181,58 +172,53 @@ report; it is not stardust's authored artifact.
 
 For each page in scope:
 
-1. Read `stardust/current/pages/<slug>.json` for the page's structure
-   and content.
-2. Read `stardust/current/_brand-extraction.json` for system
-   components and cross-promo data (the page's site-wide repeated
-   surfaces).
-3. Read `stardust/direction.md` Active section for the resolved
-   direction, divergence inputs, and command sequence.
-4. Read project-root `DESIGN.md` + `DESIGN.json` for the target
-   site system — tokens, abstract component vocabulary, named
-   system-component roles. The site system tells the agent *what
-   the design language is*; this Phase decides *how it deploys to
-   this specific page*.
+1. Read `stardust/current/pages/<slug>.json` — page structure and
+   content.
+2. Read `stardust/current/_brand-extraction.json` — system
+   components and cross-promo data (site-wide repeated surfaces).
+3. Read `stardust/direction.md` Active section — resolved direction,
+   divergence inputs, command sequence.
+4. Read project-root `DESIGN.md` + `DESIGN.json` — the target site
+   system (tokens, abstract component vocabulary, named
+   system-component roles). The site system says *what the design
+   language is*; this phase decides *how it deploys to this page*.
 5. **Author `stardust/prototypes/<slug>-shape.md`** — the per-page
-   compositional brief. Format spec:
-   `reference/page-shape-brief.md`. The brief carries the section
-   list, layout strategy, key states, interaction model, structural
-   data attributes, and the unsourced-content list (bridge to the
-placeholder contract). Author directly — no interview, no
+   compositional brief, format per `reference/page-shape-brief.md`:
+   section list, layout strategy, key states, interaction model,
+   structural data attributes, unsourced-content list (bridge to
+   the placeholder contract). Author directly — no interview, no
    impeccable invocation; this is stardust's reasoning about how
    the system deploys to this page given this content.
 6. Show the brief to the user and wait for confirmation before
-   moving to Phase 2. The user can edit the brief in place
-   (rearrange sections, kill open questions, change composition
-   decisions); re-rendering Phase 2 will rebuild the proposed file
-   from the edited brief.
+   Phase 2. The user can edit the brief in place (rearrange
+   sections, kill open questions, change composition decisions);
+   re-rendering Phase 2 rebuilds the proposed file from the edited
+   brief.
 
    **Hands-off compliance.** When `state.json.handsOff` is true,
-   the shape brief is still authored and validated but the
-   user-confirmation wait is skipped — the brief is its own record.
-   Approval (Phase 5) under hands-off follows the mode's contract
-   defined in `skills/stardust/SKILL.md` § Hands-off mode.
+   the brief is still authored and validated but the confirmation
+   wait is skipped — the brief is its own record. Approval
+   (Phase 5) under hands-off follows
+   `skills/stardust/SKILL.md` § Hands-off mode.
 
-`$impeccable shape` is **not** invoked in v0.2 (see
-`reference/page-shape-brief.md` § Authoring procedure for the
-rationale; revisit if per-page hand-authoring proves insufficient
-across sites).
+`$impeccable shape` is **not** invoked in v0.2 (rationale:
+`reference/page-shape-brief.md` § Authoring procedure; revisit if
+per-page hand-authoring proves insufficient across sites).
 
-The brief decouples site-level concerns (in DESIGN.md) from
-page-level deployment (per-page brief). A direction change
-invalidates the system; existing briefs are content-aware-stale
-only when the system change makes their composition impossible.
-This recalibration of stale-flagging is documented in
-`skills/stardust/reference/state-machine.md` § Stale flagging.
+The brief decouples site-level concerns (DESIGN.md) from page-level
+deployment (per-page brief). A direction change invalidates the
+system; existing briefs are content-aware-stale only when the system
+change makes their composition impossible (see
+`skills/stardust/reference/state-machine.md` § Stale flagging).
 
 #### Brief-time disciplines (validator-enforced)
 
 Five disciplines fire when the brief is authored. The brief
 validator rejects briefs missing any of them; failure surfaces the
 specific rule violated and stops Phase 1 before Phase 2 renders
-anything. The disciplines exist to prevent the AI-slop failure mode
-where a brief with only `(DESIGN tokens) + (captured content)` as
-input produces template-shaped output regardless of brand.
+anything. They exist to prevent the AI-slop failure mode where
+`(DESIGN tokens) + (captured content)` alone produces
+template-shaped output regardless of brand.
 
 **Discipline 1 — Captured-source lineage per section.** Every
 section in `## Sections` declares its captured-source origin. Forms:
@@ -240,11 +226,11 @@ section in `## Sections` declares its captured-source origin. Forms:
 - *"subscription-card-on-bay (consolidates captured banner 2 +
   dual-card right of `pages/home.json#landmarks[hero]`)"* — derived
   from one or more captured surfaces
-- *"site-wide system-component (carried from `_brand-extraction.json
-  #systemComponents[kind=footer]`)"* — chrome inherited from the
-  brand-surface
+- *"site-wide system-component (carried from
+  `_brand-extraction.json#systemComponents[kind=footer]`)"* —
+  chrome inherited from the brand-surface
 - *"direction-authorized new"* — composed against direction.md, not
-  derived from a captured source (require a one-line note naming
+  derived from a captured source (requires a one-line note naming
   which direction movement justifies the new section)
 
 Sections without lineage are rejected. The lineage list lives in
@@ -254,39 +240,36 @@ the rendered file.
 **Discipline 2 — Anti-template pass.** For each captured component
 pattern the page deploys (cards / banners / search rows / CTA bands
 / hero composition), the brief considers 2–3 layout alternatives
-and picks the most differentiated. Curated default-patterns-to-escape
-flags reflex picks:
+and picks the most differentiated. Curated
+default-patterns-to-escape flags reflex picks:
 
 - hero-then-bands silhouette (the universal AI silhouette)
 - 5-up image-card grid as category nav
-- nav-icon glyphs (search / cart / account) in a typographic
-  register
+- nav-icon glyphs (search / cart / account) in a typographic register
 - centered-stack hero with two-button CTA pair
 - captured-shape mirror-translated into new tokens
 
-The brief justifies any reach for a default-pattern with a
+Any reach for a default pattern must be justified with a
 captured-source citation that makes the pattern brand-appropriate
-(e.g., *"5-up grid preserved because the captured site's grid IS
-the brand's signature catalogue shape; the alternative consideration
-was a vertical ledger which the brand register rejects"*).
+(e.g. *"5-up grid preserved because the captured grid IS the
+brand's signature catalogue shape; the alternative considered was a
+vertical ledger, which the brand register rejects"*).
 
-The alternatives SHOULD be reference-grounded when reference
-research is available (per
-`skills/stardust/reference/reference-research.md`): an alternative
-cites a real reference screen in the entry's `reference?` field
-using that file's evidence shape. Taste-only alternatives remain
-valid when research is unavailable.
+Alternatives SHOULD be reference-grounded when reference research is
+available (per `skills/stardust/reference/reference-research.md`):
+an alternative cites a real reference screen in the entry's
+`reference?` field using that file's evidence shape. Taste-only
+alternatives remain valid when research is unavailable.
 
-The audit lives in `_provenance.antiTemplatePass[]` with one entry
-per captured pattern: `{ pattern, defaultReflex, alternatives[],
+The audit lives in `_provenance.antiTemplatePass[]`, one entry per
+captured pattern: `{ pattern, defaultReflex, alternatives[],
 picked, rationale, reference? }`.
 
-**Discipline 3 — Surprise budget.** The brief declares a `surprise`
-field with one of: `low | medium | high`. Moves come from the bank
-of non-template moves — see
-`skills/stardust/reference/divergence-toolkit.md` § Non-template
-move bank, with worked examples in
-`reference/anti-template-bank.md` — or an evidence-shaped extension
+**Discipline 3 — Surprise budget.** The brief declares
+`surprise: low | medium | high`. Moves come from the bank of
+non-template moves (`skills/stardust/reference/divergence-toolkit.md`
+§ Non-template move bank; worked examples in
+`reference/anti-template-bank.md`) or an evidence-shaped extension
 per the bank's § Extension rule. Tier semantics:
 
 - `low` — brand-faithful + improvements only. Variant A's role
@@ -302,59 +285,58 @@ surprise budget is **capped at `low` site-wide**. The validator
 refuses any verbatim-direction brief with `surprise: medium` or
 `high`.
 
-**`low` ≠ generic.** The budget bounds *added* divergence, not craft
-or fidelity. `low` means **brand-faithful + improvements + full
-signature preservation**, NOT "the most obvious faithful
-interpretation." The recurring failure mode (moneyhub.com migration)
-is the agent reading `low` / `verbatim` as license to strip the page
-to a plain type-hero on a flat ground — the result is faithful but
-forgettable and under-sells the redesign. Hold the craft bar at `low`:
-keep the brand's distinctive elements, apply the improvements list,
-and reproduce the signature.
+**`low` ≠ generic.** The budget bounds *added* divergence, not
+craft or fidelity. `low` means **brand-faithful + improvements +
+full signature preservation**, NOT "the most obvious faithful
+interpretation." The recurring failure mode is reading `low` /
+`verbatim` as license to strip the page to a plain type-hero on a
+flat ground — faithful but forgettable (moneyhub — see
+`reference/lessons.md`). Hold the craft bar at `low`: keep the
+brand's distinctive elements, apply the improvements list, and
+reproduce the signature.
 
 **Signature preservation is mandatory and budget-exempt.** When the
-captured page has a signature hero medium (background video / canvas /
-WebGL / Lottie), signature motion (scroll / parallax / kinetic), or a
-signature visual motif (per `intent-dimensions.md` § 8b), the brief
-**must** reproduce it — with a static fallback, `prefers-reduced-
-motion` alternative, and (for overlaid text) a legibility scrim. This
-does **not** consume the `low` allowance: carrying the brand's own
-signature forward is fidelity, not divergence (§ 8b § Surprise-budget
-exemption). Record the kept signatures in
-`_provenance.signatureElements[]` as `{ kind, capturedSource,
-mechanism, fallback }`. **Render-refusal:** a brief that flattens a
-captured video/canvas/animation hero to a still, gradient, or
-type-only hero — or drops a site-wide motif — is rejected at the
-shape-brief audit; reproduce the signature instead.
+captured page has a signature hero medium (background video /
+canvas / WebGL / Lottie), signature motion (scroll / parallax /
+kinetic), or a signature visual motif (per `intent-dimensions.md`
+§ 8b), the brief **must** reproduce it — with a static fallback,
+`prefers-reduced-motion` alternative, and (for overlaid text) a
+legibility scrim. This does **not** consume the `low` allowance:
+carrying the brand's own signature forward is fidelity, not
+divergence (§ 8b § Surprise-budget exemption). Record kept
+signatures in `_provenance.signatureElements[]` as `{ kind,
+capturedSource, mechanism, fallback }`. **Render-refusal:** a brief
+that flattens a captured video/canvas/animation hero to a still,
+gradient, or type-only hero — or drops a site-wide motif — is
+rejected at the shape-brief audit; reproduce the signature instead.
 
-**Type-scale yield clause.** When a tier-`medium`-or-higher variant's
-captured-trait amplification structurally conflicts with a
-brand-level type-scale rule from `DESIGN.md` (e.g. a
-"Names-At-Headline-Scale" rule, or any other named type-scale
-floor / ceiling), the brand-level rule may yield per-page. The
-yield must be cited in `_provenance.surpriseTier_typeScaleYields[]`
-with: `{ rule, variantDominantDimension, capturedTraitAmplified,
-yieldedTo, rationale }`. The brand-level yield clause itself
-(the named exception in `DESIGN.md`) is project-side, not
-spec-side; the spec only requires the per-page citation when the
-yield fires. See § Friction carve-out #4 below.
+**Type-scale yield clause.** When a tier-`medium`-or-higher
+variant's captured-trait amplification structurally conflicts with
+a brand-level type-scale rule from `DESIGN.md` (e.g. a
+"Names-At-Headline-Scale" rule, or any named type-scale floor /
+ceiling), the brand-level rule may yield per-page. Cite the yield
+in `_provenance.surpriseTier_typeScaleYields[]` with `{ rule,
+variantDominantDimension, capturedTraitAmplified, yieldedTo,
+rationale }`. The brand-level yield clause itself (the named
+exception in `DESIGN.md`) is project-side, not spec-side; the spec
+only requires the per-page citation when the yield fires. See
+friction carve-out #4.
 
 **Discipline 4 — Substrate transitions are deliberate, named, and
-rare.** Default: single substrate across the page. Each substrate
-exception requires a named purpose in the brief (*"highlights the
+rare.** Default: single substrate across the page. Each exception
+requires a named purpose in the brief (*"highlights the
 featured-coffee promotional moment"*). **More than two substrate
-transitions per page fails the brief.** The transitions live in
+transitions per page fails the brief.** Transitions live in
 `_provenance.substrateTransitions` as `{ default, exceptions[] }`.
 
 **Exception — substrate-keyed document-shapes (friction carve-out
-#2).** When the variant's `surprise: high` move is a
-substrate-keyed document-shape (zine, catalog-card,
-poster-sequence), the per-section substrate IS the document-shape's
-structural rhythm. The ≤ 2-transition cap does not apply; each
-section's substrate must instead carry a **per-section
-captured-source citation** (typically a per-SKU label color, a
-per-page brand color, or a per-content-type ground convention from
-the captured site). The exception is recorded in
+#2).** When the variant's `surprise: high` move is a substrate-keyed
+document-shape (zine, catalog-card, poster-sequence), the
+per-section substrate IS the document-shape's structural rhythm.
+The ≤ 2-transition cap does not apply; each section's substrate must
+instead carry a **per-section captured-source citation** (typically
+a per-SKU label color, per-page brand color, or per-content-type
+ground convention from the captured site). Record the exception in
 `_provenance.substrateTransitions.note` with the document-shape
 named and the citation source. The validator accepts > 2 transitions
 when:
@@ -366,36 +348,35 @@ when:
 3. every transition in `exceptions[]` carries a per-section
    captured-source citation.
 
-If any of the three conditions fails, the cap re-engages.
+If any condition fails, the cap re-engages.
 
-**Discipline 5 — Heading hierarchy + voice classification tracked
-per section.** The brief requires:
+**Discipline 5 — Heading hierarchy + voice classification per
+section.** The brief requires:
 
 - H1 declared once per page; subsequent sections H2; H3 children.
-- Every literal value in copy classified as one of:
-  `captured-verbatim`, `direction-authorized rewrite`, or
-  `placeholder`. No section ships with copy without a classification.
+- Every literal value in copy classified as `captured-verbatim`,
+  `direction-authorized rewrite`, or `placeholder`. No section
+  ships copy without a classification.
 
-The classification list lives in `_provenance.voiceClassification[]`
-as `{ section, classification, copy?, source? }` and propagates to
-the rendered file.
+The classification list lives in
+`_provenance.voiceClassification[]` as `{ section, classification,
+copy?, source? }` and propagates to the rendered file.
 
-**Placeholder-ribbon labels (friction carve-out #3).** System-
-component honesty-signal labels (placeholder ribbons, "TBD" badges,
-"from the brand team at migrate" markers) are **direction-authorized
-chrome**, not placeholder content. They label placeholder prose /
-data; the prose / data is what gets enumerated in
-`_provenance.unsourcedContent[]`. The ribbon text itself does not.
-Classify the ribbon labels as
+**Placeholder-ribbon labels (friction carve-out #3).**
+System-component honesty-signal labels (placeholder ribbons, "TBD"
+badges, "from the brand team at migrate" markers) are
+**direction-authorized chrome**, not placeholder content. They
+label placeholder prose/data; the prose/data is what gets
+enumerated in `_provenance.unsourcedContent[]` — the ribbon text
+itself does not. Classify ribbon labels as
 `direction-authorized chrome (per friction #3)` so the placeholder
-enumerator stays clean (no double-counting across every component
-instance).
+enumerator stays clean (no double-counting per component instance).
 
 ### Phase 2 — Render the proposed page
 
 Render `stardust/prototypes/<slug>-proposed.html` per
 `reference/proposed-file-shell.md` § Required structure. Hard
-requirements there:
+requirements:
 
 - `:root` token block as the first content of the first `<style>`
   (per `skills/stardust/reference/token-contract.md`).
@@ -410,9 +391,9 @@ requirements there:
   come from `current/pages/<slug>.json`, then voice samples, then
   direction-authorised changes — or be rendered with the mandatory
   PLACEHOLDER visual signature. Stats, addresses, quotes, tax IDs,
-  hours, prices, named-person words must never be invented. The
-  proposed file's `_provenance.unsourcedContent[]` lists every
-  placeholder so migrate can refuse to ship unverified content.
+  hours, prices, named-person words must never be invented.
+  `_provenance.unsourcedContent[]` lists every placeholder so
+  migrate can refuse to ship unverified content.
 
 Delegate the heavy creative lift to `$impeccable craft`:
 
@@ -420,158 +401,145 @@ Delegate the heavy creative lift to `$impeccable craft`:
   description.
 - Reference DESIGN.md / DESIGN.json as the design system.
 - Pass `direction.md` § Anti-references and § Divergence inputs as
-  hard constraints (so craft does not silently veer off the resolved
-  direction).
-- Skip craft's "north star mock" generation step (direction.md is the
-  brief). Skip craft's "shape" call (already done if Phase 1 needed
-  it).
+  hard constraints (so craft does not silently veer off the
+  resolved direction).
+- Skip craft's "north star mock" step (direction.md is the brief).
+  Skip craft's "shape" call (already done if Phase 1 needed it).
 
 **Modern-web-guidance consult.** When the render implements
 scroll-driven animation, view transitions, anchor positioning,
 container queries, or perf-sensitive hero media, and the
 `modern-web-guidance` plugin is installed, search it
-(`npx -y modern-web-guidance@latest search "<query>"`) and follow
-the retrieved guide; cite the guide id in
-`_provenance.guidesConsulted[]`. Skip silently when the plugin is
-absent.
+(`npx -y modern-web-guidance@latest search "<query>"`), follow the
+retrieved guide, and cite the guide id in
+`_provenance.guidesConsulted[]`. Skip silently when absent.
 
 After craft returns, validate the output:
 
 - `:root` block present and complete (token-contract.md).
 - Data attributes on every section (data-attributes.md).
-- Anti-toolbox audit clean (each hit justified per divergence-toolkit.md
-  § 1; record audit results in `DESIGN.json.extensions.divergence.anti_toolbox_hits`
-  with the audit's amendments noted).
+- Anti-toolbox audit clean (each hit justified per
+  divergence-toolkit.md § 1; record results in
+  `DESIGN.json.extensions.divergence.anti_toolbox_hits` with the
+  audit's amendments noted).
 - Impeccable hard rules respected (OKLCH, type ratio ≥ 1.25, no
   reflex slop).
 - **Content sourcing scan** — every literal value in the rendered
-  output traces to one of the allowed sources
-  (`reference/proposed-file-shell.md` § Content sourcing hierarchy).
-  Any value that doesn't is either wrapped in a `[data-placeholder]`
-  element with the mandatory visual signature, or the validation
-  fails. Build the `_provenance.unsourcedContent[]` list during
-  this scan.
+  output traces to an allowed source (hierarchy above). Any value
+  that doesn't is either wrapped in a `[data-placeholder]` element
+  with the mandatory visual signature, or validation fails. Build
+  `_provenance.unsourcedContent[]` during this scan.
 
-If validation fails, do not write the file. Surface the failure to
-the user with the specific rule violated and a suggested fix.
+If validation fails, do not write the file. Surface the specific
+rule violated and a suggested fix.
 
 #### Craft-time disciplines (pre-write validators)
 
-Four disciplines fire on the rendered file *before* it lands on
-disk. These run after craft returns its output and before the file
-is written; failure refuses the write with a substitute proposal
-(Discipline 6) or a rule citation (7, 8), and Discipline 9 registers
-detector ignores rather than refusing.
+Four disciplines fire on the rendered file after craft returns and
+*before* it lands on disk. Failure refuses the write with a
+substitute proposal (Discipline 6) or a rule citation (7, 8);
+Discipline 9 registers detector ignores rather than refusing.
 
-**Discipline 6 — Reflex-reject font pre-flight.** Grep the
-declared `font-family` declarations against the reject list in
+**Discipline 6 — Reflex-reject font pre-flight.** Grep declared
+`font-family` values against the reject list in
 `skills/stardust/reference/divergence-toolkit.md` § Reflex-reject
-fonts. If `≥ 3` reject-list families hit, refuse to write and
-propose dimensionally-equivalent off-list substitutes from the
-substitute table.
+fonts. If ≥ 3 reject-list families hit, refuse to write and propose
+dimensionally-equivalent off-list substitutes from the substitute
+table.
 
-The check fires only on rendered files whose `font-family`
-declarations the agent had freedom to pick. **Mode A renders with
-captured display + body families pinned (per
-`direct/SKILL.md` § Mode A — Brand-faithful mode) bypass the
-check** — the inherited families are not a reflex choice. Record
-the bypass reason in `_provenance.reflexRejectAudit.bypassed` with
-the captured families named.
+Fires only on files whose `font-family` declarations the agent had
+freedom to pick. **Mode A renders with captured display + body
+families pinned (per `direct/SKILL.md` § Mode A) bypass the check**
+— inherited families are not a reflex choice. Record the bypass in
+`_provenance.reflexRejectAudit.bypassed` with the captured families
+named.
 
 **Discipline 7 — Variable-font axis engagement.** When the resolved
-direction's `expressive` or `distinctiveness` axes have moved past
-their default (per
-`skills/stardust/reference/intent-dimensions.md` §§ 2 + 5), engage
-≥ 1 variable-font axis non-trivially per page using deck recipes
-from the divergence toolkit. The toolkit's font decks expose named
-axis recipes:
+direction's `expressive` or `distinctiveness` axes moved past their
+default (per `skills/stardust/reference/intent-dimensions.md`
+§§ 2 + 5), engage ≥ 1 variable-font axis non-trivially per page
+using deck recipes from the divergence toolkit:
 
-- `serif-luxury` deck → Fraunces axis recipe: `opsz 144, SOFT 100, WONK 1`
-- `bauhaus-functional` deck → Bricolage axis recipe: `opsz 96, wght 600`
-- `tactile-humanist` deck → Recursive axis recipe: `MONO 1, CRSV 0, CASL 0.5`
+- `serif-luxury` deck → Fraunces: `opsz 144, SOFT 100, WONK 1`
+- `bauhaus-functional` deck → Bricolage: `opsz 96, wght 600`
+- `tactile-humanist` deck → Recursive: `MONO 1, CRSV 0, CASL 0.5`
 
 Static-weight static-style across all type on a page that claims
 expressive or distinctive movement fails the check.
 
-**Static-only-family precedence (friction carve-out #1).** Family
-substitution rules when the captured/pinned display font does not
-ship a variable axis:
+**Static-only-family precedence (friction carve-out #1).** When the
+captured/pinned display font ships no variable axis:
 
-1. If the captured/pinned display font is variable, engage its
-   axes per deck recipes (standard path).
+1. If the captured/pinned display font is variable, engage its axes
+   per deck recipes (standard path).
 2. If the captured display font is **static-only by family**
    (Bellfort, GT Sectra static, hand-lettered custom cuts whose
    `woff2` files don't expose a parseable `fvar` table without
-   runtime inspection), **exempt the display family** from the
-   check and engage the **body family's axes** instead (typically
-   `wght` and `ital` on a workhorse like Public Sans or Hanken
-   Grotesk).
-3. **Document** the family's static-only status in
-   `DESIGN.json.extensions.divergence.font_deck.notes` so downstream
-   pages don't re-run the check.
+   runtime inspection), **exempt the display family** and engage
+   the **body family's axes** instead (typically `wght` and `ital`
+   on a workhorse like Public Sans or Hanken Grotesk).
+3. **Document** the static-only status in
+   `DESIGN.json.extensions.divergence.font_deck.notes` so
+   downstream pages don't re-run the check.
 
 A pre-flight that blindly grep'd for `font-variation-settings`
 would fire on every brand-faithful render of a static-only-display
-brand. The exemption keeps the spirit of the discipline (engage
-variable behavior where it exists) while honoring the letter when
-the captured family literally has no axes to engage.
+brand; the exemption keeps the discipline's spirit (engage variable
+behavior where it exists) while honoring the letter when the family
+has no axes.
 
 Off-deck accent fonts must ship with named **expressive positions**
 (`marginal-tag`, `pointer-scribble`, `headline-callout`,
-`badge-fill` — see toolkit § Font deck — expressive positions).
-A face introduced without a position is a reflex pick, not an
-expressive position.
+`badge-fill` — toolkit § Font deck — expressive positions). A face
+introduced without a position is a reflex pick.
 
-**Discipline 8 — Fidelity tier (`--fidelity=quick|refined|production`).**
+**Discipline 8 — Fidelity tier
+(`--fidelity=quick|refined|production`).**
 
 - `quick` (default) — sketch fidelity. Brief decisions land;
   micro-decisions stay provisional.
-- `refined` — adds a craft micro-pass per
-  `reference/fidelity-refined-pass.md`: formal type scale as CSS
-  custom properties, `font-variant-numeric: tabular-nums` on inline
-  digits, `text-wrap: balance` on headings + `text-wrap: pretty`
-  on body + `hanging-punctuation: first` on `html`, sliding
-  left-rule on nav hover, hairline hover on list items,
-  kicker + title + baseline-aligned more-link section-head triplet,
-  italic display couplet replacing structurally-vague `<b>`,
-  bottom-of-sidebar reworked as typographic plate.
+- `refined` — adds the craft micro-pass per
+  `reference/fidelity-refined-pass.md` (formal type scale as CSS
+  custom properties; `tabular-nums` on inline digits;
+  `text-wrap: balance`/`pretty` + `hanging-punctuation: first`;
+  nav / list hover refinements; kicker + title + more-link
+  section-head triplet; italic display couplet replacing vague
+  `<b>`; sidebar bottom as typographic plate — apply that file's
+  recipes).
 - `production` — `refined` + WCAG AA audit on every render + harden
   pass (loading states, error states, content-overflow edges).
 
-The tier is declared in the run invocation; persisted in
-`_provenance.fidelity`. Default is `quick`.
+The tier is declared in the run invocation and persisted in
+`_provenance.fidelity`. Default `quick`.
 
 **Discipline 9 — Copy-cadence detector bypass under verbatim
-fidelity.** This extends the Mode-A reasoning of Discipline 6 from
-fonts to prose. impeccable's design detector ships prose-voice rules
+fidelity.** Extends Discipline 6's Mode-A reasoning from fonts to
+prose. impeccable's design detector ships prose-voice rules
 (`em-dash-overuse`, `marketing-buzzword`, and similar copy-cadence
 checks) that assume the copy is the agent's to rewrite. Under
-`ia-fidelity: verbatim` — or any faithful/Mode-A render where the body
+`ia-fidelity: verbatim` — or any faithful/Mode-A render where body
 copy is `captured-verbatim` — that assumption is false by
-construction: the prose is the source brand's, reproduced exactly per
-the content-sourcing hierarchy, and rewriting it to satisfy a cadence
-rule *is* the fabrication the fidelity setting exists to prevent. So
+construction: the prose is the source brand's, reproduced exactly
+per the content-sourcing hierarchy, and rewriting it to satisfy a
+cadence rule *is* the fabrication the fidelity setting prevents. So
 when the rendered file's copy classification is `captured-verbatim`
-(per Discipline 5's `voiceClassification`), register those copy-cadence
-rules as intentional ignores for the `<slug>-proposed.html` files
-before the design hook fires — the same way Discipline 6 bypasses the
-font reflex-reject check for pinned families. Scope the ignore to the
-proposed files only, **never** to the project's own source (blocks,
-styles, components), where the rules still apply because that copy
-*is* the agent's. Record the bypass in
+(per Discipline 5's `voiceClassification`), register those
+copy-cadence rules as intentional ignores for the
+`<slug>-proposed.html` files before the design hook fires. Scope
+the ignore to the proposed files only, **never** to the project's
+own source (blocks, styles, components), where the rules still
+apply because that copy *is* the agent's. Record the bypass in
 `_provenance.copyCadenceBypass` with the rules ignored and the
-classification basis. The 2026-06-26 knack.com run hit this: the hook
-flagged em-dashes and "enterprise-grade" on Knack's own headings
-("Built on Enterprise-Grade Components") under a verbatim direction,
-and the only correct response was to leave the captured copy untouched
-and record the bypass.
+classification basis. (Motivating run: knack.com 2026-06-26 — see
+`reference/lessons.md`.)
 
-Bound the bypass: it covers prose-cadence rules only. Structural and
-craft detector rules (`design-system-radius`, contrast failures,
-reflex layout slop) are *not* exempted by verbatim fidelity — those
-govern the agent's own CSS and structure, which faithful mode does not
-freeze. Listing a rule under this bypass requires it be a copy-voice
-rule whose subject is the captured prose.
+Bound the bypass: it covers prose-cadence rules only. Structural
+and craft detector rules (`design-system-radius`, contrast
+failures, reflex layout slop) are *not* exempted by verbatim
+fidelity — those govern the agent's own CSS and structure, which
+faithful mode does not freeze. Listing a rule under this bypass
+requires it be a copy-voice rule whose subject is the captured
+prose.
 
 ### Phase 2.4 — Motion application (when `--cinematic`)
 
@@ -579,86 +547,81 @@ Fires only when `--cinematic` (with or without an explicit
 register) was passed, OR when
 `DESIGN.json.extensions.motion.register` was authored by `direct`
 and the user did not opt out. Produces
-`stardust/prototypes/<slug>-cinematic.html` **alongside** the static
-`<slug>-proposed.html` — the static prototype is never replaced.
+`stardust/prototypes/<slug>-cinematic.html` **alongside** the
+static `<slug>-proposed.html` — the static prototype is never
+replaced.
 
 Procedure:
 
-1. **Resolve the register.** For single-variant runs, read
-   `DESIGN.json.extensions.motion.register`. **For multi-variant
-   runs** (when `DESIGN-<id>.json` files exist at the project
-   root), read `DESIGN-<id>.json.extensions.motion.register` for
-   the variant currently being rendered — each variant may carry
-   its own register, or omit it entirely (variant renders
-   static). If `--cinematic=<register>` was passed at the CLI,
-   the CLI value wins **only for the variants in scope** (every
-   variant when no `<slug>` filter is set, otherwise the
-   variant(s) matching the filter).
+1. **Resolve the register.** Single-variant runs: read
+   `DESIGN.json.extensions.motion.register`. **Multi-variant runs**
+   (when `DESIGN-<id>.json` files exist at the project root): read
+   `DESIGN-<id>.json.extensions.motion.register` for the variant
+   being rendered — each variant may carry its own register or omit
+   it (variant renders static). `--cinematic=<register>` at the CLI
+   wins **only for the variants in scope** (every variant when no
+   `<slug>` filter is set, otherwise the matching variant(s)).
 
-   Record the source in `_provenance.motion.registerSource`
-   (`"direct"` for per-variant DESIGN-authored, `"user-override"`
-   for CLI). If neither path resolved a register for this
-   variant, fall through to the selection heuristic in
+   Record `_provenance.motion.registerSource` (`"direct"` for
+   per-variant DESIGN-authored, `"user-override"` for CLI). If
+   neither path resolves a register, fall through to
    `reference/motion-registers.md` § Selection heuristic. If the
-   heuristic itself returns no register (e.g. the variant's
-   PRODUCT.md Brand Personality maps to none of the five
-   registers, and no evidence-shaped extension register applies
-   per the bank's § Extension rule in
-   `reference/motion-registers.md`), skip Phase 2.4 entirely for
-   that variant — render it static.
+   heuristic itself returns no register (the variant's PRODUCT.md
+   Brand Personality maps to none of the five registers and no
+   evidence-shaped extension register applies per that file's
+   § Extension rule), skip Phase 2.4 for that variant — render it
+   static.
 
-   The per-variant resolution is what lets `uplift` produce a
+   Per-variant resolution is what lets `uplift` produce a
    three-variant set where only variant C engages motion: `direct`
    writes the register into `DESIGN-C.json` only, and Phase 2.4
-   fires for C alone (A and B render static).
+   fires for C alone.
 
 2. **Stage Lenis assets.** Copy
-   `skills/prototype/assets/motion/lenis.min.js` and `lenis.min.css`
-   into `stardust/prototypes/` (idempotent — skip if shas match).
-   Cinematic prototypes load these via relative paths.
+   `skills/prototype/assets/motion/lenis.min.js` and
+   `lenis.min.css` into `stardust/prototypes/` (idempotent — skip
+   if shas match). Cinematic prototypes load these via relative
+   paths.
 
 3. **Read the canonical runtime.** Embed the inline script from
    `reference/motion-runtime.md` § The canonical script verbatim,
-   with the `animConfig` constants rewritten per the active
-   register's token defaults (`reference/motion-registers.md` §
-   The five registers § Token defaults).
+   with `animConfig` constants rewritten per the active register's
+   token defaults (`reference/motion-registers.md` § The five
+   registers § Token defaults).
 
 4. **Layer the register's CSS.** Append the register-specific
-   keyframes and class rules (entrance keyframes, parallax CSS
-   custom properties, marquee animations, pulse animations) to
-   the file's `<style>` block. The set of keyframes is closed
-   per register; see `reference/motion-runtime.md` § Per-register
-   tuning.
+   keyframes and class rules (entrance keyframes, parallax custom
+   properties, marquee/pulse animations) to the file's `<style>`
+   block. The keyframe set is closed per register
+   (`reference/motion-runtime.md` § Per-register tuning).
 
 5. **Annotate target HTML.** Walk the rendered DOM and emit the
-   motion `data-*` attributes per the register's vocabulary:
-   - `arrival`: `[data-anim]` on section heads, body copy,
-     CTAs, and tile cards; `[data-countup]` on numeric values;
-     `[data-parallax]` on the hero photograph.
-   - `kinetic-display`: `[data-anim]` on most sections; `[data-split]`
-     on display-cap headlines (`<h1 data-split>DINE</h1>`);
-     `[data-flip]` on terminal codes / gate numbers; `.word`
-     spans on display headlines for clip-path word wipes.
-   - `live-systems`: `[data-tile-anim]` on every ops-tile and
-     card; `[data-countup]` on every numeric data value;
-     `[data-fill]` on every bar inner element; `.live-sweep`
-     on the live-data container; `.marquee__track` on the top
-     ticker.
-   - `editorial`: `[data-anim]` only; `[data-parallax]` with
-     reduced magnitude on hero imagery; never `[data-flip]` /
+   motion `data-*` attributes per the register's vocabulary —
+   apply the full per-register attribute matrix in
+   `reference/motion-registers.md` § Data-attributes consumed.
+   Summary:
+   - `arrival`: `[data-anim]` on section heads / body copy / CTAs /
+     tile cards; `[data-countup]` on numerics; `[data-parallax]` on
+     the hero photograph.
+   - `kinetic-display`: `[data-anim]` on most sections;
+     `[data-split]` on display-cap headlines; `[data-flip]` on
+     terminal codes / gate numbers; `.word` spans for clip-path
+     word wipes.
+   - `live-systems`: `[data-tile-anim]` on every ops-tile/card;
+     `[data-countup]` on every numeric; `[data-fill]` on bar
+     inners; `.live-sweep` on the live-data container;
+     `.marquee__track` on the top ticker.
+   - `editorial`: `[data-anim]` only; reduced-magnitude
+     `[data-parallax]` on hero imagery; never `[data-flip]` /
      `[data-fill]` / `[data-split]`.
-   - `kinetic-grid`: `[data-tile-anim]` on cards; `[data-anim]`
-     on section heads.
+   - `kinetic-grid`: `[data-tile-anim]` on cards; `[data-anim]` on
+     section heads.
 
-   Full per-register attribute matrix: `reference/motion-registers.md`
-   § Data-attributes consumed.
+6. **Inject the `<noscript>` fallback** from
+   `reference/motion-runtime.md` § No-JS fallback into `<head>` so
+   the file degrades to its static-end state without JavaScript.
 
-6. **Inject the `<noscript>` fallback.** Add the no-JS override
-   from `reference/motion-runtime.md` § No-JS fallback to `<head>`
-   so the file degrades to its static-end state without
-   JavaScript.
-
-7. **Update `_provenance`.** Add the `motion` block:
+7. **Update `_provenance`** with the `motion` block:
 
    ```json
    "motion": {
@@ -672,37 +635,32 @@ Procedure:
 
 8. **Hand off to Phase 2.8** (motion validation). The cinematic
    gates in `reference/motion-validation.md` § Pass 6 fire
-   automatically because the rendered file declares the
-   `_provenance.motion.register` field.
-
-The static `<slug>-proposed.html` is unaffected by this phase.
-Both files are reviewable; the brand owner sees the cinematic
-version when motion is part of the redesign brief, the static
-version when migration / accessibility audit is the focus.
+   automatically because the file declares
+   `_provenance.motion.register`.
 
 #### Output paths
 
-| File                                | Owner phase           | When            |
-|-------------------------------------|----------------------|-----------------|
-| `stardust/prototypes/<slug>-proposed.html`   | Phase 2 (always)   | Always written. |
-| `stardust/prototypes/<slug>-cinematic.html`  | Phase 2.4 (`--cinematic`) | Written alongside; static remains. |
-| `stardust/prototypes/lenis.min.js`           | Phase 2.4 (`--cinematic`) | Copied from skill assets. |
-| `stardust/prototypes/lenis.min.css`          | Phase 2.4 (`--cinematic`) | Copied from skill assets. |
+| File | Owner phase | When |
+|---|---|---|
+| `stardust/prototypes/<slug>-proposed.html` | Phase 2 (always) | Always written. |
+| `stardust/prototypes/<slug>-cinematic.html` | Phase 2.4 (`--cinematic`) | Written alongside; static remains. |
+| `stardust/prototypes/lenis.min.js` | Phase 2.4 (`--cinematic`) | Copied from skill assets. |
+| `stardust/prototypes/lenis.min.css` | Phase 2.4 (`--cinematic`) | Copied from skill assets. |
 
 #### When to use the static-only path
 
 The static prototype remains the load-bearing artifact for:
+
 - Brand-faithful inheritance reviews (motion is additive — the
   static prototype is the canonical "yes, that's us, refreshed"
   surface).
 - Accessibility audits (motion-driven pages are harder to evaluate
   in their reduced-motion state).
 - Migration consumption (`migrate` reads the static prototype as
-  its primary source. It does **not** merge the cinematic layer —
-  per `skills/migrate/SKILL.md` § Phase 2 → Cinematic sibling, it
-  carries the motion assets (`lenis.min.*`) through to
-  `migrated/assets/motion/` and records
-  `cinematic-variant-not-consumed` in the sidecar).
+  its primary source; it does **not** merge the cinematic layer —
+  per `skills/migrate/SKILL.md` § Phase 2 → Cinematic sibling it
+  carries the motion assets through to `migrated/assets/motion/`
+  and records `cinematic-variant-not-consumed` in the sidecar).
 
 The static prototype must pass every gate independently — the
 cinematic layer cannot rescue a static prototype that fails
@@ -710,13 +668,12 @@ Phases 2.5–2.7.
 
 ### Phases 2.5 – 2.8 — Quality gates: Critique → Audit → Adapt → Motion (Discipline 9)
 
-Four mandatory gate phases run by default before any prototype
-can advance to `prototyped`. They implement Discipline 9: critique
-covers *design*, audit covers *technical correctness*, adapt
-covers *viewport behaviour*, motion covers *scroll-driven and
-time-driven choreography correctness*. P0/P1 findings from **any**
-of the four block `prototyped` until acknowledged. None have an
-opt-out flag (per § No opt-outs).
+Four mandatory gate phases run by default before any prototype can
+advance to `prototyped`. Critique covers *design*, audit covers
+*technical correctness*, adapt covers *viewport behaviour*, motion
+covers *scroll- and time-driven choreography correctness*. P0/P1
+findings from **any** of the four block `prototyped` until
+acknowledged. None have an opt-out flag (§ No opt-outs).
 
 | Sub-phase | Focus | Catches |
 |---|---|---|
@@ -727,54 +684,39 @@ opt-out flag (per § No opt-outs).
 
 Phase 2.8 fires only when the rendered file declares ≥ 1 named
 choreography (per the page-shape brief's motion stack) OR uses
-`animation-timeline:`, `@scroll-timeline`, IntersectionObserver-driven
-entry triggers, or rAF loops reading `getBoundingClientRect()`,
-**OR** when Phase 2.4 (motion application under `--cinematic`)
-emitted a `<slug>-cinematic.html` file with motion attributes per
+`animation-timeline:`, `@scroll-timeline`,
+IntersectionObserver-driven entry triggers, or rAF loops reading
+`getBoundingClientRect()`, **OR** when Phase 2.4 emitted a
+`<slug>-cinematic.html` with motion attributes per
 `reference/motion-attributes.md`. Cinematic prototypes additionally
-trigger the cinematic-mode gates in `reference/motion-validation.md`
-§ Pass 6 (Lenis bootstrap, reduced-motion fallback completeness,
-scroll-jack check, three-position screenshots, register-match
-audit, motion C-cliff detector). Static prototypes skip the
-discipline entirely.
+trigger the cinematic-mode gates in
+`reference/motion-validation.md` § Pass 6 (Lenis bootstrap,
+reduced-motion fallback completeness, scroll-jack check,
+three-position screenshots, register-match audit, motion C-cliff
+detector). Static prototypes skip the discipline entirely.
 
-The wasatch dry-run on 2026-05-13 caught two real bugs the brief
-and craft phases missed (a WCAG miscalculation off by 0.27–1.86
-points on multiple pairs of /beers variant C, and an LCP image
-lazy-loaded on the first catalog entry). Both were caught by the
-**audit** half — not by critique. The detector's contrast
-computation and responsive performance check are the load-bearing
-audits; without them the file would have shipped with quantifiable
-WCAG failures.
+The audit half — not critique — caught the two real bugs in the
+wasatch dry-run (2026-05-13 — see `reference/lessons.md`); the
+detector's contrast computation and responsive performance check
+are the load-bearing audits.
 
 ### Phase 2.5 — Critique
 
 Before opening the proposed file in the browser, run **two parallel
-validators** against the rendered proposed file: `critique` and `audit`. They
-are explicitly designed as a complementary pair — critique
-covers *design* (AI-slop reflexes, hierarchy, brand fit,
-cognitive load); audit covers *technical correctness*
-(accessibility / performance / theming / responsive /
+validators** against it: `critique` and `audit`. They are a
+complementary pair — critique covers *design* (AI-slop reflexes,
+hierarchy, brand fit, cognitive load); audit covers *technical
+correctness* (accessibility / performance / theming / responsive /
 anti-patterns). Running only critique misses every quantifiable
 WCAG / perf / responsive failure; running only audit misses
-brand-misalignment and design slop. The pass is a **contract**,
-not a courtesy.
-
-The 2026-05-04 nvidia.com home prototype critique returned
-1 P0 + 2 P1 + 3 P2; the audit on the same artifact returned
-**six additional findings** (no skip-link, theme carousels
-without keyboard arrow nav, hero ~3.5MB without responsive
-`<picture>`, layout-property animation, JS-gated reveal with
-no `<noscript>` fallback, `scroll-behavior: smooth` not
-respecting `prefers-reduced-motion`). None were design issues,
-none would have been caught by critique alone. Without an
-audit gate the page would have been marked `prototyped` with
-quantifiable WCAG failures.
+brand-misalignment and design slop. The pass is a **contract**, not
+a courtesy. (Evidence: nvidia.com 2026-05-04, where audit found six
+findings critique missed — see `reference/lessons.md`.)
 
 Procedure:
 
-1. **Run both validators in parallel.** Invoke `impeccable:impeccable`
-   twice in the same Skill-tool batch:
+1. **Run both validators in parallel.** Invoke
+   `impeccable:impeccable` twice in the same Skill-tool batch:
 
    ```
    Skill { skill: "impeccable:impeccable",
@@ -784,140 +726,115 @@ Procedure:
            args: "audit stardust/prototypes/<slug>-proposed.html --json" }
    ```
 
-   Each returns a JSON findings list — each finding has
-   `priority` (P0 / P1 / P2 / P3), `category` (hierarchy /
-   contrast / motion / a11y / perf / responsive / etc.), and a
-   one-line description. Capture critique findings into
-   `_provenance.critique[]` and audit findings into
-   `_provenance.audit[]` on the proposed file (append; never
-   overwrite previous runs' entries).
+   Each returns a JSON findings list — `priority` (P0–P3),
+   `category` (hierarchy / contrast / motion / a11y / perf /
+   responsive / etc.), one-line description. Capture critique
+   findings into `_provenance.critique[]` and audit findings into
+   `_provenance.audit[]` (append; never overwrite previous runs'
+   entries).
 
-2. **Brand-faithful inversion auto-dismiss.** Both validators
-   ship known false positives on Mode A renders — Arial fallback
-   reads as "overused-font," eyebrow uppercase reads as
-   "all-caps body," pure white / pure black flagged when the
-   brand's captured palette includes them. Before surfacing
-   findings to the user, diff each finding against
+2. **Brand-faithful inversion auto-dismiss.** Both validators ship
+   known false positives on Mode A renders — Arial fallback reads
+   as "overused-font," eyebrow uppercase as "all-caps body," pure
+   white / pure black flagged when the captured palette includes
+   them. Before surfacing findings, diff each against
    `DESIGN.json#extensions.divergence.brand_faithful_inversions[]`
    and `DESIGN.md#narrative.rules` (e.g. permitted uppercase
    contexts). Drop findings whose category and target match an
    approved inversion; keep the original list in
-   `_provenance.<critique|audit>[]` with a
-   `dismissedAsBrandFaithful: true` flag for audit-trail
-   purposes. The user-facing report shows only the real hits.
+   `_provenance.<critique|audit>[]` flagged
+   `dismissedAsBrandFaithful: true` for audit trail. The
+   user-facing report shows only real hits.
 
-3. **Vision gate.** Render a screenshot of the proposed file and
-   study it NEXT TO the captured source screenshot
+3. **Vision gate.** Screenshot the proposed file and study it NEXT
+   TO the captured source screenshot
    (`stardust/current/assets/screenshots/<slug>.png` when present).
-   Judge visually, not from the DOM: **brand-fit** (would the
-   brand owner say "that's us"?), **signature preservation** (hero
-   medium / motif carried, per Discipline 3's signature clause),
-   and **hierarchy at a glance** (does the eye land where the
-   brief says it should?). Record
-   `_provenance.visionCheck = { verdict: pass|fail, observations[] }`;
-   a `fail` is a P1 finding through the same gate mechanics as
-   critique/audit findings. The vision gate complements — never
-   replaces — the deterministic critique/audit pair.
+   Judge visually, not from the DOM: **brand-fit** (would the brand
+   owner say "that's us"?), **signature preservation** (hero medium
+   / motif carried, per Discipline 3's signature clause), and
+   **hierarchy at a glance** (does the eye land where the brief
+   says?). Record `_provenance.visionCheck = { verdict: pass|fail,
+   observations[] }`; a `fail` is a P1 finding through the same
+   gate mechanics. The vision gate complements — never replaces —
+   the deterministic critique/audit pair.
 
 4. **Surface findings in the user-facing report**, grouped by
    priority across both validators with the source attributed
    (`critique:` / `audit:`). List the first 5 P0/P1 verbatim;
-   collapse P2/P3 to per-source counts with an "expand to see
-   all" pointer. Format:
+   collapse P2/P3 to per-source counts with an "expand to see all"
+   pointer. Format:
 
    ```
    Critique + audit on home-proposed.html
 
    P0 (1)
      audit:    skip-link missing — header has no <a href="#main"> as first focusable
-   P1 (4)
-     critique: hierarchy regression — H2 visually heavier than H1 in section #features
-     audit:    hero <img> 3.5MB; no responsive <picture> set despite captured srcset
-     audit:    transition: width animates layout properties (jank)
-     audit:    .hero scroll-behavior: smooth not gated by prefers-reduced-motion
+   P1 (2)
+     critique: hierarchy regression — H2 visually heavier than H1 in #features
+     audit:    hero <img> 3.5MB; no responsive <picture> despite captured srcset
    P2 (3 critique, 1 audit) — expand to see
    P3 (0)
    ```
 
-5. **Gate `prototyped` status on P0/P1 findings from EITHER
-   validator.** If the merged-and-deduped findings list (after
-   the brand-faithful auto-dismiss, plus a vision-gate `fail`
-   from step 3, which counts as P1 here) contains any P0 or P1,
-   do **not** mark the page `prototyped` in `state.json` yet. The
-   proposed file is on disk and openable in the browser, but the
-   page stays in `directed` until either:
+5. **Gate `prototyped` on P0/P1 findings from EITHER validator.**
+   If the merged-and-deduped list (after auto-dismiss, plus a
+   vision-gate `fail`, which counts as P1) contains any P0 or P1,
+   do **not** mark the page `prototyped` yet. The file is on disk
+   and openable, but the page stays `directed` until either:
    - The agent fixes the issue (run a chat-driven impeccable
-     command per Phase 4 iteration paths, then re-run Phase 2.5).
-   - The user explicitly acknowledges (e.g. "ship as-is" /
-     "accept the P1 findings"). Acknowledgement is recorded in
-     `_provenance.critique[]` AND `_provenance.audit[]` with the
-     verbatim user phrase, so re-runs see the existing
-     acknowledgement and don't re-prompt.
+     command per Phase 4, then re-run Phase 2.5).
+   - The user explicitly acknowledges ("ship as-is" / "accept the
+     P1 findings"). Record the acknowledgement verbatim in
+     `_provenance.critique[]` AND `_provenance.audit[]` so re-runs
+     see it and don't re-prompt.
 
-   P2/P3 findings do not block `prototyped`. They surface as
+   P2/P3 findings do not block `prototyped`; they surface as
    advisory.
 
 6. **Optionally spawn an LLM design-review subagent** for an
-   independent take when the user wants more than the
-   deterministic detector. Trigger only when the user explicitly
-   asks ("give me a deeper critique", "second opinion") or when
-   the deterministic pass returns ≥3 P0/P1 findings (signal that
-   the render has multiple issues worth a closer look). Default
-   off to keep the loop fast.
+   independent take — only when the user explicitly asks ("give me
+   a deeper critique", "second opinion") or when the deterministic
+   pass returns ≥ 3 P0/P1 findings. Default off to keep the loop
+   fast.
 
-Both validators are mandatory. There is no opt-out flag — if a
-finding bites and the user wants to ship anyway, they say so in
-chat ("ship as-is" / "accept the P1 findings") and the
-acknowledgement is recorded in `_provenance.critique[]` AND
-`_provenance.audit[]` verbatim. The contract is that the gate
-runs; the user can override the gate but the override is
-explicit and recorded.
-
-Failure handling: when impeccable is unavailable per the
-Delegation mechanic, prototype refuses to run (impeccable is a
-hard requirement). There is no degraded mode that ships
-unverified output.
+Both validators are mandatory; no opt-out flag exists. The user can
+override the gate in chat, but the override is explicit and
+recorded. When impeccable is unavailable per the Delegation
+mechanic, prototype refuses to run — there is no degraded mode that
+ships unverified output.
 
 ### Phase 2.6 — Audit (detector specifics)
 
-The audit sub-phase is implemented as the second parallel arm of
-the impeccable invocation in § Phase 2.5 above. This section
-documents the audit-specific detectors that fire in that arm,
-including ones the parallel critique pass does not cover.
+The audit sub-phase is the second parallel arm of the Phase 2.5
+invocation. Audit-specific detectors:
 
-**WCAG contrast computation.** Audit recomputes contrast ratios
-for every text-on-substrate pair in the file. The previous
-brief-time / craft-time hand-estimated `_provenance.wcagContrast`
-blocks are NOT authoritative; the audit's computed values are.
-Discrepancies of `≥ 0.25` between hand-estimated and computed
-ratios surface as a P1 finding. The wasatch dry-run on 2026-05-13
-surfaced 0.27–1.86 point discrepancies on /beers variant C; the
-audit-driven fix darkened the Cutthroat substrate from `#1c8a7a`
-to `#177566` to clear AA body (4.5:1) and recolored the
-pour-link from yellow to white.
+**WCAG contrast computation.** Audit recomputes contrast ratios for
+every text-on-substrate pair. Earlier hand-estimated
+`_provenance.wcagContrast` blocks are NOT authoritative; the
+audit's computed values are. Discrepancies ≥ 0.25 between
+hand-estimated and computed ratios surface as a P1 finding.
+(Wasatch dry-run evidence: `reference/lessons.md`.)
 
-**Large-text exemption check.** A pair claimed to qualify for
-WCAG's "large-text" 3:1 floor (instead of body 4.5:1) must be
-`≥ 18pt regular` OR `≥ 14pt bold` at rendered size. The audit
-verifies the size at the rendered DOM, not at the source CSS. A
-13px Bellfort 700 link claiming the large-text exemption fails
-the check (Bellfort 700 at 13px is below the 14pt bold floor); the
-finding is P0.
+**Large-text exemption check.** A pair claiming WCAG's "large-text"
+3:1 floor (instead of body 4.5:1) must be ≥ 18pt regular OR ≥ 14pt
+bold at **rendered** size — verified at the rendered DOM, not
+source CSS. A 13px Bellfort 700 link claiming the exemption fails
+(below the 14pt bold floor); the finding is P0.
 
-**LCP image audit.** The first image above the fold on the page
-must declare `loading="eager"` AND `fetchpriority="high"`. A
-lazy-loaded LCP image is a P1 finding. Detection: the first `<img>`
-whose computed `getBoundingClientRect()` intersects the initial
-viewport must satisfy both attributes.
+**LCP image audit.** The first image above the fold must declare
+`loading="eager"` AND `fetchpriority="high"`. A lazy-loaded LCP
+image is a P1 finding. Detection: the first `<img>` whose computed
+`getBoundingClientRect()` intersects the initial viewport must
+satisfy both attributes.
 
 **JS-dependent-hidden-state detector.** Per
-`notes/prototype-broken-by-default-detector-2026-04-29.md`, the
-audit catches initial-state CSS that hides content via `clip-path:
-inset(0 100% ...)`, `opacity: 0`, or `transform: translateX(-100%)`
-where the reveal depends on a JS class flip (typically an
-`IntersectionObserver` toggling `.in-view` / `.is-visible` /
-`html.js-anim`). When the observer fails (slow JS, blocked CDN,
-NoScript), the element stays permanently invisible.
+`notes/prototype-broken-by-default-detector-2026-04-29.md`, catch
+initial-state CSS hiding content via `clip-path: inset(0 100% ...)`,
+`opacity: 0`, or `transform: translateX(-100%)` where the reveal
+depends on a JS class flip (typically an IntersectionObserver
+toggling `.in-view` / `.is-visible` / `html.js-anim`). When the
+observer fails (slow JS, blocked CDN, NoScript), the element stays
+permanently invisible.
 
 Detection regex over the CSS text:
 
@@ -926,36 +843,30 @@ Detection regex over the CSS text:
 ```
 
 When a hit is found AND no `<noscript>` fallback styles the same
-selectors visible AND no `prefers-reduced-motion` rule short-
-circuits the hide, the finding is P0 (the page is broken-by-default
-for any user whose JS doesn't execute). Mitigations the page may
+selectors visible AND no `prefers-reduced-motion` rule
+short-circuits the hide, the finding is P0 (broken-by-default for
+any user whose JS doesn't execute). Mitigations the page may
 declare in `_provenance.audit.acknowledged[]`:
 
-- A `<noscript>` block that re-sets the hidden selectors to
-  visible.
-- A `prefers-reduced-motion: reduce` block that skips the hide
-  entirely.
-- An animation gate selector pattern (`html.js-anim .selector { ...
-  hidden ... }`) where the gate class is set inline in `<head>`
-  BEFORE the stylesheet loads, so observer failure doesn't strand
-  elements (the wasatch /beers variant C confirms this pattern
-  works — detector PASS on all 4 files via the `html.js-anim` gate
-  + CDN-failure fallback).
+- A `<noscript>` block re-setting the hidden selectors visible.
+- A `prefers-reduced-motion: reduce` block skipping the hide.
+- An animation gate selector pattern
+  (`html.js-anim .selector { ... hidden ... }`) where the gate
+  class is set inline in `<head>` BEFORE the stylesheet loads, so
+  observer failure doesn't strand elements (pattern confirmed on
+  wasatch /beers variant C — see `reference/lessons.md`).
 
 ### Phase 2.7 — Adapt (mandatory pre-approval)
 
 Every prototype goes through `$impeccable adapt` and the adapt
-audit before the user's approval is accepted. The cascade ships
-desktop-only HTML otherwise — viewports are tuned to ~1440×900
-through render and iteration, and nothing earlier in the pipeline
-produces responsive coverage.
+audit before approval is accepted — otherwise the cascade ships
+desktop-only HTML (viewports are tuned to ~1440×900 through render
+and iteration, and nothing earlier produces responsive coverage).
 
-This phase was Phase 5.5 in prior versions of stardust (running
-*after* approval). The current spec promotes it to Phase 2.7 so it
-gates `prototyped` alongside critique and audit. The substantive
-adapt logic is unchanged; only the trigger point moved (pre-
-approval vs post-approval). See § Adapt procedure below for the
-unchanged implementation.
+This phase was Phase 5.5 (post-approval) in prior versions; the
+current spec promotes it to Phase 2.7 so it gates `prototyped`
+alongside critique and audit. The adapt logic is unchanged — only
+the trigger point moved.
 
 #### Adapt procedure
 
@@ -972,132 +883,117 @@ Pass the captured viewport breakpoints from
 `DESIGN.json#extensions.breakpoints` if present; otherwise adapt
 picks defaults (640 / 768 / 1024 / 1280 are the stardust spec
 defaults — anything above 640 used as a "mobile breakpoint" is a
-smell per § Mobile-adapt audit below). The full target list is
+smell per § Mobile-adapt audit). The full target list is
 **1920 / 1440 / 1280 / 800 / 414 / 375** — adapt validates each
-viewport's doc-width · overflow · sticky behaviour · grid columns
-· font scaling.
+viewport's doc-width · overflow · sticky behaviour · grid columns ·
+font scaling.
 
 Validate the adapted file against the same contracts Phase 2 ran
 (`:root` token block, data attributes, anti-toolbox audit clean,
-impeccable hard rules, content sourcing). Adapt is an iteration
-over the existing render; it must not reintroduce contract
-violations.
+impeccable hard rules, content sourcing) — adapt must not
+reintroduce contract violations.
 
-Append an entry to the proposed file's `_provenance.adapt[]`
-recording: ISO timestamp, the breakpoint list applied, the number
-of `@media` rules added, and any layout decisions the adapt pass
+Append to `_provenance.adapt[]`: ISO timestamp, breakpoint list
+applied, number of `@media` rules added, and any layout decisions
 surfaced (carousel → stack, sidebar → drawer, hamburger → menu).
 
 #### Mobile-adapt audit
 
-Phase 2.7 also runs a hard audit, separate from the adapt pass
-itself, that the resulting file would survive a publish or
-migrate. The same audit re-runs at `migrate` and `--publish-sample`
-so an adapted-but-broken render can't slip through.
+Phase 2.7 also runs a hard audit, separate from the adapt pass,
+that the file would survive a publish or migrate. The same audit
+re-runs at `migrate` and `--publish-sample` so an adapted-but-broken
+render can't slip through.
 
 Refuse the file when **any** of:
 
 - `<meta name="viewport" content="width=device-width, ...">` is
-  missing or width is set to a fixed pixel value.
-- The file declares zero `@media (max-width: ...)` rules at all
-  (desktop-only).
-- The file declares mobile-targeted breakpoints **above 640px**
-  — `@media (max-width: 1024px)` as the *narrowest* breakpoint
-  is the recognisable shape of "didn't actually adapt for
-  phones." Adapt should produce at least one rule at ≤ 640px.
+  missing or width is a fixed pixel value.
+- Zero `@media (max-width: ...)` rules at all (desktop-only).
+- Mobile-targeted breakpoints **only above 640px** —
+  `@media (max-width: 1024px)` as the *narrowest* breakpoint is the
+  recognisable shape of "didn't actually adapt for phones." At
+  least one rule at ≤ 640px.
 - **At a 360px-wide rendered viewport:** a landmark causes
   `scrollWidth > clientWidth` on `document.documentElement` or
   `document.body`. Refusal code:
   `audit/responsive: horizontal-overflow-at-360px`.
-- **At a 360px-wide rendered viewport:** the computed `font-size`
-  of any descendant of a `<nav>` inside a `<header>` is below
-  11px. Refusal code: `audit/responsive: nav-readability-floor`.
-- **At a 360px-wide rendered viewport:** the computed `gap` (or
-  `column-gap`) of any flex/grid `<nav>` inside a `<header>` is
-  below 10px. Same refusal code.
+- **At 360px:** computed `font-size` of any descendant of a `<nav>`
+  inside a `<header>` below 11px. Refusal code:
+  `audit/responsive: nav-readability-floor`.
+- **At 360px:** computed `gap` (or `column-gap`) of any flex/grid
+  `<nav>` inside a `<header>` below 10px. Same refusal code.
 
-The last three conditions require actually rendering the file —
-they can't be inferred from CSS text. The canonical check is a
-small Playwright snippet (`fixtures/mobile-nav-audit.mjs`) the
-agent runs against the file at 360×800. Audit messages must
-include a pointer to the stock-template doc:
+The last three require actually rendering the file — they can't be
+inferred from CSS text. The canonical check is the Playwright
+snippet `fixtures/mobile-nav-audit.mjs`, run against the file at
+360×800. Audit messages must include:
 
 > Suggested fix: apply the stock hamburger pattern
 >   skills/prototype/reference/mobile-nav-collapse.md
 
 #### Mobile nav collapse
 
-When the audit refuses on either of the nav-related codes above,
-the agent applies the stock CSS-only hamburger pattern documented
-in `reference/mobile-nav-collapse.md` (HTML + CSS + ≤10-line
-inline `<script>` for a11y). The header gains
-`data-nav-collapse="hamburger"` so downstream consumers can detect
-the pattern is applied.
+When the audit refuses on either nav-related code, apply the stock
+CSS-only hamburger pattern from `reference/mobile-nav-collapse.md`
+(HTML + CSS + ≤10-line inline `<script>` for a11y). The header
+gains `data-nav-collapse="hamburger"` so downstream consumers can
+detect the pattern.
 
 **Source order is load-bearing.** The base
-`.ds-nav-burger { display: none; ... }` rule must be placed at
-the **top** of the `<style>` block (after `:root`, before any
-`@media` rules). The post-injection ordering check is a small
-`awk` one-liner documented in `reference/mobile-nav-collapse.md`
-§ Source order — it asserts the base rule appears at a lower line
-number than the first `@media (max-width: 640px)` rule. Exit 0 =
-correct ordering; exit 1 = regression.
+`.ds-nav-burger { display: none; ... }` rule must sit at the
+**top** of the `<style>` block (after `:root`, before any `@media`
+rules). The post-injection ordering check is the `awk` one-liner in
+`reference/mobile-nav-collapse.md` § Source order — it asserts the
+base rule appears at a lower line number than the first
+`@media (max-width: 640px)` rule. Exit 0 = correct; exit 1 =
+regression.
 
 The stock pattern is the default; `reference/mobile-nav-collapse.md`
-§ Alternative patterns documents priority+overflow, bottom nav,
-and side-drawer as valid alternatives the user can request, but
-the agent does not pick between them autonomously.
+§ Alternative patterns documents priority+overflow, bottom nav, and
+side-drawer as alternatives the user can request — the agent does
+not pick between them autonomously.
 
 ### Phase 2.8 — Motion validation (mandatory when motion declared)
 
-Static-DOM gates (2.5 critique, 2.6 audit, 2.7 adapt) all read the
-proposed file at `scrollY=0` with no time elapsed. They cannot
-catch motion-specific failure modes:
-
-- Content stuck `opacity: 0` because an anim-enter trigger fires
-  past the user's reading position.
-- Content rendered outside its parent's `overflow: clip` boundary
-  because a translateY animation magnitude exceeds the parent's
-  slack room.
-- Scroll-driven animations whose `animation-range` completes only
-  after the section has fully scrolled past, leaving the reveal
-  state invisible during the readable window.
-- rAF loops with stale baseline measurements drifting on resize /
-  font-load / lazy-image-load.
-- Section overlaps caused by transforms that don't appear in
-  static DOM.
-- `prefers-reduced-motion` regressions where the choreography is
-  disabled but the element is left at the hidden "from" state.
-- No-JS regressions where the choreography's hidden initial state
-  has no `<noscript>` fallback.
+The static-DOM gates (2.5–2.7) read the file at `scrollY=0` with no
+time elapsed; they cannot catch motion-specific failures: content
+stuck `opacity: 0` because an anim-enter trigger fires past the
+reading position; content rendered outside an `overflow: clip`
+parent because a translateY magnitude exceeds the parent's slack;
+scroll-driven animations whose `animation-range` completes only
+after the section scrolled past; rAF loops with stale baseline
+measurements drifting on resize / font-load / lazy-image-load;
+section overlaps caused by transforms invisible in static DOM;
+`prefers-reduced-motion` regressions leaving elements at the hidden
+"from" state; no-JS regressions where the hidden initial state has
+no `<noscript>` fallback.
 
 The full procedure (5 passes — scroll-position probe, finding
 classification, motion-bug checks, no-JS state, multi-viewport
 scroll-driven check) lives in `reference/motion-validation.md`.
 
 Phase 2.8 fires when the rendered file declares ≥ 1 named
-choreography (per `_provenance.motion.choreographies[]`) OR contains
-any of: `animation-timeline:`, `@scroll-timeline`, IntersectionObserver
-with `target.classList.add('anim-enter-visible')` patterns, or rAF
-loops driven by `getBoundingClientRect()`. Static prototypes skip.
+choreography (per `_provenance.motion.choreographies[]`) OR
+contains any of: `animation-timeline:`, `@scroll-timeline`,
+IntersectionObserver with
+`target.classList.add('anim-enter-visible')` patterns, or rAF loops
+driven by `getBoundingClientRect()`. Static prototypes skip.
 
-Findings are classified as **by-design** (the choreography is
-supposed to produce this state at this position; explained by a
-named choreography in the brief) or **bug** (the choreography
-produces an unintended state). Bugs block `prototyped` until
-acknowledged or fixed.
+Findings are classified **by-design** (the choreography is supposed
+to produce this state at this position; explained by a named
+choreography in the brief) or **bug** (unintended state). Bugs
+block `prototyped` until acknowledged or fixed.
 
-When a bug cannot be auto-fixed within 3 iterations of the recursive
-loop, surface to the user with the finding, the classification
-reasoning, the 3 fix attempts that were tried, and a proposed
-remediation that requires user input. Do not silently lower the
-gate.
+When a bug cannot be auto-fixed within 3 iterations of the
+recursive loop, surface to the user with the finding, the
+classification reasoning, the 3 fix attempts tried, and a proposed
+remediation requiring user input. Do not silently lower the gate.
 
-Append an entry to the proposed file's `_provenance.motionValidation`
-recording: ISO timestamp, probe positions run, viewports tested,
-findings (hiddenInViewport, sectionOverlaps, clippedReveals,
-rangeMismatches) with per-finding classification, and `fixesApplied[]`.
-Save clean-pass screenshots to `stardust/validation/<slug>/motion-<viewport>.png`.
+Append to `_provenance.motionValidation`: ISO timestamp, probe
+positions run, viewports tested, findings (hiddenInViewport,
+sectionOverlaps, clippedReveals, rangeMismatches) with per-finding
+classification, and `fixesApplied[]`. Save clean-pass screenshots
+to `stardust/validation/<slug>/motion-<viewport>.png`.
 
 #### Variant-convergence detector (Discipline 10)
 
@@ -1106,16 +1002,15 @@ When N > 1 variants render, each `<slug>-<id>-shape.md` declares:
 - A distinct `dominantDimension` value (no two variants share it;
   per `notes/variant-convergence.md` Tier 1).
 - A `compositionDelta` field listing ≥ 2 ways the variant's section
-  sequence or layout strategy diverges from each sibling variant.
-  Examples:
-  - `compositionDelta: ["section-order: hero ↔ stats", "layout: 3-up-grid → vertical-narrative"]`
-  - `compositionDelta: ["ia-priority: commercial-conversion → catalog-browse", "hero-layout: split-photo → type-led"]`
+  sequence or layout strategy diverges from each sibling variant,
+  e.g. `compositionDelta: ["section-order: hero ↔ stats",
+  "layout: 3-up-grid → vertical-narrative"]`.
 
-If `compositionDelta` is empty or trivial (only token-level
-deltas — *"Color A vs Color B"*, *"font weight 400 vs 600"*),
-Phase 1 fails the brief and restarts ideation. The validator
-checks pairwise: variant pairs `(A,B)`, `(A,C)`, `(B,C)` each
-need ≥ 2 structural changes.
+If `compositionDelta` is empty or trivial (only token-level deltas
+— *"Color A vs Color B"*, *"font weight 400 vs 600"*), Phase 1
+fails the brief and restarts ideation. The validator checks
+pairwise: variant pairs `(A,B)`, `(A,C)`, `(B,C)` each need ≥ 2
+structural changes.
 
 **Mode-aware contract** (composes with `ia-fidelity` from
 `stardust/reference/intent-dimensions.md` § 9):
@@ -1124,117 +1019,101 @@ need ≥ 2 structural changes.
   axes only (type-weight, type-scale, density, motion-energy,
   color-temperature, spacing-rhythm). Structural deltas (section
   sequence / presence / IA priority / layout strategy) are
-  **forbidden** under verbatim. The detector inverts: a surface-
-  only delta passes, a structural delta refuses.
+  **forbidden**. The detector inverts: a surface-only delta passes,
+  a structural delta refuses.
 - Under `ia-fidelity: reimagined` — A + B + C variants declare
   structural `compositionDelta` with ≥ 2 changes per pair.
   Surface-only deltas **fail** the brief.
 
-The wasatch /beers A / B / C dry-run declared 5 structural deltas
-per pair (`compositionDelta_vs_A`, `compositionDelta_vs_B` blocks
-in `_provenance`) — substrate-strategy, section-presence, photo-
-treatment, section-order, section-completeness. The detector
-PASSED on all three pairs.
-
-Single-variant runs (N = 1) skip Discipline 10 entirely.
+(Worked pass: wasatch /beers A/B/C, 5 structural deltas per pair —
+see `reference/lessons.md`.) Single-variant runs (N = 1) skip
+Discipline 10 entirely.
 
 ### Phase 4 — Open and iterate
 
-(Phase numbering skips 3; the former Phase 3 — *Compose the viewer*
-— was removed when the per-page before/after viewer was dropped.
-Cross-references throughout the docs still name Phases 4, 5, 5.5.)
+(Numbering skips 3 — the former *Compose the viewer* phase was
+removed with the per-page before/after viewer; cross-references
+elsewhere still name Phases 4, 5, 5.5.)
 
-1. Open the just-written or just-updated `<slug>-proposed.html` (or
-   the user-chosen variant suffix when N > 1) in the browser using
-   the `open <vfs-path>` shell command. This routes VFS paths through
+1. Open the just-written `<slug>-proposed.html` (or the user-chosen
+   variant suffix when N > 1) in the browser via the
+   `open <vfs-path>` shell command. This routes VFS paths through
    the preview service worker — **do not use `playwright-cli open`**
-   for local prototype files, as it bypasses the preview service worker
-   and produces a FILE NOT FOUND error. Skip in pipeline-automation mode.
+   for local prototype files; it bypasses the service worker and
+   produces FILE NOT FOUND. Skip in pipeline-automation mode.
 2. Mark the page `prototyped` in `state.json` — **gated on the
-   Phase 2.5 critique + Phase 2.6 audit + Phase 2.7 adapt +
-   Phase 2.8 motion validation (when fired) result** (Discipline 9).
-   If any of the four returned ≥ 1 P0 or P1 finding (after the
-   brand-faithful inversion auto-dismiss) and the user has not
-   acknowledged, the page stays `directed` (not `prototyped`);
-   surface the findings in the report grouped by source
-   (`critique:` / `audit:` / `adapt:` / `motion:`) and recommend
-   either fixing the issue or acknowledging explicitly. The
-   transition itself does not require *approval* (a separate
-   later step) — but it does require all gates to clear, since
-   shipping a `prototyped` flag on work that fails P0/P1 on any
-   gate misleads downstream consumers (migrate, the dashboard)
-   about the prototype's quality.
+   Phase 2.5 critique + 2.6 audit + 2.7 adapt + 2.8 motion (when
+   fired) results** (Discipline 9). If any gate returned ≥ 1 P0/P1
+   finding (after the brand-faithful auto-dismiss) and the user has
+   not acknowledged, the page stays `directed`; surface the
+   findings grouped by source (`critique:` / `audit:` / `adapt:` /
+   `motion:`) and recommend fixing or explicit acknowledgement. The
+   transition does not require *approval* (a separate later step) —
+   but all gates must clear, since a `prototyped` flag on work that
+   fails P0/P1 misleads downstream consumers (migrate, the
+   dashboard) about quality.
 3. Report the prototype path and stop. Iteration happens via
-   chat-driven impeccable commands or direct invocation (see
-   § Iteration paths below).
+   chat-driven impeccable commands or direct invocation (below).
 
 #### Iteration paths
 
-Refinement after the initial render takes one of two forms. They
-are not mutually exclusive — a single page can move through both
-across its lifetime.
+Not mutually exclusive — a page can move through both.
 
-1. **Chat-driven (default).** The user gives a refinement phrase
-   in chat — *"make the hero bolder for home"*, *"tighten the
-   cup-note grid"*, *"less corporate"*. The agent:
+1. **Chat-driven (default).** The user gives a refinement phrase —
+   *"make the hero bolder for home"*, *"less corporate"*. The agent:
    - Reads the phrase against
      `skills/stardust/reference/intent-dimensions.md` to identify
      which axes it moves.
    - Consults
      `skills/stardust/reference/impeccable-command-map.md` to pick
      the matching impeccable command (often `bolder`, `quieter`,
-     `distill`, `typeset`, `colorize`, or `layout`).
+     `distill`, `typeset`, `colorize`, `layout`).
    - Shows the resolved plan to the user before executing.
-   - Runs the chosen command against `<slug>-proposed.html` (or a
-     specific section within it, when the phrase scopes one).
+   - Runs the command against `<slug>-proposed.html` (or a specific
+     section when the phrase scopes one).
    - Re-validates per Phase 2 (`:root` block, data attributes,
-     anti-toolbox audit clean, impeccable hard rules) and updates
-     the proposed file's provenance.
-
-2. **Direct impeccable invocation.** The user runs an impeccable
-   command directly — `$impeccable bolder
+     anti-toolbox audit, impeccable hard rules) and updates the
+     file's provenance.
+2. **Direct impeccable invocation.** The user runs a command
+   directly — `$impeccable bolder
    stardust/prototypes/home-proposed.html`. Stardust isn't in the
-   loop; the browser tab reloads whatever's on disk. This is fine
-   and documented as a supported escape hatch. (Includes
-   `$impeccable live` against the proposed file when the user
-   wants in-browser picker iteration — that's an external tool
-   they invoke directly; stardust does not drive its poll loop.)
+   loop; the browser tab reloads whatever's on disk. Supported
+   escape hatch. (Includes `$impeccable live` against the proposed
+   file for in-browser picker iteration — an external tool the user
+   invokes; stardust does not drive its poll loop.)
 
-The "open and reasoned" principle from the master skill applies to
-path 1: the agent reasons publicly about the phrase before running
-any command, and never silently maps a refinement to a fixed
-command.
+The master skill's "open and reasoned" principle applies to path 1:
+reason publicly about the phrase before running any command; never
+silently map a refinement to a fixed command.
 
 ### Phase 5 — Approval (+ fold-back, Part III)
 
-Approval is **explicit**. Stardust does not auto-approve.
-
-The user signals approval by saying **"approve <slug>"** or simply
-**"approve"** in the conversation. The agent confirms the slug
-before writing state, then proceeds.
+Approval is **explicit**. Stardust does not auto-approve. The user
+signals approval with **"approve <slug>"** or **"approve"**; the
+agent confirms the slug before writing state, then proceeds.
 
 On approval:
 
 1. Verify the proposed file's provenance block lists the *current
-   active* `direction.md` (defensive check — if the direction changed
-   during iteration, the user must re-prototype against the new
-   direction first).
-2. **Run approval fold-back** per
-   `reference/approval-fold-back.md` (Part III of the merged spec).
-   When the approved variant is non-A AND `ia-fidelity` is
-   `reimagined`, the prototype reads the approved file's
-   `_provenance.differentiationFromA[andB]` block plus the brief's
-   `compositionDelta`, diffs against the active direction, and
-   proposes folding any structural moves. The user picks
+   active* `direction.md` (defensive check — if the direction
+   changed during iteration, the user must re-prototype against the
+   new direction first).
+2. **Run approval fold-back** per `reference/approval-fold-back.md`
+   (Part III of the merged spec). When the approved variant is
+   non-A AND `ia-fidelity` is `reimagined`, read the approved
+   file's `_provenance.differentiationFromA[andB]` block plus the
+   brief's `compositionDelta`, diff against the active direction,
+   and propose folding any structural moves. The user picks
    `fold site-wide` (default) / `fold page-local` / `don't fold`.
    Under `ia-fidelity: verbatim` the fold-back is a no-op by
    construction (A1/A2/A3 are surface forks; nothing structural to
    fold). Flags: `--auto-fold` skips the gate; `--no-fold` opts out
    entirely.
-3. Mark the page `approved` in `state.json`. Append a
+3. Mark the page `approved` in `state.json`; append a
    `{ status: "approved", at: <ts> }` history entry.
 4. Clear any `stale` flag on the page.
 5. Print:
+
    ```
    home: approved
      proposed: stardust/prototypes/home-proposed.html
@@ -1245,26 +1124,17 @@ On approval:
    ```
 
 Adapt no longer runs at approval time — it ran at Phase 2.7 as a
-pre-`prototyped` gate. The `mobile:` line reports the Phase 2.7
-result for review continuity.
-
-If multiple pages are in flight, approval is per-page; the user can
-approve some and continue iterating on others.
+pre-`prototyped` gate; the `mobile:` line reports the Phase 2.7
+result for review continuity. If multiple pages are in flight,
+approval is per-page; the user can approve some and keep iterating
+on others.
 
 ### Phase 5.5 — Adapt for mobile (retired; see Phase 2.7)
 
-Adapt and the mobile-adapt audit moved to **Phase 2.7** as part of
-the Discipline 9 critique → audit → adapt cycle, gating
-`prototyped` instead of approval. The 2026-05-03 lovesac.com
-showcase failure mode (stakeholders eyeballing variants on a phone
-getting the unadjusted desktop layout) is unchanged — the gate just
-fires earlier in the lifecycle, so a non-adapted prototype never
-lands as `prototyped` in the first place.
-
-The implementation (impeccable adapt invocation, mobile-adapt
-audit, mobile-nav-collapse stock pattern) lives in § Phase 2.7
-above. This section is retained as an anchor for any external
-cross-reference that still names Phase 5.5.
+Adapt and the mobile-adapt audit moved to **Phase 2.7**, gating
+`prototyped` instead of approval (lovesac 2026-05-03 — see
+`reference/lessons.md`); this anchor is retained for external
+cross-references that still name Phase 5.5.
 
 ### Stale handling
 
@@ -1283,24 +1153,25 @@ flag and update `againstDirection` to the new active direction.
 
 ## Outputs
 
-| Path                                          | Purpose                                       |
-|-----------------------------------------------|-----------------------------------------------|
-| `stardust/prototypes/<slug>-shape.md`         | Per-page compositional brief (Phase 1 output, craft input). |
-| `stardust/prototypes/<slug>-proposed.html`    | Proposed redesign (chat-driven iteration target, migration source, user-facing review surface). |
-| `stardust/state.json`                         | Updated with page status and approval history. |
-| `DESIGN.json`                                 | Updated with `extensions.divergence.anti_toolbox_hits` and any audit amendments from this prototype's render. |
+| Path | Purpose |
+|---|---|
+| `stardust/prototypes/<slug>-shape.md` | Per-page compositional brief (Phase 1 output, craft input). |
+| `stardust/prototypes/<slug>-proposed.html` | Proposed redesign (iteration target, migration source, user-facing review surface). |
+| `stardust/state.json` | Updated with page status and approval history. |
+| `DESIGN.json` | Updated with `extensions.divergence.anti_toolbox_hits` and any audit amendments from this render. |
 
 ## Failure modes
 
 - **No directed pages.** Recommend `$stardust direct` and stop.
 - **Pending direction.** Refuse to run; the user must resolve the
   direction first.
-- **Validation failure (:root block missing, data attributes missing,
-  unjustified anti-toolbox hit, impeccable rule violation).** Do not
-  write the file. Surface the specific failure and a suggested fix.
+- **Validation failure (`:root` block missing, data attributes
+  missing, unjustified anti-toolbox hit, impeccable rule
+  violation).** Do not write the file. Surface the specific failure
+  and a suggested fix.
 - **Impeccable not available.** Refuse to run — impeccable is a
-  hard requirement (Delegation mechanic). Recommend the user
-  install the impeccable plugin and re-invoke.
+  hard requirement (Delegation mechanic). Recommend installing the
+  impeccable plugin and re-invoke.
 
 ## Concurrency
 
@@ -1310,176 +1181,35 @@ are last-write-wins; warn the user if they explicitly try.
 
 ## Prep mode (--prep)
 
-When invoked with `--prep`, prototype runs an extended pass that
-fills page-type gaps and writes canon. Discovery-mode runs are
-unchanged: per-slug shape brief, render via `$impeccable craft`,
-open in browser, iterate, approve.
-
-`--prep` adds three things on top of the standard procedure:
-
-### 1. Fill page-type gaps
-
-Identify every page type in `state.json.pages[].type` that
-doesn't yet have an approved archetype. For each gap, prototype
-one representative page (the user picks which slug, or the first
-page of that type by default):
-
-- `article`-typed pages with no approved article: prototype one
-- `listing`-typed pages with no approved listing: prototype one
-- `program`, `form`, `static` — same pattern
-- `landing` — the home; prototyped first if not already done
-- `unique`-typed pages — these don't get archetypes; they're
-  rendered as one-offs at migrate time
-
-The user picks one variant per type. Subsequent pages of the
-same type are migrated by forking that approval (Path A′ in
-`skills/migrate/SKILL.md`).
-
-### 2. Canon write-back on first approval
-
-The first prototype approved (default the home; override with
-`--canon-from <slug>`) becomes the **canon-author**. On
-approval, extract canon and write back per
-`reference/canon-extraction.md`:
-
-1. Chrome HTML → `stardust/canon/header.html`,
-   `stardust/canon/footer.html`, optional regions.
-2. Compound CSS → `stardust/canon/canon.css`.
-3. Pinned tokens → `DESIGN.json.extensions.canon.pinned`.
-4. Module canonical renderings →
-   `stardust/canon/modules/<id>.html`.
-5. Compositional moves (LLM-authored, 3–7 lines) →
-   `DESIGN.json.extensions.canon.compositionalMoves`.
-
-Reference all extracted files via `{ path, sha }` in
-`DESIGN.json.extensions.canon.files`. Each canon file carries a
-`stardust:canon` provenance comment naming source slug, source
-prototype, and region.
-
-### 3. Canon write-back on subsequent approvals
-
-For non-canon-author template approvals (article, listing, etc.),
-canon-extraction runs in **diff mode** per
-`reference/canon-extraction.md` § Conflict resolution:
-
-- **Net-new items** (a module not yet in canon, a new compound
-  CSS class, a new compositional move) → append to canon
-  additively. Add a history entry naming what was added.
-- **Match canon byte-for-byte** → no-op.
-- **Conflict with canon** → default is **log as deviation**:
-  the migrated/prototyped page carries the deviation inline
-  marked with `data-deviation="<reason>"`, and the page's
-  `migrationDecisions[]` records a `canon-deviation` entry.
-  Canon stays unchanged.
-
-Override the default per-conflict via the prep summary if the
-user wants to promote the new variant to canon (which stale-flags
-downstream pages that consumed the changed item) or reject and
-re-iterate the prototype. Without an explicit override, the
-conflict logs as deviation and approval proceeds.
-
-### Prep summary
-
-```
-prototype --prep complete
-=========================
-
-Approved archetypes:
-  landing   home (V01 Polish)            canon-author
-  article   news/post-housing-summit
-  listing   news (the index)
-  program   programs/shelter
-  form      donate
-  static    about
-
-Canon: stardust/canon/ + DESIGN.json.extensions.canon
-  Sources:  home → article (1 deviation logged), listing (clean),
-            program (1 deviation logged), form (clean), static (clean)
-  Modules:  8 confirmed; canonical renderings written
-  Pinned:   sectionPadding, densityTier, typeScale set
-
-Next: $stardust migrate  (apply canon to every page in inventory)
-```
-
-Default mode is unchanged.
+Moved to `reference/prep-mode.md` — **READ that file when `--prep`
+is passed** (page-type gap fill, canon write-back, prep summary).
+This anchor is retained for external cross-references
+(e.g. `skills/prepare-migration/SKILL.md`).
 
 ## References
 
-- `reference/page-shape-brief.md` — per-page compositional brief
-  format (Phase 1 output, craft input). Page-level deployment
-  decisions live here; site-level system decisions live in
-  DESIGN.md.
-- `reference/canon-extraction.md` — the five-step canon-extraction
-  procedure performed on prototype approval in `--prep` mode.
-- `reference/proposed-file-shell.md` — proposed-file schema and
-  required structure (`:root` token block, data attributes,
-  provenance, content sourcing hierarchy, mobile-adapt audit).
-- `reference/publish-sample.md` — `--publish-sample` sub-flow:
-  eligibility checks, file staging, PR creation against the
-  upstream stardust showcase. Lands the prototype as a public
-  sample at `https://{owner}.github.io/stardust-2/`.
-- `reference/mobile-nav-collapse.md` — stock CSS-only hamburger
-  pattern Phase 2.7 auto-applies when the Mobile-adapt audit
-  refuses on `horizontal-overflow-at-360px` or
-  `nav-readability-floor`. Carries the copy-pasteable
-  HTML+CSS+JS, the audit smoke-test command, and the
-  alternative-pattern vocabulary.
-- `reference/motion-validation.md` — Phase 2.8 procedure:
-  scroll-position probe, finding classification, motion-bug
-  checks (clipped-container reveal timing, animation-range vs
-  reading position, anim-enter trigger reachability,
-  reduced-motion override completeness, no-JS state, multi-
-  viewport scroll-driven check). Reusable Playwright probe
-  patterns documented inline.
-- `reference/motion-registers.md` — five brand-faithful motion
-  registers (`arrival`, `kinetic-display`, `live-systems`,
-  `editorial`, `kinetic-grid`), the selection heuristic that
-  maps PRODUCT.md Brand Personality traits to a register, and the
-  § Extension rule for bespoke registers derived from the site's
-  own captured motion. Consumed by Phase 2.4 (motion application).
-- `reference/motion-stack.md` — technology choice for cinematic
-  prototypes: Lenis + CSS keyframes + rAF + IntersectionObserver.
-  Why not GSAP. Bundle policy + Lenis pinning procedure.
-- `reference/motion-attributes.md` — `data-*` vocabulary the
-  cinematic runtime consumes (`[data-anim]`, `[data-tile-anim]`,
-  `[data-countup]`, `[data-flip]`, `[data-fill]`, `[data-split]`,
-  `[data-parallax]`). Annotated per the active register.
-- `reference/motion-runtime.md` — the canonical inline runtime
-  script that powers every cinematic prototype. Single source of
-  truth; embedded verbatim during Phase 2.4.
-- `reference/fidelity-refined-pass.md` — concrete CSS recipes for
-  the `--fidelity=refined` craft micro-pass (Discipline 8).
-- `reference/anti-template-bank.md` — worked examples of the
-  non-template moves Discipline 3 draws from (typographic
-  substitution / substrate-promotion / inversion / document-shape
-  / scale-displacement), plus the § Extension rule for
-  evidence-shaped new moves.
-- `skills/stardust/reference/reference-research.md` — sourcing
-  real-world design references (refero MCP with WebSearch fallback,
-  graceful skip when unavailable); consumed by Discipline 2's
-  reference-grounded alternatives.
-- `reference/approval-fold-back.md` — Phase 5 fold-back procedure
-  (Part III of the merged spec): diff algorithm, surfacing UX,
-  write logic, stale flagging, `--auto-fold` / `--no-fold` flags,
-  verbatim no-op gating.
-- `fixtures/composition-delta-good.md` — example shape brief with
-  a strong structural `compositionDelta` (passes Discipline 10).
-- `fixtures/composition-delta-trivial.md` — example shape brief
-  with token-only deltas (fails Discipline 10).
-- `../stardust/reference/token-contract.md` — `:root` token
-  block (cross-cutting, used by prototype + migrate).
-- `../stardust/reference/data-attributes.md` — structural data
-  attribute vocabulary (cross-cutting, used by prototype + migrate).
-- `../stardust/reference/divergence-toolkit.md` —
-  anti-mediocrity rules consumed during render and iteration.
-- `../stardust/reference/intent-dimensions.md` — the 7-axis
-  vocabulary used to read a chat-driven refinement phrase
-  (iteration path 2).
-- `../stardust/reference/impeccable-command-map.md` — when to
-  reach for each impeccable command. Consulted during chat-driven
-  iteration (path 2) to pick the command for a refinement phrase.
-- `../stardust/reference/state-machine.md` — page lifecycle
-  and stale rules.
+- `reference/prep-mode.md` — `--prep` pass: gap fill, canon write-back, prep summary. **Read when `--prep` is passed.**
+- `reference/lessons.md` — field history (wasatch, nvidia, knack, lovesac, moneyhub) behind the gates and disciplines.
+- `reference/page-shape-brief.md` — per-page compositional brief format (Phase 1 output, craft input).
+- `reference/canon-extraction.md` — five-step canon extraction on approval in `--prep` mode.
+- `reference/proposed-file-shell.md` — proposed-file schema (`:root` block, data attributes, provenance, content sourcing hierarchy, mobile-adapt audit).
+- `reference/publish-sample.md` — `--publish-sample` sub-flow (eligibility, staging, PR; publishes at `https://{owner}.github.io/stardust-2/`).
+- `reference/mobile-nav-collapse.md` — stock hamburger pattern Phase 2.7 auto-applies; HTML+CSS+JS, smoke-test, alternative patterns.
+- `reference/motion-validation.md` — Phase 2.8 procedure: 5 passes, motion-bug checks, Playwright probe patterns.
+- `reference/motion-registers.md` — five motion registers, selection heuristic, § Extension rule. Consumed by Phase 2.4.
+- `reference/motion-stack.md` — cinematic technology choice (Lenis + CSS keyframes + rAF + IO; why not GSAP; Lenis pinning).
+- `reference/motion-attributes.md` — `data-*` vocabulary the cinematic runtime consumes, per register.
+- `reference/motion-runtime.md` — canonical inline runtime script; embedded verbatim in Phase 2.4.
+- `reference/fidelity-refined-pass.md` — CSS recipes for `--fidelity=refined` (Discipline 8).
+- `reference/anti-template-bank.md` — worked non-template moves for Discipline 3, plus § Extension rule.
+- `reference/approval-fold-back.md` — Phase 5 fold-back: diff algorithm, surfacing UX, write logic, stale flagging, flags, verbatim no-op.
+- `fixtures/composition-delta-good.md` / `fixtures/composition-delta-trivial.md` — shape briefs that pass / fail Discipline 10.
+- `skills/stardust/reference/reference-research.md` — real-world design reference sourcing; consumed by Discipline 2.
+- `../stardust/reference/token-contract.md` — `:root` token block (prototype + migrate).
+- `../stardust/reference/data-attributes.md` — structural data attribute vocabulary (prototype + migrate).
+- `../stardust/reference/divergence-toolkit.md` — anti-mediocrity rules consumed during render and iteration.
+- `../stardust/reference/intent-dimensions.md` — 7-axis vocabulary for chat-driven refinement phrases.
+- `../stardust/reference/impeccable-command-map.md` — which impeccable command fits a refinement phrase.
+- `../stardust/reference/state-machine.md` — page lifecycle and stale rules.
 - `../stardust/reference/artifact-map.md` — provenance shape.
-- impeccable's `reference/craft.md` and `reference/live.md` — the
-  underlying impeccable commands stardust delegates to.
+- impeccable's `reference/craft.md` / `reference/live.md` — the underlying delegated commands.

--- a/plugins/stardust/skills/prototype/reference/anti-template-bank.md
+++ b/plugins/stardust/skills/prototype/reference/anti-template-bank.md
@@ -282,7 +282,7 @@ surpriseMoves:
   captured site doesn't actually have a brand asset that warrants
   this treatment) fails Discipline 2: the move reads as
   "size-as-personality" — a C-cliff failure pattern per
-  `direct/SKILL.md` § C-cliff failure mode.
+  `direct/SKILL.md` § The C-cliff: render-refusal conditions.
 - Scale-displacement on a page whose IA priority depends on
   multiple beats (conversion path with steps) conflicts with the
   IA preservation rule and refuses.

--- a/plugins/stardust/skills/prototype/reference/lessons.md
+++ b/plugins/stardust/skills/prototype/reference/lessons.md
@@ -1,0 +1,70 @@
+# Prototype lessons (field history)
+
+Historical runs that motivated rules in `SKILL.md`. The **rules
+live inline in SKILL.md**; this file preserves the evidence and the
+full narratives behind them. Read when a gate's rationale is
+questioned or a rule looks over-strict.
+
+## wasatch.beer dry-run — 2026-05-13
+
+- **Gate pair (Phases 2.5/2.6).** The dry-run caught two real bugs
+  that the brief and craft phases missed — both caught by the
+  **audit** half, not critique: (1) a WCAG contrast miscalculation
+  off by 0.27–1.86 points on multiple text/substrate pairs of
+  /beers variant C (hand-estimated `_provenance.wcagContrast`
+  blocks vs the audit's computed ratios); (2) an LCP image
+  lazy-loaded on the first catalog entry. The audit-driven fix
+  darkened the Cutthroat substrate from `#1c8a7a` to `#177566` to
+  clear AA body (4.5:1) and recolored the pour-link from yellow to
+  white. Motivates: Phase 2.6's computed-contrast authority (the
+  ≥ 0.25 discrepancy P1) and the LCP image audit.
+- **JS-dependent-hidden-state mitigation.** /beers variant C passed
+  the broken-by-default detector on all 4 files via the
+  `html.js-anim` gate class set inline in `<head>` before the
+  stylesheet loads, plus a CDN-failure fallback — confirming that
+  mitigation pattern works (Phase 2.6 detector, mitigation #3).
+- **Discipline 10.** The /beers A/B/C run declared 5 structural
+  deltas per pair (`compositionDelta_vs_A` / `compositionDelta_vs_B`
+  blocks in `_provenance`): substrate-strategy, section-presence,
+  photo-treatment, section-order, section-completeness. The
+  variant-convergence detector PASSED on all three pairs.
+
+## nvidia.com home — 2026-05-04
+
+The critique on the home prototype returned 1 P0 + 2 P1 + 3 P2; the
+audit on the **same artifact** returned six additional findings: no
+skip-link, theme carousels without keyboard arrow nav, hero ~3.5MB
+without responsive `<picture>`, layout-property animation, JS-gated
+reveal with no `<noscript>` fallback, and
+`scroll-behavior: smooth` not respecting `prefers-reduced-motion`.
+None were design issues; none would have been caught by critique
+alone. Without an audit gate the page would have been marked
+`prototyped` with quantifiable WCAG failures. Motivates: Phase 2.5's
+critique + audit as a mandatory complementary pair.
+
+## knack.com — 2026-06-26
+
+Under a verbatim direction, impeccable's design hook flagged
+em-dashes and "enterprise-grade" on Knack's own captured headings
+("Built on Enterprise-Grade Components"). Rewriting captured copy to
+satisfy a cadence rule would have been exactly the fabrication the
+fidelity setting exists to prevent; the only correct response was to
+leave the captured copy untouched and record the bypass. Motivates:
+Discipline 9's copy-cadence detector bypass under verbatim fidelity.
+
+## lovesac.com showcase — 2026-05-03
+
+Stakeholders eyeballing showcase variants on a phone got the
+unadjusted desktop layout, because adapt ran post-approval (the old
+Phase 5.5). Motivates: promoting adapt + the mobile-adapt audit to
+Phase 2.7, gating `prototyped` so a non-adapted prototype never
+lands as `prototyped` in the first place.
+
+## moneyhub.com migration
+
+The agent read `surprise: low` / `verbatim` as license to strip the
+page to a plain type-hero on a flat ground — faithful but
+forgettable, under-selling the redesign. Motivates: Discipline 3's
+"`low` ≠ generic" clause (brand-faithful + improvements + full
+signature preservation, not "the most obvious faithful
+interpretation").

--- a/plugins/stardust/skills/prototype/reference/prep-mode.md
+++ b/plugins/stardust/skills/prototype/reference/prep-mode.md
@@ -1,0 +1,94 @@
+# Prep mode (`--prep`)
+
+**Read when:** `prototype` is invoked with `--prep` (typically via the
+`prepare-migration` orchestrator). Default (non-prep) runs are
+unchanged by this file: per-slug shape brief, render via
+`$impeccable craft`, open in browser, iterate, approve.
+
+When invoked with `--prep`, prototype runs an extended pass that
+fills page-type gaps and writes canon. `--prep` adds three things on
+top of the standard procedure:
+
+## 1. Fill page-type gaps
+
+Identify every page type in `state.json.pages[].type` that doesn't
+yet have an approved archetype. For each gap, prototype one
+representative page (the user picks which slug, or the first page of
+that type by default):
+
+- `article`-typed pages with no approved article: prototype one
+- `listing`-typed pages with no approved listing: prototype one
+- `program`, `form`, `static` — same pattern
+- `landing` — the home; prototyped first if not already done
+- `unique`-typed pages — these don't get archetypes; they're
+  rendered as one-offs at migrate time
+
+The user picks one variant per type. Subsequent pages of the same
+type are migrated by forking that approval (Path A′ in
+`skills/migrate/SKILL.md`).
+
+## 2. Canon write-back on first approval
+
+The first prototype approved (default the home; override with
+`--canon-from <slug>`) becomes the **canon-author**. On approval,
+extract canon and write back per `reference/canon-extraction.md`:
+
+1. Chrome HTML → `stardust/canon/header.html`,
+   `stardust/canon/footer.html`, optional regions.
+2. Compound CSS → `stardust/canon/canon.css`.
+3. Pinned tokens → `DESIGN.json.extensions.canon.pinned`.
+4. Module canonical renderings →
+   `stardust/canon/modules/<id>.html`.
+5. Compositional moves (LLM-authored, 3–7 lines) →
+   `DESIGN.json.extensions.canon.compositionalMoves`.
+
+Reference all extracted files via `{ path, sha }` in
+`DESIGN.json.extensions.canon.files`. Each canon file carries a
+`stardust:canon` provenance comment naming source slug, source
+prototype, and region.
+
+## 3. Canon write-back on subsequent approvals
+
+For non-canon-author template approvals (article, listing, etc.),
+canon-extraction runs in **diff mode** per
+`reference/canon-extraction.md` § Conflict resolution:
+
+- **Net-new items** (a module not yet in canon, a new compound CSS
+  class, a new compositional move) → append to canon additively.
+  Add a history entry naming what was added.
+- **Match canon byte-for-byte** → no-op.
+- **Conflict with canon** → default is **log as deviation**: the
+  migrated/prototyped page carries the deviation inline marked with
+  `data-deviation="<reason>"`, and the page's `migrationDecisions[]`
+  records a `canon-deviation` entry. Canon stays unchanged.
+
+Override the default per-conflict via the prep summary if the user
+wants to promote the new variant to canon (which stale-flags
+downstream pages that consumed the changed item) or reject and
+re-iterate the prototype. Without an explicit override, the conflict
+logs as deviation and approval proceeds.
+
+## Prep summary
+
+```
+prototype --prep complete
+=========================
+
+Approved archetypes:
+  landing   home (V01 Polish)            canon-author
+  article   news/post-housing-summit
+  listing   news (the index)
+  program   programs/shelter
+  form      donate
+  static    about
+
+Canon: stardust/canon/ + DESIGN.json.extensions.canon
+  Sources:  home → article (1 deviation logged), listing (clean),
+            program (1 deviation logged), form (clean), static (clean)
+  Modules:  8 confirmed; canonical renderings written
+  Pinned:   sectionPadding, densityTier, typeScale set
+
+Next: $stardust migrate  (apply canon to every page in inventory)
+```
+
+Default mode is unchanged.

--- a/plugins/stardust/skills/stardust/SKILL.md
+++ b/plugins/stardust/skills/stardust/SKILL.md
@@ -21,7 +21,7 @@ sub-commands that delegate the actual design work to **impeccable**.
    > Stardust requires impeccable. Install it from
    > <https://github.com/pbakaus/impeccable> and re-run the command.
 2. **Run impeccable's context loader once per session.** Execute the loader at
-   `<harness>/skills/impeccable/scripts/load-context.mjs`. Its JSON output
+   `<harness>/skills/impeccable/scripts/load-context.mjs` (newer impeccable versions name it `scripts/context.mjs`; run whichever exists). Its JSON output
    tells you whether `PRODUCT.md` and `DESIGN.md` exist at the project root
    (these are the *target* state for stardust). Skip the loader if it already
    ran in this session's history.

--- a/plugins/stardust/skills/uplift/SKILL.md
+++ b/plugins/stardust/skills/uplift/SKILL.md
@@ -7,69 +7,58 @@ license: Apache-2.0
 # stardust:uplift
 
 One entry point. One URL. Three presales-quality redesign variants.
-
-`uplift` collapses the `extract → direct → prototype × 3` chain into a
-single opinionated command that picks every variability axis from the
-captured brand surface rather than asking the user. The output is the
-same as the long-form chain (state.json, brand-review.html, three
-proposed files, motion validation) — the user just doesn't have to
-coordinate it.
+`uplift` collapses `extract → direct → prototype × 3` into a single
+command that picks every variability axis from the captured brand
+surface instead of asking the user. Output matches the long-form
+chain (state.json, brand-review.html, three proposed files, motion
+validation).
 
 ## Opinionated defaults
 
-- **Single-page extract** — the homepage by default (the brand
-  owner's first surface) unless `--page <slug>` overrides.
-- **Brand-faithful Mode A** — palette + typography pinned. No
-  invented colors, no fonts outside the captured surface.
-- **Three variants, fixed role contract** — A is the green-light,
-  B is the design-team motivator, C is the visionary cinematic
-  pitch.
-- **Cinematic register auto-picked** — C's motion register is
-  selected from the captured PRODUCT.md Brand Personality per
-  `../prototype/reference/motion-registers.md` § Selection
-  heuristic.
-- **"What if..." candidates are evidence-shaped** — B and C each
-  pick one captured-but-underused trait, from the eight worked
-  candidates in `reference/what-if-candidates.md` or a derived
-  candidate per its § Extension rule. Different traits per variant.
-- **Validation cascade runs** — every gate in
-  `prototype/SKILL.md` Phases 2.5–2.8 fires, including cinematic
-  Pass 6 for variant C.
+- **Single-page extract** — homepage unless `--page <slug>` overrides.
+- **Brand-faithful Mode A** — palette + typography pinned; no invented
+  colors, no fonts outside the captured surface.
+- **Three variants, fixed role contract** — A green-light,
+  B design-team motivator, C visionary cinematic pitch.
+- **Cinematic register auto-picked** — from captured PRODUCT.md Brand
+  Personality per `../prototype/reference/motion-registers.md`
+  § Selection heuristic.
+- **"What if…" candidates are evidence-shaped** — B and C each pick
+  one captured-but-underused trait from the eight worked candidates
+  in `reference/what-if-candidates.md` or a derived candidate per its
+  § Extension rule. Different traits per variant.
+- **Validation cascade runs** — every gate in `prototype/SKILL.md`
+  Phases 2.5–2.8 fires, including cinematic Pass 6 for variant C.
 
 ## Inputs
 
-- `<URL>` — required. The page to redesign. Defaults to homepage when
-  the URL has no path (`https://example.com/` → home).
-- `--page <slug>` — optional. Override the slug if the URL points
-  elsewhere or the user wants a different surface.
-- `--cinematic-register <name>` — optional. Override the auto-picked
-  register for variant C. One of `arrival`, `kinetic-display`,
-  `live-systems`, `editorial`, `kinetic-grid`. Recorded as
-  `registerSource: "user-override"` in C's provenance.
-- `--two-variants` — optional. Render only A and C (skip B). Useful
-  when the brand surface is thin and a forced three-way differentiation
-  would produce a weak middle (per the stop condition below).
-- `--re-extract` — optional. Force a fresh crawl even when a prior
-  extraction of the same URL is < 7 days old (see § Setup,
-  reuse-if-fresh).
+- `<URL>` — required. Page to redesign; a path-less URL means home.
+- `--page <slug>` — optional slug override.
+- `--cinematic-register <name>` — optional override for variant C:
+  one of `arrival`, `kinetic-display`, `live-systems`, `editorial`,
+  `kinetic-grid`. Recorded as `registerSource: "user-override"` in
+  C's provenance.
+- `--two-variants` — render only A and C (skip B), for thin brand
+  surfaces where a forced three-way split would produce a weak middle
+  (see § Stop conditions).
+- `--re-extract` — force a fresh crawl even when a prior extraction
+  of the same URL is < 7 days old (see § Setup).
 
-There are no other flags. Everything else is derived from the
-captured brand surface or governed by the underlying skills'
-contracts.
+There are no other flags. Everything else is derived from the captured
+brand surface or governed by the underlying skills' contracts.
 
 ## Setup
 
-1. Run the master skill's setup
-   (`../stardust/SKILL.md` § Setup): impeccable dep check, context
-   loader, state read.
-2. Verify Playwright is available (`extract` will fail without it —
+1. Run the master skill's setup (`../stardust/SKILL.md` § Setup):
+   impeccable dep check, context loader, state read.
+2. Verify Playwright is available (`extract` fails without it —
    surface the same install message extract would).
-3. Read `stardust/state.json` if present. **Reuse-if-fresh:** when
-   a prior extraction of the same URL is < 7 days old, skip Phase 1
-   and render against the existing capture, with a one-line notice
-   ("reusing extraction from <date> — pass `--re-extract` for a
-   fresh crawl"). `--re-extract` forces a fresh crawl regardless of
-   age; extractions ≥ 7 days old re-extract without asking.
+3. Read `stardust/state.json` if present. **Reuse-if-fresh:** when a
+   prior extraction of the same URL is < 7 days old, skip Phase 1 and
+   render against the existing capture, with a one-line notice
+   ("reusing extraction from <date> — pass `--re-extract` for a fresh
+   crawl"). `--re-extract` forces a fresh crawl regardless of age;
+   extractions ≥ 7 days old re-extract without asking.
 
 ## Procedure
 
@@ -79,21 +68,17 @@ delegate to existing skills; phases 2, 2.5, 3, 6 are owned by
 
 ### Phase 1 — Extract (delegate to `stardust:extract`)
 
-Invoke `stardust:extract <URL> --single` (single-page mode).
-Extract owns:
+Invoke `stardust:extract <URL> --single`. Extract owns: the live
+Playwright render (standard wait recipe);
+`stardust/current/_brand-extraction.json` (palette + type + motifs +
+voice + system components + photography);
+`stardust/current/pages/home.json`;
+`stardust/current/brand-review.html` with tensions detectors applied
+(the load-bearing input for Phase 2); and descriptive PRODUCT.md /
+DESIGN.md (current state, not target).
 
-- Live Playwright render with the standard wait recipe.
-- `stardust/current/_brand-extraction.json` (palette + type + motifs
-  + voice + system components + photography).
-- `stardust/current/pages/home.json` (full per-page capture).
-- `stardust/current/brand-review.html` with the tensions detectors
-  applied — this is the load-bearing input for Phase 2.
-- `stardust/current/PRODUCT.md` and `DESIGN.md` (descriptive — the
-  current state, not the target).
-
-`uplift` does not crawl beyond one page. The brand surface from a
-single homepage is sufficient for three variants; multi-page extract
-is what `stardust:extract` (without `--single`) is for.
+`uplift` never crawls beyond one page — a single homepage suffices
+for three variants; multi-page extract is plain `stardust:extract`.
 
 ### Phase 2 — Tension and trait identification (owned by `uplift`)
 
@@ -102,11 +87,9 @@ Read `stardust/current/brand-review.html` § Tensions surfaced and
 
 #### 2a — `stardust/uplift-improvements.md`
 
-At least **3** specific weaknesses observed in the captured site —
-as many as the evidence supports, no fixed count. Same load-bearing
-contract as the existing presales workflow: without specifics,
-"make it better" has no claim. Category tags (MAY repeat across
-items when the evidence supports it):
+At least **3** specific weaknesses observed in the captured site — as
+many as the evidence supports, no fixed count. Without specifics,
+"make it better" has no claim. Category tags (MAY repeat):
 
 - `[dated-pattern]` — patterns the design world has moved past (be
   specific: "centered hero with stock photo + double CTA in primary
@@ -117,149 +100,106 @@ items when the evidence supports it):
   density issues
 - `[cliché]` — conventions the brand could move past while staying
   recognisably itself
-- `[missed-opportunity]` — the captured surface doesn't capitalise
-  on its own strengths ("captured photography is excellent but the
-  layout crops it to thumbnail-size")
+- `[missed-opportunity]` — the surface doesn't capitalise on its own
+  strengths ("captured photography is excellent but the layout crops
+  it to thumbnail-size")
 
 **Specificity bar — every item.** Each item cites a measurement,
 tension ID, or screenshot observation from the capture, names the
 pattern at fault, and proposes one concrete fix. An item that fails
 the bar is cut, not padded.
 
-**Audit consumption.** When `stardust/audit/<domain-slug>/audit.json`
-exists for this origin (written by the `stardust:audit` skill),
-consume its design findings as candidate improvements instead of
-re-deriving them from scratch — cite the finding IDs in the item's
-evidence and add the audit file to `readArtifacts`.
+**Audit consumption.** When
+`stardust/audit/<domain-slug>/audit.json` exists for this origin
+(written by `stardust:audit`), consume its design findings as
+candidate improvements instead of re-deriving them — cite finding IDs
+as evidence and add the audit file to `readArtifacts`.
 
 Refuse to proceed if fewer than 3 specific weaknesses can be named
-(see § Stop conditions).
-
-Format (mirrors the provenance shape used by the rest of stardust):
-
-```markdown
----
-_provenance:
-  writtenBy: stardust:uplift
-  writtenAt: <ISO-8601>
-  againstInput: <URL>
-  readArtifacts:
-    - stardust/current/_brand-extraction.json
-    - stardust/current/pages/<slug>.json
-    - stardust/current/brand-review.html
----
-
-# Improvements — <URL>
-
-1. **[<category-tag>]** <one-line headline> — <measurement /
-   tension ID / screenshot observation> · <pattern at fault> ·
-   fix: <one concrete fix>.
-2. **[<category-tag>]** … (≥ 3 items; tags may repeat)
-```
-
-The bracketed tag preceding each weakness is a category from the
-list above. The headline is the one-sentence summary the agent will
-restate when variant A's shape brief applies the fix.
+(§ Stop conditions). READ `reference/output-templates.md`
+§ Improvements file and write the artifact in exactly that format
+(provenance frontmatter; tagged, headline-first items).
 
 #### 2b — `stardust/uplift-questions.md`
 
 Six to eight "what if we leaned into…" candidates derived from the
-captured brand surface. Each candidate cites the captured evidence
-that makes it concrete. Candidates are drawn from the catalog in
-`reference/what-if-candidates.md` — eight worked examples that are
-the **floor, not a ceiling**:
+captured brand surface, each citing the captured evidence that makes
+it concrete. READ `reference/what-if-candidates.md` — its eight
+worked candidates (display-typography amplification, photography
+re-foregrounding, live-data promotion, signature-gesture extension,
+voice-register pivot, color-ladder re-weighting, audience-routing
+reframe, motif vocabulary swap) are the **floor, not a ceiling**.
 
-1. Display-typography amplification
-2. Photography re-foregrounding
-3. Live-data promotion
-4. Signature-gesture extension
-5. Voice-register pivot
-6. Color-ladder re-weighting
-7. Audience-routing reframe
-8. Motif vocabulary swap
-
-An out-of-catalog **derived** candidate is admissible when it
-carries the same evidence shape as the catalog entries: ≥ 2
-captured citations + an explicit disqualification test + the
-variant role it serves (per `reference/what-if-candidates.md`
+An out-of-catalog **derived** candidate is admissible when it carries
+the same evidence shape: ≥ 2 captured citations + an explicit
+disqualification test + the variant role it serves (per that file's
 § Extension rule). Record each candidate's source —
 `catalog | derived` — in the candidate list.
 
-For each candidate the agent generates: a one-line "what if…"
-phrasing, the captured evidence that makes the candidate concrete,
-the variant role it best serves (B's composition bet vs C's
-cinematic bet), and whether the candidate is **disqualified** for
-this brand (e.g. "Photography re-foregrounding disqualified — the
-captured photography is generic stock; amplifying it would expose
-the weakness").
-
-The disqualification step is what keeps the agent from reflexively
+For each candidate generate: a one-line "what if…" phrasing, the
+captured evidence, the variant role it best serves (B's composition
+bet vs C's cinematic bet), and whether it is **disqualified** for this
+brand (e.g. "Photography re-foregrounding disqualified — the captured
+photography is generic stock; amplifying it would expose the
+weakness"). The disqualification step keeps the agent from reflexively
 picking the same candidate for every brand.
 
 ### Phase 2.5 — Reference grounding (owned by `uplift`)
 
-When reference research is available (per
-`skills/stardust/reference/reference-research.md` — when to fire,
-the 3–5 reference budget, the evidence shape, and provenance
-recording are all defined there), ground the Phase 2 claims in
-real-world references before Phase 3 picks directions:
+READ `skills/stardust/reference/reference-research.md` (when to fire,
+the 3–5 reference budget, evidence shape, provenance recording).
+When reference research is available, ground the Phase 2 claims
+before Phase 3 picks directions:
 
 (a) **Ground each `[dated-pattern]` claim** in
     `uplift-improvements.md` with a named contemporary
-    counter-example — a real site / screen citation showing what
-    the pattern's world moved to.
+    counter-example — a real site / screen showing what the pattern's
+    world moved to.
 (b) **Anchor variant B's composition bet** with a named real-world
-    compositional anchor — a real screen whose composition the bet
-    resembles.
-(c) **Verify C's register pick** against how motion is actually
-    used in the vertical — does the register match observed
-    contemporary practice for this kind of brand?
+    compositional anchor — a real screen the bet resembles.
+(c) **Verify C's register pick** against observed contemporary motion
+    practice for this kind of brand.
 
-Record the references per reference-research.md's provenance
-contract (`_provenance.referencesUsed[]` on the artifact each
-grounding serves). When reference research is unavailable, skip
-with a one-line note in that provenance and proceed — the phase
-degrades gracefully.
+Record references per reference-research.md's provenance contract
+(`_provenance.referencesUsed[]` on the artifact each grounding
+serves). When reference research is unavailable, skip with a one-line
+note in that provenance and proceed — the phase degrades gracefully.
 
-This phase never replaces captured-evidence discipline:
-**references justify the MOVE, captured evidence justifies the
-TRAIT.** A candidate without captured citations is inadmissible no
-matter how well-referenced its move is.
+This phase never replaces captured-evidence discipline: **references
+justify the MOVE, captured evidence justifies the TRAIT.** A candidate
+without captured citations is inadmissible no matter how
+well-referenced its move is.
 
 ### Phase 3 — Pick three variant directions (owned by `uplift`)
 
-Default: three variants (A + B + C). When `--two-variants` is
-active, skip § 3c (B's candidate selection) and the direction.md
-authored in § 3d declares only A + C. Phase 4 then writes only
-`DESIGN-A` and `DESIGN-C` files at the project root, and Phase 5
-renders accordingly. All downstream contracts (variant
-differentiation, motion validation on C, summary in Phase 6)
-operate over the reduced variant set without modification.
+Default: three variants (A + B + C). Under `--two-variants`: skip
+§ 3c, declare only A + C in § 3d; Phase 4 writes only `DESIGN-A` /
+`DESIGN-C`, Phase 5 renders accordingly, and all downstream contracts
+(differentiation, motion validation on C, Phase 6 summary) operate
+over the reduced set unmodified.
 
 #### 3a — Pick the cinematic register for variant C
 
-Read PRODUCT.md Brand Personality (from `stardust/current/PRODUCT.md`)
-and apply the heuristic in `../prototype/reference/motion-registers.md`
-§ Selection heuristic. Record the picked register + the one-line
-rationale.
+Read Brand Personality in `stardust/current/PRODUCT.md` and apply
+`../prototype/reference/motion-registers.md` § Selection heuristic.
+Record the picked register + one-line rationale.
 
 #### 3b — Pick C's "what if" candidate
 
 The candidate must be the one the picked register **naturally
-amplifies through motion**. The per-candidate **Natural register
-for C** fields in `reference/what-if-candidates.md` are the single
-source of truth for the register→candidate mapping — read the
-mapping there (a derived candidate admitted per its § Extension
-rule must declare the same field). This file does not duplicate
+amplifies through motion**. READ the per-candidate **Natural register
+for C** fields in `reference/what-if-candidates.md` — the single
+source of truth for the register→candidate mapping (a derived
+candidate must declare the same field). This file does not duplicate
 the table.
 
-**Fallback when C's natural candidates are all disqualified:**
-re-pick the second-choice register — the next-best match from
-`../prototype/reference/motion-registers.md` § Selection heuristic
-— and take its natural candidate. If the second-choice register's
-natural candidates are also all disqualified, fall through to
-`--two-variants` via stop condition (d): drop B and let C take the
-strongest remaining non-disqualified candidate.
+**Fallback when C's natural candidates are all disqualified:** re-pick
+the second-choice register — the next-best match from
+`../prototype/reference/motion-registers.md` § Selection heuristic —
+and take its natural candidate. If that register's natural candidates
+are also all disqualified, fall through to `--two-variants` via stop
+condition (d): drop B and let C take the strongest remaining
+non-disqualified candidate.
 
 #### 3c — Pick B's "what if" candidate
 
@@ -269,174 +209,99 @@ Pick from the remaining (non-disqualified, non-C) candidates in
 1. A candidate that addresses a tension surfaced in
    `brand-review.html` § Tensions.
 2. A candidate whose visual move is **composition / IA / voice**
-   rather than motion (so B and C are differentiated by axis,
-   not just intensity).
+   rather than motion (so B and C differ by axis, not intensity).
 
 #### 3d — Author `stardust/direction.md`
 
-Write the resolved direction with three variant declarations:
-
-```markdown
-## Variant A — Faithful + improvements
-
-Role: risk-averse green-light. "Yes, that's us, with the obvious
-fixes."
-Composition: same as captured.
-Motion: static (no cinematic layer).
-Improvements applied: <list from uplift-improvements.md>.
-
-## Variant B — What if we amplified <captured trait>?
-
-Role: design-team motivator. The brand's underused capability
-foregrounded.
-What if: "<one-line "what if…" framing>"
-Captured trait amplified: <trait from uplift-questions.md>
-Evidence: <captured citation>
-Composition: <specific layout strategy that amplifies the trait>
-Motion: static (no cinematic layer).
-
-## Variant C — What if motion was part of the identity?
-
-Role: visionary pitch. The brand's third dimension — kinetic.
-What if: "<one-line "what if…" framing tied to the register>"
-Cinematic register: <register> (auto-picked from PRODUCT.md
-Brand Personality)
-Captured trait amplified: <trait — the one register naturally
-amplifies>
-Evidence: <captured citation>
-Composition: identical IA to A; the bet is motion, not layout.
-Motion: cinematic, register <register>.
-```
+READ `reference/output-templates.md` § direction.md variant
+declarations and write the resolved direction with one declaration
+block per variant (A: same IA + improvements, static; B: trait +
+evidence + layout strategy, static; C: register + trait + evidence,
+identical IA to A, cinematic).
 
 ### Phase 4 — Direct (delegate to `stardust:direct`)
 
-Invoke `stardust:direct` with the resolved direction. Pass the
+Invoke `stardust:direct` with the resolved direction, passing the
 three-variant declaration as the input phrase ("uplift presales
 redesign — three variants per stardust/direction.md"). Direct owns:
 
 - Mode A authoring of PRODUCT.md, DESIGN.md, DESIGN.json (root).
 - Per-variant DESIGN-A / DESIGN-B / DESIGN-C files.
-- The motion register block in DESIGN-C.json (read from the
-  direction.md declaration).
+- The motion register block in DESIGN-C.json (from direction.md).
 - IA-priority preservation audit.
 - Density floor enforcement.
 - Anti-toolbox audit.
 - Variant differentiation contract.
 
-`uplift` does not duplicate any of those checks; it relies on
-direct's existing validators to refuse if the variants violate
-the brand-faithful contract.
+`uplift` does not duplicate any of those checks; it relies on direct's
+validators to refuse if the variants violate the brand-faithful
+contract.
 
 ### Phase 5 — Prototype × 3 (delegate to `stardust:prototype`)
 
 Render **A first, then B and C**:
 
 1. **Render A** — invoke `stardust:prototype <slug>` scoped to
-   variant A. A establishes and **freezes the canon** (tokens,
-   chrome, module renderings) that B and C inherit; rendering it
-   first removes the ordering race.
-2. **Render B, then C** (default: sequential). B and C prototype
-   the *same slug*, and same-slug concurrent runs are last-write-
-   wins on `state.json` per
-   `../stardust/reference/state-machine.md` § Concurrency — so
-   in-place parallel rendering is unsafe. **Parallel is permitted
-   only via isolated workspace copies**: each subagent gets a copy
-   of the project (git worktree or directory copy) containing only
-   its own `DESIGN-<id>.json` at the root (siblings stashed), so
-   prototype's file-presence detection renders exactly that
-   variant. The subagent returns its `<slug>-<id>-shape.md`,
-   `<slug>-<id>-proposed.html` (and C's `-cinematic.html`) plus
-   provenance; the parent copies the artifacts back and performs
-   the **single** `state.json` update for both variants.
-3. **Open each prototype as it completes** (via the `open`
-   mechanics in Phase 6 step 1) rather than waiting for all three.
+   variant A. A establishes and **freezes the canon** (tokens, chrome,
+   module renderings) that B and C inherit; rendering it first removes
+   the ordering race.
+2. **Render B, then C** (default: sequential). B and C prototype the
+   *same slug*, and same-slug concurrent runs are last-write-wins on
+   `state.json` per `../stardust/reference/state-machine.md`
+   § Concurrency — in-place parallel rendering is unsafe. **Parallel
+   is permitted only via isolated workspace copies**: each subagent
+   gets a project copy (git worktree or directory copy) containing
+   only its own `DESIGN-<id>.json` at the root (siblings stashed) —
+   file presence is the only variant selector prototype has (no
+   `--variant` flag exists). The subagent returns its
+   `<slug>-<id>-shape.md`, `<slug>-<id>-proposed.html` (and C's
+   `-cinematic.html`) plus provenance; the parent copies artifacts
+   back and performs the **single** `state.json` update for both.
+3. **Open each prototype as it completes** (via the `open` mechanics
+   in Phase 6 step 1) rather than waiting for all three.
 
-Prototype detects the variant set from the per-variant `DESIGN-A`,
-`DESIGN-B`, `DESIGN-C` files that `direct` wrote in Phase 4 —
-authoring `<slug>-A-shape.md` / `-B-shape.md` / `-C-shape.md` and
-emitting `<slug>-A-proposed.html` / `<slug>-B-proposed.html` /
-`<slug>-C-proposed.html` per the variant-convergence detector
-contract (`../prototype/SKILL.md` § Phase 2.5 / Discipline 10).
+Prototype detects the variant set from the per-variant `DESIGN-A` /
+`DESIGN-B` / `DESIGN-C` files direct wrote in Phase 4 — authoring
+`<slug>-<id>-shape.md` and emitting `<slug>-<id>-proposed.html` per
+the variant-convergence detector contract (`../prototype/SKILL.md`
+§ Phase 2.5 / Discipline 10).
 
 **Cinematic motion fires per-variant from the per-variant DESIGN
-file**, not from a CLI flag. **Never pass `--cinematic` to
-prototype from uplift.** Because Phase 4 wrote
-`extensions.motion.register` into `DESIGN-C.json` only (A and B
-omit it), prototype's Phase 2.4 (motion application) fires only
-for variant C. Variant C emits both `<slug>-C-proposed.html`
-(the static reference) and `<slug>-C-cinematic.html` (the
-register-applied surface). Variants A and B render static, never
-acquiring the motion runtime.
+file, never from a CLI flag — never pass `--cinematic` to prototype
+from uplift.** Because Phase 4 wrote `extensions.motion.register`
+into `DESIGN-C.json` only (A and B omit it), prototype's Phase 2.4
+(motion application) fires only for variant C, which emits both
+`<slug>-C-proposed.html` (static reference) and
+`<slug>-C-cinematic.html` (register-applied surface). A and B render
+static, never acquiring the motion runtime.
 
-Prototype owns:
-
-- Page-shape brief authoring per Phase 1 of prototype.
-- Render via `$impeccable craft` delegation, per variant.
-- Phase 2.4 motion application for variants whose `DESIGN-<id>.json`
-  declares an `extensions.motion.register`.
-- Phases 2.5–2.8 quality gates (critique, audit, adapt, motion)
-  per variant.
-- Variant C's cinematic-mode gates (Pass 6) per
-  `../prototype/reference/motion-validation.md`.
-- Variant-convergence detector (≥ 2 structural changes per pair)
-  per Discipline 10.
-
-Multi-variant rendering is driven by the presence of multiple
-`DESIGN-<id>.json` files at the project root, not by a CLI selector
-— prototype has no `--variant <id>` input. That is exactly why the
-parallel path in step 2 requires isolated workspace copies with a
-single pinned `DESIGN-<id>.json` each: file presence is the only
-variant selector prototype has. The A-first ordering above is what
-keeps canon consistent across the B and C runs in either path.
+Prototype owns: page-shape brief authoring (its Phase 1); render via
+`$impeccable craft` per variant; Phase 2.4 motion application for
+variants declaring `extensions.motion.register`; Phases 2.5–2.8
+quality gates (critique, audit, adapt, motion) per variant; variant
+C's cinematic-mode gates (Pass 6) per
+`../prototype/reference/motion-validation.md`; and the
+variant-convergence detector (≥ 2 structural changes per pair) per
+Discipline 10.
 
 ### Phase 6 — Open and summarize (owned by `uplift`)
 
 After all three prototypes mark `prototyped` in `state.json`:
 
-1. **Confirm all three are open in the browser** — each variant was
-   opened as it completed (Phase 5 step 3); open any that weren't,
-   using the `open` shell command (not `playwright-cli open`) so VFS
-   paths are served via the preview service worker:
+1. **Confirm all three are open in the browser** — open any that
+   weren't opened as they completed, using the `open` shell command:
    ```
    open stardust/prototypes/<slug>-A-proposed.html
    open stardust/prototypes/<slug>-B-proposed.html
    open stardust/prototypes/<slug>-C-cinematic.html
    ```
-   `playwright-cli open` bypasses the preview service worker and produces
-   a FILE NOT FOUND error for VFS paths. Always use `open <vfs-path>` for
-   local prototype files.
-2. **Print the three-pitch summary** in the chat:
-
-   ```
-   uplift complete — three variants for <URL>
-
-   A · Tomorrow's version of the site you have today.
-      Improvements applied: <count>.
-      File: stardust/prototypes/<slug>-A-proposed.html
-      Pitch: "yes, that's us, fixed."
-
-   B · What if we amplified <captured trait>?
-      Trait: <name>.
-      Composition bet: <one-line summary>.
-      File: stardust/prototypes/<slug>-B-proposed.html
-      Pitch: "the brand's underused capability, foregrounded."
-
-   C · What if motion was part of the identity?
-      Cinematic register: <register>.
-      Motion bet: <one-line summary>.
-      File: stardust/prototypes/<slug>-C-cinematic.html
-      Pitch: "the brand's third dimension."
-
-   Differentiation: A vs B ≥ 2 changes (✓), A vs C ≥ 2 changes (✓),
-   B vs C ≥ 2 changes (✓).
-
-   Validation: all three pass critique + audit + adapt; C additionally
-   passes motion validation Pass 6.
-
-   Next: iterate any variant via chat ("make B's hero quieter") or
-   approve via the standard prototype approval flow (records the
-   approval in state.json).
-   ```
+   Never use `playwright-cli open` for local prototype files — it
+   bypasses the preview service worker and produces FILE NOT FOUND
+   for VFS paths; only `open <vfs-path>` serves them correctly.
+2. **Print the three-pitch summary** in the chat. READ
+   `reference/output-templates.md` § Three-pitch summary and emit
+   that exact shape (per-variant pitch + file + bet, differentiation
+   check line, validation line, next-steps line).
 
 The summary is the user's only direct touchpoint with the three
 variants. Keep it short — the work is on disk and openable.
@@ -449,15 +314,14 @@ variants. Keep it short — the work is on disk and openable.
 | B | "What if we amplified `<captured trait>`?" | One captured-but-underused trait foregrounded in IA / composition / voice | Static | Design team that wants brand exploration |
 | C | "What if motion was part of the identity?" | Same IA as A | Fully cinematic, register from brand surface | Visionary buyer + design lead |
 
-This contract is **non-negotiable**. The "C is cinematic" rule is
-how `uplift` reliably ships a third proposition that's defensibly
-different from A and B (rather than the C-cliff failure mode of
-"everything from B but bigger").
+This contract is **non-negotiable**. The "C is cinematic" rule is how
+`uplift` reliably ships a third proposition defensibly different from
+A and B, rather than the C-cliff failure mode of "everything from B
+but bigger."
 
 If the captured brand surface can't support three differentiated
-variants (e.g. the palette has only one color, the captured page
-has only two sections, the brand register doesn't map cleanly to
-any motion register), reduce to two variants (A + C) via
+variants (e.g. one-color palette, a two-section page, a brand register
+that maps to no motion register), reduce to two variants (A + C) via
 `--two-variants` rather than ship three weak ones.
 
 ## Hard constraints
@@ -467,29 +331,29 @@ them but relies on them being enforced:
 
 - **Mode A pinning** — palette + typography from captured brand
   surface. Enforced by `direct/SKILL.md` § Mode A.
-- **IA priority preservation** — configurator stays above the
-  fold, crisis affordances stay first-viewport, etc. Enforced
-  by `direct/SKILL.md` § IA-priority preservation audit.
+- **IA priority preservation** — configurator stays above the fold,
+  crisis affordances stay first-viewport, etc. Enforced by
+  `direct/SKILL.md` § IA-priority preservation audit.
 - **Density floor** — brand-register pages with > 5 sections cap
-  `sectionPadding.desktop` at ≤ 64px. Enforced by
-  `direct/SKILL.md` § Hard floor enforcement.
-- **Variant differentiation** — each variant differs from the
-  others by ≥ 2 changes. Enforced by `direct/SKILL.md` § Variant
+  `sectionPadding.desktop` at ≤ 64px. Enforced by `direct/SKILL.md`
+  § Hard floor enforcement.
+- **Variant differentiation** — each variant differs from the others
+  by ≥ 2 changes. Enforced by `direct/SKILL.md` § Variant
   differentiation contract.
-- **Captured images reused in semantic positions** — hero stays
-  hero, story image stays story image. Enforced by
+- **Captured images reused in semantic positions** — hero stays hero,
+  story image stays story image. Enforced by
   `prototype/reference/proposed-file-shell.md` § Content sourcing
   hierarchy.
-- **No fabricated content** — stats, addresses, quotes, named
-  persons rendered as `[data-placeholder]` not invented. Enforced
-  by `prototype/SKILL.md` Phase 2 § Content sourcing scan.
-- **C-cliff refusal for variant C** — variant C bets on motion,
-  not on "everything from B but more." Enforced by
-  `prototype/reference/motion-validation.md` § Pass 6f motion
-  C-cliff detector.
-- **Reduced-motion fallback for variant C** — every motion
-  element is neutralized under `prefers-reduced-motion: reduce`.
-  Enforced by `prototype/reference/motion-validation.md` § Pass 6b.
+- **No fabricated content** — stats, addresses, quotes, named persons
+  rendered as `[data-placeholder]`, not invented. Enforced by
+  `prototype/SKILL.md` Phase 2 § Content sourcing scan.
+- **C-cliff refusal for variant C** — C bets on motion, not on
+  "everything from B but more." Enforced by
+  `prototype/reference/motion-validation.md` § Pass 6f motion C-cliff
+  detector.
+- **Reduced-motion fallback for variant C** — every motion element is
+  neutralized under `prefers-reduced-motion: reduce`. Enforced by
+  `prototype/reference/motion-validation.md` § Pass 6b.
 
 When any of these gates refuses, `uplift` surfaces the refusal
 verbatim from the underlying skill — the user sees the specific
@@ -502,92 +366,65 @@ Stop and ask only if:
 (a) **Extract fails** — site unreachable, structure unparseable,
     bot-management blocks past the headed-Chrome fallback.
 (b) **Brand surface insufficient** — palette has fewer than 2
-    distinct colors after clustering; OR the captured page has
-    fewer than 3 sections; OR the captured PRODUCT.md Brand
-    Personality maps to none of the five motion registers.
-    Surface honestly: "the captured brand surface is too thin
-    for three differentiated variants — render one strong variant
-    instead?"
+    distinct colors after clustering; OR the captured page has fewer
+    than 3 sections; OR the captured PRODUCT.md Brand Personality
+    maps to none of the five motion registers. Surface honestly:
+    "the captured brand surface is too thin for three differentiated
+    variants — render one strong variant instead?"
 (c) **Improvements list empty** — Phase 2a cannot name 3 specific
     weaknesses. Without specifics, variant A has no brief and
     "uplift" has no claim. Surface honestly.
-(d) **Two candidates equally weak** — if B's "what if…" candidate
-    and C's cinematic candidate would amplify the same captured
-    trait, the variants would not differentiate. Switch to
-    `--two-variants` (A + C only).
+(d) **Two candidates equally weak** — if B's "what if…" candidate and
+    C's cinematic candidate would amplify the same captured trait,
+    the variants would not differentiate. Switch to `--two-variants`
+    (A + C only).
 (e) **Hard rule conflict** — captured palette has a single color,
-    captured typography has no display register, captured site
-    has no system components. Brand-faithful constraint
-    impossible without invention. Surface and ask.
+    captured typography has no display register, captured site has no
+    system components. Brand-faithful constraint impossible without
+    invention. Surface and ask.
 
 The skill **does not** stop for confirmation in normal flow. The
-"PROCEED. Run all phases without stopping" property of the
-original presales prompt is preserved.
+"PROCEED. Run all phases without stopping" property of the original
+presales prompt is preserved.
 
 ## Outputs
 
-```
-stardust/
-├── state.json                              ← extracted + 3× prototyped
-├── direction.md                            ← resolved direction + 3 variant declarations
-├── uplift-improvements.md                  ← load-bearing weakness list (≥ 3 items)
-├── uplift-questions.md                     ← 6–8 "what if…" candidate list with disqualifications
-├── current/                                ← from extract
-│   ├── PRODUCT.md
-│   ├── DESIGN.md
-│   ├── DESIGN.json
-│   ├── brand-review.html
-│   ├── _brand-extraction.json
-│   ├── _crawl-log.json
-│   ├── pages/<slug>.json
-│   └── assets/
-└── prototypes/
-    ├── <slug>-A-shape.md
-    ├── <slug>-A-proposed.html              ← faithful + improvements
-    ├── <slug>-B-shape.md
-    ├── <slug>-B-proposed.html              ← "what if amplifying <trait>"
-    ├── <slug>-C-shape.md
-    ├── <slug>-C-proposed.html              ← static fallback for C
-    ├── <slug>-C-cinematic.html             ← cinematic variant C
-    ├── lenis.min.js                        ← copied from skill assets
-    └── lenis.min.css
-
-PRODUCT.md                                  ← shared (Mode A)
-DESIGN.md / DESIGN.json                     ← shared
-DESIGN-A.md / DESIGN-A.json
-DESIGN-B.md / DESIGN-B.json
-DESIGN-C.md / DESIGN-C.json                 ← carries motion.register
-```
+`stardust/`: state.json (extracted + 3× prototyped), direction.md,
+uplift-improvements.md (≥ 3 items), uplift-questions.md (6–8
+candidates), `current/` (extract capture), `prototypes/`
+(`<slug>-<id>-shape.md` + `-proposed.html` per variant, plus
+`<slug>-C-cinematic.html` and the lenis runtime files). Project root:
+shared PRODUCT.md / DESIGN.md / DESIGN.json plus per-variant
+DESIGN-A/B/C files (DESIGN-C.json carries `motion.register`). To
+verify a completed run, READ `reference/output-templates.md`
+§ Output tree for the exact layout.
 
 ## Scope
 
 - One page per run. Multi-page redesigns use the standard
   `extract` → `direct` → `prototype` chain.
 - Three review surfaces, not a deployable bundle. After the brand
-  owner picks a variant, iterate via chat-driven impeccable
-  commands and approve via the standard `prototype` approval flow.
-  Migration is `stardust:migrate`.
+  owner picks a variant, iterate via chat-driven impeccable commands
+  and approve via the standard `prototype` approval flow. Migration
+  is `stardust:migrate`.
 
 ## References
 
-- `reference/what-if-candidates.md` — the eight worked
-  captured-trait amplification candidates that B and C pick from,
-  plus the § Extension rule for evidence-shaped derived candidates.
-- `skills/stardust/reference/reference-research.md` — procedure for
-  sourcing real-world design references (Phase 2.5): when to fire,
-  the 3–5 reference budget, the evidence shape, provenance
-  recording.
-- `../prototype/reference/motion-registers.md` — register catalog
-  and selection heuristic used in Phase 3a.
+- `reference/what-if-candidates.md` — eight worked trait candidates
+  + § Extension rule for derived candidates.
+- `reference/output-templates.md` — exact formats: improvements file,
+  direction.md declarations, three-pitch summary, output tree.
+- `skills/stardust/reference/reference-research.md` — Phase 2.5
+  procedure (when to fire, budget, evidence shape, provenance).
+- `../prototype/reference/motion-registers.md` — register catalog +
+  selection heuristic (Phase 3a).
 - `../prototype/reference/motion-validation.md` § Pass 6 —
-  cinematic-mode validation gates that fire for variant C.
-- `../prototype/SKILL.md` — multi-variant rendering and motion
-  driven by the per-variant `DESIGN-<id>.json` files `direct` wrote
-  in Phase 4, not by a CLI selector or flag (uplift never passes
-  `--cinematic`).
-- `../direct/SKILL.md` § Phase 2.6 — multi-variant fork; uplift
-  passes the three-variant declaration through.
+  cinematic-mode gates for variant C.
+- `../prototype/SKILL.md` — multi-variant rendering + motion driven by
+  per-variant `DESIGN-<id>.json` files, never a CLI selector or flag.
+- `../direct/SKILL.md` § Phase 2.6 — multi-variant fork; uplift passes
+  the three-variant declaration through.
 - `../stardust/reference/data-attributes.md` — structural section
-  attributes applied by prototype to all three variants.
-- `../prototype/reference/proposed-file-shell.md` — content
-  sourcing hierarchy and placeholder convention.
+  attributes applied to all variants.
+- `../prototype/reference/proposed-file-shell.md` — content sourcing
+  hierarchy and placeholder convention.

--- a/plugins/stardust/skills/uplift/reference/output-templates.md
+++ b/plugins/stardust/skills/uplift/reference/output-templates.md
@@ -1,0 +1,147 @@
+# uplift — output templates
+
+Exact formats for the three artifacts `uplift` authors directly. Each
+template is normative: field names, ordering, and wording anchors are
+part of the contract, not illustration.
+
+## § Improvements file (Phase 2a)
+
+`stardust/uplift-improvements.md` mirrors the provenance shape used by
+the rest of stardust:
+
+```markdown
+---
+_provenance:
+  writtenBy: stardust:uplift
+  writtenAt: <ISO-8601>
+  againstInput: <URL>
+  readArtifacts:
+    - stardust/current/_brand-extraction.json
+    - stardust/current/pages/<slug>.json
+    - stardust/current/brand-review.html
+---
+
+# Improvements — <URL>
+
+1. **[<category-tag>]** <one-line headline> — <measurement /
+   tension ID / screenshot observation> · <pattern at fault> ·
+   fix: <one concrete fix>.
+2. **[<category-tag>]** … (≥ 3 items; tags may repeat)
+```
+
+The bracketed tag preceding each weakness is a category from the list
+in SKILL.md Phase 2a. The headline is the one-sentence summary the
+agent will restate when variant A's shape brief applies the fix. When
+audit findings were consumed, add the audit file to `readArtifacts`.
+
+## § direction.md variant declarations (Phase 3d)
+
+`stardust/direction.md` declares the resolved direction with one block
+per variant (omit B under `--two-variants`):
+
+```markdown
+## Variant A — Faithful + improvements
+
+Role: risk-averse green-light. "Yes, that's us, with the obvious
+fixes."
+Composition: same as captured.
+Motion: static (no cinematic layer).
+Improvements applied: <list from uplift-improvements.md>.
+
+## Variant B — What if we amplified <captured trait>?
+
+Role: design-team motivator. The brand's underused capability
+foregrounded.
+What if: "<one-line "what if…" framing>"
+Captured trait amplified: <trait from uplift-questions.md>
+Evidence: <captured citation>
+Composition: <specific layout strategy that amplifies the trait>
+Motion: static (no cinematic layer).
+
+## Variant C — What if motion was part of the identity?
+
+Role: visionary pitch. The brand's third dimension — kinetic.
+What if: "<one-line "what if…" framing tied to the register>"
+Cinematic register: <register> (auto-picked from PRODUCT.md
+Brand Personality)
+Captured trait amplified: <trait — the one register naturally
+amplifies>
+Evidence: <captured citation>
+Composition: identical IA to A; the bet is motion, not layout.
+Motion: cinematic, register <register>.
+```
+
+## § Three-pitch summary (Phase 6)
+
+Printed in the chat after all variants mark `prototyped`:
+
+```
+uplift complete — three variants for <URL>
+
+A · Tomorrow's version of the site you have today.
+   Improvements applied: <count>.
+   File: stardust/prototypes/<slug>-A-proposed.html
+   Pitch: "yes, that's us, fixed."
+
+B · What if we amplified <captured trait>?
+   Trait: <name>.
+   Composition bet: <one-line summary>.
+   File: stardust/prototypes/<slug>-B-proposed.html
+   Pitch: "the brand's underused capability, foregrounded."
+
+C · What if motion was part of the identity?
+   Cinematic register: <register>.
+   Motion bet: <one-line summary>.
+   File: stardust/prototypes/<slug>-C-cinematic.html
+   Pitch: "the brand's third dimension."
+
+Differentiation: A vs B ≥ 2 changes (✓), A vs C ≥ 2 changes (✓),
+B vs C ≥ 2 changes (✓).
+
+Validation: all three pass critique + audit + adapt; C additionally
+passes motion validation Pass 6.
+
+Next: iterate any variant via chat ("make B's hero quieter") or
+approve via the standard prototype approval flow (records the
+approval in state.json).
+```
+
+Under `--two-variants`, drop the B block and the A-vs-B / B-vs-C
+differentiation lines.
+
+## § Output tree
+
+Full on-disk layout after a successful run:
+
+```
+stardust/
+├── state.json                              ← extracted + 3× prototyped
+├── direction.md                            ← resolved direction + 3 variant declarations
+├── uplift-improvements.md                  ← load-bearing weakness list (≥ 3 items)
+├── uplift-questions.md                     ← 6–8 "what if…" candidate list with disqualifications
+├── current/                                ← from extract
+│   ├── PRODUCT.md
+│   ├── DESIGN.md
+│   ├── DESIGN.json
+│   ├── brand-review.html
+│   ├── _brand-extraction.json
+│   ├── _crawl-log.json
+│   ├── pages/<slug>.json
+│   └── assets/
+└── prototypes/
+    ├── <slug>-A-shape.md
+    ├── <slug>-A-proposed.html              ← faithful + improvements
+    ├── <slug>-B-shape.md
+    ├── <slug>-B-proposed.html              ← "what if amplifying <trait>"
+    ├── <slug>-C-shape.md
+    ├── <slug>-C-proposed.html              ← static fallback for C
+    ├── <slug>-C-cinematic.html             ← cinematic variant C
+    ├── lenis.min.js                        ← copied from skill assets
+    └── lenis.min.css
+
+PRODUCT.md                                  ← shared (Mode A)
+DESIGN.md / DESIGN.json                     ← shared
+DESIGN-A.md / DESIGN-A.json
+DESIGN-B.md / DESIGN-B.json
+DESIGN-C.md / DESIGN-C.json                 ← carries motion.register
+```

--- a/plugins/stardust/tile.json
+++ b/plugins/stardust/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe/stardust",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "summary": "Redesign an existing website to make it better. Built on top of impeccable.",
   "skills": {
     "stardust": {


### PR DESCRIPTION
Part 2 of the tessl-review quality pass (part 1: #233). Restructures the four remaining sub-80 skills (deploy 75, direct 73, prototype 78, uplift 78) under a strict design-regression-minimizing contract.

## The contract
- **Every rule, gate, discipline, and refusal condition stays inline** in SKILL.md (tersened, never moved) — in a skill plugin the prose is the program, and a rule that lives only in an unloaded file silently never fires (the L7/F6 lesson from #232).
- Only **rationale, historical narratives, worked examples, and flag-gated modal flows** (`--prep`, `--add-variant`) move to reference files.
- Every extracted reference is wired with an **imperative READ gate** at its consumption point — including inside deploy's Step-7 sub-agent brief template, so dispatched block agents are told to read the extracted disciplines.
- **Rule-preservation audited per skill**: zero deletions (deploy's #NN finding set verified mechanically by `comm`; direct by 27-token grep).

## Line counts
| Skill | Before | After | New reference files |
|---|---|---|---|
| deploy | 892 | 498 | decode-disciplines, encode-contract, font-strategy, anti-patterns, runtime-bootstrap |
| direct | 1596 | ~400 | prep-mode, add-variant, mode-notes |
| prototype | 1486 | 1215 (deliberately conservative — design-critical core) | prep-mode, lessons |
| uplift | 593 | 430 | output-templates |

## A/B validation (restructured docs followed *as written*, on scratch copies of the seven-site validation project)
- **deploy**: docs-page conversion rebuilt from the new doc — **41/41 QA green, full baseline match**, plus one real focus-ring specificity bug caught that the baseline run missed. All read gates resolved; conditional gates correctly did not fire (font-strategy never read — the brand ships no webfonts).
- **direct**: same phrase + same seed input — **structurally equivalent on every load-bearing field** (mode, pins, all 4 seed dimensions, all 4 brand-faithful inversions, improvements F-id groups, motion register, density, ia-fidelity). Two detail divergences had the restructured run *more* doc-compliant than baseline. (Caveat: scratch reset left direction.md visible; agent re-derived independently.)
- A/B-evidenced additions folded in: deploy **§ Page templates** (the Template: metadata mechanism was undocumented in old and new docs alike), harness-parity notes, hardened `collectNodes` for mixed text+inline cells, direct Mode A research clarification + craft in the roll list, impeccable pointer fixes (teach.md / load-context.mjs renamed upstream), moved-section cross-refs repaired.

## Known follow-ups (pre-existing spec gaps surfaced by A/B, out of scope here)
intent-dimensions §8 trigger vocabulary for install/sign-up funnels; orphaned-direction handling in direct Setup 4; which slugs get improvements lists on multi-page runs; audit-benchmark anchor reuse rules.

Versions aligned at 0.14.5 (plugin.json / tile.json / marketplace.json / CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)