### PR TITLE
#215 content-modeling: lead description with Use-this-when trigger

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/content-modeling/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/content-modeling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: content-modeling
-description: Create effective content models for your blocks that are easy for authors to work with. Use this skill anytime you are building new blocks, making changes to existing blocks that modify the initial structure authors work with.
+description: "Use this when you are building new AEM Edge Delivery Services blocks or changing the initial structure that authors work with in an existing block. Covers designing content models that are easy for authors to use."
 license: Apache-2.0
 metadata:
   version: "2.0.0"


### PR DESCRIPTION
Addresses #215.

**Problem** — `content-modeling` led with what it does and used the vague scope "anytime you are building new blocks", weakening routing.

**Solution** — Rewrote the description so a concrete `Use this when …` trigger is the first sentence, following the recommended `Use this when <trigger>. Covers <topics>.` pattern. Content-only change to the frontmatter `description`.

Validated with `npm run validate`. Generated with AI assistance.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWW1JFGPEM8CAD308P7V4EZ9&panel=chat)