### PR TITLE
#215 da-content: lead description with Use-this-when trigger

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/da-content/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/da-content/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: da-content
-description: Reference for producing Adobe Document Authoring (DA, da.live) and Edge Delivery Services (EDS, aka aem.live/Helix) compatible content. Use whenever generating HTML for DA upload, uploading media binaries to DA, publishing to aem.live, or driving the DA admin API (auth, source PUT, preview/publish). Covers block HTML format (canonical div-class form and accepted table alternate), section structure, page/section metadata, icons, links, images, default content, document skeleton constraints, block cell content normalization, the DA Source API contract, IMS auth, media storage, supported formats, Media Bus vs Content Bus delivery, and silent-failure rules that corrupt content.
+description: "Use this when generating HTML for Adobe Document Authoring (DA, da.live) upload, uploading media binaries to DA, publishing to aem.live, or driving the DA admin API (auth, source PUT, preview/publish). Covers block HTML format (canonical div-class form and accepted table alternate), section structure, page and section metadata, icons, links, images, default content, document skeleton constraints, block cell content normalization, the DA Source API contract, IMS auth, media storage, supported formats, Media Bus vs Content Bus delivery, and silent-failure rules that corrupt content."
 license: Apache-2.0
 metadata:
   version: "1.0.0"


### PR DESCRIPTION
Addresses #215.

**Problem** — `da-content` opened with the noun phrase "Reference for…" rather than a trigger, weakening routing.

**Solution** — Rewrote the description so the `Use this when …` trigger is the first sentence, preserving the full `Covers …` topic list. Content-only change to the frontmatter `description`.

Validated with `npm run validate`. Generated with AI assistance.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWW1JFGPEM8CAD308P7V4EZ9&panel=chat)