### PR TITLE
#215 generate-import-html: add page-import pipeline guard + Use-this-when trigger

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/generate-import-html/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/generate-import-html/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: generate-import-html
-description: Generate structured HTML from authoring analysis for AEM Edge Delivery Services. Creates section structure, applies block tables, handles metadata, and manages images folder.
+description: "Use this when the page-import pipeline needs to produce structured HTML from authoring analysis for AEM Edge Delivery Services. Covers building section structure, applying block tables, handling metadata, and managing the images folder. Do not invoke directly — called by page-import as a pipeline step."
 license: Apache-2.0
 metadata:
   version: "2.0.0"


### PR DESCRIPTION
Addresses #215.

**Problem** — `generate-import-html`'s description read as an internal pipeline label with no trigger, and gave no signal that it is a `page-import` pipeline step — so an agent could load it in isolation or skip it when routing.

**Solution** — Rewrote the description to lead with a `Use this when …` trigger and added an explicit `Do not invoke directly — called by page-import` guard, per the issue's recommendation for pipeline sub-skills. Content-only change to the frontmatter `description`.

Validated with `npm run validate`. Generated with AI assistance.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWW1JFGPEM8CAD308P7V4EZ9&panel=chat)