### PR TITLE
fix(stardust): crawler clears Cloudflare managed challenges (0.14.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "stardust",
       "source": "./plugins/stardust",
       "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-      "version": "0.14.4",
+      "version": "0.14.5",
       "category": "design",
       "keywords": [
         "design",

--- a/plugins/stardust/.claude-plugin/plugin.json
+++ b/plugins/stardust/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stardust",
   "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "author": {
     "name": "Adobe"
   },

--- a/plugins/stardust/CHANGELOG.md
+++ b/plugins/stardust/CHANGELOG.md
@@ -4,6 +4,43 @@ This file starts at 0.14.0. Prior versions (0.3.0 – 0.13.1) are documented in
 git history only (plus the branch-scoped notes in
 `CHANGELOG-redesign-adobecom.md` and `CHANGELOG-delivery-media-fidelity.md`).
 
+## 0.14.5 — crawler clears Cloudflare managed challenges
+
+`extract/scripts/crawl.mjs` — the bot-management fallback now validates the
+probe **response**, not just that the navigation resolved. A Cloudflare managed
+challenge returns an HTTP 403 interstitial (`cf-mitigated: challenge`) *without
+throwing* — `domcontentloaded` fires — so the old fallback (which only fired on
+a thrown network-fingerprint error) sailed past it and the block surfaced later
+as a fatal capture-time `HTTPError`. Observed on sagora.com during the 0.14.4
+uplift validation batch, where it required hand-patching the crawler mid-run.
+
+- **Challenge detection at the probe:** `isChallengeResponse()` flags an
+  entry-URL 403/429/503 interstitial (`cf-mitigated`, `cf-ray`,
+  `server: cloudflare`/`akamai`/edge markers). Either reject mode — a thrown
+  fingerprint block *or* a challenge response — now triggers the headed
+  fallback; the reason is recorded in `_crawl-log.json#discovery.botBlock`
+  (`fingerprint | challenge`).
+- **Stealth-hardened headed Chrome:** the fallback launches real Chrome with
+  `--disable-blink-features=AutomationControlled` +
+  `ignoreDefaultArgs: ['--enable-automation']` and spoofs
+  `navigator.webdriver` via an init script on **every** context (probe +
+  workers — the challenge re-fires per context, no cross-context cookie
+  sharing). `fetchTechnique` becomes `headed-chrome-stealth`.
+- **Challenge-solve window:** `clearChallenge()` waits for the non-interactive
+  challenge's JS to set its clearance cookie and reloads before validating
+  status — no-op on a normal 200, so zero overhead on the common path. If
+  headed + stealth + the solve window still can't clear it, the run fails with
+  a clear `BotChallengeError` (interactive solve required) rather than
+  capturing the interstitial as content.
+- Recipe doc (`extract/reference/playwright-recipe.md` § Bot-management
+  fallback) updated with the two-reject-mode retry rule and the managed-
+  challenge clearing procedure.
+
+Validated end-to-end: patched crawler on sagora.com auto-detects the challenge,
+switches to `headed-chrome-stealth`, and captures the homepage at HTTP 200
+(2 headings, ~8.9k chars, 9 images); the common headless path (example.com) is
+unchanged (no fallback, no botBlock).
+
 ## 0.14.4 — Tessl quality pass, part 1 (descriptions)
 
 Description rewrites for the two skills whose tessl-review drag included

--- a/plugins/stardust/skills/extract/reference/playwright-recipe.md
+++ b/plugins/stardust/skills/extract/reference/playwright-recipe.md
@@ -49,13 +49,47 @@ of an existing commercial site, agent-driven from a developer's
 machine) — the alternative is silently failing on most
 enterprise / large-retail / commerce origins.
 
