### PR TITLE
#215 snowflake: lead description with Use-this-when trigger

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/snowflake/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/snowflake/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: snowflake
-description: Static-to-EDS conversion that preserves the original design while making content authorable in Document Authoring. Two modes — page-level (overlay template with slot markers) and block-level (each section becomes an independent EDS block). Use when converting an AI-generated static HTML page (Stardust, Mobirise, Relume, Lovable, v0, Figma-derived hand-coded, etc.) into an Edge Delivery Services page. Triggers on "convert this page to EDS", "static-to-EDS overlay", "convert to EDS blocks", "next experimentation", "next run", "start run", or when a user provides a source URL and asks to make it editable in DA while keeping the original design intact. Do NOT use for canonical EDS block-rewrite migrations — that's the page-import skill.
+description: "Use this when converting an AI-generated static HTML page (Stardust, Mobirise, Relume, Lovable, v0, Figma-derived, etc.) into an Edge Delivery Services page while preserving the original design and making content authorable in Document Authoring — triggers include \"convert this page to EDS\", \"static-to-EDS overlay\", \"convert to EDS blocks\", \"next experimentation\", \"next run\", \"start run\", or providing a source URL to make editable in DA. Covers two modes — page-level (overlay template with slot markers) and block-level (each section becomes an independent EDS block). For canonical EDS block-rewrite migrations use page-import instead."
 license: Apache-2.0
 metadata:
   version: "1.2.0"


### PR DESCRIPTION
Addresses #215.

**Problem** — `snowflake`'s `Use when …` clause appeared after a feature summary rather than as the opening line, weakening routing.

**Solution** — Rewrote the description so the `Use this when …` trigger is the first sentence, preserving the trigger phrases, the two-mode description, and the `use page-import instead` disambiguation. Content-only change to the frontmatter `description`.

Validated with `npm run validate`. Generated with AI assistance.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWW1JFGPEM8CAD308P7V4EZ9&panel=chat)