### PR TITLE
#215 slicc-handoff: lead description with Use-this-when trigger

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/slicc-handoff/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/slicc-handoff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slicc-handoff
-description: Hand off the current task to the SLICC browser agent, or install a new skill into SLICC from a GitHub repo. Use this skill when the user says things like "handoff to slicc", "move this to slicc", "move to the browser", "test in the browser", "handoff to browser", "install this skill in slicc", "upskill slicc with this repo", "add this skill to slicc", or otherwise asks you to continue the work inside the SLICC browser agent.
+description: "Use this when the user asks to continue work in the SLICC browser agent or to install a skill into SLICC, for example \"handoff to slicc\", \"move to the browser\", \"test in the browser\", \"install this skill in slicc\", or \"upskill slicc with this repo\". Covers handing off the current task to the SLICC browser agent and installing a new skill into SLICC from a GitHub repo."
 license: Apache-2.0
 metadata:
   version: "1.0.1"


### PR DESCRIPTION
Addresses #215.

**Problem** — `slicc-handoff`'s trigger was the second sentence rather than the opening line, weakening routing.

**Solution** — Rewrote the description so the `Use this when …` trigger is the first sentence, keeping the representative user-phrase examples. Content-only change to the frontmatter `description`.

Validated with `npm run validate`. Generated with AI assistance.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWW1JFGPEM8CAD308P7V4EZ9&panel=chat)