### PR TITLE
Content Hub Extension skill

### DIFF
--- a/plugins/app-builder/skills/appbuilder-action-scaffolder/SKILL.md
+++ b/plugins/app-builder/skills/appbuilder-action-scaffolder/SKILL.md
@@ -1,6 +1,16 @@
 ---
 name: appbuilder-action-scaffolder
-description: Create, implement, deploy, and debug Adobe Runtime actions with consistent layout, validation, and error handling. Use this skill whenever the user needs to add actions to an App Builder project, understand action structure (params, response format, web/raw actions), configure actions in the manifest, use App Builder SDKs (State, Files, Events, database), deploy and invoke actions via CLI, debug action issues, or implement patterns such as webhook receivers, custom event providers, journaling consumers, large payload redirects, action sequence pipelines, and Asset Compute workers. Also trigger when users mention serverless functions in Adobe context, action logging, IMS authentication for actions, or cron-style scheduled actions.
+description: >-
+  Create, implement, deploy, and debug Adobe Runtime actions with consistent layout, validation, and
+  error handling. Use this skill whenever the user needs to add actions to an App Builder project,
+  understand action structure (params, response format, web/raw actions), configure actions in the
+  manifest, use App Builder SDKs (State, Files, Events, database), deploy and invoke actions via CLI,
+  debug action issues, or implement patterns such as webhook receivers, custom event providers,
+  journaling consumers, large payload redirects, action sequence pipelines, and Asset Compute workers.
+  Also covers web actions for Content Hub extensions — the actions/generic/index.js that receives
+  asset IDs from panels or modals, calls the AEM Assets Author API, and returns data back to the
+  Content Hub UI. Trigger on: App Builder action, Runtime action, serverless function, action logging,
+  IMS authentication for actions, Content Hub web action, AEM API from action.
 metadata:
   category: action-lifecycle
 license: Apache-2.0
@@ -27,6 +37,8 @@ Pick the template that matches the user's intent. Default to `assets/action-boil
 | Action sequence pipeline | assets/action-sequence-template.js |
 | Asset Compute worker (AEM renditions) | assets/asset-compute-worker-template.js |
 | Debug Runtime action issues | references/debugging.md |
+
+Also handles web actions for Content Hub extensions — the `actions/generic/index.js` that receives asset IDs, calls AEM Assets Author API, and returns metadata to the panel. Use `assets/action-boilerplate.js` as the starting point and wire it via `app.config.yaml` in the Content Hub extension scaffold.
 
 ## Fast Path (for clear requests)
 

--- a/plugins/app-builder/skills/appbuilder-cicd-pipeline/SKILL.md
+++ b/plugins/app-builder/skills/appbuilder-cicd-pipeline/SKILL.md
@@ -8,8 +8,9 @@ description: >-
   user mentions CI/CD for App Builder, GitHub Actions for aio deploy, automated deployment
   pipelines, continuous integration, continuous delivery, deploy automation, multi-environment
   promotion, aio app add ci, or wants to automate their App Builder build and release process.
-  Also trigger when users mention deploy workflows, release pipelines, or GitHub secrets for
-  App Builder.
+  Also trigger when users mention deploy workflows, release pipelines, GitHub secrets for
+  App Builder, deploy a Content Hub extension, aio app deploy for AEM extensions, Extension
+  Manager approval, or automate deployment of a Content Hub or AEM UI extension.
 metadata:
   category: deployment-automation
 license: Apache-2.0
