### PR TITLE
#215 code-review: lead description with Use-this-when trigger

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/code-review/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Review code for AEM Edge Delivery Services projects. Use at the end of development (before PR) for self-review, or to review pull requests. Validates code quality, performance, accessibility, and adherence to EDS best practices.
+description: "Use this when reviewing AEM Edge Delivery Services code, either self-review at the end of development before opening a PR, or reviewing an existing pull request. Covers validating code quality, performance, accessibility, and adherence to EDS best practices."
 license: Apache-2.0
 metadata:
   version: "2.0.0"

--- a/plugins/aem/edge-delivery-services/skills/code-review/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: "Use this when reviewing AEM Edge Delivery Services code, either self-review at the end of development before opening a PR, or reviewing an existing pull request. Covers validating code quality, performance, accessibility, and adherence to EDS best practices."
+description: "Use this when reviewing AEM Edge Delivery Services (EDS, Franklin, Helix) code, either self-review at the end of development before opening a PR, or reviewing an existing pull request. Validates block structure, CSS and JS patterns, DOM output, Lighthouse performance, and accessibility against EDS best practices, and posts findings as review comments or GitHub suggestions."
 license: Apache-2.0
 metadata:
   version: "2.0.0"


### PR DESCRIPTION
Addresses #215.

**Problem** — `code-review`'s trigger was the second sentence rather than the opening line, weakening routing.

**Solution** — Rewrote the description so the `Use this when …` trigger is the first sentence, following the recommended `Use this when <trigger>. Covers <topics>.` pattern. Content-only change to the frontmatter `description`.

Validated with `npm run validate`. Generated with AI assistance.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWW1JFGPEM8CAD308P7V4EZ9&panel=chat)