### PR TITLE
#215 find-test-content: lead description with Use-this-when trigger + disambiguate from page-import

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/find-test-content/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/find-test-content/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: find-test-content
-description: Search for existing content pages containing a specific block in AEM Edge Delivery Services. Reports URLs with occurrences and variants to help identify test content during development.
+description: "Use this when you need to find existing pages that already use a specific block in an AEM Edge Delivery Services project, for example to locate test content or examples during block development. Covers reporting page URLs with occurrence counts and block variants. This searches existing content; to import a new page from a URL use page-import."
 license: Apache-2.0
 metadata:
   version: "1.2.0"


### PR DESCRIPTION
Addresses #215.

**Problem** — `find-test-content`'s description had no trigger and no disambiguation from `page-import`, so an agent could misroute between finding existing content and importing a new page.

**Solution** — Rewrote the description to lead with a `Use this when …` trigger and added a `to import a new page from a URL use page-import` disambiguation. Content-only change to the frontmatter `description`.

Validated with `npm run validate`. Generated with AI assistance.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWW1JFGPEM8CAD308P7V4EZ9&panel=chat)