### PR TITLE
#215 testing-blocks: lead description with Use-this-when trigger

### DIFF
--- a/plugins/aem/edge-delivery-services/skills/testing-blocks/SKILL.md
+++ b/plugins/aem/edge-delivery-services/skills/testing-blocks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing-blocks
-description: Guide for testing code changes in AEM Edge Delivery projects including blocks, scripts, and styles. Use this skill after making code changes and before opening a pull request to validate functionality. Covers unit testing for utilities and logic, browser testing with Playwright, linting, and guidance on what to test and how
+description: "Use this when you have made AEM Edge Delivery Services code changes to blocks, scripts, or styles and need to validate them before opening a pull request. Covers unit testing for utilities and logic, browser testing with Playwright, linting, and guidance on what to test and how."
 license: Apache-2.0
 metadata:
   version: "2.0.0"


### PR DESCRIPTION
Addresses #215.

**Problem** — `testing-blocks` opened with the noun phrase "Guide for…" rather than a trigger, weakening routing.

**Solution** — Rewrote the description so the `Use this when …` trigger is the first sentence, following the recommended `Use this when <trigger>. Covers <topics>.` pattern. Content-only change to the frontmatter `description`.

Validated with `npm run validate`. Generated with AI assistance.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWW1JFGPEM8CAD308P7V4EZ9&panel=chat)