### PR TITLE
stardust:deploy — catch per-instance fidelity on the first pass (#90–92)

### DIFF
--- a/plugins/stardust/skills/deploy/IMPROVEMENTS.md
+++ b/plugins/stardust/skills/deploy/IMPROVEMENTS.md
@@ -724,3 +724,30 @@ Implemented and smoke-tested in crawl.mjs.
 - [ ] #87 content-diff JOIN/SPLIT concat-matching (node-granularity false 🔴 → 🟡 advisory) — diff SKILL.md documents the limitation; code fix pending (stardust-style e2e, learning L8)
 - [x] #88 crawl.mjs: verbatim slash forms + key-dedupe + 404 slash-retry; reducedMotion emulation + settle; codeBlocks[] capture — extract (stardust-style e2e, learnings L1/L2/L3, smoke-tested live)
 - [x] #89 --no-save playwright installs pruned by later npm i → per-skill re-probe rule; token-hygiene check moved to first hands-off commit; partial-inventory broken-link carve-out; cinematic-pickup sentence corrected — extract/stardust/migrate/prototype SKILLs (learnings L7/L6/L4/L5)
+
+---
+
+## 2026-07 Fairmas e2e — per-instance fidelity on the first pass
+
+- [x] #90 Front-loaded **style-fingerprint probe** (`scripts/style-fingerprint.mjs`) added as a Step-1
+  pre-block gate: clusters each sibling instance by a COMBINED signature — computed style-delta
+  (bg/border/color/bg-image/weight/align) **and** structural (`hasImg`/`hasSvg`/childCount) — and flags
+  any group with >1 cluster as a per-instance variation the block must reproduce. The structural half is
+  load-bearing: image-vs-image-less cards and other `:has()`/`:not()` variants share top-level computed
+  style, so a style-only probe misses them. Complements Step 10's post-deploy `content-diff` by catching
+  the variation BEFORE block code. Evidence: contact dept buttons flattened (all styled alike when only
+  the middle is accent) with no probe → blog listing (active filter chip + 24 image vs 4 image-less
+  navy title-cards) correct on the first pass with it. — SKILL.md Step 1 + Checklist.
+- [x] #91 **Token-completeness gate** — SKILL.md Step 3. A `var(--x)` a lifted block CSS references but
+  the foundation `:root` never defines **silently invalidates the whole declaration** (undefined
+  `--navy-700` in a gradient → background dropped → navy card renders light, no error/lint). Added the
+  `comm -23` grep of `blocks/**/*.css` `var()`s vs `styles.css` `:root` (must be empty) to the foundation
+  and checklist. Distinct class from variation-flattening; caught by grep, not eyeball.
+- [x] #92 **`content-diff` per-instance/role check promoted from "optional" to REQUIRED** for the first
+  page of each template — SKILL.md Step 10. The atomic-delivery/layout gates (one `<h1>`, grids compute
+  `grid`) pass GREEN while a per-instance detail is wrong (uniform card grid when one card is accent), so
+  those gates cannot be the last word. Pairs with #90: fingerprint catches variation before block code,
+  content-diff confirms it survived DA after deploy.
+- [x] Added `scripts/render-harness.mjs` — reproduces EDS block decoration locally (inject styles + block
+  CSS, run each `decorate()`, screenshot) so first-pass fidelity is verifiable with NO DA/dev-server and
+  even when `DA_TOKEN` is expired (fidelity is decided at conversion time, not deploy time).

--- a/plugins/stardust/skills/deploy/SKILL.md
+++ b/plugins/stardust/skills/deploy/SKILL.md
@@ -235,7 +235,10 @@ compute `grid`) still pass. So run the proactive probe up front:
 `node skills/deploy/scripts/style-fingerprint.mjs "file://<abs>/<proto>.html"`. For every group of
 sibling instances it clusters each instance by a COMBINED signature — computed **style-delta**
 (`background/border/color/background-image/weight/align`) AND **structural** (`hasImg`, `hasSvg`,
-child count) — and reports any group with >1 cluster as a variation the owning block MUST reproduce.
+child count) — and reports any group with >1 cluster as a **candidate** per-instance variation for
+the owning block to reproduce. It is advisory: it will also flag legitimate variation (a footer with
+one bold link among plain ones), so filter false positives with judgment — but never flatten a real
+variant (an active chip, an accent CTA, an image-less card) just because the block treats siblings uniformly.
 The structural half is load-bearing: image-vs-image-less cards (and any `:has()`/`:not()`-driven
 variant) share the same top-level computed style, so a style-only probe misses them — include the
 structural signals. The manifest becomes the block author's checklist; this is the pre-block

