### PR TITLE
#215 block-collection-and-party: lead description with Use-this-when trigger

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/block-collection-and-party/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/block-collection-and-party/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: block-collection-and-party
-description: "Use this when you are starting AEM Edge Delivery Services development and want an existing reference to build from, such as a block, build tool, code snippet, integration pattern, or plugin. Covers the Block Collection and Block Party repositories and how to find a suitable starting point."
+description: "Use this when you are starting AEM Edge Delivery Services (EDS, Franklin, Helix) development and want an existing reference to build from, such as a block, build tool, code snippet, integration pattern, or plugin. Searches the Block Collection and Block Party repositories, matches candidates against the need, and returns a suitable starting point to clone or adapt."
 license: Apache-2.0
 metadata:
   version: "1.2.0"

--- a/plugins/aem/edge-delivery-services/skills/block-collection-and-party/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/block-collection-and-party/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: block-collection-and-party
-description: The Block Collection and Block Party are repositories for existing AEM blocks, build tools, code snippets, integration patterns, plugins, and more. Use this skill anytime you are developing something and want to find a reference to use as a starting point.
+description: "Use this when you are starting AEM Edge Delivery Services development and want an existing reference to build from, such as a block, build tool, code snippet, integration pattern, or plugin. Covers the Block Collection and Block Party repositories and how to find a suitable starting point."
 license: Apache-2.0
 metadata:
   version: "1.2.0"


### PR DESCRIPTION
Addresses #215.

**Problem** — `block-collection-and-party` opened with a noun phrase and used the vague scope "anytime you are developing something", weakening routing.

**Solution** — Rewrote the description so a concrete `Use this when …` trigger is the first sentence, following the recommended `Use this when <trigger>. Covers <topics>.` pattern. Content-only change to the frontmatter `description`.

Validated with `npm run validate`. Generated with AI assistance.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWW1JFGPEM8CAD308P7V4EZ9&panel=chat)