@@ -31,6 +32,8 @@ Set up CI/CD pipelines for Adobe App Builder projects — GitHub Actions (primar
 | Azure DevOps / GitLab CI / Jenkins | references/generic-pipeline-guide.md |
 | Secrets setup guide | references/secrets-management.md |
 | Debugging deploy failures | references/debugging.md |
+
+Also covers deployment of Content Hub UI extensions via `aio app deploy` — parsing the CDN URL from deploy output, opening the deployed extension URL, and submitting for Extension Manager approval (Production workspace only).
 
 ## Fast Path (for clear requests)
 

--- a/plugins/app-builder/skills/appbuilder-e2e-testing/SKILL.md
+++ b/plugins/app-builder/skills/appbuilder-e2e-testing/SKILL.md
@@ -5,7 +5,8 @@ description: >-
   application. Covers Playwright E2E testing for ExC Shell SPAs, AEM extension UIs, and full-stack
   flows. Use when the user mentions: "E2E test", "end-to-end test", "Playwright", "browser test",
   "test my SPA in the browser", "test my AEM extension", "test the full flow", "integration test
-  with UI", "headless browser test", "E2E in CI".
+  with UI", "headless browser test", "E2E in CI", "test my Content Hub extension",
+  "test Content Hub panel in browser", "test card action", "test bulk action in browser".
   This skill is for BROWSER-based testing only. For Jest unit tests of actions or React components,
   use appbuilder-testing instead.
 metadata:
@@ -27,6 +28,9 @@ Identify the user's intent, then read the referenced sections to generate tailor
 | E2E test for ExC Shell SPA | `references/e2e-testing-patterns.md` | `assets/playwright.config.ts`, `assets/e2e-test-template.spec.ts` |
 | Test AEM extension in browser | `references/aem-extension-testing.md` | `assets/playwright.config.ts` |
 | E2E tests in CI pipeline | `references/ci-integration.md` | `assets/e2e-ci-workflow.yml` |
+| Content Hub extension E2E | `references/aem-extension-testing.md` | `assets/playwright.config.ts` |
+
+Covers E2E tests for Content Hub extensions — testing panel render in the Asset Details Dialog, card action button visibility and click, and selection bar bulk action flow using Playwright with the `?devMode=true&ext=` test URL.
 
 ## Fast Path (for clear requests)
 

--- a/plugins/app-builder/skills/appbuilder-e2e-testing/SKILL.md
+++ b/plugins/app-builder/skills/appbuilder-e2e-testing/SKILL.md
@@ -6,7 +6,8 @@ description: >-
   flows. Use when the user mentions: "E2E test", "end-to-end test", "Playwright", "browser test",
   "test my SPA in the browser", "test my AEM extension", "test the full flow", "integration test
   with UI", "headless browser test", "E2E in CI", "test my Content Hub extension",
-  "test Content Hub panel in browser", "test card action", "test bulk action in browser".
+  "test Content Hub panel in browser", "test card action", "test bulk action in browser",
+  "test add assets wizard", "test add assets panel", "test hydration panel in browser".
   This skill is for BROWSER-based testing only. For Jest unit tests of actions or React components,
   use appbuilder-testing instead.
 metadata:

--- a/plugins/app-builder/skills/appbuilder-project-init/SKILL.md
+++ b/plugins/app-builder/skills/appbuilder-project-init/SKILL.md
@@ -1,11 +1,24 @@
 ---
 name: appbuilder-project-init
-description: Initialize an Adobe App Builder project end-to-end without Developer Console UI clicks. Creates the Console project and workspace, subscribes APIs (including those needing a product profile), maps user intent to the right template, runs non-interactive `aio app init`, and guides post-init customization. Use whenever the user mentions creating an App Builder app, scaffolding a project, `aio app init`, setting up an Experience Cloud extension, adding actions or web assets, creating a Console project or workspace, adding APIs, or bootstrapping App Builder — even if they don't say "App Builder". Also for SPA templates, AEM extensions, API Mesh, Asset Compute workers, and MCP server projects. Also handles debugging init failures — template not found, `aio app init` hangs or times out, Node version mismatches, npm install failures, post-init build errors, `aio login` issues, `aio app run` showing nothing, or `aio console project create` / `workspace create` / `workspace api add` errors.
+description: >-
+  Initialize or scaffold any Adobe App Builder project end-to-end — from a single prompt to a running,
+  browser-open extension — without Developer Console UI clicks. Handles two modes: (1) Standard project
+  init: creates Console project and workspace, subscribes APIs, maps user intent to the right template,
+  runs non-interactive `aio app init`. (2) Extension Scaffolding Mode: full lifecycle for any Adobe UI
+  extension — Content Hub (panels, card actions, bulk actions), CF Console, CF Editor, Universal Editor,
+  Assets View, or ExC Shell SPA — covering surface selection, file generation, npm install, aio app use,
+  build, dev server, cert acceptance, and deploy. Use whenever the user mentions: creating an App Builder
+  app or extension, "scaffold a Content Hub extension", "create an AEM extension", "build an extension for
+  Content Hub / CF Console / Universal Editor / Assets View / ExC Shell", `aio app init`, setting up a
+  Console project or workspace, adding APIs, or bootstrapping App Builder — even if they don't say
+  "App Builder". Also for SPA templates, AEM extensions, API Mesh, Asset Compute workers, MCP server
+  projects, and debugging init failures (template not found, `aio app init` hangs, Node mismatches,
+  npm failures, `aio login` issues, `aio console` errors).
 metadata:
   category: project-initialization
 license: Apache-2.0
 compatibility: Requires aio CLI (Adobe I/O CLI) — install or refresh with `npm install -g @adobe/aio-cli` so the bundled plugins (`aio-cli-plugin-console`, `aio-cli-plugin-app`, etc.) are current. Node.js 18+ (Node 24 supported on Stage runtimes). Bash shell.
-allowed-tools: Bash(aio:*) Bash(npm:*) Bash(node:*) Read Write
+allowed-tools: Bash(aio:*) Bash(npm:*) Bash(node:*) Bash(mkdir:*) Read Write
 ---
 # App Builder Project Initialization
 
@@ -144,6 +157,9 @@ Pick the template that matches the user's intent. When unclear, default to `@ado
 | --- | --- |
 | SPA with actions + React UI | @adobe/generator-app-excshell |
 | AEM Content Fragment Console extension | @adobe/aem-cf-admin-ui-ext-tpl |
+| Content Hub extension (panels, card actions, bulk actions) | Extension Scaffolding Mode — see section below |
+| AEM UI Extension (CF Console, CF Editor, Universal Editor, Assets View) | Extension Scaffolding Mode — see section below |
+| Experience Cloud Shell SPA (full lifecycle with dev server + deploy) | Extension Scaffolding Mode — see section below |
 | AEM React SPA (WKND-based) | @adobe/generator-app-aem-react |
 | Adobe API Mesh (GraphQL) | @adobe/generator-app-api-mesh |
 | Asset Compute custom worker | @adobe/generator-app-asset-compute |
@@ -151,6 +167,14 @@ Pick the template that matches the user's intent. When unclear, default to `@ado
 | Bare / from-scratch project (no pre-scaffolded actions or UI) | init.sh init-bare |
 
 For a headless/backend-only request, prefer `init-bare` when possible. If the user still needs a template that generates UI files, plan a post-init cleanup so the final project has no `web-src` frontend directory or web manifest wiring.
+
+## Extension Scaffolding Mode
+
+For Content Hub extensions (panels, card actions, bulk actions), AEM UI extensions (CF Console, CF Editor, Universal Editor, Assets View), and ExC Shell SPAs — this skill runs a full lifecycle: surface selection → Console setup → file generation → npm install → build → dev server → deploy.
+
+Read [`references/extension-scaffolding.md`](references/extension-scaffolding.md) for the complete step-by-step workflow.
+
+**When it triggers:** user says "create a Content Hub extension", "scaffold an AEM extension", "build an extension for [surface]", or anything in the Template Decision Table rows for extension surfaces.
 
 ## Initialize via Script
 
@@ -287,6 +311,9 @@ After initialization, hand off to:
 
 - `appbuilder-action-scaffolder` — For scaffolding actions with playbook, checklist, boilerplate templates, and manifest validation
 - `appbuilder-ui-scaffolder` — Build React Spectrum UI for ExC Shell SPAs and AEM extensions
+- Chains TO `appbuilder-ui-scaffolder` — for Content Hub panel/modal UI customization, React Spectrum components, and all four Content Hub namespaces (assetDetails, card, selectionBar, addAssets)
+- Chains TO `appbuilder-cicd-pipeline` — for GitHub Actions deployment automation after `aio app deploy` works manually
+- Chains TO `appbuilder-e2e-testing` — for Playwright E2E tests against the deployed extension
 
 ## Pattern Quick-Reference
 
@@ -304,3 +331,5 @@ After initialization, hand off to:
 - [references/bootstrap.md](references/bootstrap.md) — Agentic Developer Console bootstrap (project, workspace, API subscriptions) via raw `aio console …` commands from the latest `@adobe/aio-cli`
 - [references/templates.md](references/templates.md) — Template catalog with intent mapping and per-template post-init guidance
 - [references/debugging.md](references/debugging.md) — Troubleshooting guide for init failures, Node/npm issues, login problems, and first-run errors
+- [`references/extension-scaffolding.md`](references/extension-scaffolding.md) — Complete Extension Scaffolding Mode workflow (Steps 0–17, Surface Config, Interaction Rules, Failure Recovery)
+- [`references/deployment.md`](references/deployment.md) — Stage and Production deployment, Extension Manager approval

--- a/plugins/app-builder/skills/appbuilder-project-init/references/aem-surface-templates.md
+++ b/plugins/app-builder/skills/appbuilder-project-init/references/aem-surface-templates.md
@@ -1,0 +1,661 @@
+# AEM Surface Templates (CF Console, CF Editor, Universal Editor, Assets View)
+
+These four surfaces all use **`@adobe/uix-guest`** and share the **same project skeleton** as Content Hub. Reuse [`file-templates.md`](file-templates.md) for every shared file — `package.json`, `index.html`, `index.js`, `index.css`, `actions/utils.js`, `actions/generic/index.js`, `hooks/post-deploy.js`, `README.md`, `AGENTS.md`, `.eslintrc.js` — swapping only:
+
+- the directory `aem-assets-contenthub-1` → `surfaceConfig.extDir`
+- the package name in `ext.config.yaml` → matches `extDir`
+- the extension point in `app.config.yaml` → `surfaceConfig.extensionPointId`
+- the `register()` `methods` object → the surface-specific block below
+
+Placeholders: `{{EXTENSION_NAME}}`, `{{DISPLAY_NAME}}`, `{{EXTENSION_DESCRIPTION}}`, `{{EXTENSION_DIR}}` (= `surfaceConfig.extDir`), `{{EXTENSION_POINT}}` (= `surfaceConfig.extensionPointId`).
+
+> **Auth on AEM surfaces differs from Content Hub.** These surfaces expose auth through `guestConnection.sharedContext`, not `host.auth`:
+> ```js
+> const ctx = guestConnection.sharedContext;
+> const aemHost  = ctx.get('aemHost');        // e.g. author-p12345-e67890.adobeaemcloud.com
+> const imsOrg   = ctx.get('auth').imsOrg;
+> const imsToken = ctx.get('auth').imsToken;   // Bearer token for AEM API calls
+> const apiKey   = ctx.get('auth').apiKey;
+> ```
+
+---
+
+## Shared `app.config.yaml` (all AEM surfaces)
+
+```yaml
+extensions:
+  {{EXTENSION_POINT}}:
+    $include: src/{{EXTENSION_DIR}}/ext.config.yaml
+```
+
+## Shared `ext.config.yaml` (all AEM surfaces)
+
+Real ext.config.yaml files do **not** contain a `$schema` field. The hook key is `post-app-deploy` (not `post-deploy`), and the path uses `./` prefix. The `actions: actions` line is only needed when the extension has backend actions.
+
+```yaml
+operations:
+  view:
+    - type: web
+      impl: index.html
+actions: actions
+web: web-src
+runtimeManifest:
+  packages:
+    {{EXTENSION_DIR}}:
+      license: Apache-2.0
+      actions:
+        generic:
+          function: actions/generic/index.js
+          web: 'yes'
+          runtime: 'nodejs:18'
+          inputs:
+            LOG_LEVEL: debug
+          annotations:
+            require-adobe-auth: false
+            final: true
+hooks:
+  post-app-deploy: ./hooks/post-deploy.js
+```
+
+> If the extension has no backend actions, omit `actions: actions` and the entire `runtimeManifest` block.
+
+## Shared `app-metadata.json`
+
+Real AEM extension samples ship an `app-metadata.json` at `src/app-metadata.json` that declares which extension point(s) the app registers for. It is imported and passed as `metadata` to `register()`.
+
+**`src/app-metadata.json`:**
+```json
+{
+    "extensions": [
+        {
+            "extensionPoint": "{{EXTENSION_POINT}}"
+        }
+    ]
+}
+```
+
+**Usage in `ExtensionRegistration.js`:**
+```js
+import metadata from '../../../../app-metadata.json';
+
+const guestConnection = await register({
+  id: extensionId,
+  metadata,
+  methods: { ... }
+});
+```
+
+> The `metadata` field was absent from the earlier template but is present in all real sample projects (cf-console-action-bar-button-sample, cf-console-header-menu-button-sample, cf-editor-rte-toolbar-button-sample, universal-editor-richtext-draft, universal-editor-task-management). Include it.
+
+---
+
+## § CF Console — `aem/cf-console-admin/1`
+
+Extension dir: `aem-cf-console-admin-1`
+
+### `Constants.js`
+
+```js
+// {{EXTENSION_NAME}} - Constants.js
+module.exports = {
+  extensionId: '{{EXTENSION_NAME}}'
+}
+```
+
+### `ExtensionRegistration.js`
+
+Include only the namespace blocks the user selected. Real samples show `actionBar`, `headerMenu`, and `contentFragmentGrid`.
+
+```js
+// {{EXTENSION_NAME}} - ExtensionRegistration.js
+
+import { generatePath } from "react-router";
+import { Text } from "@adobe/react-spectrum";
+import { register } from "@adobe/uix-guest";
+import { extensionId } from "./Constants";
+import metadata from '../../../../app-metadata.json';
+
+function ExtensionRegistration() {
+  const init = async () => {
+    const guestConnection = await register({
+      id: extensionId,
+      metadata,
+      methods: {
+        // ── actionBar: buttons shown when one or more fragments are selected ──
+        actionBar: {
+          getButtons() {
+            return [
+              // YOUR ACTION BAR BUTTONS CODE SHOULD BE HERE
+              {
+                'id': '{{EXTENSION_NAME}}-action-button',
+                'label': '{{DISPLAY_NAME}}',
+                'icon': 'PublishCheck',
+                onClick(selections) {
+                  // selections is an array; each item has a .fragmentId property
+                  const selectionIds = selections.map(selection => selection.fragmentId);
+                  const modalURL = "/index.html#" + generatePath(
+                    "/content-fragment/:selection/{{EXTENSION_NAME}}-modal",
+                    {
+                      selection: encodeURIComponent(selectionIds.join('|'))
+                    }
+                  );
+                  console.log("Modal URL: ", modalURL);
+
+                  guestConnection.host.modal.showUrl({
+                    title: "{{DISPLAY_NAME}}",
+                    url: modalURL,
+                    fullscreen: true,
+                  });
+                },
+              },
+            ];
+          },
+        },
+
+        // ── headerMenu: buttons always visible in the console header ─────────
+        headerMenu: {
+          getButtons() {
+            return [
+              // YOUR HEADER BUTTONS CODE SHOULD BE HERE
+              {
+                'id': '{{EXTENSION_NAME}}-header-button',
+                'label': '{{DISPLAY_NAME}}',
+                'icon': 'OpenIn',
+                // Optional: variant — 'cta' | 'primary' | 'secondary' | 'negative' | 'action'
+                variant: 'secondary',
+                // Optional: subItems for a dropdown menu
+                // subItems: [
+                //   {
+                //     id: '{{EXTENSION_NAME}}-sub-item',
+                //     label: 'Sub Item',
+                //     icon: 'Cloud',
+                //     onClick: () => { ... },
+                //   },
+                // ],
+                onClick() {
+                  const modalURL = "/index.html#/{{EXTENSION_NAME}}-header-button-modal";
+                  console.log("Modal URL: ", modalURL);
+
+                  guestConnection.host.modal.showUrl({
+                    title: "{{DISPLAY_NAME}}",
+                    url: modalURL,
+                    height: "360px",
+                    width: "550px",
+                  });
+                },
+              },
+            ];
+          },
+        },
+
+        // ── contentFragmentGrid: custom column in the fragment list ──────────
+        contentFragmentGrid: {
+          getColumns() {
+            return [
+              {
+                id: "{{EXTENSION_NAME}}-extended-column",
+                label: "{{DISPLAY_NAME}}",
+                allowsResizing: true, // optional, by default "false"
+                minWidth: 350,        // optional, no default value
+                showDivider: true,    // optional, by default "false"
+                render: async function (fragments) {
+                  return fragments.reduce((accumulator, fragment) => {
+                    accumulator[fragment.id] = 'Extended Column Value';
+                    return accumulator;
+                  }, {})
+                },
+              },
+            ];
+          }
+        }
+      },
+    });
+  };
+  init().catch(console.error);
+
+  return <Text>IFrame for integration with Host (AEM)...</Text>
+}
+
+export default ExtensionRegistration;
+```
+
+> **Selections:** Each selection object has a `.fragmentId` property (not `.id`). The action-bar-button-sample uses `selections.map(selection => selection.fragmentId)`.
+
+> **`modal.showUrl()` dimensions:** Pass height/width as strings with units (`"360px"`, `"550px"`) or use `fullscreen: true`. Do not pass bare numbers.
+
+> **`headerMenu` subItems:** A button can expose a dropdown by adding a `subItems` array. Each sub-item has the same shape as a top-level button (`id`, `label`, `icon`, `onClick`).
+
+### `App.js`
+
+```js
+// {{EXTENSION_NAME}} - App.js
+
+import React from "react";
+import ErrorBoundary from "react-error-boundary";
+import { HashRouter as Router, Routes, Route } from "react-router-dom";
+import ExtensionRegistration from "./ExtensionRegistration";
+import ActionButtonModal from "./ActionButtonModal";
+import HeaderButtonModal from "./HeaderButtonModal";
+
+function App() {
+  return (
+    <Router>
+      <ErrorBoundary onError={onError} FallbackComponent={fallbackComponent}>
+        <Routes>
+          <Route index element={<ExtensionRegistration />} />
+          <Route
+            exact path="index.html"
+            element={<ExtensionRegistration />}
+          />
+          <Route
+            exact path="content-fragment/:selection/{{EXTENSION_NAME}}-modal"
+            element={<ActionButtonModal />}
+          />
+          <Route
+            exact path="{{EXTENSION_NAME}}-header-button-modal"
+            element={<HeaderButtonModal />}
+          />
+          {/* YOUR CUSTOM ROUTES SHOULD BE HERE */}
+        </Routes>
+      </ErrorBoundary>
+    </Router>
+  )
+
+  // error handler on UI rendering failure
+  function onError(e, componentStack) {}
+
+  // component to show if UI fails rendering
+  function fallbackComponent({ componentStack, error }) {
+    return (
+      <React.Fragment>
+        <h1 style={{ textAlign: "center", marginTop: "20px" }}>
+          Phly, phly... Something went wrong :(
+        </h1>
+        <pre>{componentStack + "\n" + error.message}</pre>
+      </React.Fragment>
+    )
+  }
+}
+
+export default App
+```
+
+> **Modal close:** In a modal page component, reconnect with `attach()` and call `guestConnection.host.modal.close()` to dismiss the dialog.
+
+---
+
+## § CF Editor — `aem/cf-editor/1`
+
+Extension dir: `aem-cf-editor-1`
+
+### `Constants.js`
+
+```js
+// {{EXTENSION_NAME}} - Constants.js
+module.exports = {
+  extensionId: '{{EXTENSION_NAME}}'
+}
+```
+
+### `ExtensionRegistration.js`
+
+Real `cf-editor-all-points` shows `headerMenu`, `rte` (with `getWidgets`, `getBadges`, `getCustomButtons`, `getColors`), `field`, and `rightPanel` namespaces.
+
+```js
+// {{EXTENSION_NAME}} - ExtensionRegistration.js
+
+import { Text } from "@adobe/react-spectrum";
+import { register } from "@adobe/uix-guest";
+import { extensionId } from "./Constants";
+import metadata from '../../../../app-metadata.json';
+
+function ExtensionRegistration() {
+  const init = async () => {
+    const guestConnection = await register({
+      id: extensionId,
+      metadata,
+      methods: {
+        // ── headerMenu: context-aware — can read the open fragment ──────────
+        headerMenu: {
+          getButtons() {
+            return [
+              // @todo YOUR HEADER BUTTONS DECLARATION SHOULD BE HERE
+              {
+                id: '{{EXTENSION_NAME}}-header-button',
+                label: '{{DISPLAY_NAME}}',
+                icon: 'OpenIn',
+                onClick() {
+                  const modalURL = "/index.html#/{{EXTENSION_NAME}}-header-button-modal";
+                  console.log("Modal URL: ", modalURL);
+
+                  guestConnection.host.modal.showUrl({
+                    title: "{{DISPLAY_NAME}}",
+                    url: modalURL,
+                  });
+                },
+              },
+            ];
+          },
+        },
+
+        // ── rte: Rich Text Editor extensions ─────────────────────────────────
+        rte: {
+           getWidgets: () => ([
+             // @todo YOUR RTE WIDGETS DECLARATION SHOULD BE HERE
+             {
+               id: "{{EXTENSION_NAME}}-widget",
+               label: "{{DISPLAY_NAME}} Widget",
+               url: "/index.html#/{{EXTENSION_NAME}}-widget",
+             },
+           ]),
+
+           getBadges: () => ([
+             // @todo YOUR RTE BADGES DECLARATION SHOULD BE HERE
+             {
+               id: "{{EXTENSION_NAME}}-badge",
+               prefix: "{{",
+               suffix: "}}",
+               backgroundColor: "#D6F1FF",
+               textColor: "#54719B",
+             },
+           ]),
+
+          getCustomButtons: () => ([
+             // @todo YOUR RTE TOOLBAR BUTTONS DECLARATION SHOULD BE HERE
+             {
+               id: "{{EXTENSION_NAME}}-rte-button",
+               tooltip: "{{DISPLAY_NAME}}",
+               icon: 'Plug',
+               onClick: (state) => {
+                 // state = { html, text, selectedHtml, selectedText }
+                 return [{
+                   type: "replaceContent",
+                   value: state.html + "<p>Inserted by {{DISPLAY_NAME}}</p>"
+                 }];
+               },
+             },
+          ]),
+
+          getColors() {
+            return {
+              allowedColors: [
+                "FFCC00", "Yellow",
+                "0000CC", "Blue",
+                "FF0000", "Red",
+                "00FF00", "Green",
+              ],
+              isAllowedCustomColors: true,
+            };
+          },
+        },
+
+        // ── field: custom field renderers ─────────────────────────────────────
+        field: {
+          getDefinitions: () => {
+            return [
+              // @todo YOUR CUSTOM FIELD DEFINITIONS SHOULD BE HERE
+              // fieldNameExp is a regex matched against the CF model field name
+              {
+                fieldNameExp: '^{{EXTENSION_NAME}}_field$',
+                url: '/#/{{EXTENSION_NAME}}-field',
+              },
+            ];
+          },
+        },
+
+        // ── rightPanel: side rails in the editor ─────────────────────────────
+        rightPanel: {
+          addRails() {
+            return [
+              {
+                extension: extensionId,
+                id: "{{EXTENSION_NAME}}-rail",
+                header: "{{DISPLAY_NAME}}",
+                url: '/index.html#/rail/1',
+                icon: 'Export',
+              }
+            ];
+          },
+        },
+
+      }
+    });
+  };
+  init().catch(console.error);
+
+  return <Text>IFrame for integration with Host (AEM)...</Text>;
+}
+
+export default ExtensionRegistration;
+```
+
+> The `rte` API (custom buttons, badges, widgets, colors) may be replaced when AEM adopts a new RTE engine. It works today; plan for migration.
+
+### `App.js`
+
+```js
+// {{EXTENSION_NAME}} - App.js
+
+import React from "react";
+import ErrorBoundary from "react-error-boundary";
+import { HashRouter as Router, Routes, Route } from "react-router-dom";
+import ExtensionRegistration from "./ExtensionRegistration";
+import HeaderButtonModal from "./HeaderButtonModal";
+import RteWidget from "./RteWidget";
+import CustomField from "./CustomField";
+import RailContent from "./RailContent";
+
+function App() {
+    return (
+        <Router>
+            <ErrorBoundary onError={onError} FallbackComponent={fallbackComponent}>
+                <Routes>
+                    <Route index element={<ExtensionRegistration/>}/>
+                    <Route
+                        exact path="index.html"
+                        element={<ExtensionRegistration/>}
+                    />
+                    <Route
+                        exact path="{{EXTENSION_NAME}}-header-button-modal"
+                        element={<HeaderButtonModal/>}
+                    />
+                    <Route
+                        exact path="{{EXTENSION_NAME}}-widget"
+                        element={<RteWidget/>}
+                    />
+                    <Route
+                        exact path="{{EXTENSION_NAME}}-field"
+                        element={<CustomField/>}
+                    />
+                    <Route
+                        exact path="rail/:railId"
+                        element={<RailContent/>}
+                    />
+                    {/* YOUR CUSTOM ROUTES SHOULD BE HERE */}
+                </Routes>
+            </ErrorBoundary>
+        </Router>
+    )
+
+    // error handler on UI rendering failure
+    function onError(e, componentStack) {
+    }
+
+    // component to show if UI fails rendering
+    function fallbackComponent({componentStack, error}) {
+        return (
+            <React.Fragment>
+                <h1 style={{textAlign: "center", marginTop: "20px"}}>
+                    Phly, phly... Something went wrong :(
+                </h1>
+                <pre>{componentStack + "\n" + error.message}</pre>
+            </React.Fragment>
+        );
+    }
+}
+
+export default App;
+```
+
+---
+
+## § Universal Editor — `universal-editor/ui/1`
+
+> **Extension point is `universal-editor/ui/1`**, not `aem/universal-editor/1`. The old name is incorrect — all real project files (`app.config.yaml`, `app-metadata.json`) use `universal-editor/ui/1`.
+
+Extension dir: `universal-editor-ui-1`
+
+### `ExtensionRegistration.js`
+
+Real UE examples show two main patterns: `canvas.getRenderers()` (for custom field/component renderers in the canvas) and `rightPanel.addRails()` (for side panel rails). The product-picker example uses `canvas`; the richtext-draft and task-management examples use `rightPanel`.
+
+```js
+// {{EXTENSION_NAME}} - ExtensionRegistration.js
+
+import { Text } from "@adobe/react-spectrum";
+import { register } from "@adobe/uix-guest";
+import { extensionId } from "./Constants";
+import metadata from '../../../../app-metadata.json';
+
+function ExtensionRegistration() {
+  const init = async () => {
+    const guestConnection = await register({
+      id: extensionId,
+      metadata,
+      debug: true,
+      methods: {
+        // ── canvas: custom component/field renderers in the editor canvas ─────
+        // Use this when you need to render a custom picker or UI inside a field.
+        canvas: {
+          getRenderers() {
+            // guestConnection.configuration holds extension config from App Builder
+            const dataType = guestConnection.configuration?.["component-type"] || "{{EXTENSION_NAME}}";
+
+            return [
+              {
+                extension: extensionId,
+                dataType: dataType,
+                url: '/index.html#/{{EXTENSION_NAME}}-field',
+              },
+            ];
+          },
+        },
+
+        // ── rightPanel: side rails in the Universal Editor ────────────────────
+        // Use this to add a side panel rail alongside the page being edited.
+        rightPanel: {
+          addRails() {
+            return [
+              {
+                extension: extensionId,
+                id: "{{EXTENSION_NAME}}-rail",
+                header: "{{DISPLAY_NAME}}",
+                url: `/index.html#/{{EXTENSION_NAME}}-rail`,
+                hotkey: "w",
+                icon: "Draft",
+              }
+            ];
+          }
+        },
+      },
+    });
+  };
+  init().catch(console.error);
+
+  return <Text>IFrame for integration with Host (AEM)...</Text>;
+}
+
+export default ExtensionRegistration;
+```
+
+> Use `canvas.getRenderers()` OR `rightPanel.addRails()` depending on the extension's purpose — include only what is needed.
+
+> `guestConnection.configuration` provides the extension's App Builder configuration at runtime (e.g. environment-specific URLs, feature flags). Access it after `register()` resolves.
+
+### `App.js`
+
+```js
+// {{EXTENSION_NAME}} - App.js
+
+import React from "react";
+import ErrorBoundary from "react-error-boundary";
+import { HashRouter as Router, Routes, Route } from "react-router-dom";
+import ExtensionRegistration from "./ExtensionRegistration";
+import ExtensionField from "./ExtensionField";
+import RailContent from "./RailContent";
+
+function App() {
+  return (
+    <Router>
+      <ErrorBoundary onError={onError} FallbackComponent={fallbackComponent}>
+        <Routes>
+          <Route index element={<ExtensionRegistration />} />
+          <Route
+            exact path="index.html"
+            element={<ExtensionRegistration />}
+          />
+          <Route
+            exact path="{{EXTENSION_NAME}}-field"
+            element={<ExtensionField />}
+          />
+          <Route
+            exact path="{{EXTENSION_NAME}}-rail"
+            element={<RailContent />}
+          />
+          {/* YOUR CUSTOM ROUTES SHOULD BE HERE */}
+        </Routes>
+      </ErrorBoundary>
+    </Router>
+  );
+
+  // error handler on UI rendering failure
+  function onError(e, componentStack) {}
+
+  // component to show if UI fails rendering
+  function fallbackComponent({ componentStack, error }) {
+    return (
+      <React.Fragment>
+        <h1 style={{ textAlign: "center", marginTop: "20px" }}>
+          Phly, phly... Something went wrong :(
+        </h1>
+        <pre>{componentStack + "\n" + error.message}</pre>
+      </React.Fragment>
+    );
+  }
+}
+
+export default App;
+```
+
+---
+
+## § Assets View — `aem/assets/1`
+
+> **No verified example available.** No real example exists in the `aem-uix-examples` repository for this surface. The pattern is similar to CF Console but uses `aem/assets/1` as the extension point and `aem-assets-1` as the extension dir. Verify all namespaces and API shapes against the [official Adobe UIX Assets View docs](https://developer.adobe.com/uix/docs/services/aem-assets-view/) before using.
+
+> **Prerequisite:** AEM Assets Ultimate license. If the org lacks it, the extension won't load.
+
+Extension point: `aem/assets/1`
+Extension dir: `aem-assets-1`
+
+Use this `app.config.yaml`:
+```yaml
+extensions:
+  aem/assets/1:
+    $include: src/aem-assets-1/ext.config.yaml
+```
+
+No code template is provided here — generate code only after verifying the current namespace API against the official documentation.
+
+---
+
+## Quick reference
+
+| Surface | Extension Point | extDir | Namespaces (real examples) | Key host APIs |
+| --- | --- | --- | --- | --- |
+| CF Console | `aem/cf-console-admin/1` | `aem-cf-console-admin-1` | `actionBar`, `headerMenu` (+ `subItems`), `contentFragmentGrid` | `modal.showUrl()`, `modal.close()` |
+| CF Editor | `aem/cf-editor/1` | `aem-cf-editor-1` | `headerMenu`, `rte` (`getWidgets`, `getBadges`, `getCustomButtons`, `getColors`), `field`, `rightPanel` | `modal.showUrl()`, `toaster`, `contentFragment` |
+| Universal Editor | `universal-editor/ui/1` | `universal-editor-ui-1` | `canvas.getRenderers()`, `rightPanel.addRails()` | `guestConnection.configuration` |
+| Assets View | `aem/assets/1` | `aem-assets-1` | Not verified — see Adobe docs | Not verified |
+
+> **Modal pages and host utilities** (toaster, progressCircle, modal.showUrl) are covered in [`../appbuilder-ui-scaffolder/references/aem-extensions.md`](../../appbuilder-ui-scaffolder/references/aem-extensions.md) § Modal Dialogs and § Host Utilities — read that file for patterns; only the scaffold files above are surface-specific.

--- a/plugins/app-builder/skills/appbuilder-project-init/references/debugging.md
+++ b/plugins/app-builder/skills/appbuilder-project-init/references/debugging.md
@@ -135,3 +135,202 @@ Note: `aio app init` runs with `--no-install`, so init succeeds even when `npm i
 | Port 9080 already in use | Kill the process on 9080 (`lsof -ti:9080 | xargs kill`) or set `PORT=9081 aio app run` |
 | Missing `.env` credentials | `aio app run` needs `AIO_runtime_namespace` and `AIO_runtime_auth` in `.env` — run `aio app use` to populate |
 | Actions deploy but UI is blank | Check browser console for CORS errors; verify `app.config.yaml` has correct `web` configuration |
+
+---
+
+## Extension Lifecycle — Dev Server / Build Issues
+
+These sections apply when working with a scaffolded App Builder UI extension (Extension Scaffolding Mode). For project initialization failures, see the sections above.
+
+### `aio app run` exits immediately or never shows the localhost URL
+
+**Cause:** Build failed, or Node.js version too old.
+
+```bash
+# Check Node version (must be 18+)
+node -v
+
+# Confirm npm install completed without errors
+npm install
+
+# Rebuild first
+aio app build
+
+# Then start
+aio app run
+```
+
+If `aio app build` fails with a manifest validation error:
+```bash
+aio app build --no-config-validation
+```
+Fix the underlying YAML issue in `app.config.yaml` or `ext.config.yaml`, then rebuild without the flag.
+
+### `aio app build` fails: "function not found" or "action file missing"
+
+The action file path in `ext.config.yaml` does not match the actual file location.
+
+Check:
+```yaml
+# ext.config.yaml
+actions:
+  generic:
+    function: actions/generic/index.js   # relative to ext.config.yaml's directory
+```
+
+The file must exist at `src/<extDir>/actions/generic/index.js` (where `<extDir>` is `surfaceConfig.extDir`, e.g. `aem-assets-contenthub-1` for Content Hub).
+
+---
+
+## Extension Lifecycle — Local Testing Issues
+
+### Panel or app is blank / nothing loads
+
+**Most common cause:** Self-signed certificate not trusted.
+
+```
+Fix:
+1. Open https://localhost:9080 in the same browser
+2. Click Advanced → Proceed to localhost (unsafe)
+   OR type "thisisunsafe" in Chrome
+3. Reload the extension test URL
+```
+
+If the cert page shows an error (not just a warning), `aio app run` may not be running. Check the terminal.
+
+### Extension not visible after opening the test URL
+
+Check in order:
+
+1. **`aio app run` not running** — Confirm the dev server is up and the terminal shows `-> https://localhost:9080`.
+
+2. **`devMode=true` missing** — The local `ext=` URL param only works with `devMode=true` in the URL:
+   ```
+   https://experience.adobe.com/?devMode=true&ext=https://localhost:9080
+   ```
+
+3. **Wrong extension point in `app.config.yaml`** — The declared extension point must match the target surface (e.g. `aem/assets/contenthub/1` for Content Hub, `aem/cf-console-admin/1` for CF Console). Do not use deprecated IDs.
+
+4. **Content Hub only — `allowedRepos` filtering** — The `repo` URL parameter doesn't match `allowedRepos`. Either empty the array for dev, or add the repo you're testing with.
+
+5. **`register()` not called** — Check the browser console for errors. If `ExtensionRegistration` threw, `register()` never ran.
+
+### `attach()` fails: "No extension with id ... found"
+
+The `extensionId` in `TabPanel.js` does not match the `id` in `ExtensionRegistration.js`.
+
+Both must import `extensionId` from `Constants.js`. Check that `Constants.js` has not been edited and both files import from it:
+```js
+import { extensionId } from './Constants';
+```
+
+### Host API returns undefined or throws
+
+`attach()` must fully resolve before calling `host.*` methods. Always `await attach()` before using the connection:
+
+```js
+// Wrong — calling host API before attach resolves
+const connection = attach({ id: extensionId });
+const asset = await connection.host.assetDetails.getCurrentAsset(); // undefined connection
+
+// Correct
+const connection = await attach({ id: extensionId });
+const asset = await connection.host.assetDetails.getCurrentAsset();
+```
+
+### Content Hub — panel shows but `getCurrentAsset()` returns null
+
+This happens if the panel iframe loads before Content Hub has populated the asset context. Wrap in a try/catch and retry with a delay if needed, or check that the panel route is only rendered after `attach()` resolves.
+
+> **Note:** `getCurrentAsset()` returns the asset id as a plain string (e.g. `"urn:aaid:aem:..."`), not `{ id }`. Wrap it if needed: `const asset = { id: assetId };`
+
+---
+
+## Extension Lifecycle — Authentication Issues
+
+### Stale OAuth token — 401 even when `aio where` shows logged-in
+
+A token can appear valid in `aio where` (org/project/workspace all populated, unexpired local `expiry`) yet still be **rejected server-side** by the Console API. This is the #1 cause of "401 on everything".
+
+Run in a subshell with `CI`/`AIO_CLI_NO_TTY` unset — otherwise the browser is suppressed and login silently fails:
+
+```bash
+bash -c 'unset CI AIO_CLI_NO_TTY TERM; aio login'
+# If the token is stale (401 even when aio where shows logged in):
+bash -c 'unset CI AIO_CLI_NO_TTY TERM; aio login --force'
+```
+
+### `aio console project create` fails with 401
+
+Token is expired or the wrong org is selected. Run `aio login`, then `aio console org select <orgId>`.
+
+### `npm install` fails with E401
+
+Adobe's internal npm registry config in `.npmrc` may be conflicting. Try:
+```bash
+npm install --registry https://registry.npmjs.org
+```
+
+---
+
+## Extension Lifecycle — Developer Console Bootstrap Edge Cases
+
+### `aio console workspace create` returns "already exists"
+
+```bash
+aio console workspace list --projectName <projectName> --json
+# Stage workspace already there — skip workspace creation and proceed
+```
+
+### `aio app use` fails: workspace not found
+
+Use explicit IDs rather than names:
+```bash
+PROJECT_ID=$(aio console project list --json | node -e "
+  const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+  console.log((d.find(p=>p.name==='<projectName>')||{}).id||'');
+")
+aio console project select "$PROJECT_ID"
+
+WORKSPACE_ID=$(aio console workspace list --projectId "$PROJECT_ID" --json | node -e "
+  const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+  console.log((d.find(w=>w.name==='Stage')||{}).id||'');
+")
+aio console workspace select "$WORKSPACE_ID"
+aio app use --no-input
+```
+
+---
+
+## Extension Lifecycle — Post-Deployment Issues
+
+### Extension deployed but invisible to some users
+
+The App Builder project has extra services (Cloud Manager, AEM Assets Author API, etc.) that not all users are entitled to.
+
+**Fix:** In Adobe Developer Console, remove all services except Runtime from the project. Redeploy and reapprove.
+
+### Extension approved but not showing (no `ext=` param)
+
+Wrong workspace. Approved in Stage but deployed to Production, or vice versa.
+```bash
+aio app use -w Production
+aio app deploy
+# Reapprove in Extension Manager
+```
+
+---
+
+## Extension Lifecycle — Quick Diagnosis Checklist
+
+Run through this in order when the extension doesn't work:
+
+1. `aio where` — correct org, project, workspace?
+2. `aio app run` output — localhost URL shown?
+3. Browser console — any JS errors in `ExtensionRegistration`?
+4. Test URL — includes `devMode=true` and `ext=https://localhost:9080`?
+5. `https://localhost:9080` in browser — cert trusted?
+6. `app.config.yaml` — extension point matches the target surface (correct, non-deprecated ID)?
+7. `Constants.js` `extensionId` — imported correctly in both `ExtensionRegistration.js` and the panel/modal page?
+8. **Content Hub only** — `allowedRepos` empty (dev) or contains the test repo?
+9. **ExC Shell only** — `runtime.done()` called at the `register` level (not inside `onReady` or after a fetch)?

--- a/plugins/app-builder/skills/appbuilder-project-init/references/deployment.md
+++ b/plugins/app-builder/skills/appbuilder-project-init/references/deployment.md
@@ -1,0 +1,149 @@
+# Adobe App Builder Extension Deployment
+
+Complete deployment workflow for App Builder extensions from Stage through Production approval. Applies to all surfaces (Content Hub, CF Console, CF Editor, Universal Editor, Assets View, ExC Shell).
+
+---
+
+## Prerequisites
+
+Before deploying:
+1. `aio app run` has succeeded locally (extension visible with `ext=` URL param)
+2. `allowedRepos` in `ExtensionRegistration.js` is populated with delivery repo IDs
+3. The correct org and project are selected (`aio where` shows the right state)
+
+---
+
+## Stage Deployment
+
+Stage is used for QA and stakeholder review before Production.
+
+```bash
+# Switch workspace — unset CI/AIO_CLI_NO_TTY in subshell so credentials are downloaded
+bash -c 'unset CI AIO_CLI_NO_TTY TERM; printf "y\ny\ny\ny\n" | aio app use -w Stage --overwrite' 2>/dev/null
+
+# Deploy — capture output
+aio app deploy 2>&1 | tee /tmp/aio-deploy.log
+```
+
+After deploy completes, **always** parse the CDN URL from the log — even if actions failed:
+
+```bash
+CDN_URL=$(grep -Eo 'https://[^ ]+adobeio-static\.net[^ ]*' /tmp/aio-deploy.log | grep 'index\.html' | tail -1)
+# If no index.html variant found, take any adobeio-static.net URL:
+CDN_URL=${CDN_URL:-$(grep -Eo 'https://[^ ]+adobeio-static\.net[^ ]*' /tmp/aio-deploy.log | tail -1)}
+```
+
+Open the target surface automatically with the deployed URL — **do not just print it**. Use `surfaceConfig.openUrl` with the local `ext=https://localhost:9080` replaced by `ext=<CDN_URL>/index.html`. For Content Hub specifically:
+
+```bash
+open "https://experience.adobe.com/?devMode=true&ext=${CDN_URL}/index.html#/assets/contenthub/"
+```
+
+For other AEM surfaces (`cf-console`, `cf-editor`, `universal-editor`, `assets-view`), drop the hash:
+```bash
+open "https://experience.adobe.com/?devMode=true&ext=${CDN_URL}/index.html"
+```
+
+For ExC Shell, the CDN URL printed by `aio app deploy` is the deployed SPA URL — open it directly.
+
+**Partial failure rule:** If web assets deployed but actions failed (Runtime not provisioned in the org, or 401 on action deploy), still open the CDN URL. The extension UI loads correctly. Actions will fail only when called. Do not block on action deployment errors.
+
+---
+
+## Production Deployment
+
+```bash
+# Switch to Production workspace — unset CI/AIO_CLI_NO_TTY in subshell
+bash -c 'unset CI AIO_CLI_NO_TTY TERM; printf "y\ny\ny\ny\n" | aio app use -w Production --overwrite' 2>/dev/null
+
+# Deploy to Production
+aio app deploy
+```
+
+Production deployment must be followed by an approval step before the extension is visible to all users in the org.
+
+---
+
+## Extension Manager Approval
+
+1. Open `https://experience.adobe.com/aem/extension-manager`
+2. Find your extension by name
+3. Click **Approve**
+4. The extension becomes visible to all users in your org — no `ext=` URL parameter needed
+
+---
+
+## Workspace Selection (`aio app use`)
+
+`aio app use` rewrites `.aio` and `.env` to point at the specified workspace. Always run it before `aio app deploy` when switching targets.
+
+```bash
+# Check current workspace
+CI=true AIO_CLI_NO_TTY=true NO_COLOR=1 aio where
+
+# Switch workspace — unset CI/AIO_CLI_NO_TTY in subshell so credentials are downloaded
+bash -c 'unset CI AIO_CLI_NO_TTY TERM; printf "y\ny\ny\ny\n" | aio app use -w Stage --overwrite' 2>/dev/null
+bash -c 'unset CI AIO_CLI_NO_TTY TERM; printf "y\ny\ny\ny\n" | aio app use -w Production --overwrite' 2>/dev/null
+```
+
+If `aio app use -w <name>` does not find the workspace by name, use explicit flags (also in clean subshell):
+```bash
+bash -c 'unset CI AIO_CLI_NO_TTY TERM; aio app use --org <orgId> --project <projectName> --workspace Stage --no-input'
+```
+
+---
+
+## Re-deploy After Code Changes
+
+```bash
+# Rebuild and redeploy (from the project directory)
+aio app deploy
+```
+
+For UI-only changes (no action changes), `aio app deploy` is still the right command — it rebuilds the web-src bundle and pushes to CDN.
+
+---
+
+## Troubleshooting Deployments
+
+### Extension visible with `ext=` but not after approval
+
+The extension was approved in the wrong workspace. The `ext=` URL param bypasses workspace checks.
+
+```bash
+aio where             # confirm you're on Production
+aio app use -w Production
+aio app deploy
+# Then re-approve in Extension Manager
+```
+
+### Extension invisible to some users
+
+The App Builder project includes extra Adobe services (AEM Assets Author API, Cloud Manager, etc.). Only users entitled to those services see the extension.
+
+**Fix:** Remove all non-required services from the App Builder project in Adobe Developer Console. Keep only Runtime. Redeploy and reapprove.
+
+### `aio app deploy` fails with auth error
+
+`.env` is missing or stale. Re-wire the workspace (unset CI in a subshell so credentials are downloaded):
+```bash
+bash -c 'unset CI AIO_CLI_NO_TTY TERM; printf "y\ny\ny\ny\n" | aio app use -w Stage --overwrite' 2>/dev/null
+aio app deploy
+```
+
+### CDN propagation delay
+
+After `aio app deploy` succeeds, CDN propagation can take 1-2 minutes. If the extension shows the old version immediately after deploy, wait a moment and hard-refresh.
+
+---
+
+## Full Deployment Checklist
+
+- [ ] `aio where` shows the correct org, project, and workspace
+- [ ] `aio app use -w <workspace>` run in a clean subshell (`unset CI AIO_CLI_NO_TTY TERM`) before deploying
+- [ ] `aio app deploy` completed without errors (partial web-only success is still usable)
+- [ ] Tested with the deployed CDN URL (not localhost)
+- [ ] **Content Hub / AEM surfaces** — deployed URL opened with `?devMode=true&ext=<CDN>/index.html`
+- [ ] **Content Hub only** — `allowedRepos` populated with target delivery repo IDs before Production deploy
+- [ ] For Production: approved in Extension Manager
+- [ ] For Production: verified without `ext=` URL parameter

--- a/plugins/app-builder/skills/appbuilder-project-init/references/excshell-templates.md
+++ b/plugins/app-builder/skills/appbuilder-project-init/references/excshell-templates.md
@@ -1,0 +1,192 @@
+# Experience Cloud Shell SPA Templates (`dx/excshell/1`)
+
+The ExC Shell surface is **not** a UIX extension — it's a standalone App Builder SPA that runs inside the Experience Cloud Shell iframe. It uses **`@adobe/exc-app`** (`register()` + `runtime.done()`), NOT `@adobe/uix-guest`. There are no extension points and no `methods` object.
+
+Reuse from [`file-templates.md`](file-templates.md): `index.html`, `index.css`, `actions/utils.js`, `actions/generic/index.js`, `hooks/post-deploy.js`, `.eslintrc.js`. Everything below is ExC-Shell-specific.
+
+Placeholders: `{{EXTENSION_NAME}}`, `{{DISPLAY_NAME}}`, `{{EXTENSION_DESCRIPTION}}`, `{{EXTENSION_DIR}}` (= `dx-excshell-1`).
+
+---
+
+## `package.json`
+
+Same as Content Hub but swap `@adobe/uix-guest` for `@adobe/exc-app`:
+
+```json
+{
+  "name": "{{EXTENSION_NAME}}",
+  "version": "1.0.0",
+  "description": "{{EXTENSION_DESCRIPTION}}",
+  "license": "Apache-2.0",
+  "scripts": {
+    "test": "jest --passWithNoTests --testPathIgnorePatterns web-src",
+    "dev": "aio app run",
+    "build": "aio app build",
+    "deploy": "aio app deploy",
+    "undeploy": "aio app undeploy"
+  },
+  "dependencies": {
+    "@adobe/aio-sdk": "^5.0.0",
+    "@adobe/exc-app": "^1.4.17",
+    "@adobe/react-spectrum": "^3.33.0",
+    "chalk": "^4.0.0",
+    "js-yaml": "^4.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.0"
+  },
+  "devDependencies": {
+    "@adobe/eslint-config-aio-lib-config": "^3.0.0",
+    "eslint": "^8.0.0",
+    "jest": "^29.0.0"
+  },
+  "engines": { "node": "^18 || ^20" }
+}
+```
+
+---
+
+## `app.config.yaml`
+
+```yaml
+extensions:
+  dx/excshell/1:
+    $include: src/dx-excshell-1/ext.config.yaml
+```
+
+---
+
+## `src/dx-excshell-1/ext.config.yaml`
+
+```yaml
+$schema: https://unpkg.com/@adobe/aio-schemas@latest/schemas/aio.schema.json
+actions: actions
+web: web-src
+runtimeManifest:
+  packages:
+    dx-excshell-1:
+      license: Apache-2.0
+      actions:
+        generic:
+          function: actions/generic/index.js
+          web: 'yes'
+          runtime: 'nodejs:18'
+          inputs:
+            LOG_LEVEL: debug
+          annotations:
+            require-adobe-auth: true
+            final: true
+operations:
+  view:
+    - type: web
+      impl: index.html
+hooks:
+  post-app-deploy: ./hooks/post-deploy.js
+```
+
+> Unlike the AEM surfaces, ExC Shell actions typically set `require-adobe-auth: true` because the SPA forwards the shell's IMS token. If the app has no backend, you may delete the `actions`/`runtimeManifest` blocks entirely.
+
+> `index.js` and `index.css` are identical to the shared skeleton in [`file-templates.md`](file-templates.md) — reuse those directly.
+
+## `src/dx-excshell-1/web-src/src/components/App.js`
+
+The entire shell handshake lives here. **`runtime.done()` MUST be called at the `register` level** (not after data fetch) or the shell shows an infinite spinner.
+
+```js
+import React, { useState, useEffect } from 'react';
+import { Provider, defaultTheme, View, Heading, Text, Button, ProgressCircle, Divider } from '@adobe/react-spectrum';
+import { register } from '@adobe/exc-app';
+import actions from '../config.json';
+
+export default function App() {
+  const [shellReady, setShellReady] = useState(false);
+  const [ctx, setCtx] = useState({});           // { imsOrg, imsToken, imsProfile, locale }
+  const [actionResponse, setActionResponse] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    register({ id: '{{EXTENSION_NAME}}' }, (runtime) => {
+      runtime.ready({
+        onReady: ({ imsOrg, imsToken, imsProfile, locale }) => {
+          setCtx({ imsOrg, imsToken, imsProfile, locale });
+          setShellReady(true);
+        },
+      });
+      // CRITICAL: dismiss the shell loading spinner immediately — never wait for data here.
+      runtime.done();
+    });
+  }, []);
+
+  async function callAction() {
+    try {
+      const res = await fetch(actions['dx-excshell-1/generic'], {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${ctx.imsToken}`,
+          'x-gw-ims-org-id': ctx.imsOrg,
+        },
+        body: JSON.stringify({}),
+      });
+      setActionResponse(await res.json());
+    } catch (e) {
+      setError(e.message);
+    }
+  }
+
+  if (!shellReady) {
+    return (
+      <Provider theme={defaultTheme}>
+        <View padding="size-400" UNSAFE_style={{ display: 'flex', justifyContent: 'center' }}>
+          <ProgressCircle aria-label="Loading…" isIndeterminate />
+        </View>
+      </Provider>
+    );
+  }
+
+  return (
+    <Provider theme={defaultTheme} locale={ctx.locale} colorScheme="light">
+      <View padding="size-400">
+        <Heading level={2}>{{DISPLAY_NAME}}</Heading>
+        <Divider marginY="size-200" />
+        <Text>Signed in as {ctx.imsProfile?.name} — org {ctx.imsOrg}</Text>
+        {error && <View marginTop="size-200" backgroundColor="negative" padding="size-100" borderRadius="regular"><Text>{error}</Text></View>}
+        {actionResponse && (
+          <View marginTop="size-200" padding="size-100" backgroundColor="gray-100" borderRadius="regular"
+            UNSAFE_style={{ fontFamily: 'monospace', whiteSpace: 'pre-wrap' }}>
+            <Text>{JSON.stringify(actionResponse, null, 2)}</Text>
+          </View>
+        )}
+        <Button variant="accent" marginTop="size-300" onPress={callAction}>Call backend action</Button>
+      </View>
+    </Provider>
+  );
+}
+```
+
+---
+
+## `src/dx-excshell-1/web-src/src/config.json`
+
+```json
+{
+  "dx-excshell-1/generic": "https://localhost:9080/api/v1/web/dx-excshell-1/generic"
+}
+```
+
+Overwritten by `aio app run` (localhost) and `aio app deploy` (CDN). Do not edit by hand.
+
+---
+
+## Key differences from the AEM/Content Hub surfaces
+
+| | AEM / Content Hub (`uix-guest`) | ExC Shell (`exc-app`) |
+| --- | --- | --- |
+| SDK | `@adobe/uix-guest` | `@adobe/exc-app` |
+| Entry call | `register({ id, methods })` | `register({ id }, (runtime) => …)` |
+| Auth | `host.auth` / `sharedContext.get('auth')` | `runtime.ready({ onReady })` context |
+| Extension points | yes (`assetDetails`, `actionBar`, …) | none — it's a full SPA |
+| Must call `runtime.done()` | no | **yes — or the shell spins forever** |
+| Local view | inside an AEM surface via `?ext=` | the SPA serves directly at `https://localhost:9080` |
+
+See [`../appbuilder-ui-scaffolder/references/shell-integration.md`](../../appbuilder-ui-scaffolder/references/shell-integration.md) for pitfalls, host-API reference, and IMS token passthrough patterns.

