### PR TITLE
docs(stardust): add container-width (--max-width) sizing guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "name": "stardust",
       "source": "./plugins/stardust",
       "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "category": "design",
       "keywords": [
         "design",

--- a/plugins/stardust/.claude-plugin/plugin.json
+++ b/plugins/stardust/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stardust",
   "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "author": {
     "name": "Adobe"
   },

--- a/plugins/stardust/.tessl-plugin/plugin.json
+++ b/plugins/stardust/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe/stardust",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Redesign an existing website to make it better. Built on top of impeccable.",
   "skills": [
     "skills/stardust",

--- a/plugins/stardust/CHANGELOG.md
+++ b/plugins/stardust/CHANGELOG.md
@@ -4,6 +4,18 @@ This file starts at 0.14.0. Prior versions (0.3.0 – 0.13.1) are documented in
 git history only (plus the branch-scoped notes in
 `CHANGELOG-redesign-adobecom.md` and `CHANGELOG-delivery-media-fidelity.md`).
 
+## 0.16.1 — container-width sizing guidance in the token contract
+
+Docs only, no behavioral surface. New `## Sizing --max-width` section in
+`skills/stardust/reference/token-contract.md`: stardust ships no default
+container width — inherit the captured container when it holds up (widening
+one step within the site's own framework vocabulary when it reads dated),
+measure-first (1200–1280px) when the capture has no measurable container,
+and persist the derived value to DESIGN.json
+`extensions.breakpoints.containerMaxWidth` with the change flagged in the
+page-shape brief. Cross-referenced from
+`skills/prototype/reference/page-shape-brief.md` § Layout strategy.
+
 ## 0.16.0 — two new entry points: replica (same-design migration) and reskin (content × donor design)
 
 Round-1 outcome of the three-new-use-cases exploration (research, candidate

--- a/plugins/stardust/README.md
+++ b/plugins/stardust/README.md
@@ -85,7 +85,8 @@ otherwise with a clear install hint.
 
 ## Status
 
-`v0.16.0` — two new entry points: `replica` (same-design migration with a
+`v0.16.1` — container-width (`--max-width`) sizing guidance in the token
+contract. Previously in `v0.16.0` — two new entry points: `replica` (same-design migration with a
 measured source-fidelity gate) and `reskin` (byte-faithful content onto a
 donor design system), both field-tested and hardened, plus the shared
 live-measurement module (`diff/scripts/live-session.mjs`) and diff-probe

--- a/plugins/stardust/skills/prototype/reference/page-shape-brief.md
+++ b/plugins/stardust/skills/prototype/reference/page-shape-brief.md
@@ -223,9 +223,9 @@ than discover them in the proposed HTML.
 **Optional** but recommended:
 
 - `## Layout strategy` — when the page deploys an unusual layout
-  rule that's not the system default. Container-width changes from
-  the captured value are flagged here (see the stardust skill's
-  `reference/token-contract.md` § Sizing `--max-width`).
+  rule that's not the system default (e.g. container-width changes
+  from the captured value, per
+  `skills/stardust/reference/token-contract.md` § Sizing `--max-width`).
 - `## Key states` — when the page has non-default empty / loading /
   error states the migrate path-B render needs to know about.
 - `## Interaction model` — when the page has non-trivial JS-free

--- a/plugins/stardust/skills/prototype/reference/page-shape-brief.md
+++ b/plugins/stardust/skills/prototype/reference/page-shape-brief.md
@@ -223,7 +223,9 @@ than discover them in the proposed HTML.
 **Optional** but recommended:
 
 - `## Layout strategy` — when the page deploys an unusual layout
-  rule that's not the system default.
+  rule that's not the system default. Container-width changes from
+  the captured value are flagged here (see the stardust skill's
+  `reference/token-contract.md` § Sizing `--max-width`).
 - `## Key states` — when the page has non-default empty / loading /
   error states the migrate path-B render needs to know about.
 - `## Interaction model` — when the page has non-trivial JS-free

--- a/plugins/stardust/skills/stardust/reference/token-contract.md
+++ b/plugins/stardust/skills/stardust/reference/token-contract.md
@@ -118,26 +118,25 @@ a comment showing the role name above the token.
 The `1200px` in the example block is illustrative, not normative —
 stardust ships **no default container width**. Derive it per project:
 
-1. **Captured surface first (Mode A).** Inherit the captured
-   container. When it reads dated at modern viewports (≤1024px is the
-   usual smell), widen **one step within the site's own framework
-   vocabulary** — Bootstrap 960 → 1140, Tailwind `max-w-5xl` →
-   `max-w-6xl`/`7xl` — never jump to a generic number.
-2. **Measure-first when there is no usable capture** (rebrand /
-   signal-thin). Body prose caps at 65–75ch regardless of container,
-   so grids and heroes size it: a 3-up card grid wants ~1100–1300px
-   (cards at 340–400px), converging on **1200–1280px** for marketing
-   surfaces. Widths past ~1320px need deliberate inner columns, not a
-   wider text block.
-3. **Record the choice.** Changing the captured container is a
-   surface execution call, not a divergence move — but flag it in the
-   page-shape brief's `## Layout strategy` (and `## Open questions
-   for craft` when the step-up is debatable) so the reviewer can veto
-   it before render.
-
-Anti-patterns: hardcoding one "stardust default" across projects;
-jumping a Bootstrap-960 site straight to 1280 under Mode A; widening
-the container as a substitute for capping prose measure.
+1. **Captured surface first** (Mode A, per `direct/SKILL.md`).
+   Inherit the captured container when it holds up. When it reads
+   dated at modern viewports (≤1024px is the usual smell), widen
+   **one step within the site's own framework vocabulary** —
+   Bootstrap 960 → 1140, Tailwind `max-w-5xl` → `max-w-6xl`/`7xl` —
+   never jump to a generic number.
+2. **Measure-first when the capture has no measurable container**
+   (rebrand / signal-thin capture without one). Body prose caps at
+   65–75ch regardless of container, so grids and heroes size it: a
+   3-up card grid wants ~1100–1300px (cards at 340–400px), converging
+   on **1200–1280px** for marketing surfaces. Widths past ~1320px
+   need deliberate inner columns, not a wider text block.
+3. **Record the choice.** Persist the derived value to DESIGN.json
+   `extensions.breakpoints.containerMaxWidth` (the sourcing table
+   above) so `migrate` re-derives the same width. A change from the
+   captured value needs no divergence justification, but it must be
+   visible: flag it in the page-shape brief's `## Layout strategy`
+   (and `## Open questions for craft` when the step-up is debatable)
+   so the reviewer can veto it before render.
 
 ## Why these names
 

--- a/plugins/stardust/skills/stardust/reference/token-contract.md
+++ b/plugins/stardust/skills/stardust/reference/token-contract.md
@@ -113,6 +113,32 @@ rule. The agent references them by their actual role name in DESIGN.md
 (`Pomodoro`, `Vault`, `Zenith`) when building the `:root` block, with
 a comment showing the role name above the token.
 
+## Sizing `--max-width`
+
+The `1200px` in the example block is illustrative, not normative —
+stardust ships **no default container width**. Derive it per project:
+
+1. **Captured surface first (Mode A).** Inherit the captured
+   container. When it reads dated at modern viewports (≤1024px is the
+   usual smell), widen **one step within the site's own framework
+   vocabulary** — Bootstrap 960 → 1140, Tailwind `max-w-5xl` →
+   `max-w-6xl`/`7xl` — never jump to a generic number.
+2. **Measure-first when there is no usable capture** (rebrand /
+   signal-thin). Body prose caps at 65–75ch regardless of container,
+   so grids and heroes size it: a 3-up card grid wants ~1100–1300px
+   (cards at 340–400px), converging on **1200–1280px** for marketing
+   surfaces. Widths past ~1320px need deliberate inner columns, not a
+   wider text block.
+3. **Record the choice.** Changing the captured container is a
+   surface execution call, not a divergence move — but flag it in the
+   page-shape brief's `## Layout strategy` (and `## Open questions
+   for craft` when the step-up is debatable) so the reviewer can veto
+   it before render.
+
+Anti-patterns: hardcoding one "stardust default" across projects;
+jumping a Bootstrap-960 site straight to 1280 under Mode A; widening
+the container as a substitute for capping prose measure.
+
 ## Why these names
 
 The `--heading-*` / `--body-*` / `--color-*` / `--spacing-*` token


### PR DESCRIPTION
## Summary

Stardust deliberately ships **no default container width**, but the `1200px` in the token-contract example block could read as normative. This PR adds a short `## Sizing --max-width` section to `plugins/stardust/skills/stardust/reference/token-contract.md` documenting how to derive the value per project:

1. **Captured surface first (Mode A)** — inherit the captured container; when it reads dated at modern viewports, widen one step within the site's own framework vocabulary (Bootstrap 960 → 1140, Tailwind `max-w-5xl` → `max-w-6xl`/`7xl`) rather than jumping to a generic number.
2. **Measure-first when there is no usable capture** — prose caps at 65–75ch regardless, so grids/heroes size the container, converging on 1200–1280px for marketing surfaces.
3. **Record the choice** — container changes from the captured value are flagged in the page-shape brief's `## Layout strategy` so the reviewer can veto before render.

Also adds a one-line cross-reference in `plugins/stardust/skills/prototype/reference/page-shape-brief.md`'s `## Layout strategy` section description pointing to the new guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)