-**Retry rule.** When the first navigation in a run returns any
-of `ERR_HTTP2_PROTOCOL_ERROR`, `ERR_QUIC_PROTOCOL_ERROR`, or
-hangs for the entire hard-cap on a connection that doesn't
-fingerprint cleanly: do **not** retry headless. Switch to
+**Retry rule.** Two distinct reject modes must both trigger the
+fallback — validate the *response*, not just that the navigation
+resolved:
+
+1. **Network fingerprint block** — the first navigation *throws*
+   `ERR_HTTP2_PROTOCOL_ERROR`, `ERR_QUIC_PROTOCOL_ERROR`, or hangs
+   for the entire hard-cap on a connection that doesn't fingerprint
+   cleanly.
+2. **Challenge / edge block** — the navigation *succeeds*
+   (`domcontentloaded` fires, no throw) but the response is a
+   **403/429/503 interstitial**, not the page. Cloudflare's managed
+   challenge is the canonical case: `cf-mitigated: challenge` +
+   HTTP 403. Because the goto resolves, a probe that only catches
+   throws sails straight past it and the block only surfaces later
+   as a fatal capture-time `HTTPError`. Detect it by inspecting the
+   probe response status/headers (`cf-mitigated`, `cf-ray`,
+   `server: cloudflare`/`akamai`, edge 403/429/503).
+
+On either: do **not** retry headless. Switch to
 `headless: false, channel: 'chrome'` immediately and record the
-switch in `_crawl-log.json#discovery.fetchTechnique` so re-runs
-start in headed mode without rediscovering the issue.
+switch in `_crawl-log.json#discovery.fetchTechnique` (with
+`#discovery.botBlock` = `fingerprint | challenge`) so re-runs start
+in headed mode without rediscovering the issue.
+
+**Clearing a managed challenge.** Headed real Chrome alone clears
+the *fingerprint* block, but Cloudflare's managed challenge also
+probes for automation signals — clearing it additionally needs the
+automation flags stripped: launch with
+`args: ['--disable-blink-features=AutomationControlled']` +
+`ignoreDefaultArgs: ['--enable-automation']`, and spoof
+`navigator.webdriver → undefined` via `context.addInitScript` on
+**every** context (the challenge re-fires per context — no
+cross-context cookie sharing — so a worker that skipped the spoof
+is re-challenged even after the probe cleared it). The
+non-interactive challenge serves the interstitial, runs its JS,
+sets a clearance cookie, then the page becomes reachable: wait
+~4s and `reload()` to pick up the cookie before validating the
+status. If headed + stealth + the solve window still can't clear
+it, the site requires an *interactive* solve — surface that as a
+hard failure (`BotChallengeError`) rather than capturing the
+interstitial as content.
 
 **Sub-resource fetches.** Once a page context is open in headed
 Chrome, additional fetches (sitemap, logo file, ad-hoc inspection

--- a/plugins/stardust/skills/extract/scripts/crawl.mjs
+++ b/plugins/stardust/skills/extract/scripts/crawl.mjs
@@ -107,14 +107,84 @@ function assignSlugs(urls) {
   });
 }
 
-// ---- bot-management fallback: headless first, headed real Chrome on H2 reject ----
+// ---- bot-management fallback: headless first, headed real Chrome on reject ----
 async function launchWithFallback() {
   const headless = await chromium.launch({ headless: true });
   return { browser: headless, technique: 'headless' };
 }
