### PR TITLE
#215 da-auth: lead description with Use-this-when trigger

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/da-auth/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/da-auth/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: da-auth
-description: Obtains a valid Adobe IMS access token for the DA (Document Authoring) API. Use this skill as a prerequisite step whenever another skill needs to call admin.da.live — for example, before pushing HTML content, listing documents, or triggering a DA preview. Do NOT use this skill if you already have a valid DA_TOKEN in scope from a previous step in the same session.
+description: "Use this when another step needs to call the admin.da.live API, for example before pushing HTML content, listing documents, or triggering a DA preview, and you do not already have a valid DA_TOKEN in scope from an earlier step in the same session. Covers obtaining a valid Adobe IMS access token for the DA (Document Authoring) API."
 license: Apache-2.0
 metadata:
   version: "1.1.0"


### PR DESCRIPTION
Addresses #215.

**Problem** — `da-auth`'s trigger was the second sentence rather than the opening line, weakening routing.

**Solution** — Rewrote the description so the `Use this when …` trigger is the first sentence, folding the existing DA_TOKEN skip-guard into that trigger. Content-only change to the frontmatter `description`.

Validated with `npm run validate`. Generated with AI assistance.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWW1JFGPEM8CAD308P7V4EZ9&panel=chat)