--- a/plugins/app-builder/skills/appbuilder-project-init/references/extension-scaffolding.md
+++ b/plugins/app-builder/skills/appbuilder-project-init/references/extension-scaffolding.md
@@ -1,0 +1,749 @@
+# AEM UI Extension Scaffolding — Full Workflow
+
+Complete step-by-step workflow for scaffolding any Adobe App Builder UI extension from scratch.
+Covers: Console setup, surface selection, file generation, build, dev server, cert acceptance, and deploy.
+
+Read this file when `appbuilder-project-init` enters Extension Scaffolding Mode.
+
+> **When to use this mode:** User wants to create a NEW App Builder UI extension — Content Hub panels/card actions/bulk actions, CF Console/Editor action bars, Universal Editor header buttons, Assets View actions, or ExC Shell SPAs. This mode handles everything: surface selection, Developer Console setup, file generation, npm install, build, dev server, cert acceptance, and deployment. If the user already has a scaffolded project and wants to customize the UI, use `appbuilder-ui-scaffolder` instead.
+
+Drives the complete lifecycle for an Adobe App Builder UI extension — from one prompt to a running, open browser tab — for **any** supported surface. Uses `AskUserQuestion` for every user decision. Never prints a test URL without opening it. Never asks the user to type anything.
+
+> **Why this mode is generic.** ~80% of the work (login, token validation, org/project/workspace setup, npm install, `aio app use`, build, dev server, cert page, deploy) is **identical for every surface**. Only four things vary per surface: which surface to build (Step 0), the scaffold files (Step 10), the URL to open (Step 16), and the follow-up customization map (Step 18). All four are driven by a single **Surface Config** entry, so adding a new surface in the future means adding one config row + one template section — not rewriting the workflow.
+
+---
+
+### Surface Config (the heart of the generic design)
+
+Step 0 picks a surface and loads its config into a `surfaceConfig` object. Every downstream step reads from it instead of hardcoding Content Hub values.
+
+| `surfaceKey` | Surface | `extensionPointId` | `extDir` (`src/…`) | SDK | Templates | Available namespaces (Step 2) |
+| --- | --- | --- | --- | --- | --- | --- |
+| `content-hub` | Content Hub | `aem/assets/contenthub/1` | `aem-assets-contenthub-1` | `@adobe/uix-guest` | [`references/file-templates.md`](references/file-templates.md) | `assetDetails` (tab panels), `card` (per-asset card buttons + collection tiles), `selectionBar` (bulk action bar), `addAssets` (wizard panels + beforeUpload hook + onUploadComplete hook) |
+| `cf-console` | Content Fragment Console | `aem/cf-console-admin/1` | `aem-cf-console-admin-1` | `@adobe/uix-guest` | [`references/aem-surface-templates.md` § CF Console](references/aem-surface-templates.md) | `actionBar`, `headerMenu`, `contentFragmentGrid` |
+| `cf-editor` | Content Fragment Editor | `aem/cf-editor/1` | `aem-cf-editor-1` | `@adobe/uix-guest` | [`references/aem-surface-templates.md` § CF Editor](references/aem-surface-templates.md) | `headerMenu`, `rte` |
+| `universal-editor` | Universal Editor | `universal-editor/ui/1` | `universal-editor-ui-1` | `@adobe/uix-guest` | [`references/aem-surface-templates.md` § Universal Editor](references/aem-surface-templates.md) | `canvas.getRenderers()`, `rightPanel.addRails()` |
+| `assets-view` | Assets View (Assets Ultimate license) | `aem/assets/1` | `aem-assets-1` | `@adobe/uix-guest` | [`references/aem-surface-templates.md` § Assets View](references/aem-surface-templates.md) | `actionBar`, `headerMenu` |
+| `exc-shell` | Experience Cloud Shell SPA | `dx/excshell/1` | `dx-excshell-1` | `@adobe/exc-app` | [`references/excshell-templates.md`](references/excshell-templates.md) | n/a (standalone SPA, no extension points) |
+
+**Open URLs (used in Step 16), keyed by `surfaceKey`:**
+
+| `surfaceKey` | Local dev open URL |
+| --- | --- |
+| `content-hub` | `https://experience.adobe.com/?devMode=true&ext=https://localhost:9080#/assets/contenthub/` |
+| `cf-console` | `https://experience.adobe.com/?devMode=true&ext=https://localhost:9080` → then navigate to **Content Fragments** |
+| `cf-editor` | `https://experience.adobe.com/?devMode=true&ext=https://localhost:9080` → open a fragment in the **CF Editor** |
+| `universal-editor` | `https://experience.adobe.com/?devMode=true&ext=https://localhost:9080` → open the **Universal Editor** |
+| `assets-view` | `https://experience.adobe.com/?devMode=true&ext=https://localhost:9080` → navigate to **Assets** |
+| `exc-shell` | `https://localhost:9080` (the cert page IS the running SPA) — to embed in the shell, use `https://experience.adobe.com/?devMode=true&ext=https://localhost:9080` |
+
+The AEM extension surfaces (CF Console / Editor / UE / Assets View) all load through the **same `?ext=` extension tester base** — they differ only in which AEM app you navigate to after the shell opens. Only Content Hub has a stable deep-link hash (`#/assets/contenthub/`). Do not fabricate deep-link hashes for the other surfaces — open the tester base and tell the user where to navigate.
+
+---
+
+### What the skill does vs what the customer does
+
+| Skill (automatic) | Customer (3 moments only) |
+| --- | --- |
+| Ask which surface + all questions via MCQ — no typing | Accept self-signed cert at `https://localhost:9080` (once per browser session) |
+| CLI install check, login detection, org/project/workspace setup | Navigate to the target surface in the shell (AEM surfaces only) |
+| Generate all scaffold files for the chosen surface | Approve in Extension Manager (Production deployments only) |
+| npm install → aio app use → aio app build → aio app run | |
+| Open cert page automatically after dev server starts | |
+| Ask "Done?" then open the target surface automatically | |
+| Ask about deployment via MCQ | |
+
+---
+
+### Interaction Rules (how to ask, decline, and resume)
+
+These rules govern every user-facing moment in the workflow. They keep the flow moving and make sure the user is never left guessing what a choice means or what to do after declining.
+
+**1. Always use `AskUserQuestion` for choices.** Every time a user needs to make a decision, use the `AskUserQuestion` tool with MCQ options. **Never print a numbered list and ask the user to type a number or name.** The user should never type anything except when they select "Other" in a question.
+
+**2. Every option must state what it does — never bare "Yes"/"No".** A user should be able to pick an option without inferring its meaning. Always give each option a `label` that names the action *and* a `description` that spells out the consequence. Write `label: "Yes — install the aio CLI now"` / `description: "Runs npm install -g @adobe/aio-cli, ~30s"`, not `label: "Yes"`. The "No"/decline option must say what happens instead (e.g. "No — I'll install it myself; I'll print the command and pause").
+
+**3. Declining must never dead-end — always give a next step.** Whenever the user picks the "No"/decline/"I'll do it myself" option in any question, do NOT just stop. Respond with: (a) a one-line confirmation of what was skipped, (b) the exact command or manual action they need to perform, and (c) how to resume — tell them to type **`continue`** (or re-run the skill) once they've done it, and state which step you'll pick up from. Example after declining the dev-server auto-start: *"No problem — start it yourself with `cd <path> && PORT=9080 aio app run`, then type `continue` and I'll open the cert page (Step 15)."* Never leave the user at a prompt with no idea what to do next.
+
+**4. ALL file writes are fully automatic — no confirmation, no per-file questions, no permission prompts, ever.** This applies to EVERY `Write`/`Edit`/`Bash mkdir` call anywhere in this mode — scaffold files (Step 10), config files, template files, customization edits (Step 18), or any other file operation. Do NOT ask "Ready to scaffold?", "Should I create this file?", "OK to write this file?", "Is it okay to write X?", or any variant — before, during, or after any file write. Do NOT say "I'll now write X" and pause. Do NOT announce each file before writing it. Just write all files immediately, one after another, no pauses. The project settings pre-authorize `Write` and `Bash(mkdir *)` so the harness will not prompt either. The only `AskUserQuestion` calls in this flow are genuine decisions (surface, name, extension points, workspace, output dir, install/login/deploy). Writing files is never a question — it is a silent, automatic action.
+
+**5. If the flow is interrupted mid-run, tell the user how to pick up.** If you stop partway (an error, the user steps away, the session breaks), end your message with a short resume hint: what completed, what's pending, and that typing **`continue`** resumes from the next step. State the step number so it's unambiguous (e.g. *"Stopped after npm install. Type `continue` to resume from Step 12 (wire to workspace)."*).
+
+**6. When a command is denied at the permission prompt, never silently halt.** Claude Code shows its own permission dialog before running a Bash command — "1. Yes / 2. Yes, and don't ask again / 3. No". This dialog is the *harness*, not our `AskUserQuestion` MCQ, so we can't change its buttons or add text to it. What we control is the response **after** the user picks **No (3)**: the tool call comes back denied. When that happens, do NOT just stop. Reply with (a) which command was blocked and what step it belongs to, (b) why it's needed (e.g. "this creates the project folders — the scaffold can't continue without them"), and (c) how to proceed: either approve it (and that picking **2. Yes, and don't ask again** avoids future prompts for similar commands) or run it themselves and type **`continue`**. Tip for the user: the scaffold runs many routine `mkdir`/`npm`/`aio` commands, so choosing **2. Yes, and don't ask again** early makes the rest of the run prompt-free.
+
+---
+
+### Full Workflow
+
+#### Step 0 — Identify the target surface (run FIRST, before Step 1)
+
+Do NOT assume every "create an extension" request means Content Hub. Decide based on the request:
+
+- **The request explicitly names a surface** (e.g. "Content Hub extension", "CF Console action bar", "Universal Editor header button", "ExC Shell app", or an extension point ID like `aem/cf-console-admin/1`) → set `surfaceConfig` from the matching row in the Surface Config table and skip straight to Step 1. **Important:** "Content Hub" alone is a surface, NOT a namespace — always ask Step 2 to choose which namespace(s).
+- **The request is generic** ("create an extension", "build an Adobe/App Builder extension", "I want to extend Adobe", no surface named) → you MUST ask which surface first. Use `AskUserQuestion` with exactly 3 options — this covers all 6 surfaces across two questions with no "Other" path needed:
+
+**Question 1 — surface family:**
+```
+question: "What kind of Adobe App Builder extension do you want to build?"
+options:
+  - label: "Content Hub"
+    description: "Extend Content Hub — aem/assets/contenthub/1. Supports: tab panels in Asset Details, card/collection-tile action buttons, bulk-action bar buttons, and Add Assets wizard panels. You'll choose which surface(s) in the next step."
+  - label: "AEM UI Extension"
+    description: "Customize an AEM surface — Content Fragment Console, CF Editor, Universal Editor, or Assets View."
+  - label: "Experience Cloud Shell app"
+    description: "A standalone App Builder SPA inside the Experience Cloud Shell — dx/excshell/1."
+```
+
+- If **Content Hub** → `surfaceKey = content-hub`, continue to Step 1.
+- If **Experience Cloud Shell** → `surfaceKey = exc-shell`, continue to Step 1.
+- If **AEM UI Extension** → ask **Question 2** immediately:
+
+**Question 2 — which AEM surface (all 4 fit, no "Other" needed):**
+```
+question: "Which AEM surface are you extending?"
+options:
+  - label: "Content Fragment Console"
+    description: "Action bar buttons, header menu, or custom grid columns — aem/cf-console-admin/1."
+  - label: "Content Fragment Editor"
+    description: "Header menu buttons or RTE toolbar customizations — aem/cf-editor/1."
+  - label: "Universal Editor"
+    description: "Canvas renderers or right-panel rails — universal-editor/ui/1."
+  - label: "Assets View"
+    description: "Action bar / header menu buttons — aem/assets/1 (requires Assets Ultimate license)."
+```
+
+**After the answer:** look up the chosen surface in the Surface Config table and store the whole row as `surfaceConfig` (`surfaceKey`, `extensionPointId`, `extDir`, `sdk`, templates ref, open URL, available namespaces). **Every downstream step reads from `surfaceConfig` — there are no hardcoded Content Hub paths past this point.** Then continue to Step 1.
+
+---
+
+#### Step 1 — Extension Name
+
+Use the `AskUserQuestion` tool. Tailor the suggested names to `surfaceConfig.surfaceKey`:
+
+- `content-hub`: `asset-metadata-panel`, `asset-card-actions`, `asset-bulk-export`
+- `cf-console` / `cf-editor`: `cf-export-action`, `cf-validate-button`, `cf-status-column`
+- `universal-editor`: `ue-preview-button`, `ue-properties-panel`
+- `assets-view`: `assets-bulk-action`, `assets-header-menu`
+- `exc-shell`: `my-dashboard-app`, `reporting-spa`
+
+```
+question: "What should we name your extension?"
+options:
+  - label: "<surface-appropriate suggestion 1>"
+  - label: "<surface-appropriate suggestion 2>"
+  - label: "<surface-appropriate suggestion 3>"
+```
+
+The user can also select "Other" to type their own kebab-case name. Store the result as `extensionName`.
+
+Validate: must be kebab-case (lowercase letters and hyphens only). If the user types something invalid (e.g. `My Extension`), suggest the corrected form (`my-extension`) and use `AskUserQuestion` again:
+
+```
+question: "\"My Extension\" needs to be kebab-case. Use \"my-extension\"?"
+options:
+  - label: "Yes, use \"my-extension\""
+  - label: "Let me type a different name"
+```
+
+---
+
+#### Step 2 — Choose extension point(s) within the surface
+
+**Auto-select rule:** If the user's original prompt already names a specific namespace / extension point, do NOT ask — auto-select it and skip to Step 3. Examples:
+- "Add buttons to asset cards" / "card action" / "asset card" → auto-select `namespaces = ["card"]`
+- "Add a panel to the Asset Details dialog" / "asset details panel" / "tab panel in asset details" → auto-select `namespaces = ["assetDetails"]`
+- "Add a bulk action" / "selection bar" / "bulk action bar" → auto-select `namespaces = ["selectionBar"]`
+- "Add Assets wizard" / "before upload hook" / "hydration panel" / "add assets panel" → auto-select `namespaces = ["addAssets"]`
+- "Content Hub extension with card and bulk actions" → auto-select `namespaces = ["card", "selectionBar"]`
+
+**Never auto-select based on the surface label alone.** "Content Hub" or "Content Hub extension" (with no namespace hint) is generic → always ask the multiSelect question below.
+
+Only ask the multiSelect question below when the prompt is **generic** (e.g. "create a Content Hub extension" with no namespace hint).
+
+What you ask depends on `surfaceConfig.surfaceKey`:
+
+- **`content-hub`** — four namespaces are available. Use `AskUserQuestion` with `multiSelect: true`:
+  ```
+  question: "Which Content Hub surfaces do you want to extend?" (multiSelect: true)
+  options:
+    - label: "Asset Details panel"
+      description: "Add custom tab panels to the Asset Details Dialog side rail — assetDetails namespace"
+    - label: "Asset card / collection tile action"
+      description: "Add buttons to asset card menus (Assets grid, inside a collection, link share) and to collection tiles on the Collections grid — card namespace. getActionButtons receives actionContext (context: assets|collection|collections|share). onActionClick receives (resourceType, buttonId, resourceId, actionContext)."
+    - label: "Selection bar (bulk action)"
+      description: "Add buttons to the bulk-action bar shown when assets are selected — selectionBar namespace. getActionButtons receives actionContext with source + selection. onActionClick receives (buttonId, assetIds[])."
+    - label: "Add Assets wizard"
+      description: "Inject panels before/after the native Upload step, gate or enrich metadata before upload starts, and react after upload completes — addAssets namespace. getPanels returns [{id, title, position:'pre'|'post', contentUrl}]. beforeUpload(ctx) can block upload or merge metadata. onUploadComplete(ctx) fires after upload."
+  ```
+  Store the selected namespace keys as `namespaces` (e.g. `["assetDetails", "card"]`). At least one must be selected. The `card` and `selectionBar` namespaces open a modal on click — their `onActionClick` methods call `guestConnection.host.modal.openDialog()`, which requires using `let guestConnection` (not `const`) so the closure can reference it after `register()` resolves. The `addAssets` namespace uses `postMessage` (not `host.modal`) to signal step readiness from wizard panels — do not mix `openDialog` into `addAssets` panel components.
+
+- **`cf-console`** — ask which extension point(s) to wire (multiSelect):
+  ```
+  question: "Which CF Console extension points should I wire up?" (multiSelect: true)
+  options:
+    - label: "Action bar button"   description: "Appears when fragments are selected — actionBar"
+    - label: "Header menu button"  description: "Always visible in the console header — headerMenu"
+    - label: "Custom grid column"  description: "Adds a column to the fragment list — contentFragmentGrid"
+  ```
+- **`cf-editor`** — multiSelect over `headerMenu` (header buttons) and `rte` (RTE toolbar buttons / badges).
+- **`universal-editor`** — multiSelect over `headerMenu` and a properties-rail panel.
+- **`assets-view`** — multiSelect over `actionBar` and `headerMenu`. Note the Assets Ultimate license requirement.
+- **`exc-shell`** — **skip this step entirely.** An ExC Shell app has no extension points; set `namespaces = []` and continue.
+
+Store the selected namespace keys as `namespaces` — Step 10 uses them to decide which methods blocks / template sections to include.
+
+---
+
+#### Step 3 — Workspace
+
+Use the `AskUserQuestion` tool:
+
+```
+question: "Which workspace should this extension use?"
+options:
+  - label: "Stage"
+    description: "For development and testing — recommended to start here"
+  - label: "Production"
+    description: "For final release"
+```
+
+Store `workspace` as the selected value.
+
+---
+
+#### Step 4 — Output Directory
+
+Use the `AskUserQuestion` tool:
+
+```
+question: "Where should the project be created?"
+options:
+  - label: "~/Desktop/<extensionName>"
+    description: "Create on your Desktop (recommended)"
+  - label: "~/Documents/<extensionName>"
+    description: "Create in your Documents folder"
+```
+
+Resolve the final `outputPath` to an absolute path, e.g. `$HOME/Desktop/<extensionName>`.
+
+---
+
+#### Step 5 — Check aio CLI Installed
+
+```bash
+aio --version 2>/dev/null
+```
+
+- **Installed:** Continue immediately.
+- **Not installed:** Use `AskUserQuestion`:
+
+```
+question: "The Adobe I/O CLI (aio) is not installed. Should I install it for you?"
+options:
+  - label: "Yes — install it now"
+    description: "Runs npm install -g @adobe/aio-cli (~30s), then continues automatically"
+  - label: "No — I'll install it myself"
+    description: "I'll print the install command and pause; type 'continue' once it's installed"
+```
+
+If "Yes":
+```bash
+npm install -g @adobe/aio-cli
+```
+
+If "No": print `npm install -g @adobe/aio-cli`, tell the user to run it, and that typing `continue` resumes from Step 5 (login check). Do not proceed until the CLI is present.
+
+---
+
+#### Step 6 — Check Login AND Validate the Token
+
+**`aio where` is NOT a sufficient login check.** A token can show fully logged-in in `aio where` (Org/Project/Workspace all populated) and an unexpired local `expiry`, yet still be **rejected server-side** by the Console API with:
+
+```
+401 - Unauthorized ({"title":"ErrInvalidOauthToken","status":401,"error_code":401013,"message":"Oauth token is not valid"})
+```
+
+This is the #1 cause of "401 on everything" — a **stale token**, NOT a restricted org. No env-flag trick (`CI`, `unset`, `aio where`) can fix an invalid token. The ONLY fix is a fresh `aio login --force`. So this step does two checks: context presence, then a real token-validity probe.
+
+**6a — Context check (fast, no browser):**
+
+```bash
+CI=true AIO_CLI_NO_TTY=true NO_COLOR=1 aio where 2>/dev/null
+```
+
+**If output is empty or contains "not logged":** Run `aio login` in a subshell with CI/AIO_CLI_NO_TTY completely **unset** — `env VAR=` only sets to empty string but the variable still exists; must use `unset`:
+
+```bash
+bash -c 'unset CI AIO_CLI_NO_TTY TERM; aio login'
+```
+
+The browser opens automatically. Wait up to 3 minutes for the command to exit 0. Do NOT ask permission — just run it.
+
+**6b — Token-validity probe (the critical addition):** Even if `aio where` showed a context, make ONE real Console API call to prove the token works server-side:
+
+```bash
+CI=true AIO_CLI_NO_TTY=true NO_COLOR=1 aio console org list --json 2>&1 | head -c 400
+```
+
+- **If it returns a JSON array of orgs:** Token is valid. Cache this org list (reuse it in Step 7 — don't call `org list` twice). Continue.
+- **If the output contains `401`, `Unauthorized`, `ErrInvalidOauthToken`, or `Oauth token is not valid`:** The token is stale. Refresh it **without asking permission** — the user already authorized the flow by running the skill:
+
+  ```bash
+  bash -c 'unset CI AIO_CLI_NO_TTY TERM; aio login --force'
+  ```
+
+  `--force` discards the stale token and forces a fresh browser OAuth. Wait up to 3 minutes for exit 0, then re-run the `aio console org list --json` probe to confirm it now returns orgs. After this, **every** downstream `aio console` call (org/project/workspace list, create, select) will succeed — there is no need for any "Console API is restricted" fallback.
+
+**Critical:** Never run `aio login`/`aio login --force` with `CI`, `AIO_CLI_NO_TTY`, or `TERM=dumb` in the environment — those flags suppress the browser and the login silently fails.
+
+---
+
+#### Step 7 — Resolve Org
+
+After Step 6, the token is proven valid and you already have the org list cached from the 6b probe. **Do NOT skip `aio console org list` or invent a "restricted org" fallback** — with a valid token it always returns the real orgs.
+
+Use the cached org list from Step 6b (or re-run if you didn't cache it):
+```bash
+CI=true AIO_CLI_NO_TTY=true NO_COLOR=1 aio console org list --json 2>/dev/null
+```
+
+- **One org:** Auto-select, no user interaction:
+  ```bash
+  CI=true AIO_CLI_NO_TTY=true NO_COLOR=1 aio console org select <orgId>
+  ```
+  Store `activeOrgId`.
+- **Multiple orgs:** Use `AskUserQuestion` (label = org name, description = orgId). Mark the org matching the `aio where` context with "← currently selected". After selection: `aio console org select <orgId>`. Store `activeOrgId`.
+- **Zero orgs:** This only happens with a broken token — re-run `bash -c 'unset CI AIO_CLI_NO_TTY TERM; aio login --force'`, then retry org list.
+
+---
+
+#### Step 8 — Resolve Project
+
+Now that the org context is established (either from `aio where` or explicit select in Step 7), list projects **within that org**. This call does NOT need `aio console org list` to have succeeded first — the org is already in the aio context:
+
+```bash
+CI=true AIO_CLI_NO_TTY=true NO_COLOR=1 aio console project list --json 2>/dev/null
+```
+
+This returns the real list of all projects for the current org from Developer Console — not hardcoded, not from `aio where`.
+
+**If the list is empty (zero projects):** Auto-create without asking:
+```bash
+CI=true AIO_CLI_NO_TTY=true NO_COLOR=1 aio console project create -n <alphanumericName> --json 2>/dev/null
+```
+Select it. Store `activeProjectId`, `activeProjectName`. Set `isNewProject = true`. Continue to Step 9.
+
+**If projects exist:** Always use `AskUserQuestion` — never auto-select without user approval. Show the full real list from Console API. Mark the project matching `existingProject` (from `aio where`) with "← currently active":
+
+```
+question: "Which project should I use?"
+options: (one per project from Console API, label = project name, description = "projectId: <id>"; mark currently active)
+         + { label: "Create a new project", description: "I'll create a fresh App Builder project for you" }
+```
+
+**If user picks an existing project:**
+```bash
+CI=true AIO_CLI_NO_TTY=true NO_COLOR=1 aio console project select <projectId>
+```
+Store `activeProjectId`, `activeProjectName`. Set `isNewProject = false`.
+
+**If user picks "Create a new project":** Ask for a name:
+```
+question: "What should the new project be named? (alphanumeric only, no hyphens)"
+options:
+  - label: "<extensionName with hyphens stripped>"
+    description: "Derived from your extension name"
+  - label: "appbuilderext"
+    description: "Generic name"
+```
+Create it:
+```bash
+CI=true AIO_CLI_NO_TTY=true NO_COLOR=1 aio console project create -n <alphanumericName> --json 2>/dev/null
+```
+Select using the `id` from JSON output:
+```bash
+CI=true AIO_CLI_NO_TTY=true NO_COLOR=1 aio console project select <projectId>
+```
+Store `activeProjectId`, `activeProjectName`. Set `isNewProject = true`.
+
+If `aio console project create` exits non-zero with "already exists": list projects, select the matching one, set `isNewProject = false`.
+
+**If `aio console project list` returns 401 here:** This should not happen after Step 6 — it means the token went stale mid-flow. Do NOT treat it as a restricted org and do NOT fall back to the `aio where` project name. Re-run the token refresh and retry the listing:
+```bash
+bash -c 'unset CI AIO_CLI_NO_TTY TERM; aio login --force'
+CI=true AIO_CLI_NO_TTY=true NO_COLOR=1 aio console project list --json 2>/dev/null
+```
+
+---
+
+#### Step 9 — Select Workspace + I/O Runtime note
+
+After Step 6 the token is valid, so the Console API works — use the normal path below. (There is no "Console API restricted" path; a 401 at any point means a stale token → `aio login --force` and retry, never a fallback to `aio where` config.)
+
+Select the workspace by name:
+```bash
+CI=true AIO_CLI_NO_TTY=true NO_COLOR=1 aio console workspace select <workspace>
+```
+
+**Note on I/O Runtime (do NOT run `aio console workspace service add`):** That subcommand **does not exist** in current aio CLI (11.1.2+) — it errors `Command console:ws:service not found`. It also isn't needed: `aio console project create` makes an **App Builder** project, and every App Builder workspace gets an I/O Runtime namespace automatically (pattern `<orgId>-<project>-<workspace>`, e.g. `274796-myext-stage`). `aio app use` (Step 12) downloads those `AIO_RUNTIME_NAMESPACE`/`AIO_RUNTIME_AUTH` creds into `.env`. So skip any service-add here. **The #1 reason `.env` comes back empty is a STALE TOKEN (the same 401 issue as Step 6), NOT a missing entitlement** — if Step 6's token probe passed, `aio app use` will populate `.env` fine.
+
+If `isNewProject = false` (existing project): check if the chosen workspace exists and create if missing:
+```bash
+CI=true AIO_CLI_NO_TTY=true NO_COLOR=1 aio console workspace list --projectName <projectName> --json 2>/dev/null
+```
+If `<workspace>` not in list:
+```bash
+CI=true AIO_CLI_NO_TTY=true NO_COLOR=1 aio console workspace create --projectName <projectName> --name <workspace> --json 2>/dev/null
+```
+
+---
+
+#### Step 10 — Scaffold Project Files (surface-specific)
+
+**FULLY AUTOMATIC — start writing immediately, zero questions.** Say "Scaffolding project files to `<outputPath>`..." then call `mkdir` and `Write` for every file in one uninterrupted sequence. Do NOT pause between files, do NOT say "I'll now create X", do NOT ask "Should I write X?", do NOT confirm each file with the user — just write them all. The user pre-authorized every file write by running this skill. The permission system is configured to auto-approve `Write` and `Bash(mkdir *)` — there will be no prompts.
+
+Create directories:
+
+```bash
+mkdir -p <outputPath>/src/<surfaceConfig.extDir>/web-src/src/components
+mkdir -p <outputPath>/src/<surfaceConfig.extDir>/actions/generic
+mkdir -p <outputPath>/hooks
+```
+
+Read [`references/file-templates.md`](references/file-templates.md) and write **all scaffold files** by substituting placeholders (`{{EXTENSION_NAME}}`, `{{DISPLAY_NAME}}`, `{{EXTENSION_DESCRIPTION}}`, `{{EXTENSION_DIR}}`, `{{EXTENSION_POINT}}`):
+
+- `package.json`
+- `app.config.yaml`
+- `src/<extDir>/ext.config.yaml`
+- `extension-manifest.json`
+- `.eslintrc.js`
+- `hooks/post-deploy.js`
+- `src/<extDir>/web-src/index.html`
+- `src/<extDir>/web-src/src/index.js`
+- `src/<extDir>/web-src/src/index.css`
+- `src/<extDir>/web-src/src/config.json`
+- `src/<extDir>/web-src/src/components/Constants.js`
+- `src/<extDir>/actions/utils.js`
+- `src/<extDir>/actions/generic/index.js`
+- `src/<extDir>/web-src/src/components/App.js`
+- `src/<extDir>/web-src/src/components/ExtensionRegistration.js`
+- Any namespace-specific components (e.g. `TabPanel.js` for `assetDetails`, `CardActionModal.js` for `card`, `SelectionBarModal.js` for `selectionBar`) — include only for the namespaces selected in Step 2
+
+For non-Content-Hub AEM surfaces, also read [`references/aem-surface-templates.md`](references/aem-surface-templates.md) for the surface-specific `ext.config.yaml`. For ExC Shell, read [`references/excshell-templates.md`](references/excshell-templates.md) for the full SPA skeleton (different SDK).
+
+---
+
+#### Step 11 — npm install
+
+```bash
+cd <outputPath>
+npm install
+```
+
+If E401 (registry auth failure):
+```bash
+npm install --registry https://registry.npmjs.org
+```
+
+---
+
+#### Step 12 — Wire to Workspace (`aio app use`)
+
+**Must run in a subshell with CI/AIO_CLI_NO_TTY completely unset.** Without this, credential download is silently skipped and `.env` stays empty → 401 on build/deploy:
+
+```bash
+cd <outputPath>
+bash -c 'unset CI AIO_CLI_NO_TTY TERM; aio app use -w <workspace> --overwrite --no-input'
+```
+
+If that exits non-zero (the `.aio` config already has org/project context, so no extra flags needed):
+```bash
+cd <outputPath>
+bash -c 'unset CI AIO_CLI_NO_TTY TERM; printf "y\ny\ny\ny\n" | aio app use -w <workspace> --overwrite'
+```
+
+**Check `.env` validity:**
+
+```bash
+node -e "
+const fs = require('fs');
+try {
+  const c = fs.readFileSync('<outputPath>/.env', 'utf8');
+  const ok = /AIO_RUNTIME_NAMESPACE=\S+/.test(c) && /AIO_RUNTIME_AUTH=\S+/.test(c);
+  console.log(ok ? 'VALID' : 'INVALID');
+} catch(e) { console.log('INVALID'); }
+"
+```
+
+**If `INVALID`:** Almost always a **stale token** — the credential download in `aio app use` failed silently. Do NOT conclude the org lacks Runtime, and do NOT run `aio console workspace service add` (it doesn't exist). Fix it:
+
+```bash
+bash -c 'unset CI AIO_CLI_NO_TTY TERM; aio login --force'
+cd <outputPath>
+bash -c 'unset CI AIO_CLI_NO_TTY TERM; printf "y\ny\ny\ny\n" | aio app use -w <workspace> --overwrite' 2>/dev/null
+```
+
+Re-run the `isEnvValid` check. Only if `.env` is STILL empty after a confirmed-fresh-token `aio app use` is the workspace genuinely without a Runtime namespace — rare; in that case the UI still works and only actions are unavailable.
+
+**If `VALID`:** Store `envValid = true`.
+
+> **ExC Shell note:** An ExC Shell SPA with no backend actions doesn't strictly need a Runtime namespace to render. An `INVALID` `.env` is non-blocking for `exc-shell` if the app has no actions — the SPA still serves. Only block on it if the app calls web actions.
+
+---
+
+#### Step 13 — Build
+
+```bash
+cd <outputPath>
+aio app build
+```
+
+If this fails with a config validation error:
+```bash
+aio app build --no-config-validation
+```
+Fix the YAML issue then rebuild without the flag.
+
+If build fails for other reasons: read the error, fix it (usually a missing package or malformed template), then rebuild.
+
+---
+
+#### Step 14 — Start Dev Server
+
+Check if port 9080 is free:
+
+```bash
+lsof -ti:9080
+```
+
+If a PID is returned, kill it automatically — the user already authorized the full workflow by running the skill, so there is no need to ask permission to free the port:
+
+```bash
+kill <pid> 2>/dev/null; sleep 2
+```
+
+If the port is still in use after `kill`, use `kill -9 <pid>`. Only if that also fails, tell the user to free port 9080 manually and stop.
+
+**Do NOT ask "should I start the dev server?" after freeing the port.** Freeing the port and starting the server are one continuous action — once the port is clear, start the server immediately in the same step.
+
+Start the dev server in background. **Set `PORT=9080` explicitly.** Redirect output to a log and poll for the localhost URL:
+
+```bash
+cd <outputPath>
+PORT=9080 aio app run > /tmp/aio-run-<extensionName>.log 2>&1 &
+AIO_PID=$!
+
+for i in $(seq 1 60); do
+  grep -qE "https?://localhost:[0-9]+" /tmp/aio-run-<extensionName>.log 2>/dev/null && break
+  sleep 2
+done
+
+cat /tmp/aio-run-<extensionName>.log
+echo "PID: $AIO_PID"
+```
+
+**If `localhost:9080` appears in log:** Dev server is up. Proceed to Step 15.
+
+**If loop ends without the URL (120 seconds elapsed):** Use `AskUserQuestion`:
+
+```
+question: "The dev server didn't start automatically. Should I try starting it again?"
+options:
+  - label: "Yes — rebuild and retry the dev server"
+    description: "Re-runs aio app build, then tries PORT=9080 aio app run again"
+  - label: "No — I'll start it manually"
+    description: "I'll print the command and pause; type 'continue' once localhost:9080 is up"
+```
+
+If "Yes": re-run `aio app build` then retry the dev server loop.
+If "No": print `cd <outputPath> && PORT=9080 aio app run`, tell the user to run it, and that once the page loads they should type `continue` to resume from Step 15 (open cert page). Do not just stop without this hint.
+
+---
+
+#### Step 15 — Open Cert Page (after dev server URL confirmed)
+
+Open the cert page **only after** the dev server URL appears in the log:
+
+```bash
+open "https://localhost:9080"
+```
+
+*(On Linux use `xdg-open`, on Windows use `start ""`)*
+
+Then use `AskUserQuestion`:
+
+```
+question: "I opened https://localhost:9080 in your browser. Accept the self-signed certificate there (click Advanced → Proceed to localhost, or type 'thisisunsafe'). The page will then show instructions to return here."
+options:
+  - label: "Done — open the extension"
+    description: "Cert accepted; open the target surface now (Step 16)"
+  - label: "Reopen the cert page"
+    description: "Open https://localhost:9080 again so I can accept the cert"
+```
+
+If "Reopen the cert page":
+```bash
+open "https://localhost:9080"
+```
+Ask the same question again.
+
+---
+
+#### Step 16 — Open the Target Surface Automatically (surface-specific)
+
+Only after the user confirms "Done", open the surface via Bash — **never just print the URL**. Use the open URL for `surfaceConfig.surfaceKey` from the Open URLs table:
+
+```bash
+open "<surfaceConfig.openUrl>"
+```
+
+- **`content-hub`** — opens directly to the panel:
+  ```bash
+  open "https://experience.adobe.com/?devMode=true&ext=https://localhost:9080#/assets/contenthub/"
+  ```
+- **`cf-console` / `cf-editor` / `universal-editor` / `assets-view`** — open the extension tester base, then tell the user where to navigate (these surfaces have no stable deep-link hash):
+  ```bash
+  open "https://experience.adobe.com/?devMode=true&ext=https://localhost:9080"
+  ```
+  Then say, e.g.: *"Navigate to **Content Fragments** — your action bar button appears when you select a fragment."*
+- **`exc-shell`** — the SPA is already running at `https://localhost:9080` (the cert page). Confirm it loaded; to embed it in the shell, open `https://experience.adobe.com/?devMode=true&ext=https://localhost:9080`.
+
+**Rules (Content Hub specifics):**
+- **No `&repo=`** — the scaffold sets `allowedRepos = []` so any repo works for local dev.
+- **No `/index.html`** after `localhost:9080` — that is only for deployed (CDN) URLs.
+- **Do not print and ask the user to click** — run `open` via Bash.
+
+---
+
+#### Step 17 — Ask About Deployment
+
+The workspace was already chosen in Step 3 — do NOT ask again which workspace to deploy to. Just ask whether to deploy now or later:
+
+```
+question: "Extension is running locally on <workspace>. Deploy it now?"
+options:
+  - label: "Yes — deploy to <workspace> now"
+    description: "Runs aio app deploy, then opens the deployed CDN test URL automatically"
+  - label: "Not now — keep running locally"
+    description: "Stays on localhost:9080; type 'continue' or 'deploy' later to deploy from Step 17"
+```
+
+If "Yes": run the deploy flow below immediately — do not wait for the user to do anything.
+
+If "Not now": confirm the extension is still running locally and tell the user it can be deployed anytime by typing `deploy` (resumes at Step 17). Don't end the conversation with a bare "okay".
+
+**Deploy flow:**
+
+```bash
+cd <outputPath>
+
+# Deploy — capture full output (workspace is already wired from Step 12)
+aio app deploy 2>&1 | tee /tmp/aio-deploy-<extensionName>.log
+```
+
+After `aio app deploy` completes, **always** parse the CDN base domain from the log regardless of exit code, build the test URL, and **open it in the same command**. The deployed URL is built from the surface's open URL with the local `ext=https://localhost:9080` replaced by `ext=<baseDomain>/index.html`:
+
+```bash
+node -e "
+const fs = require('fs');
+const log = fs.readFileSync('/tmp/aio-deploy-<extensionName>.log', 'utf8');
+const m = log.match(/(https:\/\/[a-z0-9-]+\.adobeio-static\.net)/i);
+if (m) { console.log(m[1]); } else { process.exit(1); }
+" | { read BASE; echo "Opening: $BASE";
+  # For content-hub, append the deep-link hash. For other AEM surfaces, open the tester base and navigate.
+  open "https://experience.adobe.com/?devMode=true&ext=${BASE}/index.html#/assets/contenthub/"; }
+```
+
+> For surfaces other than `content-hub`, drop the `#/assets/contenthub/` hash — open `https://experience.adobe.com/?devMode=true&ext=${BASE}/index.html` and tell the user where to navigate. For `exc-shell`, the deployed SPA URL printed by `aio app deploy` is the app itself.
+
+**CRITICAL:** the deployed CDN test URL MUST be opened via `open`, never just printed. Only after the `open` has actually run may you print the link in the summary for reference.
+
+**Partial failure is still a success:** If web assets deployed but actions failed (org has no I/O Runtime, or 401 on action deploy), the extension UI still works. Open the CDN URL, note that actions are unavailable in this org — do not treat it as a blocking error.
+
+If the workspace from Step 3 is Production: after opening the deployed URL, use `AskUserQuestion`:
+```
+question: "Extension deployed to Production! To make it visible to all users without the ext= parameter, approve it in Extension Manager."
+options:
+  - label: "Open Extension Manager"
+  - label: "I'll approve it later"
+```
+If "Open Extension Manager": `open "https://experience.adobe.com/aem/extension-manager"`
+
+**After Step 17 completes (whether deployed or kept local), ALWAYS print the "Where to edit" file map below.** Do not wait for a follow-up request — show it unconditionally, every run, every session. Keep it simple: just tell the customer which file to open for each kind of change.
+
+The output must look exactly like this (filter rows to only the namespaces selected in Step 2 — omit rows for namespaces that were not chosen):
+
+```
+## Where to edit your extension
+
+All UI files are under `src/<extDir>/web-src/src/components/`
+
+| What you want to change | File to edit |
+|---|---|
+| Which panels / buttons appear, their title, icon, or label | `ExtensionRegistration.js` |
+| Asset Details panel content (tab UI) | `TabPanel.js` |          ← only if assetDetails selected
+| Card action modal content | `CardActionModal.js` |              ← only if card selected
+| Selection bar (bulk action) modal content | `SelectionBarModal.js` |  ← only if selectionBar selected
+| Add Assets wizard panel content | `AddAssetsPanel.js` |          ← only if addAssets selected
+| Server-side logic / AEM API calls | `actions/generic/index.js` |
+```
+
+Then add one line: *"Let me know what you'd like to build and I'll make the changes."*
+
+---
+
+### Failure Recovery
+
+| Symptom | Action |
+| --- | --- |
+| `aio where` shows "not logged" | Automatically run `bash -c 'unset CI AIO_CLI_NO_TTY TERM; aio login'` — never ask permission, browser opens, wait for exit 0 |
+| `aio console *` returns 401 / `ErrInvalidOauthToken` / `Oauth token is not valid` (even though `aio where` shows logged-in) | **Stale token, NOT a restricted org.** Run `bash -c 'unset CI AIO_CLI_NO_TTY TERM; aio login --force'`, then retry. Never fall back to `aio where` config values. |
+| `aio console project create` → "already exists" | List projects, select matching one, continue |
+| `aio console workspace create` → "already exists" | Skip, continue |
+| `aio app use` exits non-zero | Fallback: `bash -c 'unset CI AIO_CLI_NO_TTY TERM; aio app use -w <workspace> --overwrite --no-input'` |
+| `.env` missing `AIO_RUNTIME_NAMESPACE` | Usually a STALE TOKEN — run `aio login --force` then re-run `aio app use -w <ws> --overwrite`. Do NOT run `workspace service add` (doesn't exist) or assume missing entitlement. For `exc-shell` with no actions, non-blocking. |
+| `npm install` → E401 | `npm install --registry https://registry.npmjs.org` |
+| `aio app build` → validation error | `aio app build --no-config-validation`; fix YAML; rebuild without flag |
+| `aio app run` log never shows `localhost:9080` | Re-run `aio app build`; check `node -v` ≥ 18; check `cat /tmp/aio-run-<name>.log` for errors |
+| Panel/app blank in browser | Cert not accepted — run `open https://localhost:9080` and use `AskUserQuestion` again |
+| Extension not visible (AEM surfaces) | Confirm you navigated to the correct AEM app; check `ext=https://localhost:9080` and `devMode=true` are in the URL; check the extension point ID in `ext.config.yaml` matches `surfaceConfig.extensionPointId` |
+| Content Hub panel not visible | Check `allowedRepos` is empty; check URL uses `#/assets/contenthub/`; check `devMode=true` |
+| ExC Shell stuck on spinner | `runtime.done()` was not called (or called too late) — call it at the `register` level, not after data fetch — see [`references/excshell-templates.md`](references/excshell-templates.md) |
+| Deploy: CDN URL not found in log | Check `cat /tmp/aio-deploy-<name>.log`; look for any `.adobeio-static.net` URL manually |
+
+---
+
+### Quality Checklist
+
+- [ ] `surfaceConfig` was set in Step 0 and every path/URL downstream reads from it (no hardcoded Content Hub values for non-CH surfaces)
+- [ ] `app.config.yaml` uses `surfaceConfig.extensionPointId`
+- [ ] Source directory is `src/<surfaceConfig.extDir>/`
+- [ ] For `uix-guest` surfaces: `ExtensionRegistration.js` imports `register`, secondary pages import `attach`, both use the same `extensionId` from `Constants.js`
+- [ ] For `exc-shell`: `App.js` imports `register` from `@adobe/exc-app` and calls `runtime.done()` at register level
+- [ ] `npm install` succeeded (Step 11)
+- [ ] `aio app use` ran in a subshell with `unset CI AIO_CLI_NO_TTY TERM` (Step 12)
+- [ ] `.env` has `AIO_RUNTIME_NAMESPACE` and `AIO_RUNTIME_AUTH` (or non-blocking for actionless `exc-shell`)
+- [ ] `aio app build` succeeded (Step 13)
+- [ ] `PORT=9080 aio app run` is running and log shows `localhost:9080` (Step 14)
+- [ ] Cert page opened via `open` **after** dev server URL confirmed
+- [ ] Target surface opened via `open` (Bash), not just printed as text
+
+---
+
+## Adding a New Surface
+
+The workflow (Steps 1–9, 11–15, 17) is surface-agnostic — only four things vary per surface. To support a new App Builder surface in the future, do only these:
+
+1. **Add one row to the Surface Config table** (top of this file) — `surfaceKey`, `extensionPointId`, `extDir`, `sdk`, templates ref, available namespaces, and open URL.
+
+2. **Add one option to Step 0** — one new entry in the `AskUserQuestion` surface selection (Question 1 or 2 depending on family).
+
+3. **Add a template section** — if the surface uses `@adobe/uix-guest` and shares the standard skeleton, add a section to [`references/aem-surface-templates.md`](aem-surface-templates.md) with its `ext.config.yaml` + `ExtensionRegistration.js` methods block. If it uses a different SDK, add a new dedicated reference file.
+
+4. **Add a Step 2 branch** — which namespaces / extension points the surface offers, as a `multiSelect` `AskUserQuestion`.
+
+5. **Add a Step 18 customization sub-table** — the file-to-edit map for the new surface's requests.
+
+Everything else (login, token validation, org/project/workspace, install, build, dev server, cert, deploy) is reused unchanged because every step reads from `surfaceConfig`.
+
+**Rule of thumb:** if the new surface uses `register()` from `@adobe/uix-guest`, it's ~90% reuse — you only author the `methods` object and one template section. If it uses a different SDK, you author a new skeleton but still reuse the entire Console/build/deploy workflow.

--- a/plugins/app-builder/skills/appbuilder-project-init/references/file-templates.md
+++ b/plugins/app-builder/skills/appbuilder-project-init/references/file-templates.md
@@ -1,0 +1,1181 @@
+# Content Hub Extension File Templates (+ shared uix-guest skeleton)
+
+Complete templates for all scaffold files. Before writing, substitute:
+- `{{EXTENSION_NAME}}` → kebab-case name (e.g. `my-asset-viewer`)
+- `{{DISPLAY_NAME}}` → Title Case name (e.g. `My Asset Viewer`)
+- `{{EXTENSION_DESCRIPTION}}` → one-sentence description
+- `{{EXTENSION_DIR}}` → for Content Hub, `aem-assets-contenthub-1`; for other AEM surfaces, `surfaceConfig.extDir`
+
+Extension point used throughout: `aem/assets/contenthub/1`
+Source directory: `src/aem-assets-contenthub-1/`
+
+> **Dual role.** This file is both the Content Hub template set AND the **shared `@adobe/uix-guest` skeleton** reused by the other AEM surfaces (CF Console, CF Editor, Universal Editor, Assets View). When scaffolding one of those surfaces, reuse every file here — `package.json`, `index.html`, `index.js`, `index.css`, `Constants.js`, `App.js`, `actions/*`, `hooks/post-deploy.js`, `README`/`AGENTS`, `.eslintrc.js` — swapping `aem-assets-contenthub-1` → `surfaceConfig.extDir`, the extension point → `surfaceConfig.extensionPointId`, and the `register()` `methods` object → the surface block in [`aem-surface-templates.md`](aem-surface-templates.md). ExC Shell does NOT share this skeleton (different SDK) — see [`excshell-templates.md`](excshell-templates.md).
+
+---
+
+## `package.json`
+
+```json
+{
+  "name": "{{EXTENSION_NAME}}",
+  "version": "1.0.0",
+  "description": "{{EXTENSION_DESCRIPTION}}",
+  "author": "",
+  "license": "Apache-2.0",
+  "scripts": {
+    "test": "jest --passWithNoTests --testPathIgnorePatterns web-src",
+    "dev": "aio app run",
+    "build": "aio app build",
+    "deploy": "aio app deploy",
+    "undeploy": "aio app undeploy"
+  },
+  "dependencies": {
+    "@adobe/aio-sdk": "^5.0.0",
+    "@adobe/uix-guest": "0.10.5",
+    "@adobe/react-spectrum": "^3.0.0",
+    "chalk": "^4.0.0",
+    "js-yaml": "^4.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-router-dom": "^6.0.0",
+    "react-error-boundary": "^4.0.0"
+  },
+  "devDependencies": {
+    "@adobe/eslint-config-aio-lib-config": "^3.0.0",
+    "eslint": "^8.0.0",
+    "jest": "^29.0.0"
+  },
+  "engines": {
+    "node": "^18 || ^20"
+  }
+}
+```
+
+---
+
+## `app.config.yaml`
+
+```yaml
+extensions:
+  aem/assets/contenthub/1:
+    $include: src/aem-assets-contenthub-1/ext.config.yaml
+```
+
+**Critical:** Use `aem/assets/contenthub/1` — not the deprecated `aem/contenthub/assets/details/1`. If the user's existing project has the old extension point ID, update both this file and the directory name.
+
+---
+
+## `src/aem-assets-contenthub-1/ext.config.yaml`
+
+```yaml
+$schema: https://unpkg.com/@adobe/aio-schemas@latest/schemas/aio.schema.json
+actions: actions
+web: web-src
+runtimeManifest:
+  packages:
+    aem-assets-contenthub-1:
+      license: Apache-2.0
+      actions:
+        generic:
+          function: actions/generic/index.js
+          web: 'yes'
+          runtime: 'nodejs:18'
+          inputs:
+            LOG_LEVEL: debug
+          annotations:
+            require-adobe-auth: false
+            final: true
+operations:
+  view:
+    - type: web
+      impl: index.html
+hooks:
+  post-app-deploy: ./hooks/post-deploy.js
+```
+
+---
+
+## `extension-manifest.json`
+
+```json
+{
+  "name": "{{EXTENSION_NAME}}",
+  "id": "aem-assets-contenthub-1",
+  "description": "{{EXTENSION_DESCRIPTION}}",
+  "version": "1.0.0",
+  "engines": {
+    "aio-cli": ">=10.0.0"
+  },
+  "keywords": ["contenthub", "assets", "extension", "uix"],
+  "author": "",
+  "license": "Apache-2.0",
+  "extensionPoints": ["aem/assets/contenthub/1"]
+}
+```
+
+---
+
+## `.eslintrc.js`
+
+```js
+module.exports = {
+  root: true,
+  extends: ['@adobe/eslint-config-aio-lib-config'],
+  env: {
+    node: true,
+    es2020: true,
+    browser: true
+  },
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    ecmaFeatures: { jsx: true }
+  }
+};
+```
+
+---
+
+## `AGENTS.md`
+
+```markdown
+# {{DISPLAY_NAME}} — Agent Guidelines
+
+## Extension Point
+
+`aem/assets/contenthub/1` — Content Hub extensibility.
+
+## Active Namespaces
+
+- `assetDetails` — tab panels in the Asset Details Dialog side rail
+- `card` — action buttons on asset cards (Assets grid, collection, link share) and on collection tiles in the Collections grid
+- `selectionBar` — bulk action buttons in the selection bar (multi-select)
+
+(Remove entries for namespaces not wired in ExtensionRegistration.js)
+
+## Project Structure
+
+- `src/aem-assets-contenthub-1/web-src/` — React SPA (Spectrum UI, UIX Guest)
+- `src/aem-assets-contenthub-1/actions/` — Adobe I/O Runtime web actions
+- `app.config.yaml` — declares `aem/assets/contenthub/1` extension point
+- `src/aem-assets-contenthub-1/ext.config.yaml` — runtime manifest
+
+## Building & Running
+
+Use `aio` CLI commands (not npm scripts directly):
+- `aio app build` — build and deploy actions to I/O Runtime, compile web-src
+- `aio app run` — start local dev server at https://localhost:9080
+- `aio app deploy` — full deployment to Stage/Production
+
+## Local Test URL
+
+```
+https://experience.adobe.com/?devMode=true&ext=https://localhost:9080#/assets/contenthub/
+```
+
+First time: accept the self-signed cert at https://localhost:9080.
+
+## Key Files to Customize
+
+- `ExtensionRegistration.js` — declares all namespaces. Uses `let guestConnection` so `onActionClick` can call `host.modal.openDialog()` after `register()` resolves.
+- `TabPanel.js` — panel UI for `assetDetails` namespace (rendered in iframe)
+- `CardActionModal.js` — modal UI for `card` namespace; reads its data from the `contentUrl` query (`URLSearchParams`), NOT `getPayload()`
+- `SelectionBarModal.js` — modal UI for `selectionBar` namespace; reads `assetIds[]` from the `contentUrl` query (`URLSearchParams` + `JSON.parse`), NOT `getPayload()`
+- `actions/generic/index.js` — server-side logic for AEM API calls
+
+## Host APIs (via `guestConnection.host` in any attached page)
+
+- `auth.getIMSInfo()` → `{ imsOrg, imsOrgName, accessToken }`
+- `auth.getApiKey()` → API key string  ← note: `getApiKey`, not `getAPIKey`
+- `discovery.getAemHost()` → `https://<repoId>/`
+- `toast.display({ variant, message })` → show toast; variants: `neutral`, `positive`, `negative`, `info`
+- `i18n.getLocalizationInfo()` → `{ locale }`
+- `modal.openDialog({ title, contentUrl, type?, size?, payload? })` → open modal dialog. **Single config object from the guest's side** — the UIX host auto-injects `{ id }`; never pass it yourself. Pass data to the modal either via the `contentUrl` query string (e.g. `/#card-action-modal?resourceId=...&resourceType=...`) or via `payload`.
+- `modal.getPayload()` → returns the `payload` passed to `openDialog()`. Call from the modal page after `attach()`.
+- `modal.closeDialog()` → close the current modal (call from the modal page after `attach()`)
+
+## assetDetails: getCurrentAsset()
+
+`assetDetails.getCurrentAsset()` returns the asset id as a plain **STRING** (e.g. `"urn:aaid:aem:..."`), NOT an object. Use it directly or wrap: `const asset = { id: assetId }`.
+
+## card: getActionButtons receives actionContext
+
+The host calls `getActionButtons(actionContext)` with:
+- `actionContext.context`: `'assets'` | `'collection'` | `'collections'` | `'share'` — the source view.
+  `assets`, `collection`, and `share` are asset-card surfaces; `collections` is a collection tile
+  on the Collections grid. Use it to vary buttons per surface, or ignore it to show the same set.
+
+The same `card` namespace serves both asset cards and collection tiles — distinguish them via
+`actionContext.context` (and `resourceType` on click).
+
+## card: onActionClick signature
+
+Called by the host as `onActionClick(resourceType, buttonId, resourceId, actionContext)`:
+- `resourceType`: `'asset'` (asset cards) or `'collection'` (collection tiles)
+- `buttonId`: the `id` from `getActionButtons()`
+- `resourceId`: the asset or collection URN string
+- `actionContext`: `{ context }` — same surface values as above
+
+## selectionBar: getActionButtons receives actionContext
+
+The host calls `selectionBar.getActionButtons(actionContext)` with:
+- `actionContext.context`: `'assets'` | `'collections'` | `'collection'` | `'share'` — the source view
+- `actionContext.resourceSelection.resources`: `[{id: string}, ...]` — the current selection
+
+Use this to conditionally show/hide buttons depending on where the bar appears, or ignore it.
+
+## selectionBar: onActionClick signature
+
+Called by the host as `onActionClick(buttonId, assetIds)`:
+- `buttonId`: the `id` from `getActionButtons()`
+- `assetIds`: `string[]` — array of selected asset URNs
+
+Note: the host prefixes the rendered button id as `ext:<extensionId>:<btn.id>` to avoid collisions with native actions. Your extension code uses the original `btn.id` — the prefix is host-internal only.
+```
+
+---
+
+## `hooks/post-deploy.js`
+
+```js
+const chalk = require('chalk');
+const fs = require('fs');
+const yaml = require('js-yaml');
+
+module.exports = (config) => {
+  try {
+    const yamlFile = fs.readFileSync(`${config.root}/app.config.yaml`, 'utf8');
+    const yamlData = yaml.load(yamlFile);
+    const { extensions } = yamlData;
+    const extension = Object.keys(extensions)[0];
+    const previewData = {
+      extensionPoint: extension,
+      url: config.project.workspace.app_url,
+    };
+    const base64EncodedData = Buffer.from(JSON.stringify(previewData)).toString('base64');
+    console.log(chalk.magenta(chalk.bold('For a developer preview of your UI extension in the Content Hub environment, follow the URL:')));
+    const env = process.env.AIO_CLI_ENV === 'stage' ? '-stage' : '';
+    console.log(chalk.magenta(chalk.bold(`  -> https://experience${env}.adobe.com/aem/extension-manager/preview/${base64EncodedData}`)));
+  } catch (_) {
+    // Non-fatal: just skip the preview URL
+  }
+};
+```
+
+---
+
+## `src/aem-assets-contenthub-1/web-src/index.html`
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{EXTENSION_NAME}}</title>
+</head>
+<body>
+<noscript>You need to enable JavaScript to run this app.</noscript>
+<div id="root"></div>
+<script src="./src/index.js" async type="module"></script>
+</body>
+</html>
+```
+
+---
+
+## `src/aem-assets-contenthub-1/web-src/src/index.js`
+
+```js
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './components/App.js';
+import './index.css';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);
+```
+
+---
+
+## `src/aem-assets-contenthub-1/web-src/src/index.css`
+
+```css
+html, body {
+  margin: 0;
+}
+```
+
+---
+
+## `src/aem-assets-contenthub-1/web-src/src/config.json`
+
+```json
+{
+  "aem-assets-contenthub-1/generic": "https://localhost:9080/api/v1/web/aem-assets-contenthub-1/generic"
+}
+```
+
+This file is overwritten by `aio app run` (localhost URL) and `aio app deploy` (cloud URL). Do not edit manually.
+
+---
+
+## `src/aem-assets-contenthub-1/web-src/src/components/Constants.js`
+
+```js
+export const extensionId = 'sample-extension';
+```
+
+The `extensionId` **must** be identical in `register()` (ExtensionRegistration.js) and `attach()` (TabPanel.js). Both import from this file.
+
+---
+
+## `src/aem-assets-contenthub-1/web-src/src/components/App.js`
+
+Include only the imports and routes for the namespaces selected in Step 2. Remove unused imports/routes.
+
+```js
+import React from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { HashRouter as Router, Routes, Route } from 'react-router-dom';
+import ExtensionRegistration from './ExtensionRegistration';
+import TabPanel from './TabPanel';                    // assetDetails namespace — remove if not selected
+import CardActionModal from './CardActionModal';       // card namespace — remove if not selected
+import SelectionBarModal from './SelectionBarModal';  // selectionBar namespace — remove if not selected
+import AddAssetsPanel from './AddAssetsPanel';         // addAssets namespace — remove if not selected
+
+function App() {
+  return (
+    <Router>
+      <ErrorBoundary onError={onError} FallbackComponent={fallbackComponent}>
+        <Routes>
+          <Route index element={<ExtensionRegistration />} />
+          <Route path="index.html" element={<ExtensionRegistration />} />
+          {/* assetDetails namespace — remove if not selected */}
+          <Route path="tab-panel" element={<TabPanel />} />
+          {/* card namespace — remove if not selected */}
+          <Route path="card-action-modal" element={<CardActionModal />} />
+          {/* selectionBar namespace — remove if not selected */}
+          <Route path="selection-bar-modal" element={<SelectionBarModal />} />
+          {/* addAssets namespace — remove both routes if not selected */}
+          <Route path="pre-step" element={<AddAssetsPanel />} />
+          <Route path="post-step" element={<AddAssetsPanel />} />
+        </Routes>
+      </ErrorBoundary>
+    </Router>
+  );
+
+  function onError(e, componentStack) {
+    console.error('Extension error:', e, componentStack);
+  }
+
+  function fallbackComponent({ componentStack, error }) {
+    return (
+      <React.Fragment>
+        <h1 style={{ textAlign: 'center', marginTop: '20px' }}>Extension rendering error</h1>
+        <pre>{componentStack + '\n' + error.message}</pre>
+      </React.Fragment>
+    );
+  }
+}
+
+export default App;
+```
+
+**Adding more panels:** Add a new `<Route path="my-second-panel" element={<MySecondPanel />} />` here, and a matching `contentUrl: '/#my-second-panel'` entry in `ExtensionRegistration.js`.
+
+---
+
+## `src/aem-assets-contenthub-1/web-src/src/components/ExtensionRegistration.js`
+
+Contains all four Content Hub namespaces. **When scaffolding, include only the namespace blocks the user selected in Step 2.** Each block is clearly marked — remove unused ones. `card` and `selectionBar` require `let guestConnection` (not `const`) because `onActionClick` is called after `register()` resolves. `addAssets` does NOT need `guestConnection` — its lifecycle hooks run synchronously without calling host APIs.
+
+```js
+import React from 'react';
+import { Text, View } from '@adobe/react-spectrum';
+import { register } from '@adobe/uix-guest';
+import { extensionId } from './Constants';
+
+// Restrict extension to specific repos.
+// Format: 'delivery-pXXX-eYYY.adobeaemcloud.com'
+// Empty array = allow any repo (safe for development; populate before deploying to Production).
+const allowedRepos = [
+  // 'delivery-p12345-e167890.adobeaemcloud.com',
+];
+
+function getRepo() {
+  return new URLSearchParams(window.location.search).get('repo');
+}
+
+function shouldSkipRegistration(repo) {
+  return allowedRepos.length > 0 && !allowedRepos.includes(repo);
+}
+
+function ExtensionRegistration() {
+  const repo = getRepo();
+
+  if (shouldSkipRegistration(repo)) {
+    return <Text>IFrame for integration with Host (Content Hub), Skipped registration as repo is not allowed</Text>;
+  }
+
+  const init = async () => {
+    // `let` (not `const`) so card/selectionBar onActionClick handlers can close over it after register() resolves.
+    let guestConnection = await register({
+      id: extensionId,
+      methods: {
+
+        // ── ASSET DETAILS NAMESPACE ──────────────────────────────────────────
+        // Tab panels in the Asset Details Dialog side rail.
+        // Remove this block if assetDetails was not selected.
+        assetDetails: {
+          getTabPanels() {
+            return [
+              {
+                id: '{{EXTENSION_NAME}}-panel',
+                title: '{{DISPLAY_NAME}}',
+                tooltip: '{{DISPLAY_NAME}}',
+                icon: 'Extension',          // React-Spectrum workflow icon name
+                contentUrl: '/#tab-panel',  // must match a <Route path> in App.js
+              },
+            ];
+          },
+        },
+
+        // ── ASSET CARD NAMESPACE ─────────────────────────────────────────────
+        // Buttons on individual asset card menus (3-dot / overlay) AND on collection
+        // tiles in the Collections grid (the tile's ⋯ menu). Remove this block if card
+        // was not selected.
+        // getActionButtons receives an actionContext from the host:
+        //   { context: 'assets'|'collection'|'collections'|'share' }
+        //   'assets' (browse grid), 'collection' (assets inside a collection),
+        //   'share' (link share view) are asset-card surfaces;
+        //   'collections' is a collection tile on the Collections grid.
+        // onActionClick is called with (resourceType, buttonId, resourceId, actionContext)
+        //   resourceType: 'asset' (asset cards) | 'collection' (collection tiles)
+        card: {
+          getActionButtons(actionContext) {
+            // Vary buttons by actionContext.context, or ignore it to show the same set.
+            return [
+              {
+                id: '{{EXTENSION_NAME}}-card-action',
+                label: '{{DISPLAY_NAME}}',
+                icon: 'Edit',               // React-Spectrum workflow icon name
+              },
+            ];
+          },
+          async onActionClick(resourceType, buttonId, resourceId, actionContext) {
+            // openDialog takes a SINGLE config object — NO { id } first arg, NO payload field.
+            // Pass data to the modal via the contentUrl query string (read it there with URLSearchParams).
+            await guestConnection.host.modal.openDialog({
+              title: '{{DISPLAY_NAME}}',
+              contentUrl: `/#card-action-modal?resourceId=${encodeURIComponent(resourceId)}&resourceType=${encodeURIComponent(resourceType)}`,  // route in App.js + query data
+              type: 'modal',
+              size: 'M',
+            });
+          },
+        },
+
+        // ── SELECTION BAR NAMESPACE ──────────────────────────────────────────
+        // Bulk action buttons in the selection bar (shown when assets are selected).
+        // Remove this block if selectionBar was not selected.
+        //
+        // getActionButtons receives an actionContext from the host:
+        //   { context: 'assets'|'collections'|'collection'|'share',
+        //     resourceSelection: { resources: [{id: string}, ...] } }
+        // Use it to conditionally show/hide buttons per source, or ignore it to always show.
+        //
+        // onActionClick is called by the host with (buttonId, assetIds[])
+        selectionBar: {
+          getActionButtons(actionContext) {
+            // actionContext.context tells you where the selection bar is shown:
+            //   'assets' (browse grid), 'collections' (collections list),
+            //   'collection' (inside a collection), 'share' (link share view).
+            // actionContext.resourceSelection.resources is the current selection as [{id}, ...].
+            return [
+              {
+                id: '{{EXTENSION_NAME}}-bulk-action',
+                label: '{{DISPLAY_NAME}}',
+                icon: 'Download',           // React-Spectrum workflow icon name
+              },
+            ];
+          },
+          async onActionClick(buttonId, assetIds) {
+            // Single config object — NO { id }, NO payload. Pass assetIds via the contentUrl query.
+            const ids = encodeURIComponent(JSON.stringify(assetIds || []));
+            await guestConnection.host.modal.openDialog({
+              title: `{{DISPLAY_NAME}} (${assetIds.length} asset${assetIds.length !== 1 ? 's' : ''})`,
+              contentUrl: `/#selection-bar-modal?assetIds=${ids}`,  // route in App.js + query data
+              type: 'modal',
+              size: 'M',
+            });
+          },
+        },
+
+        // ── ADD ASSETS NAMESPACE ─────────────────────────────────────────────
+        // Extends the "Add Assets" (hydration) flow with wizard panels and lifecycle hooks.
+        // Remove this block if addAssets was not selected.
+        //
+        // getPanels() returns panels injected before ('pre') or after ('post') the Upload step.
+        // 'pre' panels gate the Next button — the panel must send a postMessage to unlock it.
+        // 'post' panels are always ready (no signal required).
+        //
+        // beforeUpload(ctx) is called before upload starts:
+        //   ctx: { files, metadata, uploadPath }
+        //   return { proceed: true, metadata } to pass through (optionally merging extra metadata)
+        //   return { proceed: false, message: '...' } to block the upload with a user-facing message
+        //
+        // onUploadComplete(ctx) fires after upload finishes (parallel, fire-and-forget).
+        addAssets: {
+          getPanels() {
+            return [
+              {
+                id: '{{EXTENSION_NAME}}-pre-step',
+                title: '{{DISPLAY_NAME}} Pre-Upload',
+                position: 'pre',               // shown BEFORE the Upload step
+                contentUrl: '/#pre-step',      // must match a <Route path> in App.js
+              },
+              // Add more panels here, or remove this array entry if you only need post panels.
+              {
+                id: '{{EXTENSION_NAME}}-post-step',
+                title: '{{DISPLAY_NAME}} Post-Upload',
+                position: 'post',              // shown AFTER the Upload step
+                contentUrl: '/#post-step',
+              },
+            ];
+          },
+          async beforeUpload({ files, metadata, uploadPath }) {
+            // Return { proceed: true, metadata } to continue (optionally inject extra metadata).
+            // Return { proceed: false, message: '...' } to block with a user-facing error.
+            return { proceed: true, metadata };
+          },
+          async onUploadComplete({ files, metadata, uploadPath }) {
+            // Fires after all files finish uploading (fire-and-forget, return value ignored).
+            console.log('{{EXTENSION_NAME}} onUploadComplete', { fileCount: files.length, uploadPath });
+          },
+        },
+
+      },
+    });
+  };
+
+  init().catch(console.error);
+  return (
+    <View padding="size-400" UNSAFE_style={{ fontFamily: 'sans-serif', textAlign: 'center', marginTop: '80px' }}>
+      <Text UNSAFE_style={{ fontSize: '48px', display: 'block', marginBottom: '16px' }}>✅</Text>
+      <Text UNSAFE_style={{ fontSize: '20px', fontWeight: 'bold', display: 'block', marginBottom: '12px' }}>
+        Certificate accepted!
+      </Text>
+      <Text UNSAFE_style={{ fontSize: '15px', color: '#555', display: 'block' }}>
+        Return to <strong>Claude Code</strong> in your terminal and click{' '}
+        <strong>&quot;Done — open the extension&quot;</strong> to continue.
+      </Text>
+    </View>
+  );
+}
+
+export default ExtensionRegistration;
+```
+
+---
+
+## `src/aem-assets-contenthub-1/web-src/src/components/TabPanel.js`
+
+This is the panel content rendered inside Content Hub's iframe. All Host API calls go through `guestConnection.host`.
+
+```js
+import React, { useState, useEffect } from 'react';
+import { attach } from '@adobe/uix-guest';
+import {
+  Provider,
+  defaultTheme,
+  View,
+  Heading,
+  Text,
+  Button,
+  ProgressCircle,
+  Divider,
+} from '@adobe/react-spectrum';
+import { extensionId } from './Constants';
+import actions from '../config.json';
+
+export default function TabPanel() {
+  const [guestConnection, setGuestConnection] = useState(null);
+  const [asset, setAsset] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [actionResponse, setActionResponse] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        // Reconnect to the registered extension.
+        // extensionId must match the id used in register() — both come from Constants.js.
+        const connection = await attach({ id: extensionId });
+        setGuestConnection(connection);
+
+        // getCurrentAsset() returns the asset id as a plain string (e.g. "urn:aaid:aem:...").
+        // Note: this is Content Hub's API. Assets View uses a different method.
+        const assetId = await connection.host.assetDetails.getCurrentAsset();
+        setAsset({ id: assetId });
+
+        // ── Call a web action with the asset ID ────────────────────────────
+        // Uncomment and customize for AEM API calls:
+        //
+        // const { accessToken, imsOrg } = await connection.host.auth.getIMSInfo();
+        // const apiKey = await connection.host.auth.getApiKey();
+        // const aemHost = await connection.host.discovery.getAemHost();
+        // const actionUrl = actions['aem-assets-contenthub-1/generic'];
+        //
+        // const response = await fetch(actionUrl, {
+        //   method: 'POST',
+        //   headers: {
+        //     'Content-Type': 'application/json',
+        //     // Add these when action has require-adobe-auth: true:
+        //     // 'Authorization': `Bearer ${accessToken}`,
+        //     // 'x-gw-ims-org-id': imsOrg,
+        //   },
+        //   body: JSON.stringify({ assetId: currentAsset.id, aemHost, apiKey, imsOrg }),
+        // });
+        // const data = await response.json();
+        // setActionResponse(data);
+
+      } catch (err) {
+        console.error('Panel initialization error:', err);
+        setError('Failed to initialize panel: ' + err.message);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  function displayToast(variant, message) {
+    if (guestConnection) {
+      guestConnection.host.toast.display({ variant, message });
+    }
+  }
+
+  if (loading) {
+    return (
+      <Provider theme={defaultTheme}>
+        <View padding="size-400" height="100vh">
+          <View UNSAFE_style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '200px' }}>
+            <ProgressCircle aria-label="Loading..." isIndeterminate />
+          </View>
+        </View>
+      </Provider>
+    );
+  }
+
+  return (
+    <Provider theme={defaultTheme}>
+      <View padding="size-400">
+        <Heading level={3}>{{DISPLAY_NAME}}</Heading>
+
+        <Divider marginY="size-200" />
+
+        {error && (
+          <View marginBottom="size-200" backgroundColor="negative" padding="size-100" borderRadius="regular">
+            <Text>{error}</Text>
+          </View>
+        )}
+
+        {asset && (
+          <View marginBottom="size-200">
+            <Text><strong>Asset ID:</strong></Text>
+            <View marginTop="size-100" padding="size-100" backgroundColor="gray-100" borderRadius="regular">
+              <Text UNSAFE_style={{ fontFamily: 'monospace', fontSize: '12px', wordBreak: 'break-all' }}>
+                {asset.id}
+              </Text>
+            </View>
+          </View>
+        )}
+
+        {actionResponse && (
+          <View marginBottom="size-200">
+            <Divider marginY="size-200" />
+            <Text><strong>Action Response:</strong></Text>
+            <View marginTop="size-100" padding="size-100" backgroundColor="gray-100" borderRadius="regular"
+              UNSAFE_style={{ fontFamily: 'monospace', fontSize: '12px', whiteSpace: 'pre-wrap' }}>
+              <Text>{JSON.stringify(actionResponse, null, 2)}</Text>
+            </View>
+          </View>
+        )}
+
+        <Button
+          variant="accent"
+          marginTop="size-300"
+          onPress={() => displayToast('positive', 'Action from {{DISPLAY_NAME}} panel!')}
+        >
+          Show Toast
+        </Button>
+      </View>
+    </Provider>
+  );
+}
+```
+
+---
+
+## `src/aem-assets-contenthub-1/web-src/src/components/CardActionModal.js`
+
+Modal opened when a card action button is clicked. Reads the data passed via the `contentUrl` query string (the simpler alternative to `openDialog()`'s `payload`/`getPayload()` — either works), and uses `attach()` only so it can call `closeDialog()`. Only scaffold this file if `card` was selected in Step 2.
+
+```js
+import React, { useState, useEffect } from 'react';
+import { attach } from '@adobe/uix-guest';
+import {
+  Provider,
+  defaultTheme,
+  View,
+  Text,
+  Button,
+  ProgressCircle,
+} from '@adobe/react-spectrum';
+import { extensionId } from './Constants';
+
+export default function CardActionModal() {
+  const [guestConnection, setGuestConnection] = useState(null);
+  const [payload, setPayload] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      // Read data from the modal URL query (alternative: openDialog()'s payload + host.modal.getPayload()).
+      // contentUrl was `/#card-action-modal?resourceId=...&resourceType=...`.
+      const params = new URLSearchParams(window.location.hash.split('?')[1] || '');
+      setPayload({ resourceId: params.get('resourceId'), resourceType: params.get('resourceType') });
+      // attach() is only needed so the Close button can call host.modal.closeDialog().
+      const connection = await attach({ id: extensionId });
+      setGuestConnection(connection);
+    })();
+  }, []);
+
+  if (!payload) {
+    return (
+      <Provider theme={defaultTheme}>
+        <View padding="size-400" height="100vh">
+          <View UNSAFE_style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '200px' }}>
+            <ProgressCircle aria-label="Loading..." isIndeterminate />
+          </View>
+        </View>
+      </Provider>
+    );
+  }
+
+  return (
+    <Provider theme={defaultTheme}>
+      <View padding="size-300">
+        <View marginBottom="size-200">
+          <Text UNSAFE_style={{ display: 'block', fontSize: '12px', color: '#6e6e6e', marginBottom: '4px' }}>
+            Resource Type
+          </Text>
+          <Text UNSAFE_style={{ display: 'block' }}>{payload.resourceType}</Text>
+        </View>
+
+        <View marginBottom="size-300">
+          <Text UNSAFE_style={{ display: 'block', fontSize: '12px', color: '#6e6e6e', marginBottom: '4px' }}>
+            Resource ID
+          </Text>
+          <View padding="size-100" backgroundColor="gray-100" borderRadius="regular">
+            <Text UNSAFE_style={{ fontFamily: 'monospace', fontSize: '12px', wordBreak: 'break-all', display: 'block' }}>
+              {payload.resourceId}
+            </Text>
+          </View>
+        </View>
+
+        {/* Add your custom UI here */}
+
+        <Button
+          variant="accent"
+          onPress={() => guestConnection?.host.modal.closeDialog()}
+        >
+          Close
+        </Button>
+      </View>
+    </Provider>
+  );
+}
+```
+
+---
+
+## `src/aem-assets-contenthub-1/web-src/src/components/SelectionBarModal.js`
+
+Modal opened when a selection bar (bulk action) button is clicked. Reads `assetIds[]` from the `contentUrl` query (the simpler alternative to `openDialog()`'s `payload`/`getPayload()` — either works). Only scaffold this file if `selectionBar` was selected in Step 2.
+
+```js
+import React, { useState, useEffect } from 'react';
+import { attach } from '@adobe/uix-guest';
+import {
+  Provider,
+  defaultTheme,
+  View,
+  Text,
+  Button,
+  ProgressCircle,
+  ListView,
+  Item,
+} from '@adobe/react-spectrum';
+import { extensionId } from './Constants';
+
+export default function SelectionBarModal() {
+  const [guestConnection, setGuestConnection] = useState(null);
+  const [payload, setPayload] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      // Read assetIds from the modal URL query (alternative: openDialog()'s payload + host.modal.getPayload()).
+      // contentUrl was `/#selection-bar-modal?assetIds=<json>`.
+      const params = new URLSearchParams(window.location.hash.split('?')[1] || '');
+      const raw = params.get('assetIds');
+      setPayload({ assetIds: raw ? JSON.parse(raw) : [] });
+      // attach() is only needed so the Close button can call host.modal.closeDialog().
+      const connection = await attach({ id: extensionId });
+      setGuestConnection(connection);
+    })();
+  }, []);
+
+  if (!payload) {
+    return (
+      <Provider theme={defaultTheme}>
+        <View padding="size-400" height="100vh">
+          <View UNSAFE_style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '200px' }}>
+            <ProgressCircle aria-label="Loading..." isIndeterminate />
+          </View>
+        </View>
+      </Provider>
+    );
+  }
+
+  return (
+    <Provider theme={defaultTheme}>
+      <View padding="size-300">
+        <View marginBottom="size-200">
+          <Text UNSAFE_style={{ display: 'block', fontSize: '12px', color: '#6e6e6e', marginBottom: '4px' }}>
+            {payload.assetIds.length} asset{payload.assetIds.length !== 1 ? 's' : ''} selected
+          </Text>
+        </View>
+
+        <View marginBottom="size-300" maxHeight="size-3000" overflow="auto">
+          <ListView aria-label="Selected assets" items={payload.assetIds.map(id => ({ id }))}>
+            {item => (
+              <Item key={item.id}>
+                <Text UNSAFE_style={{ fontFamily: 'monospace', fontSize: '12px' }}>{item.id}</Text>
+              </Item>
+            )}
+          </ListView>
+        </View>
+
+        {/* Add your bulk-action logic here */}
+
+        <Button
+          variant="accent"
+          onPress={() => guestConnection?.host.modal.closeDialog()}
+        >
+          Close
+        </Button>
+      </View>
+    </Provider>
+  );
+}
+```
+
+---
+
+## `src/aem-assets-contenthub-1/web-src/src/components/AddAssetsPanel.js`
+
+Wizard panel rendered inside a `GuestUIFrame` for the `addAssets` namespace. Used for both `pre` and `post` position panels (same component, different route).
+
+**Critical:** `getPanelId()` strips the leading `#` (and optional `/`) from `window.location.hash`.
+`contentUrl: '/#pre-step'` loads as hash `#pre-step` (NOT `#/pre-step`) — using `.replace('#/', '')` silently fails and sends the wrong `panelId` in the `postMessage`, keeping Next permanently disabled.
+Always use the regex `/^#\/?/` as shown below.
+
+```js
+import React, { useState, useEffect } from 'react';
+import { attach } from '@adobe/uix-guest';
+import {
+  Provider,
+  defaultTheme,
+  View,
+  Heading,
+  Text,
+  Button,
+  ProgressCircle,
+} from '@adobe/react-spectrum';
+import { extensionId } from './Constants';
+
+// contentUrl '/#pre-step' loads with hash '#pre-step' (no slash after #).
+// Use /^#\/?/ to strip '#' or '#/' — plain '#/' replace silently fails and breaks the panelId.
+function getPanelId() {
+  const route = window.location.hash.replace(/^#\/?/, '').split('?')[0];
+  return `{{EXTENSION_NAME}}-${route}`;
+}
+
+function isPrePanel() {
+  return window.location.hash.includes('pre-step');
+}
+
+export default function AddAssetsPanel() {
+  const [guestConnection, setGuestConnection] = useState(null);
+  const [ready, setReady] = useState(false);
+  const panelId = getPanelId();
+  const isPre = isPrePanel();
+
+  useEffect(() => {
+    (async () => {
+      const connection = await attach({ id: extensionId });
+      setGuestConnection(connection);
+      // Post panels default to ready (no signalling required).
+      if (!isPre) setReady(true);
+    })();
+  }, []);
+
+  function markReady() {
+    // Signal the wizard host: Next button becomes clickable for this panel.
+    // panelId must exactly match the id returned by getPanels() in ExtensionRegistration.js.
+    window.parent.postMessage(
+      { type: 'addAssets:setReadyToAdvance', panelId, ready: true },
+      '*'
+    );
+    setReady(true);
+  }
+
+  if (!guestConnection) {
+    return (
+      <Provider theme={defaultTheme}>
+        <View padding="size-400" height="100vh">
+          <View UNSAFE_style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '200px' }}>
+            <ProgressCircle aria-label="Loading..." isIndeterminate />
+          </View>
+        </View>
+      </Provider>
+    );
+  }
+
+  return (
+    <Provider theme={defaultTheme}>
+      <View padding="size-400">
+        <Heading level={3}>
+          {{DISPLAY_NAME}} — {isPre ? 'Pre-Upload' : 'Post-Upload'}
+        </Heading>
+
+        <View marginTop="size-300" marginBottom="size-300">
+          <Text>
+            {isPre
+              ? 'Complete any required steps before uploading your assets, then click "Ready to Upload" to proceed.'
+              : 'Your assets have been uploaded. Review or tag them below.'}
+          </Text>
+        </View>
+
+        {/* Add your custom wizard panel UI here */}
+
+        {isPre && !ready && (
+          <Button variant="accent" onPress={markReady}>
+            Ready to Upload
+          </Button>
+        )}
+
+        {ready && (
+          <Text UNSAFE_style={{ color: '#2d9d78' }}>
+            ✓ {isPre ? 'Ready to proceed to upload.' : 'Upload complete.'}
+          </Text>
+        )}
+      </View>
+    </Provider>
+  );
+}
+```
+
+---
+
+## `src/aem-assets-contenthub-1/actions/utils.js`
+
+```js
+function errorResponse(statusCode, message) {
+  return { statusCode, body: { error: message } };
+}
+
+function getBearerToken(params) {
+  const authHeader = params.__ow_headers?.authorization || params.authorization;
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    return authHeader.substring(7);
+  }
+  throw new Error('Missing or invalid authorization header');
+}
+
+function checkMissingRequestInputs(params, requiredParams) {
+  const missing = requiredParams.filter(param => !params[param]);
+  if (missing.length > 0) {
+    return `Missing required parameters: ${missing.join(', ')}`;
+  }
+  return null;
+}
+
+module.exports = { errorResponse, getBearerToken, checkMissingRequestInputs };
+```
+
+---
+
+## `src/aem-assets-contenthub-1/actions/generic/index.js`
+
+The web action called by the panel. Customize with real AEM API logic.
+
+```js
+const { errorResponse, getBearerToken, checkMissingRequestInputs } = require('../utils');
+
+/**
+ * Generic Web Action — {{DISPLAY_NAME}}
+ *
+ * Called from TabPanel.js with the current asset ID.
+ * Customize this to call AEM Assets Author API.
+ *
+ * Params passed from the panel:
+ *   assetId  — asset urn from host.assetDetails.getCurrentAsset()
+ *   aemHost  — AEM author URL from host.discovery.getAemHost()
+ *   apiKey   — from host.auth.getApiKey() (never hardcode)
+ *   imsOrg   — from host.auth.getIMSInfo()
+ *
+ * To call authenticated AEM APIs:
+ *   1. Set require-adobe-auth: true in ext.config.yaml
+ *   2. Send Authorization header from the panel
+ *   3. Uncomment the fetch block below
+ */
+async function main(params) {
+  console.log('{{EXTENSION_NAME}} action called', JSON.stringify({ assetId: params.assetId }, null, 2));
+
+  try {
+    // Uncomment for authenticated AEM API calls:
+    // const token = getBearerToken(params);
+    // const { assetId, aemHost, apiKey, imsOrg } = params;
+    //
+    // const response = await fetch(`https://${aemHost}/adobe/assets/${assetId}/metadata`, {
+    //   headers: {
+    //     'Authorization': `Bearer ${token}`,
+    //     'X-Api-Key': apiKey,           // always from frontend — never hardcode
+    //     'x-gw-ims-org-id': imsOrg,
+    //     'Content-Type': 'application/json',
+    //   },
+    // });
+    // const data = await response.json();
+    // const metadata = data.value ?? data;
+    // return { statusCode: 200, body: { metadata } };
+
+    return {
+      statusCode: 200,
+      body: {
+        message: 'Action executed successfully',
+        extension: '{{EXTENSION_NAME}}',
+        timestamp: new Date().toISOString(),
+        assetId: params.assetId || null,
+      },
+    };
+
+  } catch (error) {
+    console.error('Action error:', error);
+    return errorResponse(500, `Action failed: ${error.message}`);
+  }
+}
+
+exports.main = main;
+```
+
+---
+
+## `README.md`
+
+```markdown
+# {{DISPLAY_NAME}}
+
+Content Hub UI extension for the `aem/assets/contenthub/1` extension point.
+
+## Extension Point
+
+`aem/assets/contenthub/1` — adds custom tab panels to the Asset Details Dialog.
+
+## Project Structure
+
+```
+src/aem-assets-contenthub-1/
+  web-src/src/components/
+    ExtensionRegistration.js  — registers tab panels with Content Hub
+    TabPanel.js               — custom panel UI (rendered in iframe)
+    App.js                    — React routing
+    Constants.js              — extensionId (shared between register + attach)
+  actions/
+    generic/index.js          — I/O Runtime web action (AEM API calls)
+    utils.js                  — shared action utilities
+  ext.config.yaml             — runtime manifest + action definitions
+app.config.yaml               — declares aem/assets/contenthub/1 extension point
+```
+
+## Development
+
+```bash
+npm install
+aio app build
+aio app run
+```
+
+Test URL:
+```
+https://experience.adobe.com/?devMode=true&ext=https://localhost:9080#/assets/contenthub/
+```
+
+No `&repo=` needed for local dev — the scaffold sets `allowedRepos = []`, so any repo (or none) works.
+
+> First time only: accept the self-signed cert at https://localhost:9080 before loading the test URL.
+
+## Allowed Repos
+
+Before deploying to Production, update `allowedRepos` in `ExtensionRegistration.js` with your delivery repo IDs — this restricts which AEM repos may load the extension:
+
+```js
+const allowedRepos = ['delivery-p12345-e167890.adobeaemcloud.com'];
+```
+
+## Deploy
+
+**Stage:** `aio app use -w Stage && aio app deploy`
+
+**Production:** `aio app use -w Production && aio app deploy`
+
+Approve in [Extension Manager](https://experience.adobe.com/aem/extension-manager) after deploying to Production.
+```
+
+---
+
+## Adding a Second Panel
+
+When the user wants a second tab panel, make these changes:
+
+### In `ExtensionRegistration.js` — add to the `getTabPanels()` array:
+
+```js
+getTabPanels() {
+  return [
+    {
+      id: '{{EXTENSION_NAME}}-panel',
+      title: '{{DISPLAY_NAME}}',
+      tooltip: '{{DISPLAY_NAME}}',
+      icon: 'Extension',
+      contentUrl: '/#tab-panel',
+    },
+    {
+      id: '{{EXTENSION_NAME}}-second-panel',
+      title: 'Second Panel',
+      tooltip: 'Second Panel',
+      icon: 'Info',
+      contentUrl: '/#second-panel',    // must match the route added in App.js
+    },
+  ];
+},
+```
+
+### In `App.js` — add a route:
+
+```js
+import SecondPanel from './SecondPanel';   // create this component
+
+<Route path="second-panel" element={<SecondPanel />} />
+```
+
+### Create `SecondPanel.js` — copy the `TabPanel.js` template, rename the component and customize the UI.

--- a/plugins/app-builder/skills/appbuilder-project-init/references/file-templates.md
+++ b/plugins/app-builder/skills/appbuilder-project-init/references/file-templates.md
@@ -5,9 +5,10 @@ Complete templates for all scaffold files. Before writing, substitute:
 - `{{DISPLAY_NAME}}` → Title Case name (e.g. `My Asset Viewer`)
 - `{{EXTENSION_DESCRIPTION}}` → one-sentence description
 - `{{EXTENSION_DIR}}` → for Content Hub, `aem-assets-contenthub-1`; for other AEM surfaces, `surfaceConfig.extDir`
+- `{{EXTENSION_POINT}}` → for Content Hub, `aem/assets/contenthub/1`; for other AEM surfaces, `surfaceConfig.extensionPointId`
 
-Extension point used throughout: `aem/assets/contenthub/1`
-Source directory: `src/aem-assets-contenthub-1/`
+Extension point used throughout (Content Hub): `aem/assets/contenthub/1`
+Source directory (Content Hub): `src/aem-assets-contenthub-1/`
 
 > **Dual role.** This file is both the Content Hub template set AND the **shared `@adobe/uix-guest` skeleton** reused by the other AEM surfaces (CF Console, CF Editor, Universal Editor, Assets View). When scaffolding one of those surfaces, reuse every file here — `package.json`, `index.html`, `index.js`, `index.css`, `Constants.js`, `App.js`, `actions/*`, `hooks/post-deploy.js`, `README`/`AGENTS`, `.eslintrc.js` — swapping `aem-assets-contenthub-1` → `surfaceConfig.extDir`, the extension point → `surfaceConfig.extensionPointId`, and the `register()` `methods` object → the surface block in [`aem-surface-templates.md`](aem-surface-templates.md). ExC Shell does NOT share this skeleton (different SDK) — see [`excshell-templates.md`](excshell-templates.md).
 
@@ -57,15 +58,15 @@ Source directory: `src/aem-assets-contenthub-1/`
 
 ```yaml
 extensions:
-  aem/assets/contenthub/1:
-    $include: src/aem-assets-contenthub-1/ext.config.yaml
+  {{EXTENSION_POINT}}:
+    $include: src/{{EXTENSION_DIR}}/ext.config.yaml
 ```
 
-**Critical:** Use `aem/assets/contenthub/1` — not the deprecated `aem/contenthub/assets/details/1`. If the user's existing project has the old extension point ID, update both this file and the directory name.
+**Critical (Content Hub):** Use `aem/assets/contenthub/1` — not the deprecated `aem/contenthub/assets/details/1`. If the user's existing project has the old extension point ID, update both this file and the directory name.
 
 ---
 
-## `src/aem-assets-contenthub-1/ext.config.yaml`
+## `src/{{EXTENSION_DIR}}/ext.config.yaml`
 
 ```yaml
 $schema: https://unpkg.com/@adobe/aio-schemas@latest/schemas/aio.schema.json
@@ -73,7 +74,7 @@ actions: actions
 web: web-src
 runtimeManifest:
   packages:
-    aem-assets-contenthub-1:
+    {{EXTENSION_DIR}}:
       license: Apache-2.0
       actions:
         generic:
@@ -109,7 +110,7 @@ hooks:
   "keywords": ["contenthub", "assets", "extension", "uix"],
   "author": "",
   "license": "Apache-2.0",
-  "extensionPoints": ["aem/assets/contenthub/1"]
+  "extensionPoints": ["{{EXTENSION_POINT}}"]
 }
 ```
 
@@ -150,6 +151,7 @@ module.exports = {
 - `assetDetails` — tab panels in the Asset Details Dialog side rail
 - `card` — action buttons on asset cards (Assets grid, collection, link share) and on collection tiles in the Collections grid
 - `selectionBar` — bulk action buttons in the selection bar (multi-select)
+- `addAssets` — wizard panels before/after the Upload step; `beforeUpload` hook to gate/enrich uploads; `onUploadComplete` hook after upload finishes
 
 (Remove entries for namespaces not wired in ExtensionRegistration.js)
 

--- a/plugins/app-builder/skills/appbuilder-testing/SKILL.md
+++ b/plugins/app-builder/skills/appbuilder-testing/SKILL.md
@@ -10,7 +10,9 @@ description: >-
   aio app test, or wants to verify action behavior before deployment. Also trigger when users mention
   Jest configuration for App Builder, test coverage, CI test setup, React component test, Testing
   Library, UI test, Provider wrapper, test my page, test my form, test my table, test my component,
-  mock shell context, mock extension context, debug test failures, or fix Jest errors.
+  mock shell context, mock extension context, debug test failures, or fix Jest errors. Also covers
+  unit and component tests for Content Hub extensions: ExtensionRegistration.js, TabPanel.js,
+  CardActionModal.js, SelectionBarModal.js — using uix-guest mock helpers.
 metadata:
   category: testing
 license: Apache-2.0
@@ -40,6 +42,8 @@ Pick the template or reference that matches the user's intent. Default to `asset
 | Contract test for API interactions | references/testing-patterns.md | — |
 | Pre-deployment verification | references/checklist.md | — |
 | Debug test failures | references/debugging.md | — |
+
+Covers unit and component tests for Content Hub extension files: `ExtensionRegistration.js` (registration mocking), `TabPanel.js` (attach() mock + host API stubs), `CardActionModal.js` / `SelectionBarModal.js` (modal open/close flow). Use `assets/uix-guest-mock-helper.js` for the `@adobe/uix-guest` host API stubs needed by all three namespaces.
 
 ## Fast Path (for clear requests)
 

--- a/plugins/app-builder/skills/appbuilder-ui-scaffolder/SKILL.md
+++ b/plugins/app-builder/skills/appbuilder-ui-scaffolder/SKILL.md
@@ -1,15 +1,19 @@
 ---
 name: appbuilder-ui-scaffolder
 description: >-
-  Generate React Spectrum UI components for Adobe Experience Cloud Shell SPAs and AEM UI Extensions.
-  Provides patterns for pages, forms, data tables, dialogs, and navigation using @adobe/react-spectrum.
-  Guides ExC Shell integration with @adobe/exc-app including runtime.done(), IMS token passthrough,
-  and shell theming. Guides AEM UI Extension development with @adobe/uix-guest for Content Fragment
-  Console, CF Editor, Universal Editor, and Assets View surfaces. Trigger on: building App Builder UI,
-  React Spectrum components, ExC Shell pages, forms, data tables, dialogs, modals, navigation, theming,
-  web-src, Spectrum design system, @adobe/exc-app, AEM extension, AEM UI extension, Content Fragment
-  Console, Universal Editor extension, uix-guest, @adobe/uix-guest, extension points for AEM,
-  customizing AEM surfaces.
+  Generate React Spectrum UI components and customize existing App Builder UI extensions. Covers:
+  ExC Shell SPAs (@adobe/exc-app, runtime.done(), IMS tokens, theming), AEM UI Extensions
+  (@adobe/uix-guest: CF Console, CF Editor, Universal Editor, Assets View), and Content Hub extensions
+  (panels in Asset Details Dialog, card actions on asset cards and collection tiles, bulk actions in
+  the selection bar, Add Assets wizard panels — all via aem/assets/contenthub/1). Use when the user
+  already has a scaffolded extension and wants to customize or build the UI: add panels, buttons,
+  modals, forms, tables, dialogs, or navigation. Trigger on: Content Hub panel, Content Hub card
+  action, Content Hub bulk action, add assets wizard, hydration panel, asset details panel, asset
+  card button, selection bar button, React Spectrum, @adobe/uix-guest,
+  uix-guest, Tab Panel, ExtensionRegistration, App Builder UI, forms, data tables, dialogs, modals,
+  web-src, Spectrum, @adobe/exc-app, AEM extension UI, customize AEM extension.
+  For CREATING a new extension from scratch (Console setup + file generation + dev server), use
+  appbuilder-project-init instead.
 metadata:
   category: frontend
 license: Apache-2.0
@@ -34,6 +38,8 @@ Identify the user's intent, then read the referenced sections to generate tailor
 | ExC Shell setup | `references/shell-integration.md` | `@adobe/exc-app`, `Provider`, `defaultTheme` |
 | Connect UI to backend actions | `references/action-integration.md` | `fetch()` with IMS token |
 | AEM UI Extension (CF Console, CF Editor, Universal Editor) | `references/aem-extensions.md` | `@adobe/uix-guest`, `register()`, `sharedContext` |
+| Any extension — scaffold NEW from scratch | Extension Scaffolding Mode in `appbuilder-project-init` | Use `appbuilder-project-init` — Extension Scaffolding Mode (handles Console setup, file generation, build, dev server, deploy for every surface) |
+| Content Hub extension (customize existing — panels, card actions, bulk actions, add assets wizard) | `references/contenthub-extensions.md` | `@adobe/uix-guest`, `register()`, `attach()`, `assetDetails.getTabPanels()`, `card`/`selectionBar`/`addAssets` namespaces, `host.modal`, `postMessage` readiness signalling |
 | Debug UI issues | `references/debugging.md` | Shell spinner, CORS, blank screen, auth |
 
 ## Fast Path (for clear requests)
@@ -55,6 +61,7 @@ Examples of fast-path triggers:
 - "Build a Content Fragment Console extension" → Read `references/aem-extensions.md` § CF Console, generate directly
 - "Add a header menu button to the Universal Editor" → Read `references/aem-extensions.md` § Universal Editor, generate directly
 - "Create an AEM extension with uix-guest" → Read `references/aem-extensions.md` § Core Registration, generate directly
+- "Create / scaffold a new extension from scratch" → Redirect to the `appbuilder-project-init` skill (Extension Scaffolding Mode — asks which surface, then handles full lifecycle: Console setup, file generation, build, dev server, deploy)
 
 If there is any ambiguity — multiple patterns could fit, constraints are unclear, or the user hasn't specified enough — fall through to the full workflow below.
 
@@ -93,6 +100,11 @@ If there is any ambiguity — multiple patterns could fit, constraints are uncle
 - "Build a Content Fragment Console extension with an action bar button."
 - "Add a custom RTE toolbar button in the Content Fragment Editor."
 - "Create a Universal Editor extension with a header menu button."
+- "Add a custom panel to the Content Hub Asset Details Dialog."
+- "Build a Content Hub extension that shows asset metadata in a side panel."
+- "Add an action button to Content Hub asset cards."
+- "Add a bulk action to the Content Hub selection bar."
+- "Customize the Content Hub extension UI with React Spectrum."
 
 ## Inputs To Request
 
@@ -126,11 +138,15 @@ If there is any ambiguity — multiple patterns could fit, constraints are uncle
 - Use `references/action-integration.md` for calling backend actions from the SPA.
 - Use `references/checklist.md` for pre-handoff UI quality validation.
 - Use `references/aem-extensions.md` for AEM UI Extension patterns (`@adobe/uix-guest`, Content Fragment Console/Editor, Universal Editor, Assets View).
+- Use `references/contenthub-extensions.md` for Content Hub extension patterns (`@adobe/uix-guest`, `aem/assets/contenthub/1`, asset details tab panels, Host APIs, web actions).
 - Use `references/debugging.md` for common SPA debugging scenarios (shell spinner, CORS, auth, blank screen, performance).
 
 ## Chaining
 
-- Chains FROM `appbuilder-project-init` (after SPA project is scaffolded with `dx/excshell/1` extension)
+- Chains FROM `appbuilder-project-init` (Extension Scaffolding Mode) — once the extension is scaffolded and running locally, this skill handles UI customization and React Spectrum patterns
 - Works alongside `appbuilder-action-scaffolder` for full-stack features (UI calls backend actions)
 - Chains TO `appbuilder-testing` (test generated UI components)
 - Chains TO `appbuilder-cicd-pipeline` (deploy frontend changes)
+- What's Next: After building Content Hub extension UI here, chain TO: `appbuilder-testing` (unit/component tests), `appbuilder-cicd-pipeline` (GitHub Actions deployment), `appbuilder-e2e-testing` (Playwright E2E tests against the deployed extension)
+
+Use `references/contenthub-extensions.md` for Content Hub extension patterns (`@adobe/uix-guest`, `aem/assets/contenthub/1`, asset details tab panels, Host APIs, web actions).

--- a/plugins/app-builder/skills/appbuilder-ui-scaffolder/references/contenthub-extensions.md
+++ b/plugins/app-builder/skills/appbuilder-ui-scaffolder/references/contenthub-extensions.md
@@ -1,0 +1,732 @@
+# Content Hub UI Extension Patterns
+
+API patterns and Host API reference for customizing Content Hub UI extensions using `@adobe/uix-guest`. These extensions run as App Builder apps inside iframes and can extend **four** Content Hub surfaces from a single `register()` call:
+
+- **Asset Details Dialog** (`assetDetails` namespace) — custom tab panels in the side rail.
+- **Asset card actions** (`card` namespace) — buttons on asset cards (Assets grid, inside a collection, link share) **and** on collection tiles in the Collections grid. The extension differentiates surfaces via `actionContext.context`.
+- **Selection bar / bulk actions** (`selectionBar` namespace) — buttons in the multi-select action bar.
+- **Add Assets wizard** (`addAssets` namespace) — inject panels before/after the upload step, gate uploads, and react to upload completion.
+
+> **Scaffolding:** To create a new Content Hub extension from scratch, use the `appbuilder-project-init` skill (Extension Scaffolding Mode) — it handles the full workflow (Developer Console, file generation, build, dev server) and already wires all three namespaces. This file is a pattern reference for customizing and extending an already-scaffolded project.
+
+**Extension point:** `aem/assets/contenthub/1` (unified — all four Content Hub surfaces via method namespaces in one `register()` call)
+
+---
+
+## Core Registration Pattern
+
+Every Content Hub extension starts with `register()` from `@adobe/uix-guest`. This establishes the two-way communication channel between the extension (guest) and Content Hub (host).
+
+```js
+import { register } from '@adobe/uix-guest';
+
+// `let` (not `const`): card/selectionBar onActionClick handlers reference the
+// connection AFTER register() resolves, to open a modal via host.modal.openDialog().
+let guestConnection;
+
+guestConnection = await register({
+  id: 'my.company.extension-name',  // unique ID — use reverse-domain format
+  methods: {
+    // Declare which surfaces to extend via namespaces — opt into any combination:
+    assetDetails: {
+      getTabPanels() { ... }         // tab panels in the Asset Details Dialog
+    },
+    card: {
+      getActionButtons(actionContext) { ... }     // buttons on asset cards + collection tiles
+      async onActionClick(resourceType, buttonId, resourceId, actionContext) { ... }
+    },
+    selectionBar: {
+      getActionButtons(actionContext) { ... }     // buttons in the bulk-action bar
+      async onActionClick(buttonId, assetIds) { ... }
+    },
+    addAssets: {
+      getPanels() { ... }                         // wizard panels before/after the Upload step
+      async beforeUpload(ctx) { ... }             // gate or enrich metadata before upload starts
+      async onUploadComplete(ctx) { ... }         // react after upload finishes
+    },
+  },
+});
+```
+
+The single extension point `aem/assets/contenthub/1` covers all four Content Hub surfaces. One `register()` call handles every namespace the extension opts into.
+
+**Currently available namespaces:** `assetDetails`, `card`, `selectionBar`, and `addAssets` — all four are live in the host. The `card` namespace covers both asset cards (Assets grid, inside a collection, link share) **and** collection tiles on the Collections grid — the host passes the surface in `actionContext.context` so a single implementation handles all of them. Card and selection-bar actions are gated by the `EXTENSIBILITY_AEM_CONTENTHUB` feature flag (`ASSETS-66401_extensibility_aem_contenthub`); when the flag is off the host returns no extension buttons/panels for those surfaces, but `assetDetails` panels still render. The host invokes each namespace's methods from `useExtensionTabPanelsAssetDetails` / `useExtensionCardActions` (exports both `useExtensionAssetCardActions` and `useExtensionCollectionCardActions`) / `useExtensionBulkActionBar` / `useExtensionAddAssetsPanels` + `useExtensionAddAssetsHooks` (Content Hub repo, `src/utils/hooks/extensibility/`). There is no separate `collections` namespace — collection tiles reuse `card`.
+
+### `register()` vs `attach()`
+
+- **`register()`** — Used on the extension entry page. Declares capabilities. Returns a connection. Call once on load.
+- **`attach()`** — Used on secondary pages (panel content inside an iframe). Reconnects without re-declaring capabilities.
+
+```js
+// In a tab panel page rendered inside the Content Hub iframe
+import { attach } from '@adobe/uix-guest';
+
+const guestConnection = await attach({
+  id: 'my.company.extension-name',  // must exactly match the id in register()
+});
+```
+
+**Critical:** Both `register()` and `attach()` must use the same `id`. Export it from `Constants.js` and import it in both files.
+
+---
+
+## Extension Point Configuration
+
+### `app.config.yaml`
+
+```yaml
+extensions:
+  aem/assets/contenthub/1:
+    $include: src/aem-assets-contenthub-1/ext.config.yaml
+```
+
+### Project Structure
+
+```
+app.config.yaml                               ← declares aem/assets/contenthub/1
+src/aem-assets-contenthub-1/
+  ext.config.yaml                             ← runtime manifest + action definitions
+  web-src/src/components/
+    Constants.js                              ← extensionId (shared)
+    ExtensionRegistration.js                  ← register() call (all namespaces)
+    App.js                                    ← React routing
+    TabPanel.js                               ← assetDetails panel UI (uses attach())
+    CardActionModal.js                        ← card namespace modal (uses attach())
+    SelectionBarModal.js                      ← selectionBar namespace modal (uses attach())
+    AddAssetsPanel.js                         ← addAssets wizard panel UI (uses attach())
+  actions/
+    generic/index.js                          ← web action (AEM API calls)
+    utils.js                                  ← shared utilities
+```
+
+> Only scaffold the component for the namespaces you use — `TabPanel.js` for `assetDetails`, `CardActionModal.js` for `card`, `SelectionBarModal.js` for `selectionBar`, `AddAssetsPanel.js` for `addAssets`.
+
+---
+
+## Asset Details Extension (`assetDetails` namespace)
+
+The `assetDetails` namespace adds custom tab panels to the Asset Details Dialog side rail. Content Hub manages panel toggling, deep-linking, and header rendering — the extension only provides the panel content via an iframe.
+
+### Registering Tab Panels
+
+```js
+methods: {
+  assetDetails: {
+    getTabPanels() {
+      return [
+        {
+          id: 'my-panel',              // unique within this extension
+          title: 'My Panel',          // panel header (rendered by Content Hub)
+          tooltip: 'My Panel',        // side-rail icon tooltip
+          icon: 'Extension',          // React-Spectrum workflow icon name
+          contentUrl: '/#tab-panel',  // hash route in this guest app
+        },
+      ];
+    },
+  },
+}
+```
+
+**Panel descriptor properties:**
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `id` | string | Unique panel ID within this extension |
+| `title` | string | Panel header (Content Hub renders this) |
+| `tooltip` | string | Tooltip on the side-rail icon |
+| `icon` | string | React-Spectrum workflow icon name |
+| `contentUrl` | string | Hash route (e.g. `/#tab-panel`) — must match an `<Route>` in `App.js` |
+
+### Restricting to Specific Repos
+
+```js
+const allowedRepos = [
+  'delivery-p12345-e167890.adobeaemcloud.com',
+];
+
+function shouldSkipRegistration(repo) {
+  return allowedRepos.length > 0 && !allowedRepos.includes(repo);
+}
+```
+
+Empty `allowedRepos` = loads for any repo (safe for development).
+
+---
+
+## Asset Card Actions (`card` namespace)
+
+The `card` namespace adds action buttons to asset cards (the overflow / hover menu on each card in the Assets grid, inside a collection, or the link-share view) **and** to collection tiles on the Collections grid (the tile's ⋯ menu). The host passes the current surface in `actionContext`, so one implementation serves every card surface. The host renders each button and, on click, calls back into the extension.
+
+### Registering card buttons
+
+```js
+methods: {
+  card: {
+    // Host calls getActionButtons(actionContext) with context about the current surface.
+    // actionContext.context: 'assets' | 'collection' | 'collections' | 'share'
+    //   'assets'      — Assets browse grid (asset card)
+    //   'collection'  — assets inside a collection (asset card)
+    //   'share'       — link-share view (asset card)
+    //   'collections' — collection tile on the Collections grid
+    getActionButtons(actionContext) {
+      // Vary buttons by actionContext.context, or ignore it to show the same set everywhere.
+      return [
+        {
+          id: 'my-card-action',     // unique within this extension
+          label: 'Edit Metadata',   // button label (card uses `label`, NOT `title`)
+          icon: 'Edit',             // React-Spectrum workflow icon name
+        },
+      ];
+    },
+    // Host calls this on click, passing (resourceType, buttonId, resourceId, actionContext).
+    async onActionClick(resourceType, buttonId, resourceId, actionContext) {
+      // resourceType:  'asset' (asset cards) | 'collection' (collection tiles)
+      // buttonId:      the `id` from getActionButtons()
+      // resourceId:    the asset or collection URN string
+      // actionContext: { context } — same surface values as above
+      // openDialog takes a SINGLE config object — NO { id } first arg, NO payload field.
+      // Pass data to the modal via the contentUrl query string.
+      await guestConnection.host.modal.openDialog({
+        title: 'Edit Metadata',
+        contentUrl: `/#card-action-modal?resourceId=${encodeURIComponent(resourceId)}&resourceType=${encodeURIComponent(resourceType)}`,  // route in App.js + query
+        type: 'modal',
+        size: 'M',
+      });
+    },
+  },
+}
+```
+
+**Button descriptor (card):** only `id`, `label`, and `icon` are read by the host — `title`/`tooltip`/`variant` are ignored for card buttons.
+
+**`getActionButtons(actionContext)`** — the host passes `{ context }` (the source surface). Use it to conditionally show/hide buttons per surface, or ignore it to always show the same set.
+
+**`onActionClick(resourceType, buttonId, resourceId, actionContext)`** — exact argument order the host uses. It's optional (the host guards with `?.`): omit it for a no-op button, but you need it to open a modal. Because it fires *after* `register()` resolves, declare the connection with `let guestConnection` so the handler can reference it.
+
+> Host proof: `extension.apis.card.onActionClick?.(ResourceType.ASSET, btn.id, assetId, {context: source})` (asset cards) and `extension.apis.card.onActionClick?.(ResourceType.COLLECTION, btn.id, collectionId, {context: 'collections'})` (collection tiles) in `useExtensionCardActions.ts`.
+
+---
+
+## Selection Bar / Bulk Actions (`selectionBar` namespace)
+
+The `selectionBar` namespace adds buttons to the bulk-action bar shown when one or more assets are selected. Unlike `card`, the host passes an **action context** to `getActionButtons`, telling the extension which view the bar is in and what's selected.
+
+### Registering selection-bar buttons
+
+```js
+methods: {
+  selectionBar: {
+    // Host calls getActionButtons(actionContext) with context about the current view + selection.
+    // actionContext shape:
+    //   { context: 'assets'|'collections'|'collection'|'share',
+    //     resourceSelection: { resources: [{id: string}, ...] } }
+    //
+    // context values:
+    //   'assets'      — browse grid
+    //   'collections' — collections list
+    //   'collection'  — inside a single collection
+    //   'share'       — link share view
+    getActionButtons(actionContext) {
+      // Optional: filter buttons by source view
+      // if (actionContext.context === 'share') return [];  // hide in link-share view
+      return [
+        {
+          id: 'my-bulk-action',
+          label: 'Bulk Export',     // selectionBar uses `label`, NOT `title`
+          icon: 'Download',         // React-Spectrum workflow icon name
+        },
+      ];
+    },
+    // Host calls this on click, passing (buttonId, assetIds[]).
+    async onActionClick(buttonId, assetIds) {
+      // buttonId:  the `id` from getActionButtons()
+      // assetIds:  string[] — URNs of every currently selected asset
+      // Single config object — NO { id }, NO payload. Pass assetIds via the contentUrl query.
+      const ids = encodeURIComponent(JSON.stringify(assetIds || []));
+      await guestConnection.host.modal.openDialog({
+        title: `Bulk Export (${assetIds.length})`,
+        contentUrl: `/#selection-bar-modal?assetIds=${ids}`,  // route in App.js + query
+        type: 'modal',
+        size: 'M',
+      });
+    },
+  },
+}
+```
+
+**Button descriptor (selectionBar):** same as card — `id`, `label`, `icon`.
+
+**`getActionButtons(actionContext)`** — unlike `card.getActionButtons()` (no args), selectionBar receives context about the source view and current selection. Use it to conditionally show/hide buttons, or ignore the parameter to always show.
+
+**`onActionClick(buttonId, assetIds)`** — note this signature differs from `card`: **no `resourceType`**, and the second arg is an **array** of asset IDs. Like card, it's optional and fires after `register()` resolves (use `let guestConnection`).
+
+**Button ID prefixing:** The host renders each selection-bar extension button with a prefixed id (`ext:<extensionId>:<btn.id>`) to avoid collisions with native action bar items. This is host-internal — your extension code uses the original `btn.id` as returned from `getActionButtons`. The `onActionClick` handler also receives the original `btn.id`, not the prefixed form.
+
+> Host proof: `extension.apis.selectionBar.getActionButtons(actionContext)` and `extension.apis.selectionBar.onActionClick(btn.id, assetIds)` in `useExtensionBulkActionBar.ts`.
+
+---
+
+## Add Assets Wizard (`addAssets` namespace)
+
+The `addAssets` namespace integrates with the "Add Assets" (hydration) flow. Extensions can:
+
+1. **Inject wizard panels** (`getPanels()`) — rendered as full-dialog steps before (`'pre'`) or after (`'post'`) the native Upload step.
+2. **Gate or enrich uploads** (`beforeUpload(ctx)`) — called before the file upload starts; can block the upload or inject/merge metadata.
+3. **React to upload completion** (`onUploadComplete(ctx)`) — fires after the upload finishes (parallel, fire-and-forget).
+
+### Registering add-assets methods
+
+```js
+methods: {
+  addAssets: {
+    getPanels() {
+      return [
+        {
+          id: 'my-pre-step',          // unique within this extension
+          title: 'Select Campaign',   // dialog heading
+          position: 'pre',            // 'pre' | 'post' — before or after the Upload step
+          contentUrl: '/#pre-step',   // hash route in App.js
+        },
+        {
+          id: 'my-post-step',
+          title: 'Tag Assets',
+          position: 'post',
+          contentUrl: '/#post-step',
+        },
+      ];
+    },
+
+    // Called before upload starts. Return { proceed: false } to block, or
+    // { proceed: true, metadata: {...} } to inject/merge metadata.
+    async beforeUpload({ files, metadata, uploadPath }) {
+      const extra = { 'xdm:campaignName': 'Q3 Launch' };
+      return { proceed: true, metadata: { ...metadata, ...extra } };
+    },
+
+    // Called after all files finish uploading. Return value is ignored.
+    async onUploadComplete({ files, metadata, uploadPath }) {
+      // e.g. post to a webhook, update a campaign tracker
+    },
+  },
+}
+```
+
+### Panel descriptor (`getPanels`)
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `id` | string | Unique panel ID within this extension |
+| `title` | string | Dialog heading for this wizard step |
+| `position` | `'pre' \| 'post'` | `'pre'` = shown before the Upload step; `'post'` = after |
+| `contentUrl` | string | Hash route rendered in a `GuestUIFrame` (must match a `<Route>` in `App.js`) |
+
+### Wizard step order
+
+```
+[pre panels in order] → [Upload / hydration step] → [post panels in order]
+```
+
+A `pre` panel blocks the **Next** button by default. To unblock it, the panel's iframe sends a `postMessage`:
+
+```js
+// Inside the GuestUIFrame iframe of a 'pre' panel:
+window.parent.postMessage(
+  { type: 'addAssets:setReadyToAdvance', panelId: 'my-pre-step', ready: true },
+  '*'
+);
+```
+
+`post` panels default to ready (no signal required — informational or fire-and-forget).
+
+### `beforeUpload` return contract
+
+```ts
+// Input ctx:
+{ files: File[], metadata: Record<string, unknown>, uploadPath: string }
+
+// Return:
+{ proceed: boolean; metadata: Record<string, unknown>; message?: string }
+```
+
+- `proceed: false` → upload blocked; show `message` to the user.
+- `proceed: true` → merge `metadata` (returned metadata is spread onto the existing form metadata).
+- Multiple extensions: any single `false` blocks the upload; all `metadata` objects are merged (last-writer-wins per key).
+
+### `onUploadComplete` context
+
+```ts
+{ files: { name: string; size: number; type: string }[], metadata: Record<string, unknown>, uploadPath: string }
+```
+
+All registered handlers run in parallel (`Promise.allSettled`). Individual failures are logged but do not block the wizard.
+
+### Add Assets panel component
+
+The wizard panel renders inside a `GuestUIFrame`. Use `attach()` to reconnect if you need Host APIs (auth, toast, etc.).
+
+```js
+import { attach } from '@adobe/uix-guest';
+import { extensionId } from './Constants';
+
+export default function AddAssetsPanel() {
+  const [guestConnection, setGuestConnection] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      const connection = await attach({ id: extensionId });
+      setGuestConnection(connection);
+    })();
+  }, []);
+
+  const markReady = () => {
+    window.parent.postMessage(
+      { type: 'addAssets:setReadyToAdvance', panelId: 'my-pre-step', ready: true },
+      '*'
+    );
+  };
+
+  // Render your form / UI.
+  // Call markReady() when the user has completed this step.
+}
+```
+
+> Host proof: `useExtensionAddAssetsPanels` (panels, `getPanels`) and `useExtensionAddAssetsHooks` (`beforeUpload`, `onUploadComplete`) in `src/utils/hooks/extensibility/` (Content Hub repo). Wired into `AddAssetsWizardDialog.tsx`.
+
+---
+
+## Opening a Modal for an Action (`modal` namespace)
+
+Card and selection-bar actions have no panel of their own — they open a modal dialog whose content is another route in the same guest app. The `modal` Host API is available to all four Content Hub surfaces.
+
+**Signature:** from the guest's perspective, `openDialog` is called with a **single config object** — `openDialog({ title, contentUrl, type?, size?, payload? })`. You never pass `{ id }` yourself; the UIX host auto-injects the extension id as the first argument on its side of the proxy. Data can reach the modal page two ways: via the `payload` field (retrieved with `modal.getPayload()`) or via a query string on `contentUrl` — pick whichever is more convenient.
+
+```js
+// From an onActionClick handler (register page):
+await guestConnection.host.modal.openDialog({
+  title: 'Dialog title',
+  contentUrl: `/#card-action-modal?resourceId=${encodeURIComponent(resourceId)}&resourceType=${encodeURIComponent(resourceType)}`,  // hash route + query data
+  type: 'modal',                      // optional: 'modal' | 'fullscreen'
+  size: 'M',                          // optional: 'S' | 'M' | 'L'
+  // payload: { resourceId, resourceType },  // alternative to the query string — read with modal.getPayload()
+});
+```
+
+Inside the modal page (a route rendered in its own iframe), read the data and reconnect with `attach()`:
+
+```js
+import { attach } from '@adobe/uix-guest';
+import { extensionId } from './Constants';
+
+// Query-string approach (simplest — no extra round trip):
+const params = new URLSearchParams(window.location.hash.split('?')[1] || '');
+const resourceId = params.get('resourceId');
+const resourceType = params.get('resourceType'); // 'asset' | 'collection'
+
+const connection = await attach({ id: extensionId });
+// Payload approach (alternative to the query string):
+// const { resourceId, resourceType } = await connection.host.modal.getPayload();
+// ... render UI, run the action ...
+await connection.host.modal.closeDialog();                 // dismiss the dialog
+```
+
+| Method | Signature | Purpose |
+| --- | --- | --- |
+| `modal.openDialog` | `({ title, contentUrl, type?, size?, payload? })` | Open a dialog rendering `contentUrl`. Single object from the guest's side — the host auto-injects `{ id }`. |
+| `modal.getPayload` | `() => unknown` | Returns the `payload` passed to `openDialog()`. Call from the modal page after `attach()`. |
+| `modal.closeDialog` | `() => void` | Close the current dialog (call from the modal page after `attach()`) |
+
+---
+
+## React Routing (`App.js`)
+
+Extensions use hash routing. Every panel has its own route; `contentUrl` in `getTabPanels()` must match a `<Route path>`.
+
+```js
+import { HashRouter as Router, Routes, Route } from 'react-router-dom';
+import ExtensionRegistration from './ExtensionRegistration';
+import TabPanel from './TabPanel';                   // assetDetails
+import CardActionModal from './CardActionModal';      // card
+import SelectionBarModal from './SelectionBarModal';  // selectionBar
+import AddAssetsPanel from './AddAssetsPanel';        // addAssets
+
+<Router>
+  <Routes>
+    <Route index element={<ExtensionRegistration />} />
+    <Route path="index.html" element={<ExtensionRegistration />} />
+    <Route path="tab-panel" element={<TabPanel />} />                  {/* assetDetails contentUrl */}
+    <Route path="card-action-modal" element={<CardActionModal />} />    {/* card modal contentUrl */}
+    <Route path="selection-bar-modal" element={<SelectionBarModal />} />{/* selectionBar modal contentUrl */}
+    <Route path="pre-step" element={<AddAssetsPanel />} />              {/* addAssets pre-panel contentUrl */}
+    <Route path="post-step" element={<AddAssetsPanel />} />             {/* addAssets post-panel contentUrl */}
+    {/* One route per panel/modal — each contentUrl maps to a route here */}
+  </Routes>
+</Router>
+```
+
+Keep only the routes for the namespaces you use. Each `contentUrl` in a `getTabPanels()` / `openDialog()` / `getPanels()` call must match a `<Route path>` here.
+
+---
+
+## Tab Panel Component
+
+The panel renders inside Content Hub's iframe. Use `attach()` to reconnect and access Host APIs.
+
+```js
+import { attach } from '@adobe/uix-guest';
+import { extensionId } from './Constants';
+
+export default function TabPanel() {
+  const [guestConnection, setGuestConnection] = useState(null);
+  const [asset, setAsset] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      const connection = await attach({ id: extensionId });
+      setGuestConnection(connection);
+
+      // getCurrentAsset() returns the asset id as a plain string (e.g. "urn:aaid:aem:...").
+      const assetId = await connection.host.assetDetails.getCurrentAsset();
+      setAsset({ id: assetId });
+    })();
+  }, []);
+
+  // Render UI with React Spectrum components...
+}
+```
+
+---
+
+## Modal Component (card / selectionBar)
+
+The modal page is just another `attach()`-based component, distinguished by reading its data **from the URL query or from `modal.getPayload()`**, whichever `openDialog()` used. Same shape for `CardActionModal.js` and `SelectionBarModal.js` — only the fields differ (`resourceId` + `resourceType` for card, `assetIds` JSON for selectionBar).
+
+```js
+import { attach } from '@adobe/uix-guest';
+import { extensionId } from './Constants';
+
+export default function CardActionModal() {
+  const [guestConnection, setGuestConnection] = useState(null);
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      // Query-string approach — read what onActionClick put in the contentUrl query.
+      // (Alternative: `await connection.host.modal.getPayload()` if openDialog() used `payload`.)
+      const params = new URLSearchParams(window.location.hash.split('?')[1] || '');
+      setData({
+        resourceId: params.get('resourceId'),
+        resourceType: params.get('resourceType'), // 'asset' | 'collection'
+      });
+      // (selectionBar: const ids = JSON.parse(params.get('assetIds') || '[]'))
+      const connection = await attach({ id: extensionId });  // only needed for closeDialog()
+      setGuestConnection(connection);
+    })();
+  }, []);
+
+  // Render UI with data.resourceId + data.resourceType (card) / data.assetIds (selectionBar),
+  // then close with: guestConnection.host.modal.closeDialog()
+}
+```
+
+---
+
+## Host APIs
+
+All APIs are available via `guestConnection.host`. Both `register()` and `attach()` return the same connection object. All invocations are asynchronous and return a Promise.
+
+### Authentication (`auth` namespace)
+
+```js
+const { imsOrg, imsOrgName, accessToken } = await guestConnection.host.auth.getIMSInfo();
+const apiKey = await guestConnection.host.auth.getApiKey();
+// Never hardcode apiKey — always get it via this method
+```
+
+### Discovery (`discovery` namespace)
+
+```js
+const aemHost = await guestConnection.host.discovery.getAemHost();
+// e.g. "author-p12345-e67890.adobeaemcloud.com"
+// Use in web actions for AEM Assets Author API calls
+```
+
+### Toast (`toast` namespace)
+
+```js
+guestConnection.host.toast.display({ variant: 'positive', message: 'Saved!' });
+// variant: 'neutral' | 'positive' | 'info' | 'negative'
+```
+
+### i18n (`i18n` namespace)
+
+```js
+const { locale } = await guestConnection.host.i18n.getLocalizationInfo();
+// e.g. "en-US"
+```
+
+### Modal (`modal` namespace)
+
+Available on all three surfaces. Used by `card`/`selectionBar` to open a dialog, and by any modal page to read its data and close:
+
+```js
+guestConnection.host.modal.openDialog({ title, contentUrl, type, size, payload });  // single object — host auto-injects { id }
+// inside the modal page, read data either from the URL query...
+const params = new URLSearchParams(window.location.hash.split('?')[1] || '');
+// ...or via the payload, if openDialog() set one:
+const payload = await guestConnection.host.modal.getPayload();
+guestConnection.host.modal.closeDialog();
+```
+
+### Asset Details (`assetDetails` namespace)
+
+Only available when registered under the `assetDetails` namespace:
+
+```js
+const assetId = await guestConnection.host.assetDetails.getCurrentAsset();
+// Returns the asset id as a plain string (e.g. "urn:aaid:aem:...").
+// Wrap if needed: const asset = { id: assetId };
+// Pass assetId (or asset.id) to a web action to call AEM Assets Author API
+```
+
+---
+
+## Calling Web Actions from a Panel
+
+Never call AEM APIs directly from the browser (CORS blocks them). Route all AEM API calls through web actions.
+
+```js
+// In TabPanel.js
+const { accessToken, imsOrg } = await guestConnection.host.auth.getIMSInfo();
+const apiKey = await guestConnection.host.auth.getApiKey();
+const aemHost = await guestConnection.host.discovery.getAemHost();
+const currentAsset = await guestConnection.host.assetDetails.getCurrentAsset();
+const actionUrl = actions['aem-assets-contenthub-1/generic'];  // from config.json
+
+const response = await fetch(actionUrl, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    // Include these when action has require-adobe-auth: true:
+    // 'Authorization': `Bearer ${accessToken}`,
+    // 'x-gw-ims-org-id': imsOrg,
+  },
+  body: JSON.stringify({ assetId: currentAsset.id, aemHost, apiKey, imsOrg }),
+});
+const data = await response.json();
+```
+
+**In the web action (`actions/generic/index.js`):**
+
+```js
+async function main(params) {
+  const { assetId, aemHost, apiKey, imsOrg } = params;
+  const token = params.__ow_headers?.authorization?.substring(7); // when require-adobe-auth: true
+
+  const response = await fetch(`https://${aemHost}/adobe/assets/${assetId}/metadata`, {
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'X-Api-Key': apiKey,
+      'x-gw-ims-org-id': imsOrg,
+    },
+  });
+  const data = await response.json();
+  return { statusCode: 200, body: { metadata: data.value ?? data } };
+}
+```
+
+---
+
+## Local Development
+
+### Run the dev server
+
+```bash
+aio app build
+aio app run
+```
+
+### Test URL
+
+```
+https://experience.adobe.com/?devMode=true&ext=https://localhost:9080#/assets/contenthub/
+```
+
+| Parameter | Purpose |
+| --- | --- |
+| `devMode=true` | Enables developer mode |
+| `ext=https://localhost:9080` | Loads local extension |
+
+No `&repo=` needed — the scaffold sets `allowedRepos = []`, so any repo works for local dev (see `appbuilder-project-init` SKILL.md Extension Scaffolding Mode Step 16).
+
+**Self-signed cert (first time only):** Navigate to `https://localhost:9080` and click "Proceed to localhost (unsafe)". The extension panel will be blank until the cert is trusted.
+
+---
+
+## Common Gotchas
+
+1. **Wrong extension point ID** — Use `aem/assets/contenthub/1`. The deprecated ID `aem/contenthub/assets/details/1` still works during the transition period but should not be used in new projects.
+
+2. **`attach()` ID mismatch** — The `id` in `attach()` must exactly match the `id` in `register()`. Both should import `extensionId` from `Constants.js`.
+
+3. **Panel blank (cert not trusted)** — Navigate to `https://localhost:9080` and accept the cert before loading the Content Hub URL.
+
+4. **`getCurrentAsset()` returns a STRING** — `host.assetDetails.getCurrentAsset()` returns the asset id as a plain string (e.g. `"urn:aaid:aem:..."`), NOT `{ id }`. Use it directly or wrap: `const asset = { id: assetId }`. (Assets View is a different surface — it uses `host.details.getCurrentResourceInfo()` with a different shape. Do not mix them.)
+
+5. **`const guestConnection` breaks card/selectionBar** — Their `onActionClick` handlers fire *after* `register()` resolves and must reference the connection to call `host.modal.openDialog()`. Declare it `let guestConnection;` and assign inside `register()`, or the handler closes over `undefined`.
+
+5a. **`openDialog` signature — single object from the guest's side** — Content Hub's `host.modal.openDialog` is called as **one** config object: `openDialog({ title, contentUrl, type, size, payload })`. Never pass `{ id }` yourself — the UIX host auto-injects the extension id as the first argument on its side of the proxy; passing it explicitly makes the host receive a malformed request, and the call retries every 500ms until it fails with `... timed out after 10000ms` and `[object Object] doesn't exist` (a `host.toast.display` in the same handler still works, which makes it look like the connection is fine). Data can reach the modal page via `payload` (read with `host.modal.getPayload()` after `attach()`) or via a `contentUrl` query string (`/#card-action-modal?resourceId=...&resourceType=...`, read with `new URLSearchParams(window.location.hash.split('?')[1])`) — both are supported, pick one. Close with `host.modal.closeDialog()`. (Note: this is the **opposite** of the other AEM surfaces — CF Console/Editor/UE/Assets View use `host.modal.showUrl({ title, url })` + `close()`. Content Hub uses `openDialog`/`closeDialog`. Don't cross them.)
+
+6. **`card` vs `selectionBar` signatures differ** — Both `getActionButtons(actionContext)` receive a context, but the shapes differ: card gets `{ context }` only, while selectionBar gets `{ context, resourceSelection }`. On click, card `onActionClick(resourceType, buttonId, resourceId, actionContext)` gets a single resource + its type (`'asset'` or `'collection'`); selectionBar `onActionClick(buttonId, assetIds)` gets no resource type and `assetIds` is an array. Don't copy one signature for the other.
+
+7. **Card/selectionBar buttons use `label`, not `title`** — only `id`, `label`, `icon` are read for those two. (`assetDetails` panels use `title`/`tooltip`.) A button with only `title` set renders blank.
+
+8. **Card/selectionBar buttons missing entirely** — they're gated by the `EXTENSIBILITY_AEM_CONTENTHUB` feature flag. If the flag is off in the environment, the host returns no extension buttons for those surfaces (asset-details panels still show).
+
+9. **CORS on AEM API calls** — Never fetch AEM APIs from the browser. Use web actions (I/O Runtime server-side).
+
+10. **`config.json` action URL** — This file is overwritten by `aio app run` (localhost). Never edit manually.
+
+11. **`addAssets` pre-panel `Next` stays disabled forever** — `pre` panels block Next by default; the panel must send `window.parent.postMessage({ type: 'addAssets:setReadyToAdvance', panelId: '<id>', ready: true }, '*')` when complete. `post` panels are pre-unblocked and don't need this.
+
+12. **`beforeUpload` return shape** — must return `{ proceed, metadata }`. Returning `undefined` or omitting `metadata` results in lost metadata. Return `{ proceed: true, metadata: ctx.metadata }` if you make no changes (spread ctx.metadata to pass it through). Returning `{ proceed: false }` without a `message` shows no user-facing reason — always include `message`.
+
+13. **`addAssets` wizard panels vs `card`/`selectionBar` modals** — wizard panels use `postMessage` for readiness signalling (no `guestConnection.host.modal`). Do not call `host.modal.openDialog` from a wizard panel — it opens a nested dialog, which breaks the wizard flow.
+
+---
+
+## Quick Reference
+
+**Extension point:** `aem/assets/contenthub/1`
+**Source directory:** `src/aem-assets-contenthub-1/`
+
+| Surface | Namespace | Key method(s) | Click / lifecycle handler |
+| --- | --- | --- | --- |
+| Asset Details Dialog | `assetDetails` | `getTabPanels()` | — (renders `contentUrl` in a tab) |
+| Asset cards (Assets/Collection/Share) | `card` | `getActionButtons(actionContext)` | `onActionClick(resourceType, buttonId, resourceId, actionContext)` — `resourceType='asset'` |
+| Collection tiles (Collections grid) | `card` | `getActionButtons(actionContext)` | `onActionClick(resourceType, buttonId, resourceId, actionContext)` — `resourceType='collection'`, `context='collections'` |
+| Selection bar (bulk) | `selectionBar` | `getActionButtons(actionContext)` | `onActionClick(buttonId, assetIds[])` |
+| Add Assets wizard | `addAssets` | `getPanels()` | `beforeUpload(ctx)` / `onUploadComplete(ctx)` |
+
+**Button/panel descriptor fields:**
+
+| Namespace | `get…()` returns array of |
+| --- | --- |
+| `assetDetails` | `{ id, title, tooltip, icon, contentUrl }` |
+| `card` | `{ id, label, icon }` |
+| `selectionBar` | `{ id, label, icon }` |
+| `addAssets` | `{ id, title, position: 'pre'\|'post', contentUrl }` |
+
+**Host API summary:**
+
+| Namespace | Method | Returns |
+| --- | --- | --- |
+| `auth` | `getIMSInfo()` | `{ imsOrg, imsOrgName, accessToken }` |
+| `auth` | `getApiKey()` | API key string |
+| `discovery` | `getAemHost()` | AEM author URL |
+| `toast` | `display({ variant, message })` | void |
+| `i18n` | `getLocalizationInfo()` | `{ locale }` |
+| `modal` | `openDialog({ title, contentUrl, type?, size? })` | void — single object, NO `{ id }`, NO `payload`; pass data via the `contentUrl` query |
+| `modal` | `closeDialog()` | void |
+| `assetDetails` | `getCurrentAsset()` | string asset ID — normalize to `{ id }` in your component |
+
+**Toast variants:** `neutral` | `positive` | `info` | `negative`


### PR DESCRIPTION
Description

Adds end-to-end AI-assisted scaffolding for Adobe App Builder UI extensions across all supported surfaces — Content Hub, Content Fragment Console, CF Editor, Universal Editor, Assets View, and Experience Cloud Shell.

A single skill now drives the complete extension lifecycle: Developer Console project and workspace setup, scaffold file generation, npm install, build, local dev server, cert acceptance, and deployment — all through a guided conversation with no manual steps.

The skill reuses and composes existing Adobe Skills for project initialization, UI scaffolding, and testing, making it composable and extensible to new surfaces with minimal additional work.

Also includes:
- Updated appbuilder-ui-scaffolder to reference the new scaffold-from-scratch flow
- New contenthub-extensions.md reference covering all four Content Hub namespaces: assetDetails, card, selectionBar, and addAssets

Checklist:
- [ ] I have signed the Adobe Open Source CLA.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