+// Stealth-hardened headed real Chrome. Headed alone clears TLS/H2-fingerprint
+// blocks, but Cloudflare's *managed challenge* also probes for automation
+// signals — clearing it needs the automation flags stripped (sagora.com e2e
+// finding). `--disable-blink-features=AutomationControlled` +
+// dropping `--enable-automation` + the navigator.webdriver spoof (applied
+// per-context in newContext) are what let the non-interactive challenge solve.
+const STEALTH_ARGS = ['--disable-blink-features=AutomationControlled'];
+async function launchHeadedStealth() {
+  return chromium.launch({
+    headless: false,
+    channel: 'chrome',
+    args: STEALTH_ARGS,
+    ignoreDefaultArgs: ['--enable-automation'],
+  });
+}
+// A context factory so the stealth init script lands on EVERY context (probe +
+// workers) once the run is in stealth mode — the challenge re-fires per context
+// (no cross-context cookie sharing), so a worker that skipped the spoof would be
+// re-challenged even after the probe cleared it.
+async function newContext(browser, stealth) {
+  const ctx = await browser.newContext(CRAWL_CONTEXT);
+  if (stealth) {
+    await ctx.addInitScript(() => {
+      Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+    });
+  }
+  return ctx;
+}
+// Network-level fingerprint reject: navigation THROWS before any JS runs.
 function isFingerprintBlock(err) {
   const m = String(err && err.message || err);
   return /ERR_HTTP2_PROTOCOL_ERROR|ERR_QUIC_PROTOCOL_ERROR|ERR_CONNECTION_RESET|net::ERR/.test(m);
+}
+// Bot-management CHALLENGE / block: navigation SUCCEEDS (domcontentloaded fires,
+// no throw) but the response is a 403/429/503 interstitial, not the page. The
+// original fallback only caught isFingerprintBlock() throws, so a Cloudflare
+// managed challenge (cf-mitigated: challenge, HTTP 403) sailed past the probe
+// and only blew up at capture-time as a fatal HTTPError. Validate the RESPONSE,
+// not just DOM-ready.
+function isChallengeResponse(resp) {
+  if (!resp) return false;
+  const status = resp.status();
+  const h = resp.headers();
+  // Cloudflare stamps this header specifically on managed/JS-challenge responses.
+  if ((h['cf-mitigated'] || '').toLowerCase() === 'challenge') return true;
+  // A real page effectively never serves the ENTRY URL as a hard 403/429/503;
+  // when it does it's an edge interstitial (Cloudflare / Akamai / F5 / Imperva),
+  // and headed real Chrome is the correct response regardless of vendor. The
+  // CDN-signal check keeps a legitimate app-level 403 (e.g. an auth-gated deep
+  // page) from needlessly triggering the headed relaunch.
+  if (status === 403 || status === 429 || status === 503) {
+    const server = (h['server'] || '').toLowerCase();
+    if (h['cf-ray'] || server.includes('cloudflare')) return true;
+    if (h['x-akamai-transformed'] || server.includes('akamai')) return true;
+    if (server.includes('big-ip') || server.includes('imperva') || h['x-iinfo']) return true;
+    // Unknown edge, but an entry-URL hard block is still worth one headed retry.
+    return true;
+  }
+  return false;
+}
+// Cloudflare's non-interactive managed challenge serves the 403/503 interstitial,
+// runs its JS, sets a clearance cookie, then the real page becomes reachable.
+// Wait for that window and reload to pick up the cookie before treating the
+// status as a hard failure. No-op for a normal 200 (isChallengeResponse false),
+// so zero overhead on the common path.
+async function clearChallenge(page, resp) {
+  for (let attempt = 0; attempt < 3 && isChallengeResponse(resp); attempt += 1) {
+    await page.waitForTimeout(4000);
+    const reloaded = await page.reload({ waitUntil: 'domcontentloaded', timeout: 45000 })
+      .catch(() => null);
+    if (reloaded) resp = reloaded;
+  }
+  return resp;
 }
 
 // ---- URL normalization: one canonical form for entry, --pages, sitemap, BFS ----
@@ -410,6 +480,11 @@ async function capturePage(context, url, slug, args) {
   let resp = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 45000 });
   // response validation
   if (!resp) throw Object.assign(new Error('no response'), { errorClass: 'TimeoutError' });
+  // bot-management challenge (Cloudflare cf-mitigated: challenge, etc.): the
+  // worker's fresh context is re-challenged even after the probe cleared it, so
+  // give the interstitial its JS-solve window and reload before validating —
+  // otherwise a solvable 403 is thrown as a fatal HTTPError.
+  resp = await clearChallenge(page, resp);
   let status = resp.status();
   // 404 on a slash variant: retry ONCE with the trailing slash flipped before
   // recording a failure (stardust-style e2e finding — slash-required hosts).
