### PR TITLE
#215 scrape-webpage: add page-import pipeline guard + Use-this-when trigger

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/scrape-webpage/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/scrape-webpage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scrape-webpage
-description: Scrape webpage content, extract metadata, download images, and prepare for import/migration to AEM Edge Delivery Services. Returns analysis JSON with paths, metadata, cleaned HTML, and local images.
+description: "Use this when the page-import pipeline needs to fetch a source webpage and prepare it for import/migration to AEM Edge Delivery Services. Covers scraping content, extracting metadata, downloading images, and returning analysis JSON with paths, metadata, cleaned HTML, and local images. Do not invoke directly — called by page-import as a pipeline step."
 license: Apache-2.0
 metadata:
   version: "2.0.1"


### PR DESCRIPTION
Addresses #215.

**Problem** — `scrape-webpage`'s description opened with what it does, not when to invoke it, and gave no signal that it is a `page-import` pipeline step — so an agent could load it in isolation or skip it when routing.

**Solution** — Rewrote the description to lead with a `Use this when …` trigger and added an explicit `Do not invoke directly — called by page-import` guard, per the issue's recommendation for pipeline sub-skills. Content-only change to the frontmatter `description`.

Validated with `npm run validate`. Generated with AI assistance.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWW1JFGPEM8CAD308P7V4EZ9&panel=chat)