--- a/plugins/stardust/skills/deploy/SKILL.md
+++ b/plugins/stardust/skills/deploy/SKILL.md
@@ -226,6 +226,21 @@ team: team-hero, team-roster, work-style, recent, careers, closing
 
 A useful pattern: dispatch the `Explore` subagent at thoroughness=quick with this exact ask. You don't need a 22-pattern punch list — you need filenames + section names. **Resist the urge to "find shared patterns."** Pattern reuse will emerge organically when two sections turn out to be byte-identical.
 
+**Fingerprint per-instance variation BEFORE writing block code (#90).** A section-name list is
+copy-level; it does NOT reveal that instances *inside* a repeated group look different — an active
+filter chip vs its outline siblings, a filled accent CTA among outline CTAs, image cards vs
+image-less title-cards. Those are the details a copy-driven conversion silently flattens (a whole
+grid of identical cards, one CTA styled like the rest), and the mandatory gates (one `<h1>`, grids
+compute `grid`) still pass. So run the proactive probe up front:
+`node skills/deploy/scripts/style-fingerprint.mjs "file://<abs>/<proto>.html"`. For every group of
+sibling instances it clusters each instance by a COMBINED signature — computed **style-delta**
+(`background/border/color/background-image/weight/align`) AND **structural** (`hasImg`, `hasSvg`,
+child count) — and reports any group with >1 cluster as a variation the owning block MUST reproduce.
+The structural half is load-bearing: image-vs-image-less cards (and any `:has()`/`:not()`-driven
+variant) share the same top-level computed style, so a style-only probe misses them — include the
+structural signals. The manifest becomes the block author's checklist; this is the pre-block
+complement to Step 10's post-deploy `content-diff` (which catches the same class of miss too late).
+
 ### 2. Decide names + reuse — LOCK BEFORE WRITING ANY CODE
 
 Naming rules:
@@ -270,6 +285,18 @@ Update `styles/styles.css` to the following — and ONLY the following:
 That's it. No section-style classes. No motion primitives. No utility classes beyond the button system.
 
 `scripts/scripts.js` stays minimal — only the page boot. No reveal-on-scroll. No marquee init. No header scroll-state. Per-block animation is owned by per-block CSS.
+
+**Token-completeness gate — every `var(--x)` a block references MUST be defined in `:root` (#91).**
+Lifting a section's CSS into a block routinely drags in a token the block author never added to the
+foundation (`var(--navy-700)` in a gradient, `var(--accent-2)` in a hover). A referenced-but-undefined
+custom property **silently invalidates the WHOLE declaration** — `background: linear-gradient(var(--navy) 0%, var(--navy-700) 100%)`
+with `--navy-700` undefined drops the entire background and the element falls back (a navy card renders
+light), with no error and no lint flag. Gate it mechanically after the foundation and before deploy:
+```bash
+comm -23 <(grep -rhoE 'var\(--[a-z0-9-]+\)' blocks/**/*.css | sed 's/var(//;s/)//' | sort -u) \
+        <(grep -oE '\--[a-z0-9-]+' styles/styles.css | sort -u)   # MUST be empty
+```
+Any line printed is a token a block uses that `:root` doesn't define — add it to the foundation `:root`.
 
 ### 4. Self-host fonts and minimize CLS — never put font loads in `head.html`
 
@@ -729,9 +756,17 @@ for (const n of ['hero','quick','used','stats','service','offers','brands','loca
 
 Cross-check each flag against the prototype: full-bleed is correct only where the prototype section has no inner max-width wrapper.
 
-## Step 10 — Visual + structural diff & reconcile (optional, recommended)
+## Step 10 — Visual + structural diff & reconcile (content-diff REQUIRED)
 
 After deploy, reconcile the EDS page against the source prototype with **two complementary probes — run BOTH** (#78). They catch disjoint failure classes; either alone gives a false "looks fine":
+
+**The `content-diff` per-instance/role check is a REQUIRED gate for the first page of each template (#92),
+not optional.** The atomic-delivery gates verify structure/layout (one `<h1>`, grids compute `grid`) and
+pass GREEN while a per-instance detail is wrong — a card grid styled uniformly when one card is accent, an
+active chip rendered like its siblings. Those are exactly the misses `content-diff` sees and the layout
+gates cannot. So the page is not `deployed` until `content-diff` shows **0 structural 🔴** for the first
+page of each template. Pair it with the Step 1 fingerprint (#90): the fingerprint catches the variation
+BEFORE block code, `content-diff` confirms it survived DA AFTER deploy.
 
 1. **`skills/diff/scripts/visual-diff.mjs` — the PIXEL/layout probe.** Reasons about rendered geometry: stretched images (#36), dropped max-width wraps (#37), blank renders (#40), surface/ground colour flips (#59). Good at "this looks broken." STRUCTURALLY BLIND to "the right text is in the wrong slot" or "one CTA is gone" — those keep full pixels and plausible colours, so no flag fires.
 2. **`skills/diff/scripts/content-diff.mjs` — the STRUCTURAL content+type probe.** Extracts an ordered, role-classified inventory ({heading, eyebrow, cta+href, body}) from each `<main>` — classifying by computed style + tag so the prototype's `.ds-*` DOM and the EDS block DOM compare symmetrically — and DIFFS them: `MISSING CTA/HEADING/EYEBROW` (🔴 dropped content — caught the `the-place` CTA), `ROLE SWAP` (🔴 same text, wrong slot — caught the `the-people` eyebrow↔body scramble #76), `MISSING BODY`/`EXTRA` (🟡 placeholder→real-copy or invented prose), and `FONT FORK` (🟠 a matched line whose rendered FACE differs, by **width probe** not `document.fonts.check` — the #77 method, grouped into one advisory). This is the layer the pixel probe can't see.
@@ -849,6 +884,9 @@ A block that builds its own layout/view wrapper (common for interactive blocks t
 - [ ] Each section in the prototype `<main>` has a corresponding block call in the content page.
 - [ ] **Content page is a body fragment** for the Source-API deploy: starts at `<body>`, **no `<!DOCTYPE>`/`<html>`/`<head>`** — EDS injects the project `head.html` at delivery. (Only the mount deploy tolerates a full doc.)
 - [ ] Ran `node skills/deploy/scripts/sanitise.js` on the content before any DA write (non-ASCII → entities).
+- [ ] **Per-instance variation fingerprinted (#90)** — ran `style-fingerprint.mjs` on the prototype BEFORE block code; every group with >1 style/structural cluster (active chip, accent CTA, image vs image-less card) is reproduced by its block, not flattened.
+- [ ] **Token-completeness clean (#91)** — every `var(--x)` referenced in `blocks/**/*.css` is defined in `styles.css` `:root` (the `comm -23` grep prints nothing); no undefined-var-dropped background/color.
+- [ ] **`content-diff` shows 0 structural 🔴 (#92)** for the first page of each template — required, not optional.
 - [ ] `<header></header>` and `<footer></footer>` are EMPTY (static fragments load automatically via `postlcp.js`).
 - [ ] **Page begins with a `metadata` block** (#34): real Title (≤60 chars, from the `<h1>`, never a block name) + Description (~155 chars). `header: off` / `footer: off` / `Robots` rows go in the same block when needed.
 - [ ] **Exactly one `<h1>` per page** (#35): the hero/lead headline is `<h1>`; section titles are `<h2>`/`<h3>`; no headline left as a bare `<div>` (interactive blocks included — the lead title is `<h1>` in server-visible markup).

--- a/plugins/stardust/skills/deploy/scripts/render-harness.mjs
+++ b/plugins/stardust/skills/deploy/scripts/render-harness.mjs
@@ -1,4 +1,13 @@
-// Reproduce EDS block decoration locally (no DA / dev-server) to verify conversion fidelity.
+/**
+ * render-harness.mjs — reproduce EDS block decoration locally (no DA / dev-server).
+ *
+ * Injects styles.css + each block's CSS, runs every block's decorate() over the authored
+ * content, and screenshots — so first-pass conversion fidelity is verifiable even when
+ * DA_TOKEN is expired (fidelity is decided at conversion time, not deploy time).
+ *
+ * Usage:
+ *   node render-harness.mjs <content/path.html> <out.png> <block-name> [block-name ...]
+ */
 import { chromium } from 'playwright';
 import fs from 'fs';
 const contentPath = process.argv[2], out = process.argv[3];

--- a/plugins/stardust/skills/deploy/scripts/render-harness.mjs
+++ b/plugins/stardust/skills/deploy/scripts/render-harness.mjs
@@ -1,0 +1,25 @@
+// Reproduce EDS block decoration locally (no DA / dev-server) to verify conversion fidelity.
+import { chromium } from 'playwright';
+import fs from 'fs';
+const contentPath = process.argv[2], out = process.argv[3];
+const blocks = process.argv.slice(4);
+const raw = fs.readFileSync(contentPath, 'utf8');
+const main = raw.match(/<main>([\s\S]*?)<\/main>/)[1]
+  .replace(/<div class="metadata">[\s\S]*?<\/div>\s*<\/div>\s*<\/div>/, ''); // drop metadata block
+const styles = fs.readFileSync('eds/styles/styles.css', 'utf8');
+const blockCss = blocks.map((n) => { try { return fs.readFileSync(`eds/blocks/${n}/${n}.css`, 'utf8'); } catch { return ''; } }).join('\n');
+const b = await chromium.launch();
+const p = await b.newPage({ viewport: { width: 1280, height: 900 } });
+await p.setContent(`<!doctype html><html><head><meta charset="utf-8"><style>body{margin:0}main .section{padding:0}${styles}\n${blockCss}</style></head><body><main>${main}</main></body></html>`, { waitUntil: 'networkidle' });
+for (const name of blocks) {
+  const js = fs.readFileSync(`eds/blocks/${name}/${name}.js`, 'utf8').replace(/export default\s+/, '');
+  await p.addScriptTag({ content: `window.__b=window.__b||{};window.__b[${JSON.stringify(name)}]=(function(){${js}\nreturn decorate;})();` });
+}
+await p.evaluate((names) => {
+  names.forEach((n) => document.querySelectorAll('.' + n).forEach((el) => { try { window.__b[n](el); } catch (e) { el.setAttribute('data-err', e.message); } }));
+}, blocks);
+await p.waitForTimeout(1200);
+await p.screenshot({ path: out, fullPage: true });
+const errs = await p.evaluate(() => [...document.querySelectorAll('[data-err]')].map((e) => e.className + ': ' + e.getAttribute('data-err')));
+console.log('rendered', out, '| block errors:', JSON.stringify(errs));
+await b.close();

--- a/plugins/stardust/skills/deploy/scripts/style-fingerprint.mjs
+++ b/plugins/stardust/skills/deploy/scripts/style-fingerprint.mjs
@@ -1,6 +1,16 @@
-// Style-fingerprint probe: render a prototype and, for every group of sibling
-// elements, flag where instances DIFFER in computed style — the per-instance
-// details that a copy-only conversion flattens. Output feeds the block author.
+/**
+ * style-fingerprint.mjs — proactive per-instance variation probe (deploy Step 1, #90).
+ *
+ * Renders a prototype and, for every group of sibling instances, clusters each by a
+ * COMBINED signature — computed style-delta (bg/border/color/bg-image/weight/align) AND
+ * structural (hasImg/hasSvg/childCount). Any group with >1 cluster is a candidate
+ * per-instance variation the owning block should reproduce (the agent filters legitimate
+ * variation). The structural half catches :has()/:not() variants a style-only probe misses.
+ *
+ * Usage:
+ *   node style-fingerprint.mjs "file:///abs/path/to/<prototype>.html"
+ * Output: JSON — [{ section, bg, color, variationGroups:[{selector,count,variants:[{style,indices}]}] }]
+ */
 import { chromium } from 'playwright';
 const url = process.argv[2];
 const b = await chromium.launch();
@@ -12,7 +22,7 @@ const out = await p.evaluate(() => {
     // STYLE-DELTA signals (the instance's own computed style)
     bg: s.backgroundColor, border: s.borderColor + ' ' + s.borderWidth, color: s.color,
     bgImg: s.backgroundImage === 'none' ? 'none' : 'img', weight: s.fontWeight,
-    align: s.textAlign, radius: s.borderTopLeftRadius,
+    align: s.textAlign,
     // STRUCTURAL/CONTENT signals (what the instance CONTAINS — catches :has()/:not() variants)
     hasImg: !!el.querySelector('img,picture'), hasSvg: !!el.querySelector('svg'),
     kids: el.children.length }; };

--- a/plugins/stardust/skills/deploy/scripts/style-fingerprint.mjs
+++ b/plugins/stardust/skills/deploy/scripts/style-fingerprint.mjs
@@ -1,0 +1,51 @@
+// Style-fingerprint probe: render a prototype and, for every group of sibling
+// elements, flag where instances DIFFER in computed style — the per-instance
+// details that a copy-only conversion flattens. Output feeds the block author.
+import { chromium } from 'playwright';
+const url = process.argv[2];
+const b = await chromium.launch();
+const p = await b.newPage({ viewport: { width: 1280, height: 900 } });
+await p.goto(url, { waitUntil: 'networkidle', timeout: 60000 });
+await p.waitForTimeout(1200);
+const out = await p.evaluate(() => {
+  const KEY = (el) => { const s = getComputedStyle(el); return {
+    // STYLE-DELTA signals (the instance's own computed style)
+    bg: s.backgroundColor, border: s.borderColor + ' ' + s.borderWidth, color: s.color,
+    bgImg: s.backgroundImage === 'none' ? 'none' : 'img', weight: s.fontWeight,
+    align: s.textAlign, radius: s.borderTopLeftRadius,
+    // STRUCTURAL/CONTENT signals (what the instance CONTAINS — catches :has()/:not() variants)
+    hasImg: !!el.querySelector('img,picture'), hasSvg: !!el.querySelector('svg'),
+    kids: el.children.length }; };
+  const sig = (f) => `${f.bg}|${f.border}|${f.color}|${f.bgImg}|${f.weight}|${f.align}|img:${f.hasImg}|svg:${f.hasSvg}|kids:${f.kids}`;
+  const sections = [...document.querySelectorAll('[data-section],section')];
+  const report = [];
+  for (const sec of sections) {
+    const name = sec.getAttribute('data-section') || sec.className.split(' ')[0] || 'section';
+    const s = getComputedStyle(sec);
+    const groups = [];
+    // find containers whose direct children form a repeated group (>=2 same-tag+class)
+    const containers = new Set([sec, ...sec.querySelectorAll('*')]);
+    for (const c of containers) {
+      const kids = [...c.children];
+      if (kids.length < 2) continue;
+      const byKey = {};
+      kids.forEach((k, i) => { const key = k.tagName + '.' + (k.className.toString().split(' ')[0] || ''); (byKey[key] ||= []).push({ i, el: k }); });
+      for (const [key, members] of Object.entries(byKey)) {
+        if (members.length < 2) continue;
+        const clusters = {};
+        members.forEach((m) => { const g = sig(KEY(m.el)); (clusters[g] ||= []).push(m.i); });
+        const variants = Object.entries(clusters);
+        if (variants.length > 1) { // INTRA-GROUP VARIATION — the thing to preserve
+          groups.push({ selector: key, count: members.length,
+            variants: variants.map(([g, idx]) => ({ style: g, indices: idx })) });
+        }
+      }
+    }
+    if (name && (groups.length || s.backgroundColor !== 'rgba(0, 0, 0, 0)')) {
+      report.push({ section: name, bg: s.backgroundColor, color: s.color, variationGroups: groups });
+    }
+  }
+  return report;
+});
+console.log(JSON.stringify(out, null, 1));
+await b.close();


### PR DESCRIPTION
## Problem

Found in a real Fairmas end-to-end conversion. `stardust:deploy` re-authors a prototype into an author-friendly EDS content model, and by design abstracts sibling sections into reusable blocks. But that means **per-instance variation gets silently flattened** — a card grid rendered uniformly when only the middle card is an accent button; an active filter chip styled like its outline siblings — and **every mandatory gate still passes green** (one `<h1>`, grids compute `grid`, blocks decorated, 0 errors). The layout gates check structure, not per-element treatment.

The root cause is a seam: Step 1's audit is deliberately copy-level ("section list, resist finding patterns"), and Step 5 *trusts the agent to notice* variants. Nothing catches per-instance variation **before** block code; Step 10's diff catches it, but it's marked optional and runs after deploy.

## Changes (findings #90–92)

- **#90 — style-fingerprint probe (`scripts/style-fingerprint.mjs`), Step 1.** A proactive pre-block gate: for every group of sibling instances, cluster by a **combined** signature — computed style-delta (bg/border/color/bg-image/weight/align) **and** structural (`hasImg`/`hasSvg`/childCount). Any group with >1 cluster is a variation the block must reproduce. The structural half is load-bearing: image-vs-image-less cards (and any `:has()`/`:not()` variant) share top-level computed style, so a style-only probe misses them.
- **#91 — token-completeness gate, Step 3.** A `var(--x)` a lifted block CSS references but `:root` never defines **silently invalidates the whole declaration** (undefined `--navy-700` in a gradient → background dropped → a navy card renders light, no error/lint). Added a one-line `comm -23` grep of `blocks/**/*.css` `var()`s vs `styles.css` `:root` to the foundation + checklist.
- **#92 — `content-diff` per-instance/role check promoted optional → REQUIRED** for the first page of each template. Pairs with #90: fingerprint catches variation before block code; content-diff confirms it survived DA after deploy.
- **`scripts/render-harness.mjs`** — reproduce EDS block decoration locally (inject styles + block CSS, run each `decorate()`, screenshot) so first-pass fidelity is verifiable with no DA/dev-server, even when `DA_TOKEN` is expired (fidelity is decided at conversion time, not deploy time).

## Evidence

- **Without** the probe: a contact page shipped with all three department-card CTAs styled identically when only the middle should be an accent button — passed every mandatory gate.
- **With** the probe: a 28-card blog listing converted correctly on the **first pass** — active "All" filter chip, 24 image cards, 4 image-less navy title-cards, active pager page — all surfaced by the fingerprint before any block code. The only fix needed was #91 (`--navy-700`), caught by the grep, not an eyeball. Verified live end-to-end through DA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)