### PR TITLE
#215 analyze-and-plan: lead description with Use-this-when trigger

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/analyze-and-plan/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/analyze-and-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analyze-and-plan
-description: Analyzes development requirements and generates structured acceptance criteria for AEM Edge Delivery Services (EDS) tasks. Use when the user needs to define acceptance criteria, write requirements, scope work, or create a definition of done for EDS blocks, components, variants, bug fixes, or styling changes. Produces task breakdowns, identifies edge cases, and documents analysis for new blocks, variants, behavior modifications, CSS-only changes, and bug fixes.
+description: "Use this when you need to define acceptance criteria, write requirements, scope work, or create a definition of done for AEM Edge Delivery Services (EDS) tasks such as new blocks, variants, behavior modifications, CSS-only changes, or bug fixes. Covers analyzing development requirements, producing task breakdowns, identifying edge cases, and documenting the analysis."
 license: Apache-2.0
 metadata:
   version: "2.0.0"


### PR DESCRIPTION
Addresses #215.

**Problem** — `analyze-and-plan`'s `Use when …` clause appeared after a feature summary rather than as the opening line, weakening routing.

**Solution** — Rewrote the description so the `Use this when …` trigger is the first sentence, following the recommended `Use this when <trigger>. Covers <topics>.` pattern. Content-only change to the frontmatter `description`.

Validated with `npm run validate`. Generated with AI assistance.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWW1JFGPEM8CAD308P7V4EZ9&panel=chat)