### PR TITLE
#215 identify-page-structure: add page-import pipeline guard + Use-this-when trigger

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/identify-page-structure/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/identify-page-structure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: identify-page-structure
-description: "Use this when the page-import pipeline needs to identify section boundaries and content sequences within a scraped webpage for AEM Edge Delivery Services import. Covers two-level analysis (sections, then sequences per section) and surveying available blocks. Do not invoke directly — called by page-import as a pipeline step."
+description: "Use this when the page-import pipeline needs to identify section boundaries and content sequences within a scraped webpage for AEM Edge Delivery Services import. Outputs an ordered list of sections, the content sequence within each section, and candidate block-type annotations via two-level analysis (sections, then sequences per section). Do not invoke directly — called by page-import as a pipeline step."
 license: Apache-2.0
 metadata:
   version: "1.0.0"

--- a/plugins/aem/edge-delivery-services/skills/identify-page-structure/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/identify-page-structure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: identify-page-structure
-description: Identify section boundaries and content sequences within a scraped webpage for AEM Edge Delivery Services import. Performs two-level analysis (sections, then sequences per section) and surveys available blocks.
+description: "Use this when the page-import pipeline needs to identify section boundaries and content sequences within a scraped webpage for AEM Edge Delivery Services import. Covers two-level analysis (sections, then sequences per section) and surveying available blocks. Do not invoke directly — called by page-import as a pipeline step."
 license: Apache-2.0
 metadata:
   version: "1.0.0"


### PR DESCRIPTION
Addresses #215.

**Problem** — `identify-page-structure`'s description read as an internal pipeline label with no trigger, and gave no signal that it is a `page-import` pipeline step — so an agent could load it in isolation or skip it when routing.

**Solution** — Rewrote the description to lead with a `Use this when …` trigger and added an explicit `Do not invoke directly — called by page-import` guard, per the issue's recommendation for pipeline sub-skills. Content-only change to the frontmatter `description`.

Validated with `npm run validate`. Generated with AI assistance.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWW1JFGPEM8CAD308P7V4EZ9&panel=chat)