### PR TITLE
#215 block-inventory: add page-import pipeline guard + Use-this-when trigger

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/block-inventory/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/block-inventory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: block-inventory
-description: Survey available blocks from local AEM Edge Delivery Services project and Block Collection to understand the block palette available for authoring. Returns block inventory with purposes to inform content modeling decisions.
+description: "Use this when the page-import pipeline needs to survey the block palette available from a local AEM Edge Delivery Services project and the Block Collection to inform content modeling decisions. Covers returning a block inventory annotated with each block's purpose. Do not invoke directly — called by page-import as a pipeline step."
 license: Apache-2.0
 metadata:
   version: "1.0.0"

--- a/plugins/aem/edge-delivery-services/skills/block-inventory/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/block-inventory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: block-inventory
-description: "Use this when the page-import pipeline needs to survey the block palette available from a local AEM Edge Delivery Services project and the Block Collection to inform content modeling decisions. Covers returning a block inventory annotated with each block's purpose. Do not invoke directly — called by page-import as a pipeline step."
+description: "Use this when the page-import pipeline needs to survey the block palette available from a local AEM Edge Delivery Services project and the Block Collection to inform content modeling decisions. Scans local block folders, searches the Block Collection for common blocks, resolves each block's purpose, and returns a consolidated block inventory annotated with per-block purpose and availability. Do not invoke directly — called by page-import as a pipeline step."
 license: Apache-2.0
 metadata:
   version: "1.0.0"


### PR DESCRIPTION
Addresses #215.

**Problem** — `block-inventory`'s description opened with what it does, not when to invoke it, and gave no signal that it is a `page-import` pipeline step — so an agent could load it in isolation or skip it when routing.

**Solution** — Rewrote the description to lead with a `Use this when …` trigger and added an explicit `Do not invoke directly — called by page-import` guard, per the issue's recommendation for pipeline sub-skills. Content-only change to the frontmatter `description`.

Validated with `npm run validate`. Generated with AI assistance.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWW1JFGPEM8CAD308P7V4EZ9&panel=chat)