### PR TITLE
#215 page-decomposition: add page-import pipeline guard + Use-this-when trigger

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/page-decomposition/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/page-decomposition/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: page-decomposition
-description: Analyze content sequences within a section and provide neutral descriptions for AEM Edge Delivery Services. Invoked per section during page import to identify breaking points between default content and blocks.
+description: "Use this when the page-import pipeline needs to analyze the content sequences within a single section and describe them neutrally for AEM Edge Delivery Services. Covers identifying breaking points between default content and blocks, one section at a time. Do not invoke directly — called by page-import per section."
 license: Apache-2.0
 metadata:
   version: "1.0.0"


### PR DESCRIPTION
Addresses #215.

**Problem** — `page-decomposition` said "Invoked per section" but had no guard against direct invocation and led with what it does rather than when to invoke it.

**Solution** — Rewrote the description to lead with a `Use this when …` trigger and added an explicit `Do not invoke directly — called by page-import per section` guard, per the issue's recommendation for pipeline sub-skills. Content-only change to the frontmatter `description`.

Validated with `npm run validate`. Generated with AI assistance.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWW1JFGPEM8CAD308P7V4EZ9&panel=chat)