### PR TITLE
#215 building-blocks: lead description with Use-this-when trigger + disambiguate from content-driven-development

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/building-blocks/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/building-blocks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: building-blocks
-description: Guide for implementing code changes in AEM Edge Delivery Services. Handles block development (new or modified), core functionality changes (scripts.js, styles, delayed.js, etc.), or both. Use this skill for all implementation work guided by the content-driven-development workflow.
+description: "Use this when implementing code changes in AEM Edge Delivery Services, whether new or modified blocks, core functionality (scripts.js, styles, delayed.js, etc.), or both. Covers the hands-on implementation work guided by the content-driven-development workflow. For the overall development process use content-driven-development."
 license: Apache-2.0
 metadata:
   version: "2.0.0"

--- a/plugins/aem/edge-delivery-services/skills/building-blocks/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/building-blocks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: building-blocks
-description: "Use this when implementing code changes in AEM Edge Delivery Services, whether new or modified blocks, core functionality (scripts.js, styles, delayed.js, etc.), or both. Covers the hands-on implementation work guided by the content-driven-development workflow. For the overall development process use content-driven-development."
+description: "Use this when implementing code changes in AEM Edge Delivery Services (EDS, Franklin, Helix), whether new or modified blocks, core functionality (scripts.js, styles, delayed.js, etc.), or both. Creates and modifies block folders and decorate functions, updates core scripts, scopes CSS, and wires up delayed loading. For the overall development process use content-driven-development."
 license: Apache-2.0
 metadata:
   version: "2.0.0"


### PR DESCRIPTION
Addresses #215.

**Problem** — `building-blocks` opened with the noun phrase "Guide for…" and had no disambiguation from `content-driven-development`, weakening routing.

**Solution** — Rewrote the description so the `Use this when …` trigger is the first sentence and added a `For the overall development process use content-driven-development` disambiguation. Content-only change to the frontmatter `description`.

Validated with `npm run validate`. Generated with AI assistance.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWW1JFGPEM8CAD308P7V4EZ9&panel=chat)