@@ -497,23 +572,45 @@ async function main() {
   const outPages = path.join(args.out, 'pages');
   await mkdir(outPages, { recursive: true });
 
+  let stealth = false;
   let { browser, technique } = await launchWithFallback();
-  let context = await browser.newContext(CRAWL_CONTEXT);
+  let context = await newContext(browser, stealth);
   let probe = await context.newPage();
 
   // bot-management probe on the entry URL; switch to headed real Chrome on reject.
+  // Two distinct reject modes must both trigger the fallback:
+  //   1. a network fingerprint block — the goto THROWS (isFingerprintBlock);
+  //   2. a challenge / edge block — the goto SUCCEEDS but returns a 403/429/503
+  //      interstitial (isChallengeResponse). This one previously slipped through
+  //      the probe and only failed at capture-time (sagora.com Cloudflare finding).
+  let botBlock = null; // 'fingerprint' | 'challenge'
   try {
-    await probe.goto(args.url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    const probeResp = await probe.goto(args.url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    if (isChallengeResponse(probeResp)) botBlock = 'challenge';
   } catch (err) {
-    if (isFingerprintBlock(err)) {
+    if (isFingerprintBlock(err)) botBlock = 'fingerprint';
+    else throw err;
+  }
+  if (botBlock) {
+    await browser.close();
+    console.error(`[crawl] bot-management block (${botBlock}) — switching to headed real Chrome (channel:chrome) with stealth hardening`);
+    browser = await launchHeadedStealth();
+    technique = 'headed-chrome-stealth';
+    stealth = true;
+    context = await newContext(browser, stealth);
+    probe = await context.newPage();
+    let probeResp = await probe.goto(args.url, { waitUntil: 'domcontentloaded', timeout: 45000 });
+    probeResp = await clearChallenge(probe, probeResp);
+    // If headed + stealth + the challenge-solve window STILL can't clear it, do
+    // not proceed to capture the interstitial as if it were content — surface a
+    // clear, actionable failure (this is stop-condition (a) for the skill).
+    if (isChallengeResponse(probeResp)) {
       await browser.close();
-      console.error('[crawl] fingerprint block — switching to headed real Chrome (channel:chrome)');
-      browser = await chromium.launch({ headless: false, channel: 'chrome' });
-      technique = 'headed-chrome';
-      context = await browser.newContext(CRAWL_CONTEXT);
-      probe = await context.newPage();
-      await probe.goto(args.url, { waitUntil: 'domcontentloaded', timeout: 45000 });
-    } else throw err;
+      throw Object.assign(
+        new Error(`bot-management challenge not cleared after headed real-Chrome + stealth fallback (entry status ${probeResp ? probeResp.status() : 'n/a'}) — the site requires an interactive challenge solve; run against it in a headed session you can complete by hand`),
+        { errorClass: 'BotChallengeError' },
+      );
+    }
   }
 
   // adopt the post-redirect origin (apex→www etc.): the same-origin filter and
@@ -534,7 +631,7 @@ async function main() {
   await probe.close();
   console.error(`[crawl] technique=${technique} pages=${urls.length}`);
 
-  const log = { discovery: { fetchTechnique: technique, count: urls.length, concurrency: args.concurrency, ...(originRedirect ? { originRedirect } : {}) }, consent: { method: args.consent ? 'auto' : 'skipped' }, crawl: { failures: [] } };
+  const log = { discovery: { fetchTechnique: technique, count: urls.length, concurrency: args.concurrency, ...(botBlock ? { botBlock } : {}), ...(originRedirect ? { originRedirect } : {}) }, consent: { method: args.consent ? 'auto' : 'skipped' }, crawl: { failures: [] } };
   let ok = 0;
   await context.close();
 
@@ -547,7 +644,7 @@ async function main() {
   const slugs = assignSlugs(urls);
   let nextIdx = 0;
   async function worker() {
-    const ctx = await browser.newContext(CRAWL_CONTEXT);
+    const ctx = await newContext(browser, stealth);
     while (nextIdx < urls.length) {
       const idx = nextIdx;
       nextIdx += 1;

--- a/plugins/stardust/skills/extract/scripts/crawl.mjs
+++ b/plugins/stardust/skills/extract/scripts/crawl.mjs
@@ -157,18 +157,18 @@ function isChallengeResponse(resp) {
   const h = resp.headers();
   // Cloudflare stamps this header specifically on managed/JS-challenge responses.
   if ((h['cf-mitigated'] || '').toLowerCase() === 'challenge') return true;
-  // A real page effectively never serves the ENTRY URL as a hard 403/429/503;
-  // when it does it's an edge interstitial (Cloudflare / Akamai / F5 / Imperva),
-  // and headed real Chrome is the correct response regardless of vendor. The
-  // CDN-signal check keeps a legitimate app-level 403 (e.g. an auth-gated deep
-  // page) from needlessly triggering the headed relaunch.
+  // A hard 403/429/503 that ALSO carries an edge/CDN signature is an edge
+  // interstitial (Cloudflare / Akamai / F5 / Imperva) — headed real Chrome is the
+  // correct response regardless of vendor. Requiring the edge signature (not the
+  // bare status) is deliberate: isChallengeResponse gates clearChallenge() on
+  // EVERY page, so a legitimate app-level 403 (e.g. an auth-gated deep page with
+  // no CDN header) must fail fast, not eat the ~12s challenge-solve retry loop.
   if (status === 403 || status === 429 || status === 503) {
     const server = (h['server'] || '').toLowerCase();
     if (h['cf-ray'] || server.includes('cloudflare')) return true;
     if (h['x-akamai-transformed'] || server.includes('akamai')) return true;
     if (server.includes('big-ip') || server.includes('imperva') || h['x-iinfo']) return true;
-    // Unknown edge, but an entry-URL hard block is still worth one headed retry.
-    return true;
+    // no edge signature — treat as a genuine app-level status, not a challenge.
   }
   return false;
 }

--- a/plugins/stardust/tile.json
+++ b/plugins/stardust/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe/stardust",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "summary": "Redesign an existing website to make it better. Built on top of impeccable.",
   "skills": {
     "stardust": {


### PR DESCRIPTION
## Problem

The extract crawler (`skills/extract/scripts/crawl.mjs`) has a bot-management fallback that switches from headless to headed real Chrome when a site blocks the bundled-chromium fingerprint. But it only fired on a **thrown** network-fingerprint error (`ERR_HTTP2_PROTOCOL_ERROR` etc.).

A **Cloudflare managed challenge** doesn't throw — it returns an HTTP **403** interstitial with `cf-mitigated: challenge`, and `domcontentloaded` fires normally. So the challenge sailed straight past the entry probe, discovery ran against the challenge page, and the block only surfaced later in `capturePage` as a fatal `HTTPError`.

Found during the 0.14.4 `uplift` validation batch: **sagora.com** could not be extracted without hand-patching the crawler mid-run.

> The fallback trigger logic should validate capture success, not just DOM-ready.

## Fix

Validate the probe **response**, not just that the navigation resolved:

- **`isChallengeResponse()`** — flags an entry-URL `403/429/503` edge interstitial via `cf-mitigated` / `cf-ray` / `server: cloudflare|akamai|imperva|big-ip`. Either reject mode (thrown fingerprint block **or** challenge response) now triggers the headed fallback; the reason is recorded in `_crawl-log.json#discovery.botBlock` (`fingerprint | challenge`).
- **`launchHeadedStealth()`** — headed real Chrome alone clears a fingerprint block but not a managed challenge, which also probes for automation signals. Launch strips the automation flags (`--disable-blink-features=AutomationControlled` + `ignoreDefaultArgs: ['--enable-automation']`) and spoofs `navigator.webdriver` via `addInitScript` on **every** context (probe + workers — the challenge re-fires per context, no cross-context cookie sharing). `fetchTechnique` becomes `headed-chrome-stealth`.
- **`clearChallenge()`** — waits for the non-interactive challenge's clearance cookie and reloads before validating status. No-op on a normal 200 → **zero overhead on the common path**. If headed + stealth + the solve window still can't clear it, the run fails with an actionable `BotChallengeError` instead of capturing the interstitial as content.
- Recipe doc (`extract/reference/playwright-recipe.md` § Bot-management fallback) updated with the two-reject-mode retry rule and the managed-challenge clearing procedure.

Version bumped 0.14.4 → **0.14.5** across `plugin.json` / `tile.json` / `marketplace.json`, with a CHANGELOG entry.

## Validation

Ran the patched crawler end-to-end (not just unit-level):

| Case | Result |
|------|--------|
| **sagora.com** (the reported failure) | probe detects `botBlock: challenge` → `fetchTechnique: headed-chrome-stealth` → captured **HTTP 200**, 2 headings, ~8.9k chars main text, 9 real images, correct title, **0 failures** |
| **example.com** (common path regression) | stays `headless`, **no** fallback, `botBlock` absent, HTTP 200 — unchanged |

`node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)