### PR TITLE
fix(stardust): migrate eval criteria.json to tessl weighted_checklist…

### DIFF
--- a/plugins/stardust/evals/README.md
+++ b/plugins/stardust/evals/README.md
@@ -46,14 +46,15 @@ Each eval lives in its own directory and contains exactly two files:
 
 - `task.md` — Setup, User prompt, Expected behavior. Human-readable
   scenario specification.
-- `criteria.json` — Weighted scoring rubric. Each criterion has an
-  `id`, a `weight`, and a `description`. `total` should equal the
-  sum of weights. Used by the eval runner to score the agent's
-  output.
+- `criteria.json` — Weighted scoring rubric in the tessl
+  `weighted_checklist` shape. Top level is `{ "context", "type":
+  "weighted_checklist", "checklist" }`; each checklist item has a
+  `name`, a `max_score`, and a `description`. The `max_score` values
+  sum to 100 per eval. Used by the eval runner (and enforced by
+  `tessl plugin publish`) to score the agent's output.
 
-This format mirrors v1's structure (and the format other Adobe-skills
-plugins use), so the eval runner that worked for v1 should work for
-v2 evals without modification.
+This format matches the one the other Adobe-skills plugins use, so the
+shared eval runner scores these evals without modification.
 
 ## Evals in this suite
 
@@ -100,9 +101,9 @@ in adobe/skills). Each eval is self-describing: a runner reads
 `task.md` for the scenario, executes it against a clean stardust
 project, and scores the output against `criteria.json`.
 
-A criterion passes if its `description` is satisfied as judged by
-the runner. Per-criterion verdicts are combined as a weighted sum
-out of `total` (100 per eval).
+A checklist item passes if its `description` is satisfied as judged by
+the runner. Per-item verdicts are combined as a weighted sum of
+`max_score` (100 per eval).
 
 ## What stardust v2 evals deliberately do NOT test
 

--- a/plugins/stardust/evals/direct-from-phrase/criteria.json
+++ b/plugins/stardust/evals/direct-from-phrase/criteria.json
@@ -1,18 +1,66 @@
 {
-  "name": "direct-from-phrase",
-  "total": 100,
-  "criteria": [
-    { "id": "activated",                  "weight": 5,  "description": "The stardust:direct skill was invoked with the freeform phrase as input." },
-    { "id": "dimensional_restatement",    "weight": 10, "description": "The agent restated the phrase in stardust's dimensional vocabulary (register / expressive axis / tone / density / distinctiveness / audience / constraints) before doing anything else. Each axis is named and either marked as moved (with direction), pinned, or left alone." },
-    { "id": "gaps_identified",            "weight": 5,  "description": "The agent explicitly identified what's underspecified before asking questions. 'Young' as too coarse (or equivalent) was called out." },
-    { "id": "question_ceiling",           "weight": 10, "description": "At most TWO clarifying questions were asked. Each had concrete options + an 'other' / 'skip' escape hatch and cited which dimension it resolved." },
-    { "id": "plan_shown_before_execution","weight": 15, "description": "After answers (or with no questions needed), the agent showed the resolved plan to the user BEFORE running any impeccable command or writing any file. Plan included: one-sentence restatement, assumptions, command sequence with reasoning, pages affected." },
-    { "id": "divergence_resolved",        "weight": 10, "description": "Divergence inputs resolved: 4-dim seed (decade x craft x register x ground-family), font deck pick, palette resolution. Recorded in DESIGN.json.extensions.divergence per the v2 storage shape." },
-    { "id": "product_md_direct",          "weight": 10, "description": "PRODUCT.md authored directly at project root using impeccable's teach.md as format spec. The agent did NOT invoke $impeccable teach. Sections present: Register, Users, Product Purpose, Brand Personality, Anti-references, Design Principles, Accessibility & Inclusion." },
-    { "id": "design_md_direct",           "weight": 10, "description": "DESIGN.md and DESIGN.json authored directly at project root. DESIGN.md uses Stitch frontmatter + 6 canonical sections. DESIGN.json schemaVersion 2 with extensions (divergence, componentStyle, voice) and narrative blocks." },
-    { "id": "direction_md_shape",         "weight": 10, "description": "stardust/direction.md exists with provenance + YAML frontmatter + # Active direction section containing required sub-sections: Phrase, Restatement, Movements, Divergence inputs, Command sequence (proposed), User confirmation, Pages in scope. Anti-references explicitly written (or '(none)')." },
-    { "id": "state_updated",              "weight": 5,  "description": "stardust/state.json updated: direction.resolvedAt set, direction.phrase verbatim, in-scope pages move from 'extracted' to 'directed' with history entries." },
-    { "id": "no_silent_command_mapping",  "weight": 5,  "description": "The agent did NOT silently map the phrase to a fixed command lookup. Reasoning was visible (dimensional vocabulary used, command choices justified)." },
-    { "id": "no_eds_references",          "weight": 5,  "description": "No mention of EDS, AEM, dev servers, or framework targets." }
+  "context": "Phase 2 (direct): tests dimensional restatement of a freeform phrase, at most two clarifying questions, plan-before-execution, direct authoring of the target spec, and the direction.md trace.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "activated",
+      "max_score": 5,
+      "description": "The stardust:direct skill was invoked with the freeform phrase as input."
+    },
+    {
+      "name": "dimensional_restatement",
+      "max_score": 10,
+      "description": "The agent restated the phrase in stardust's dimensional vocabulary (register / expressive axis / tone / density / distinctiveness / audience / constraints) before doing anything else. Each axis is named and either marked as moved (with direction), pinned, or left alone."
+    },
+    {
+      "name": "gaps_identified",
+      "max_score": 5,
+      "description": "The agent explicitly identified what's underspecified before asking questions. 'Young' as too coarse (or equivalent) was called out."
+    },
+    {
+      "name": "question_ceiling",
+      "max_score": 10,
+      "description": "At most TWO clarifying questions were asked. Each had concrete options + an 'other' / 'skip' escape hatch and cited which dimension it resolved."
+    },
+    {
+      "name": "plan_shown_before_execution",
+      "max_score": 15,
+      "description": "After answers (or with no questions needed), the agent showed the resolved plan to the user BEFORE running any impeccable command or writing any file. Plan included: one-sentence restatement, assumptions, command sequence with reasoning, pages affected."
+    },
+    {
+      "name": "divergence_resolved",
+      "max_score": 10,
+      "description": "Divergence inputs resolved: 4-dim seed (decade x craft x register x ground-family), font deck pick, palette resolution. Recorded in DESIGN.json.extensions.divergence per the v2 storage shape."
+    },
+    {
+      "name": "product_md_direct",
+      "max_score": 10,
+      "description": "PRODUCT.md authored directly at project root using impeccable's teach.md as format spec. The agent did NOT invoke $impeccable teach. Sections present: Register, Users, Product Purpose, Brand Personality, Anti-references, Design Principles, Accessibility & Inclusion."
+    },
+    {
+      "name": "design_md_direct",
+      "max_score": 10,
+      "description": "DESIGN.md and DESIGN.json authored directly at project root. DESIGN.md uses Stitch frontmatter + 6 canonical sections. DESIGN.json schemaVersion 2 with extensions (divergence, componentStyle, voice) and narrative blocks."
+    },
+    {
+      "name": "direction_md_shape",
+      "max_score": 10,
+      "description": "stardust/direction.md exists with provenance + YAML frontmatter + # Active direction section containing required sub-sections: Phrase, Restatement, Movements, Divergence inputs, Command sequence (proposed), User confirmation, Pages in scope. Anti-references explicitly written (or '(none)')."
+    },
+    {
+      "name": "state_updated",
+      "max_score": 5,
+      "description": "stardust/state.json updated: direction.resolvedAt set, direction.phrase verbatim, in-scope pages move from 'extracted' to 'directed' with history entries."
+    },
+    {
+      "name": "no_silent_command_mapping",
+      "max_score": 5,
+      "description": "The agent did NOT silently map the phrase to a fixed command lookup. Reasoning was visible (dimensional vocabulary used, command choices justified)."
+    },
+    {
+      "name": "no_eds_references",
+      "max_score": 5,
+      "description": "No mention of EDS, AEM, dev servers, or framework targets."
+    }
   ]
 }

--- a/plugins/stardust/evals/extract-multipage/criteria.json
+++ b/plugins/stardust/evals/extract-multipage/criteria.json
@@ -1,19 +1,71 @@
 {
-  "name": "extract-multipage",
-  "total": 100,
-  "criteria": [
-    { "id": "activated",                 "weight": 5,  "description": "The stardust:extract skill was invoked." },
-    { "id": "impeccable_dep_check",      "weight": 5,  "description": "Master skill setup ran first; impeccable was confirmed installed before extract proceeded." },
-    { "id": "discovery_before_crawl",    "weight": 10, "description": "Discovery (sitemap.xml -> sitemap_index -> robots.txt -> BFS crawl) happened before any per-page rendering. The discovered URL list was visible in the agent's narration." },
-    { "id": "page_cap_confirmation",     "weight": 10, "description": "The default 25-page cap was applied and the user was shown the kept list AND the cut list before crawling proceeded. Confirmation was solicited (no silent crawling beyond the cap)." },
-    { "id": "playwright_over_webfetch",  "weight": 10, "description": "Playwright was used for per-page rendering (1440x900 @ 2x DPR, networkidle + 1.5s, scroll-to-bottom pass). WebFetch / curl was NOT used as a substitute." },
-    { "id": "per_page_json_shape",       "weight": 10, "description": "Each stardust/current/pages/<slug>.json contains all required top-level keys: _provenance (first key), slug, url, finalUrl, title, og, themeColor, headings, landmarks, ctas, links, media, forms, widgets, perSectionStyle." },
-    { "id": "brand_extraction_shape",    "weight": 10, "description": "stardust/current/_brand-extraction.json exists with all sections: logo, palette (with role names + occurrences + sourceSelectors), type (heading + body families with weights / sizes), spacing, motifs (borderRadius / shadows / patterns), componentStyle (v1 fields preserved), voice samples, register guess." },
-    { "id": "logo_locator_chain",        "weight": 5,  "description": "Logo extracted via the priority chain. _brand-extraction.json.logo.source names the method used (inline-svg | img | apple-touch-icon | og-image | favicon | synthesized). File saved under stardust/current/assets/ (NOT icons/)." },
-    { "id": "current_product_md_direct", "weight": 10, "description": "stardust/current/PRODUCT.md was authored directly (sections per impeccable's teach.md format spec). The agent did NOT invoke $impeccable teach for the current-state file." },
-    { "id": "current_design_md_direct",  "weight": 10, "description": "stardust/current/DESIGN.md and DESIGN.json were authored directly. DESIGN.md uses Stitch frontmatter (colors, typography, rounded, spacing, components) and the 6 canonical sections. DESIGN.json schemaVersion 2 with extensions block." },
-    { "id": "state_json_shape",          "weight": 5,  "description": "stardust/state.json exists with _provenance first, site (originUrl/extractedAt/pageCap/totalDiscovered/crawled), direction (resolvedAt null at this stage), and pages[] (one entry per crawled page, status=extracted)." },
-    { "id": "provenance_stamped",        "weight": 5,  "description": "Every artifact carries a stardust:provenance block per artifact-map.md (first <head> child for HTML, first line above frontmatter for markdown, _provenance first key for JSON)." },
-    { "id": "no_eds_references",         "weight": 5,  "description": "No mention of EDS, AEM, localhost:3000, dev servers, or framework targets in outputs or narration." }
+  "context": "Phase 1 (extract): tests a multi-page crawl with a cap using Playwright (not WebFetch), correct output file shapes, and direct authoring of the current PRODUCT.md / DESIGN.md.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "activated",
+      "max_score": 5,
+      "description": "The stardust:extract skill was invoked."
+    },
+    {
+      "name": "impeccable_dep_check",
+      "max_score": 5,
+      "description": "Master skill setup ran first; impeccable was confirmed installed before extract proceeded."
+    },
+    {
+      "name": "discovery_before_crawl",
+      "max_score": 10,
+      "description": "Discovery (sitemap.xml -> sitemap_index -> robots.txt -> BFS crawl) happened before any per-page rendering. The discovered URL list was visible in the agent's narration."
+    },
+    {
+      "name": "page_cap_confirmation",
+      "max_score": 10,
+      "description": "The default 25-page cap was applied and the user was shown the kept list AND the cut list before crawling proceeded. Confirmation was solicited (no silent crawling beyond the cap)."
+    },
+    {
+      "name": "playwright_over_webfetch",
+      "max_score": 10,
+      "description": "Playwright was used for per-page rendering (1440x900 @ 2x DPR, networkidle + 1.5s, scroll-to-bottom pass). WebFetch / curl was NOT used as a substitute."
+    },
+    {
+      "name": "per_page_json_shape",
+      "max_score": 10,
+      "description": "Each stardust/current/pages/<slug>.json contains all required top-level keys: _provenance (first key), slug, url, finalUrl, title, og, themeColor, headings, landmarks, ctas, links, media, forms, widgets, perSectionStyle."
+    },
+    {
+      "name": "brand_extraction_shape",
+      "max_score": 10,
+      "description": "stardust/current/_brand-extraction.json exists with all sections: logo, palette (with role names + occurrences + sourceSelectors), type (heading + body families with weights / sizes), spacing, motifs (borderRadius / shadows / patterns), componentStyle (v1 fields preserved), voice samples, register guess."
+    },
+    {
+      "name": "logo_locator_chain",
+      "max_score": 5,
+      "description": "Logo extracted via the priority chain. _brand-extraction.json.logo.source names the method used (inline-svg | img | apple-touch-icon | og-image | favicon | synthesized). File saved under stardust/current/assets/ (NOT icons/)."
+    },
+    {
+      "name": "current_product_md_direct",
+      "max_score": 10,
+      "description": "stardust/current/PRODUCT.md was authored directly (sections per impeccable's teach.md format spec). The agent did NOT invoke $impeccable teach for the current-state file."
+    },
+    {
+      "name": "current_design_md_direct",
+      "max_score": 10,
+      "description": "stardust/current/DESIGN.md and DESIGN.json were authored directly. DESIGN.md uses Stitch frontmatter (colors, typography, rounded, spacing, components) and the 6 canonical sections. DESIGN.json schemaVersion 2 with extensions block."
+    },
+    {
+      "name": "state_json_shape",
+      "max_score": 5,
+      "description": "stardust/state.json exists with _provenance first, site (originUrl/extractedAt/pageCap/totalDiscovered/crawled), direction (resolvedAt null at this stage), and pages[] (one entry per crawled page, status=extracted)."
+    },
+    {
+      "name": "provenance_stamped",
+      "max_score": 5,
+      "description": "Every artifact carries a stardust:provenance block per artifact-map.md (first <head> child for HTML, first line above frontmatter for markdown, _provenance first key for JSON)."
+    },
+    {
+      "name": "no_eds_references",
+      "max_score": 5,
+      "description": "No mention of EDS, AEM, localhost:3000, dev servers, or framework targets in outputs or narration."
+    }
   ]
 }

--- a/plugins/stardust/evals/intent-reasoning-style/criteria.json
+++ b/plugins/stardust/evals/intent-reasoning-style/criteria.json
@@ -1,16 +1,56 @@
 {
-  "name": "intent-reasoning-style",
-  "total": 100,
-  "criteria": [
-    { "id": "routed_to_freeform_branch", "weight": 5,  "description": "The phrase 'I want it to be amazing' was routed to the master skill's freeform-phrase branch (intent-reasoning.md procedure) rather than directly to a sub-command." },
-    { "id": "dimensional_restatement",   "weight": 15, "description": "The agent restated the phrase in the dimensional vocabulary (intent-dimensions.md) before doing anything else. The restatement explicitly identified that the phrase moves NO directional axis." },
-    { "id": "amazing_vs_better_distinguished","weight": 10, "description": "The agent distinguished 'amazing' from 'better': 'better' has a default meaning (impeccable critique + audit pass), 'amazing' does not. Asking-then-stopping is the correct path for 'amazing'." },
-    { "id": "question_ceiling",          "weight": 15, "description": "At MOST two clarifying questions asked. Each was high-leverage (asking it changes the plan), each had concrete options + an 'other' / 'skip' escape hatch, each cited which dimension or gap it resolves." },
-    { "id": "no_silent_command_mapping", "weight": 15, "description": "The agent did NOT silently pick a command sequence. It did NOT fall back to 'make it better' defaults. It did NOT propose a multi-command sequence ('bolder + colorize + typeset + ...') that 'covers all bases' to avoid asking." },
-    { "id": "no_premature_authoring",    "weight": 15, "description": "PRODUCT.md, DESIGN.md, DESIGN.json, and a complete direction.md were NOT written. The agent refused to author tokens from incomplete reasoning." },
-    { "id": "pending_direction_persisted","weight": 10, "description": "The agent persisted the partial reasoning so resuming is possible: a # Pending direction (<ts>) section in stardust/direction.md with at least Phrase, Reasoning so far, Open questions. (Optional but expected.)" },
-    { "id": "downstream_block_explained","weight": 5,  "description": "The agent made explicit (in narration or in the pending direction's open questions) that prototype and migrate refuse to run while direction is pending." },
-    { "id": "reasoning_visible",         "weight": 5,  "description": "The reasoning was VISIBLE in the agent's output. The user can read what dimensions were considered, what was found missing, and why each question was asked. No magic." },
-    { "id": "no_eds_references",         "weight": 5,  "description": "No mention of EDS, AEM, dev servers, framework targets." }
+  "context": "Master-skill principle (open and reasoned): tests that vague phrases get clarified rather than silently mapped to commands, and that pending direction is persisted.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "routed_to_freeform_branch",
+      "max_score": 5,
+      "description": "The phrase 'I want it to be amazing' was routed to the master skill's freeform-phrase branch (intent-reasoning.md procedure) rather than directly to a sub-command."
+    },
+    {
+      "name": "dimensional_restatement",
+      "max_score": 15,
+      "description": "The agent restated the phrase in the dimensional vocabulary (intent-dimensions.md) before doing anything else. The restatement explicitly identified that the phrase moves NO directional axis."
+    },
+    {
+      "name": "amazing_vs_better_distinguished",
+      "max_score": 10,
+      "description": "The agent distinguished 'amazing' from 'better': 'better' has a default meaning (impeccable critique + audit pass), 'amazing' does not. Asking-then-stopping is the correct path for 'amazing'."
+    },
+    {
+      "name": "question_ceiling",
+      "max_score": 15,
+      "description": "At MOST two clarifying questions asked. Each was high-leverage (asking it changes the plan), each had concrete options + an 'other' / 'skip' escape hatch, each cited which dimension or gap it resolves."
+    },
+    {
+      "name": "no_silent_command_mapping",
+      "max_score": 15,
+      "description": "The agent did NOT silently pick a command sequence. It did NOT fall back to 'make it better' defaults. It did NOT propose a multi-command sequence ('bolder + colorize + typeset + ...') that 'covers all bases' to avoid asking."
+    },
+    {
+      "name": "no_premature_authoring",
+      "max_score": 15,
+      "description": "PRODUCT.md, DESIGN.md, DESIGN.json, and a complete direction.md were NOT written. The agent refused to author tokens from incomplete reasoning."
+    },
+    {
+      "name": "pending_direction_persisted",
+      "max_score": 10,
+      "description": "The agent persisted the partial reasoning so resuming is possible: a # Pending direction (<ts>) section in stardust/direction.md with at least Phrase, Reasoning so far, Open questions. (Optional but expected.)"
+    },
+    {
+      "name": "downstream_block_explained",
+      "max_score": 5,
+      "description": "The agent made explicit (in narration or in the pending direction's open questions) that prototype and migrate refuse to run while direction is pending."
+    },
+    {
+      "name": "reasoning_visible",
+      "max_score": 5,
+      "description": "The reasoning was VISIBLE in the agent's output. The user can read what dimensions were considered, what was found missing, and why each question was asked. No magic."
+    },
+    {
+      "name": "no_eds_references",
+      "max_score": 5,
+      "description": "No mention of EDS, AEM, dev servers, framework targets."
+    }
   ]
 }

--- a/plugins/stardust/evals/migrate-incremental/criteria.json
+++ b/plugins/stardust/evals/migrate-incremental/criteria.json
@@ -1,21 +1,81 @@
 {
-  "name": "migrate-incremental",
-  "total": 100,
-  "criteria": [
-    { "id": "activated",                 "weight": 5,  "description": "The stardust:migrate skill was invoked." },
-    { "id": "plan_printed",              "weight": 5,  "description": "The plan was printed before any writes: in-scope count partitioned by render path (A: approved-from-prototype; B: directed-no-prototype), DESIGN.md and DESIGN.json shas, output destination, idempotent-skip note." },
-    { "id": "path_a_used_for_approved",  "weight": 10, "description": "Approved pages (home, pricing) used render path A: read the proposed file's body verbatim, refreshed only the :root block from latest DESIGN.md. Provenance renderPath = 'approved-from-prototype'." },
-    { "id": "path_b_used_for_directed",  "weight": 10, "description": "Directed-but-not-prototyped pages (about, features, contact) used render path B: rendered from scratch using current/pages/<slug>.json IA + DESIGN.json components. Provenance renderPath = 'directed-no-prototype'." },
-    { "id": "output_path_mapping",       "weight": 10, "description": "Nested index.html structure: migrated/index.html for home, migrated/<slug>/index.html for others, multi-segment slugs (e.g. docs__api) nest as docs/api/index.html. Verified for at least the 5 pages in scope." },
-    { "id": "root_block_refreshed",      "weight": 10, "description": "Every migrated page's :root block matches the LATEST DESIGN.md tokens via the mapping table in token-contract.md." },
-    { "id": "data_attributes_preserved", "weight": 5,  "description": "Every <section> has data-section, data-intent, data-layout. Path A preserved them from the proposed file; path B applied them per the landmark purpose heuristic." },
-    { "id": "content_preserved",         "weight": 10, "description": "Every page's headlines, body copy, CTA labels, nav labels, and link destinations match the source (current/pages/<slug>.json or proposed.html). The redesign restyles, it does not rewrite." },
-    { "id": "internal_links_rewritten",  "weight": 5,  "description": "Internal links (same host as state.json.site.originUrl) rewritten to root-relative paths matching the migrated tree. External links and mailto:/tel: pass through unchanged. Missing targets get data-broken-link='true' + a provenance log entry." },
-    { "id": "assets_copied",             "weight": 5,  "description": "stardust/migrated/assets/ contains the logo and the referenced media files (only files referenced by migrated pages). Asset paths in HTML rewritten to /assets/..." },
-    { "id": "robots_and_sitemap",        "weight": 3,  "description": "stardust/migrated/robots.txt and stardust/migrated/sitemap.xml are present and derived from the migrated inventory." },
-    { "id": "provenance_complete",       "weight": 5,  "description": "Each page's provenance includes designMd sha, designJson sha, sourceCurrent sha, sourceProposed sha (path A only), renderPath, againstDirection, divergenceVersion." },
-    { "id": "state_marked_migrated",     "weight": 4,  "description": "state.json: all 5 pages moved to status 'migrated' after run 1, with history entries appended and any stale flags cleared." },
-    { "id": "idempotent_skip_run2",      "weight": 10, "description": "Run 2 (no changes between runs) produced zero file writes. Every page sha-compared and skipped. Summary: 0 migrated, 5 unchanged. state.json NOT updated for unchanged pages." },
-    { "id": "no_eds_references",         "weight": 3,  "description": "No mention of EDS, AEM, framework component generation, or production CMS payload. Output is platform-agnostic static HTML only." }
+  "context": "Phase 4 (migrate): tests both render paths (A and B), nested index.html output, content preservation, and the idempotent skip on re-run.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "activated",
+      "max_score": 5,
+      "description": "The stardust:migrate skill was invoked."
+    },
+    {
+      "name": "plan_printed",
+      "max_score": 5,
+      "description": "The plan was printed before any writes: in-scope count partitioned by render path (A: approved-from-prototype; B: directed-no-prototype), DESIGN.md and DESIGN.json shas, output destination, idempotent-skip note."
+    },
+    {
+      "name": "path_a_used_for_approved",
+      "max_score": 10,
+      "description": "Approved pages (home, pricing) used render path A: read the proposed file's body verbatim, refreshed only the :root block from latest DESIGN.md. Provenance renderPath = 'approved-from-prototype'."
+    },
+    {
+      "name": "path_b_used_for_directed",
+      "max_score": 10,
+      "description": "Directed-but-not-prototyped pages (about, features, contact) used render path B: rendered from scratch using current/pages/<slug>.json IA + DESIGN.json components. Provenance renderPath = 'directed-no-prototype'."
+    },
+    {
+      "name": "output_path_mapping",
+      "max_score": 10,
+      "description": "Nested index.html structure: migrated/index.html for home, migrated/<slug>/index.html for others, multi-segment slugs (e.g. docs__api) nest as docs/api/index.html. Verified for at least the 5 pages in scope."
+    },
+    {
+      "name": "root_block_refreshed",
+      "max_score": 10,
+      "description": "Every migrated page's :root block matches the LATEST DESIGN.md tokens via the mapping table in token-contract.md."
+    },
+    {
+      "name": "data_attributes_preserved",
+      "max_score": 5,
+      "description": "Every <section> has data-section, data-intent, data-layout. Path A preserved them from the proposed file; path B applied them per the landmark purpose heuristic."
+    },
+    {
+      "name": "content_preserved",
+      "max_score": 10,
+      "description": "Every page's headlines, body copy, CTA labels, nav labels, and link destinations match the source (current/pages/<slug>.json or proposed.html). The redesign restyles, it does not rewrite."
+    },
+    {
+      "name": "internal_links_rewritten",
+      "max_score": 5,
+      "description": "Internal links (same host as state.json.site.originUrl) rewritten to root-relative paths matching the migrated tree. External links and mailto:/tel: pass through unchanged. Missing targets get data-broken-link='true' + a provenance log entry."
+    },
+    {
+      "name": "assets_copied",
+      "max_score": 5,
+      "description": "stardust/migrated/assets/ contains the logo and the referenced media files (only files referenced by migrated pages). Asset paths in HTML rewritten to /assets/..."
+    },
+    {
+      "name": "robots_and_sitemap",
+      "max_score": 3,
+      "description": "stardust/migrated/robots.txt and stardust/migrated/sitemap.xml are present and derived from the migrated inventory."
+    },
+    {
+      "name": "provenance_complete",
+      "max_score": 5,
+      "description": "Each page's provenance includes designMd sha, designJson sha, sourceCurrent sha, sourceProposed sha (path A only), renderPath, againstDirection, divergenceVersion."
+    },
+    {
+      "name": "state_marked_migrated",
+      "max_score": 4,
+      "description": "state.json: all 5 pages moved to status 'migrated' after run 1, with history entries appended and any stale flags cleared."
+    },
+    {
+      "name": "idempotent_skip_run2",
+      "max_score": 10,
+      "description": "Run 2 (no changes between runs) produced zero file writes. Every page sha-compared and skipped. Summary: 0 migrated, 5 unchanged. state.json NOT updated for unchanged pages."
+    },
+    {
+      "name": "no_eds_references",
+      "max_score": 3,
+      "description": "No mention of EDS, AEM, framework component generation, or production CMS payload. Output is platform-agnostic static HTML only."
+    }
   ]
 }

--- a/plugins/stardust/evals/migrate-multi-template/criteria.json
+++ b/plugins/stardust/evals/migrate-multi-template/criteria.json
@@ -1,30 +1,126 @@
 {
-  "name": "migrate-multi-template",
-  "total": 100,
-  "criteria": [
-    { "id": "activated",                       "weight": 2,  "description": "The stardust:migrate skill was invoked." },
-    { "id": "plan_printed_with_branches",      "weight": 4,  "description": "Plan printed before any writes: in-scope count partitioned by render branch (Path A approved-from-prototype, Path A' template-applied from sibling, Path B unique-render), DESIGN.md / DESIGN.json / canon shas, output destination, idempotent-skip note." },
-    { "id": "path_a_render",                   "weight": 4,  "description": "Approved pages (home, news/post-housing-summit, news) used Path A: proposed.html body verbatim, :root refreshed from latest DESIGN.md (canon.pinned values winning for pinned tokens), canon.css injected. Provenance renderBranch = 'A'." },
-    { "id": "path_a_prime_render",             "weight": 12, "description": "Directed pages whose type matches an approved sibling (18 article, 2 program, 1 form) used Path A': forked the matching archetype's structure from prototypes/<sibling>-proposed.html, injected this page's typed slots from current/pages/<slug>.json § slots, applied canon. Provenance renderBranch = 'A''." },
-    { "id": "path_b_unique_render",            "weight": 5,  "description": "The unique-typed page (404) used Path B: composed from DESIGN.md/json tokens + canon header/footer + module catalog + canon.css. Logged a unique-render decision in migrationDecisions[]. Provenance renderBranch = 'B'." },
-    { "id": "data_attributes_full_set",        "weight": 4,  "description": "Required data-* vocabulary applied: data-template on body/main matching page type; data-section on every <section>; data-module on each module instance; data-slot on slot containers locally scoped to nearest data-template/data-module parent. v2.1 additive set per skills/stardust/reference/data-attributes.md." },
-    { "id": "canon_chrome_applied",            "weight": 5,  "description": "Header and footer emitted from stardust/canon/header.html and stardust/canon/footer.html verbatim. Container elements carry data-canon flag. Identical bytes across all 25 migrated pages (canon-author home and the 24 templates + unique pages all share the same chrome)." },
-    { "id": "canon_css_injected",              "weight": 1,  "description": "Contents of stardust/canon/canon.css injected as the second block in each page's first <style>, alongside :root. Identical canon CSS bytes across all migrated pages." },
-    { "id": "modules_rendered_via_canon",      "weight": 6,  "description": "Each data-module instance rendered via stardust/canon/modules/<id>.html with this page's slot values injected into the canonical structure. Cross-page consistency: hotline-211 instances on home/get-help/donate render identically except for slot values." },
-    { "id": "metadata_composition",            "weight": 5,  "description": "Head metadata composed per metadata-and-jsonld.md five categories. System-fixed (charset, viewport) on every page. Brand-level (theme-color, og:site_name, Organization JSON-LD) from DESIGN.json.extensions.metadata. Page-specific preserved (title, description, og, twitter) from current/pages/<slug>.json. Stripped: GTM/pixels/chat/consent SDKs all removed." },
-    { "id": "jsonld_per_page_type",            "weight": 4,  "description": "Page-type-driven JSON-LD: Article schema on news posts (headline, author, datePublished, articleBody), ItemList on news (the listing), Organization extension on static pages (about/team), no JSON-LD on the 404 unique page." },
-    { "id": "canonical_strategy",              "weight": 2,  "description": "Canonical preserved from current/pages/<slug>.json metadata when state.json.site.deployUrl is unset (Run 9, presales/staging mode); rewritten to https://<deployUrl>/<slug-path>/ when deployUrl is set (Run 10). Behavior verified per metadata-and-jsonld.md § Canonical." },
-    { "id": "internal_links_always_rewritten", "weight": 5,  "description": "Every same-host <a href> rewritten to the migrated-tree path (root-relative, e.g. /about/, /docs/api/). Missing slugs (target not in inventory) get the would-be migrated path + data-broken-link='true' + a log entry in provenance.brokenInternalLinks[]. No same-host links escape to the live origin." },
-    { "id": "brand_faithful_inversions_lifted","weight": 4,  "description": "Validation reads DESIGN.json.extensions.divergence.brand_faithful_inversions[] and lifts the corresponding impeccable hard rules. Positive case (Run 1): inversions in effect → migration succeeds with #FFFFFF/#000000/hex/0px corners/ALL CAPS retained. Negative case (Run 11): inversion removed from direction.md → validation refuses every page still using the now-restored hard rule." },
-    { "id": "content_preserved",               "weight": 4,  "description": "Headlines, body copy, CTA labels, nav labels, alt text, link destinations all match the source (current/pages/<slug>.json or prototypes/<archetype>-proposed.html). The redesign restyles, never rewrites. Tone unchanged for body content." },
-    { "id": "meta_json_sidecar",               "weight": 6,  "description": "Every migrated page's directory contains both index.html AND _meta.json. Sidecar carries: slug, type, renderBranch, template (Path A'), modules[], slotsFilled[], canonShas, deviations[], migrationDecisions[], metadata, jsonLd, migratedAt, sha pointers (designMd, designJson, sourceCurrent, sourceProposed)." },
-    { "id": "migration_decisions_logged",      "weight": 5,  "description": "migrationDecisions[] entries cover all non-trivial choices: template-applied / template-adapted (with adaptations array), unique-render, module-bespoke-slot, canon-deviation, metadata-override. Each entry has kind + reason at minimum; specifics per kind." },
-    { "id": "idempotent_skip_run2",            "weight": 5,  "description": "Run 2 (no changes) produced zero file writes. Every page sha-compared across designMd, designJson, sourceCurrent, sourceProposed (Path A), canonShas, archetypeSha (Path A'). All match → all 25 skipped. Summary: 0 migrated, 25 unchanged. state.json NOT updated for unchanged pages." },
-    { "id": "sha_driven_rerender",             "weight": 3,  "description": "Run 3 (DESIGN.md edited) re-renders all 25 pages because designMd sha changed; canon.pinned values still take precedence over the edited DESIGN.md range. Run 4 (canon.css edited) re-renders all 25 pages because canon css sha changed. Both run summaries surface the cause." },
-    { "id": "broken_link_reporting_run5",      "weight": 4,  "description": "Run 5 (after slug removed from inventory): pages that linked to the removed slug get hrefs rewritten to the would-be migrated path AND data-broken-link='true' attribute. Run summary surfaces 'Broken internal links: N' with target slugs and referencing-page counts." },
-    { "id": "bespoke_slot_promotion_run6",     "weight": 3,  "description": "Run 6 (3+ instances of a bespoke slot, e.g. 'state' on hotline-211): run summary surfaces a 'Bespoke slots crossing promotion threshold' section recommending `$stardust prepare-migration --refine-module`. Each instance carries data-bespoke flag and a module-bespoke-slot decision in its sidecar." },
-    { "id": "color_reservation_violation_run7","weight": 3,  "description": "Run 7 (page uses #DC323D outside its reserved trh-100-lockup module): page is NOT written. state.json.lastRun.failures[] records { slug, kind: 'color-reservation', color, reservedFor, found }. Run summary surfaces the failure with the offending color and a remediation hint." },
-    { "id": "template_adaptation_run8",        "weight": 3,  "description": "Run 8 (article page with content not in archetype, e.g. video embed): Path A' renders the article using the archetype, places the extra content in an overflow region after the body slot, logs a template-adapted decision in migrationDecisions[] with adaptations array naming the what / where / via." },
-    { "id": "no_eds_references",               "weight": 1,  "description": "No mention of EDS, AEM, framework component generation, or production CMS payload. Output is platform-agnostic static HTML only; the data-* vocabulary plus _meta.json sidecar are the contract for downstream conversion plugins." }
+  "context": "Phase 4 (migrate): tests three render branches (Path A / A-prime / B), canon and modules, bespoke-slot promotion, broken-link reporting, and color-reservation refusal.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "activated",
+      "max_score": 2,
+      "description": "The stardust:migrate skill was invoked."
+    },
+    {
+      "name": "plan_printed_with_branches",
+      "max_score": 4,
+      "description": "Plan printed before any writes: in-scope count partitioned by render branch (Path A approved-from-prototype, Path A' template-applied from sibling, Path B unique-render), DESIGN.md / DESIGN.json / canon shas, output destination, idempotent-skip note."
+    },
+    {
+      "name": "path_a_render",
+      "max_score": 4,
+      "description": "Approved pages (home, news/post-housing-summit, news) used Path A: proposed.html body verbatim, :root refreshed from latest DESIGN.md (canon.pinned values winning for pinned tokens), canon.css injected. Provenance renderBranch = 'A'."
+    },
+    {
+      "name": "path_a_prime_render",
+      "max_score": 12,
+      "description": "Directed pages whose type matches an approved sibling (18 article, 2 program, 1 form) used Path A': forked the matching archetype's structure from prototypes/<sibling>-proposed.html, injected this page's typed slots from current/pages/<slug>.json § slots, applied canon. Provenance renderBranch = 'A''."
+    },
+    {
+      "name": "path_b_unique_render",
+      "max_score": 5,
+      "description": "The unique-typed page (404) used Path B: composed from DESIGN.md/json tokens + canon header/footer + module catalog + canon.css. Logged a unique-render decision in migrationDecisions[]. Provenance renderBranch = 'B'."
+    },
+    {
+      "name": "data_attributes_full_set",
+      "max_score": 4,
+      "description": "Required data-* vocabulary applied: data-template on body/main matching page type; data-section on every <section>; data-module on each module instance; data-slot on slot containers locally scoped to nearest data-template/data-module parent. v2.1 additive set per skills/stardust/reference/data-attributes.md."
+    },
+    {
+      "name": "canon_chrome_applied",
+      "max_score": 5,
+      "description": "Header and footer emitted from stardust/canon/header.html and stardust/canon/footer.html verbatim. Container elements carry data-canon flag. Identical bytes across all 25 migrated pages (canon-author home and the 24 templates + unique pages all share the same chrome)."
+    },
+    {
+      "name": "canon_css_injected",
+      "max_score": 1,
+      "description": "Contents of stardust/canon/canon.css injected as the second block in each page's first <style>, alongside :root. Identical canon CSS bytes across all migrated pages."
+    },
+    {
+      "name": "modules_rendered_via_canon",
+      "max_score": 6,
+      "description": "Each data-module instance rendered via stardust/canon/modules/<id>.html with this page's slot values injected into the canonical structure. Cross-page consistency: hotline-211 instances on home/get-help/donate render identically except for slot values."
+    },
+    {
+      "name": "metadata_composition",
+      "max_score": 5,
+      "description": "Head metadata composed per metadata-and-jsonld.md five categories. System-fixed (charset, viewport) on every page. Brand-level (theme-color, og:site_name, Organization JSON-LD) from DESIGN.json.extensions.metadata. Page-specific preserved (title, description, og, twitter) from current/pages/<slug>.json. Stripped: GTM/pixels/chat/consent SDKs all removed."
+    },
+    {
+      "name": "jsonld_per_page_type",
+      "max_score": 4,
+      "description": "Page-type-driven JSON-LD: Article schema on news posts (headline, author, datePublished, articleBody), ItemList on news (the listing), Organization extension on static pages (about/team), no JSON-LD on the 404 unique page."
+    },
+    {
+      "name": "canonical_strategy",
+      "max_score": 2,
+      "description": "Canonical preserved from current/pages/<slug>.json metadata when state.json.site.deployUrl is unset (Run 9, presales/staging mode); rewritten to https://<deployUrl>/<slug-path>/ when deployUrl is set (Run 10). Behavior verified per metadata-and-jsonld.md § Canonical."
+    },
+    {
+      "name": "internal_links_always_rewritten",
+      "max_score": 5,
+      "description": "Every same-host <a href> rewritten to the migrated-tree path (root-relative, e.g. /about/, /docs/api/). Missing slugs (target not in inventory) get the would-be migrated path + data-broken-link='true' + a log entry in provenance.brokenInternalLinks[]. No same-host links escape to the live origin."
+    },
+    {
+      "name": "brand_faithful_inversions_lifted",
+      "max_score": 4,
+      "description": "Validation reads DESIGN.json.extensions.divergence.brand_faithful_inversions[] and lifts the corresponding impeccable hard rules. Positive case (Run 1): inversions in effect → migration succeeds with #FFFFFF/#000000/hex/0px corners/ALL CAPS retained. Negative case (Run 11): inversion removed from direction.md → validation refuses every page still using the now-restored hard rule."
+    },
+    {
+      "name": "content_preserved",
+      "max_score": 4,
+      "description": "Headlines, body copy, CTA labels, nav labels, alt text, link destinations all match the source (current/pages/<slug>.json or prototypes/<archetype>-proposed.html). The redesign restyles, never rewrites. Tone unchanged for body content."
+    },
+    {
+      "name": "meta_json_sidecar",
+      "max_score": 6,
+      "description": "Every migrated page's directory contains both index.html AND _meta.json. Sidecar carries: slug, type, renderBranch, template (Path A'), modules[], slotsFilled[], canonShas, deviations[], migrationDecisions[], metadata, jsonLd, migratedAt, sha pointers (designMd, designJson, sourceCurrent, sourceProposed)."
+    },
+    {
+      "name": "migration_decisions_logged",
+      "max_score": 5,
+      "description": "migrationDecisions[] entries cover all non-trivial choices: template-applied / template-adapted (with adaptations array), unique-render, module-bespoke-slot, canon-deviation, metadata-override. Each entry has kind + reason at minimum; specifics per kind."
+    },
+    {
+      "name": "idempotent_skip_run2",
+      "max_score": 5,
+      "description": "Run 2 (no changes) produced zero file writes. Every page sha-compared across designMd, designJson, sourceCurrent, sourceProposed (Path A), canonShas, archetypeSha (Path A'). All match → all 25 skipped. Summary: 0 migrated, 25 unchanged. state.json NOT updated for unchanged pages."
+    },
+    {
+      "name": "sha_driven_rerender",
+      "max_score": 3,
+      "description": "Run 3 (DESIGN.md edited) re-renders all 25 pages because designMd sha changed; canon.pinned values still take precedence over the edited DESIGN.md range. Run 4 (canon.css edited) re-renders all 25 pages because canon css sha changed. Both run summaries surface the cause."
+    },
+    {
+      "name": "broken_link_reporting_run5",
+      "max_score": 4,
+      "description": "Run 5 (after slug removed from inventory): pages that linked to the removed slug get hrefs rewritten to the would-be migrated path AND data-broken-link='true' attribute. Run summary surfaces 'Broken internal links: N' with target slugs and referencing-page counts."
+    },
+    {
+      "name": "bespoke_slot_promotion_run6",
+      "max_score": 3,
+      "description": "Run 6 (3+ instances of a bespoke slot, e.g. 'state' on hotline-211): run summary surfaces a 'Bespoke slots crossing promotion threshold' section recommending `$stardust prepare-migration --refine-module`. Each instance carries data-bespoke flag and a module-bespoke-slot decision in its sidecar."
+    },
+    {
+      "name": "color_reservation_violation_run7",
+      "max_score": 3,
+      "description": "Run 7 (page uses #DC323D outside its reserved trh-100-lockup module): page is NOT written. state.json.lastRun.failures[] records { slug, kind: 'color-reservation', color, reservedFor, found }. Run summary surfaces the failure with the offending color and a remediation hint."
+    },
+    {
+      "name": "template_adaptation_run8",
+      "max_score": 3,
+      "description": "Run 8 (article page with content not in archetype, e.g. video embed): Path A' renders the article using the archetype, places the extra content in an overflow region after the body slot, logs a template-adapted decision in migrationDecisions[] with adaptations array naming the what / where / via."
+    },
+    {
+      "name": "no_eds_references",
+      "max_score": 1,
+      "description": "No mention of EDS, AEM, framework component generation, or production CMS payload. Output is platform-agnostic static HTML only; the data-* vocabulary plus _meta.json sidecar are the contract for downstream conversion plugins."
+    }
   ]
 }

--- a/plugins/stardust/evals/migrate-self-contained-bundle/criteria.json
+++ b/plugins/stardust/evals/migrate-self-contained-bundle/criteria.json
@@ -1,29 +1,121 @@
 {
-  "name": "migrate-self-contained-bundle",
-  "total": 100,
-  "criteria": [
-    { "id": "activated",                       "weight": 3,  "description": "The stardust:migrate skill was invoked." },
-    { "id": "no_current_escapes",              "weight": 6,  "description": "After run 1, no HTML file under stardust/migrated/ contains the substring '../current/'. Self-containment verified by absence of escape segments. (Acceptance criterion #1.)" },
-    { "id": "zip_deploy_ready",                "weight": 5,  "description": "Running 'cd stardust/migrated && zip -r out.zip .' produces a zip that renders identically in three contexts: extracted and served at the host root, extracted and served at any subpath, AND opened directly via file://. No 404s on any bundled asset. (Acceptance criteria #2, #3 + the new file:// portability guarantee.)" },
-    { "id": "idempotent_modulo_timestamp",     "weight": 5,  "description": "Re-running migrate without source changes produces output that differs only in the migrate-provenance timestamp line. With --pin-timestamp, output is byte-identical to the prior run. (Acceptance criterion #4.)" },
-    { "id": "asset_count_in_report",           "weight": 3,  "description": "Run summary includes 'N pages, M bundled assets, KKK KB HTML total — self-contained, zip-and-deploy' so the user sees the bundle composition at a glance. (Acceptance criterion #5.)" },
-    { "id": "missing_asset_surfaced",          "weight": 4,  "description": "The 'generated/missing.jpg' reference surfaces in the run report's Missing assets block AND in state.json.migrate.missingAssets[]. Migrate completes successfully (warnings, not errors). (Acceptance criterion #6.)" },
-    { "id": "detection_src_href",              "weight": 3,  "description": "Detection shape #1 (single-URL src/href): the <link rel=\"icon\"> and <img src> references are bundled and rewritten to depth-aware relative paths of the form <prefix>assets/<subpath>, where prefix is './' for depth-0 pages and '../'.repeat(depth) for nested pages." },
-    { "id": "detection_srcset",                "weight": 5,  "description": "Detection shape #2 (srcset multi-URL): each URL in the comma-separated list is rewritten independently to depth-aware relative form; descriptors (1x, 2x, 768w) preserved verbatim; whitespace between entries preserved." },
-    { "id": "detection_inline_style",          "weight": 3,  "description": "Detection shape #3 (inline style=\"...url(...)...\"): background-image url() is rewritten to depth-aware relative form." },
-    { "id": "detection_style_block_url",       "weight": 4,  "description": "Detection shape #4 (<style>-block url()): both @font-face src: url() and .grid background url() are rewritten to depth-aware relative form." },
-    { "id": "depth_aware_paths",               "weight": 6,  "description": "Asset and internal-page references are emitted as depth-aware relative paths, NOT root-relative. From home (depth 0): './assets/foo'. From beers/index.html (depth 1): '../assets/foo' and '../about/index.html'. From docs/api/index.html (depth 2): '../../assets/foo'. Per migration-procedure.md § Reference shape." },
-    { "id": "prefix_normalises_authoring",     "weight": 4,  "description": "Root-relative authoring ('/assets/generated/hero-1x.jpg') and bare-relative authoring ('assets/foo') are BOTH normalised to the depth-aware relative form on the emitted page. Authoring style is not preserved verbatim — the contract is 'one shape, works everywhere'." },
-    { "id": "asset_subpath_preserved",         "weight": 3,  "description": "Source subdir structure preserved verbatim under stardust/migrated/assets/: generated/hero-1x.jpg, fonts/inter-var.woff2, photos/family portrait.jpg all land at the expected paths." },
-    { "id": "percent_encoded_subpath",         "weight": 3,  "description": "The reference to '<prefix>assets/photos/family%20portrait.jpg' is preserved encoded in HTML but the file-system access decodes to 'photos/family portrait.jpg' and the file copies correctly." },
-    { "id": "path_traversal_refused",          "weight": 3,  "description": "The '/assets/../etc/passwd' reference is refused: no copy, the HTML reference is left unchanged (so the issue surfaces visibly on deploy), and the page's _meta.json#migrationDecisions[] records kind: 'asset-path-traversal'." },
-    { "id": "scheme_bearing_url_skipped",      "weight": 2,  "description": "The 'https://fonts.googleapis.com/...' stylesheet link is left external — not bundled, not rewritten, not flagged as missing. CDN URLs are by-design external." },
-    { "id": "pagemap_constructed",             "weight": 6,  "description": "state.json.migrate.pageMap[] is built BEFORE per-page rendering and lists every in-scope source URL with its outputPath (URL-literal rule per migration-procedure.md § Output path mapping): /beers-bev/ -> beers/index.html, /about-us/history.html -> about-us/history.html (preserve .html leaf, no extra index.html). Each entry: { sourceUrl, outputPath, slug }." },
-    { "id": "internal_links_via_pagemap",      "weight": 5,  "description": "Internal <a href> rewrites resolve via pageMap.outputPath lookup, NOT slug synthesis. Same-origin absolute hrefs (https://<origin>/path) are stripped to their path portion and looked up via pageMap, then emitted as depth-aware relative refs. A target URL with no pageMap entry is flagged data-broken-link='true' and logged under provenance.brokenInternalLinks[]." },
-    { "id": "state_json_migrate_block",        "weight": 6,  "description": "state.json.migrate is written with: selfContained: true, outputDir, pageMap[] (built first), totalAssetsBundled, bundledAssets[] (unique subpath set), per-page assetsBundled counts, missingAssets[], cleanedAssets[]. Field order and shapes match migrate-output-format.md § State.json contract." },
-    { "id": "self_contained_signal",           "weight": 2,  "description": "state.json.migrate.selfContained === true is the forward-compat signal — downstream consumers can test for it." },
-    { "id": "cross_page_dedup",                "weight": 3,  "description": "When two pages reference the same asset, the bundler copies it exactly once. The global Set is seeded from state.json.migrate.bundledAssets[] so cross-run dedup works even when only some pages re-render. Each page emits the asset with its own depth-aware prefix; the underlying copy is shared." },
-    { "id": "stale_cleanup_clean_flag",        "weight": 3,  "description": "Run 3 with --clean removes assets that were bundled in the prior run but are no longer referenced. --clean implies --force (every page re-renders so the bundledAssets set is the complete union; idempotent-skipped pages' references are not missed). state.json.migrate.cleanedAssets[] records what was removed. Without --clean, the run is additive and honors the idempotent skip." },
-    { "id": "portability_audit_passes",        "weight": 13, "description": "Phase 3 portability audit (per SKILL.md § Phase 3) passes: (a) no '../current/' escapes; (b) no absolute internal href/src ('grep -rE \"(href|src)=/[^/]\"' empty); (c) no absolute url() ('grep -rE \"url\\(\\s*[\\\"\\']?\\s*/[^/]\"' empty); (d) no directory-only hrefs ('grep -rE \"href=\\\"(\\.{0,2}/|[a-zA-Z0-9_-])[^:\\\"#?]*/\\\"\"' empty); (e) pagemap-audit.mjs exits 0; (f) file-protocol-audit.mjs exits 0. Any non-empty grep output or non-zero fixture exit fails the run." }
+  "context": "Phase 4 (migrate): tests the self-contained zip-and-deploy bundle — six asset detection shapes, nine edge cases, six acceptance criteria, and the state.json migrate block with selfContained: true.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "activated",
+      "max_score": 3,
+      "description": "The stardust:migrate skill was invoked."
+    },
+    {
+      "name": "no_current_escapes",
+      "max_score": 6,
+      "description": "After run 1, no HTML file under stardust/migrated/ contains the substring '../current/'. Self-containment verified by absence of escape segments. (Acceptance criterion #1.)"
+    },
+    {
+      "name": "zip_deploy_ready",
+      "max_score": 5,
+      "description": "Running 'cd stardust/migrated && zip -r out.zip .' produces a zip that renders identically in three contexts: extracted and served at the host root, extracted and served at any subpath, AND opened directly via file://. No 404s on any bundled asset. (Acceptance criteria #2, #3 + the new file:// portability guarantee.)"
+    },
+    {
+      "name": "idempotent_modulo_timestamp",
+      "max_score": 5,
+      "description": "Re-running migrate without source changes produces output that differs only in the migrate-provenance timestamp line. With --pin-timestamp, output is byte-identical to the prior run. (Acceptance criterion #4.)"
+    },
+    {
+      "name": "asset_count_in_report",
+      "max_score": 3,
+      "description": "Run summary includes 'N pages, M bundled assets, KKK KB HTML total — self-contained, zip-and-deploy' so the user sees the bundle composition at a glance. (Acceptance criterion #5.)"
+    },
+    {
+      "name": "missing_asset_surfaced",
+      "max_score": 4,
+      "description": "The 'generated/missing.jpg' reference surfaces in the run report's Missing assets block AND in state.json.migrate.missingAssets[]. Migrate completes successfully (warnings, not errors). (Acceptance criterion #6.)"
+    },
+    {
+      "name": "detection_src_href",
+      "max_score": 3,
+      "description": "Detection shape #1 (single-URL src/href): the <link rel=\"icon\"> and <img src> references are bundled and rewritten to depth-aware relative paths of the form <prefix>assets/<subpath>, where prefix is './' for depth-0 pages and '../'.repeat(depth) for nested pages."
+    },
+    {
+      "name": "detection_srcset",
+      "max_score": 5,
+      "description": "Detection shape #2 (srcset multi-URL): each URL in the comma-separated list is rewritten independently to depth-aware relative form; descriptors (1x, 2x, 768w) preserved verbatim; whitespace between entries preserved."
+    },
+    {
+      "name": "detection_inline_style",
+      "max_score": 3,
+      "description": "Detection shape #3 (inline style=\"...url(...)...\"): background-image url() is rewritten to depth-aware relative form."
+    },
+    {
+      "name": "detection_style_block_url",
+      "max_score": 4,
+      "description": "Detection shape #4 (<style>-block url()): both @font-face src: url() and .grid background url() are rewritten to depth-aware relative form."
+    },
+    {
+      "name": "depth_aware_paths",
+      "max_score": 6,
+      "description": "Asset and internal-page references are emitted as depth-aware relative paths, NOT root-relative. From home (depth 0): './assets/foo'. From beers/index.html (depth 1): '../assets/foo' and '../about/index.html'. From docs/api/index.html (depth 2): '../../assets/foo'. Per migration-procedure.md § Reference shape."
+    },
+    {
+      "name": "prefix_normalises_authoring",
+      "max_score": 4,
+      "description": "Root-relative authoring ('/assets/generated/hero-1x.jpg') and bare-relative authoring ('assets/foo') are BOTH normalised to the depth-aware relative form on the emitted page. Authoring style is not preserved verbatim — the contract is 'one shape, works everywhere'."
+    },
+    {
+      "name": "asset_subpath_preserved",
+      "max_score": 3,
+      "description": "Source subdir structure preserved verbatim under stardust/migrated/assets/: generated/hero-1x.jpg, fonts/inter-var.woff2, photos/family portrait.jpg all land at the expected paths."
+    },
+    {
+      "name": "percent_encoded_subpath",
+      "max_score": 3,
+      "description": "The reference to '<prefix>assets/photos/family%20portrait.jpg' is preserved encoded in HTML but the file-system access decodes to 'photos/family portrait.jpg' and the file copies correctly."
+    },
+    {
+      "name": "path_traversal_refused",
+      "max_score": 3,
+      "description": "The '/assets/../etc/passwd' reference is refused: no copy, the HTML reference is left unchanged (so the issue surfaces visibly on deploy), and the page's _meta.json#migrationDecisions[] records kind: 'asset-path-traversal'."
+    },
+    {
+      "name": "scheme_bearing_url_skipped",
+      "max_score": 2,
+      "description": "The 'https://fonts.googleapis.com/...' stylesheet link is left external — not bundled, not rewritten, not flagged as missing. CDN URLs are by-design external."
+    },
+    {
+      "name": "pagemap_constructed",
+      "max_score": 6,
+      "description": "state.json.migrate.pageMap[] is built BEFORE per-page rendering and lists every in-scope source URL with its outputPath (URL-literal rule per migration-procedure.md § Output path mapping): /beers-bev/ -> beers/index.html, /about-us/history.html -> about-us/history.html (preserve .html leaf, no extra index.html). Each entry: { sourceUrl, outputPath, slug }."
+    },
+    {
+      "name": "internal_links_via_pagemap",
+      "max_score": 5,
+      "description": "Internal <a href> rewrites resolve via pageMap.outputPath lookup, NOT slug synthesis. Same-origin absolute hrefs (https://<origin>/path) are stripped to their path portion and looked up via pageMap, then emitted as depth-aware relative refs. A target URL with no pageMap entry is flagged data-broken-link='true' and logged under provenance.brokenInternalLinks[]."
+    },
+    {
+      "name": "state_json_migrate_block",
+      "max_score": 6,
+      "description": "state.json.migrate is written with: selfContained: true, outputDir, pageMap[] (built first), totalAssetsBundled, bundledAssets[] (unique subpath set), per-page assetsBundled counts, missingAssets[], cleanedAssets[]. Field order and shapes match migrate-output-format.md § State.json contract."
+    },
+    {
+      "name": "self_contained_signal",
+      "max_score": 2,
+      "description": "state.json.migrate.selfContained === true is the forward-compat signal — downstream consumers can test for it."
+    },
+    {
+      "name": "cross_page_dedup",
+      "max_score": 3,
+      "description": "When two pages reference the same asset, the bundler copies it exactly once. The global Set is seeded from state.json.migrate.bundledAssets[] so cross-run dedup works even when only some pages re-render. Each page emits the asset with its own depth-aware prefix; the underlying copy is shared."
+    },
+    {
+      "name": "stale_cleanup_clean_flag",
+      "max_score": 3,
+      "description": "Run 3 with --clean removes assets that were bundled in the prior run but are no longer referenced. --clean implies --force (every page re-renders so the bundledAssets set is the complete union; idempotent-skipped pages' references are not missed). state.json.migrate.cleanedAssets[] records what was removed. Without --clean, the run is additive and honors the idempotent skip."
+    },
+    {
+      "name": "portability_audit_passes",
+      "max_score": 13,
+      "description": "Phase 3 portability audit (per SKILL.md § Phase 3) passes: (a) no '../current/' escapes; (b) no absolute internal href/src ('grep -rE \"(href|src)=/[^/]\"' empty); (c) no absolute url() ('grep -rE \"url\\(\\s*[\\\"\\']?\\s*/[^/]\"' empty); (d) no directory-only hrefs ('grep -rE \"href=\\\"(\\.{0,2}/|[a-zA-Z0-9_-])[^:\\\"#?]*/\\\"\"' empty); (e) pagemap-audit.mjs exits 0; (f) file-protocol-audit.mjs exits 0. Any non-empty grep output or non-zero fixture exit fails the run."
+    }
   ]
 }

--- a/plugins/stardust/evals/prototype-before-after/criteria.json
+++ b/plugins/stardust/evals/prototype-before-after/criteria.json
@@ -1,18 +1,66 @@
 {
-  "name": "prototype-before-after",
-  "total": 100,
-  "criteria": [
-    { "id": "activated",                 "weight": 5,  "description": "The stardust:prototype skill was invoked." },
-    { "id": "single_proposed_file",      "weight": 15, "description": "Exactly one file is written for the page: stardust/prototypes/home-proposed.html. No separate before/after viewer file (home.html) is composed — the viewer was dropped from the skill." },
-    { "id": "root_token_block",          "weight": 15, "description": "home-proposed.html has the :root block as the first content of the first <style>. All required tokens present per token-contract.md (--heading-*, --body, --body-sm, --line-height-*, --color-bg, --color-fg, --color-accent, --spacing-*, --section-padding, --max-width, --radius)." },
-    { "id": "data_attributes_on_sections","weight": 10, "description": "Every <section> in home-proposed.html has data-section, data-intent, data-layout. Optional attributes (data-items, data-media, data-interactive) used where applicable. Lowercase kebab-case slugs." },
-    { "id": "provenance_complete",       "weight": 10, "description": "home-proposed.html has a stardust:provenance block as the first child of <head> listing: writtenBy, writtenAt, page, pageUrl, againstDirection (with the active direction's resolvedAt), readArtifacts, divergenceVersion, fontDeck, paletteSource." },
-    { "id": "self_contained",            "weight": 10, "description": "home-proposed.html is self-contained: no external CSS files, no external JS files, no analytics, no fonts loaded from CDN that aren't justified by the chosen font deck. The only inline <script> allowed is the ≤10-line mobile-nav a11y shim when the stock hamburger pattern is applied." },
-    { "id": "content_preserved",         "weight": 10, "description": "Content from current/pages/home.json is preserved: hero headline, body copy, CTA labels, navigation labels, link destinations. The redesign restyles, it does not rewrite." },
-    { "id": "delegates_to_craft",        "weight": 5,  "description": "The agent invoked $impeccable craft (or its equivalent flow) to perform the creative rendering, rather than inventing the design from scratch in stardust." },
-    { "id": "browser_opened",            "weight": 5,  "description": "home-proposed.html was opened in the default browser via open / xdg-open / start. Skipped only in pipeline-automation mode." },
-    { "id": "approval_chat_only",        "weight": 5,  "description": "Approval is documented as chat-only ('approve <slug>' or 'approve'). The agent does not reference a viewer button or postMessage mechanism." },
-    { "id": "state_prototyped_not_approved", "weight": 7, "description": "state.json marks home as 'prototyped' with prototypePath pointing at stardust/prototypes/home-proposed.html. Approval is a separate explicit step the user takes; the agent did not auto-approve." },
-    { "id": "no_eds_references",         "weight": 3,  "description": "No mention of EDS, AEM, framework targets, or production CMS output in either file or in narration." }
+  "context": "Phase 3 (prototype): tests one proposed file per page, the :root block and data attributes, content preservation, delegation to impeccable craft, and opening the result in a browser.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "activated",
+      "max_score": 5,
+      "description": "The stardust:prototype skill was invoked."
+    },
+    {
+      "name": "single_proposed_file",
+      "max_score": 15,
+      "description": "Exactly one file is written for the page: stardust/prototypes/home-proposed.html. No separate before/after viewer file (home.html) is composed — the viewer was dropped from the skill."
+    },
+    {
+      "name": "root_token_block",
+      "max_score": 15,
+      "description": "home-proposed.html has the :root block as the first content of the first <style>. All required tokens present per token-contract.md (--heading-*, --body, --body-sm, --line-height-*, --color-bg, --color-fg, --color-accent, --spacing-*, --section-padding, --max-width, --radius)."
+    },
+    {
+      "name": "data_attributes_on_sections",
+      "max_score": 10,
+      "description": "Every <section> in home-proposed.html has data-section, data-intent, data-layout. Optional attributes (data-items, data-media, data-interactive) used where applicable. Lowercase kebab-case slugs."
+    },
+    {
+      "name": "provenance_complete",
+      "max_score": 10,
+      "description": "home-proposed.html has a stardust:provenance block as the first child of <head> listing: writtenBy, writtenAt, page, pageUrl, againstDirection (with the active direction's resolvedAt), readArtifacts, divergenceVersion, fontDeck, paletteSource."
+    },
+    {
+      "name": "self_contained",
+      "max_score": 10,
+      "description": "home-proposed.html is self-contained: no external CSS files, no external JS files, no analytics, no fonts loaded from CDN that aren't justified by the chosen font deck. The only inline <script> allowed is the ≤10-line mobile-nav a11y shim when the stock hamburger pattern is applied."
+    },
+    {
+      "name": "content_preserved",
+      "max_score": 10,
+      "description": "Content from current/pages/home.json is preserved: hero headline, body copy, CTA labels, navigation labels, link destinations. The redesign restyles, it does not rewrite."
+    },
+    {
+      "name": "delegates_to_craft",
+      "max_score": 5,
+      "description": "The agent invoked $impeccable craft (or its equivalent flow) to perform the creative rendering, rather than inventing the design from scratch in stardust."
+    },
+    {
+      "name": "browser_opened",
+      "max_score": 5,
+      "description": "home-proposed.html was opened in the default browser via open / xdg-open / start. Skipped only in pipeline-automation mode."
+    },
+    {
+      "name": "approval_chat_only",
+      "max_score": 5,
+      "description": "Approval is documented as chat-only ('approve <slug>' or 'approve'). The agent does not reference a viewer button or postMessage mechanism."
+    },
+    {
+      "name": "state_prototyped_not_approved",
+      "max_score": 7,
+      "description": "state.json marks home as 'prototyped' with prototypePath pointing at stardust/prototypes/home-proposed.html. Approval is a separate explicit step the user takes; the agent did not auto-approve."
+    },
+    {
+      "name": "no_eds_references",
+      "max_score": 3,
+      "description": "No mention of EDS, AEM, framework targets, or production CMS output in either file or in narration."
+    }
   ]
 }

--- a/plugins/stardust/evals/replica-source-fidelity/criteria.json
+++ b/plugins/stardust/evals/replica-source-fidelity/criteria.json
@@ -1,15 +1,56 @@
 {
-  "criteria": [
-    { "id": "extract_prep_unmodified", "weight": 10, "description": "stardust:extract --prep runs unchanged and produces the standard stardust/current/ artifacts (pages/*.json, screenshots, brand extraction, descriptive PRODUCT/DESIGN specs); no extract file or behavior is modified." },
-    { "id": "mechanical_promotion_no_direct", "weight": 15, "description": "The target spec at the project root is a verbatim promotion of stardust/current/{PRODUCT,DESIGN}.{md,json}; stardust/direction.md records preserve mode; stardust:direct is never invoked and no divergence/palette/type re-selection occurs." },
-    { "id": "inconsistency_register", "weight": 10, "description": "stardust/replica/inconsistency-register.md exists; it is empty when no findings are supplied, and any entry carries captured evidence, the minimal change, and a status (applied/deferred). No design delta appears in the prototype without a register entry." },
-    { "id": "clean_reauthoring", "weight": 15, "description": "Archetype prototypes are clean re-authored HTML/CSS: semantic structure, tokenized CSS with values traceable to the source site's own stylesheets, no copied DOM/class-soup/framework artifacts, content verbatim from the captured page JSON." },
-    { "id": "source_fidelity_gate_runs", "weight": 20, "description": "The source-fidelity gate runs all three probes (content-diff and visual-diff with --profile generic against the live URL, plus stitch-shot + pixel-compare) and its evidence (per-iteration metrics, band breakdown, height delta, diff images) is written under stardust/replica/." },
-    { "id": "both_breakpoints_gated", "weight": 10, "description": "The gate runs at both 1440 and 360; mobile results are recorded, not assumed from desktop." },
-    { "id": "iteration_discipline", "weight": 5, "description": "At most 3 measured iterations per breakpoint; unresolved deltas are logged as residuals rather than silently accepted or endlessly iterated." },
-    { "id": "font_policy", "weight": 5, "description": "Fonts are loaded from the same public source or substituted with a metric-matched free face; no commercial/licensed kit is rehosted; the brand family stays first in the font stack." },
-    { "id": "standard_handoff", "weight": 5, "description": "Archetypes land at stardust/prototypes/<slug>-proposed.html and page lifecycle lives in core state.json, so migrate/deploy/rollout consume them without modification." },
-    { "id": "provenance", "weight": 5, "description": "Captured artifacts carry live-render provenance; no synthesized content or invented sections appear anywhere in the recreation." }
-  ],
-  "total": 100
+  "context": "Entry point (replica): tests the mechanical preserve direction (no direct), the inconsistency register, clean re-authoring, the measured source-fidelity gate at both breakpoints, and the standard handoff.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "extract_prep_unmodified",
+      "max_score": 10,
+      "description": "stardust:extract --prep runs unchanged and produces the standard stardust/current/ artifacts (pages/*.json, screenshots, brand extraction, descriptive PRODUCT/DESIGN specs); no extract file or behavior is modified."
+    },
+    {
+      "name": "mechanical_promotion_no_direct",
+      "max_score": 15,
+      "description": "The target spec at the project root is a verbatim promotion of stardust/current/{PRODUCT,DESIGN}.{md,json}; stardust/direction.md records preserve mode; stardust:direct is never invoked and no divergence/palette/type re-selection occurs."
+    },
+    {
+      "name": "inconsistency_register",
+      "max_score": 10,
+      "description": "stardust/replica/inconsistency-register.md exists; it is empty when no findings are supplied, and any entry carries captured evidence, the minimal change, and a status (applied/deferred). No design delta appears in the prototype without a register entry."
+    },
+    {
+      "name": "clean_reauthoring",
+      "max_score": 15,
+      "description": "Archetype prototypes are clean re-authored HTML/CSS: semantic structure, tokenized CSS with values traceable to the source site's own stylesheets, no copied DOM/class-soup/framework artifacts, content verbatim from the captured page JSON."
+    },
+    {
+      "name": "source_fidelity_gate_runs",
+      "max_score": 20,
+      "description": "The source-fidelity gate runs all three probes (content-diff and visual-diff with --profile generic against the live URL, plus stitch-shot + pixel-compare) and its evidence (per-iteration metrics, band breakdown, height delta, diff images) is written under stardust/replica/."
+    },
+    {
+      "name": "both_breakpoints_gated",
+      "max_score": 10,
+      "description": "The gate runs at both 1440 and 360; mobile results are recorded, not assumed from desktop."
+    },
+    {
+      "name": "iteration_discipline",
+      "max_score": 5,
+      "description": "At most 3 measured iterations per breakpoint; unresolved deltas are logged as residuals rather than silently accepted or endlessly iterated."
+    },
+    {
+      "name": "font_policy",
+      "max_score": 5,
+      "description": "Fonts are loaded from the same public source or substituted with a metric-matched free face; no commercial/licensed kit is rehosted; the brand family stays first in the font stack."
+    },
+    {
+      "name": "standard_handoff",
+      "max_score": 5,
+      "description": "Archetypes land at stardust/prototypes/<slug>-proposed.html and page lifecycle lives in core state.json, so migrate/deploy/rollout consume them without modification."
+    },
+    {
+      "name": "provenance",
+      "max_score": 5,
+      "description": "Captured artifacts carry live-render provenance; no synthesized content or invented sections appear anywhere in the recreation."
+    }
+  ]
 }

--- a/plugins/stardust/evals/reskin-content-fidelity/criteria.json
+++ b/plugins/stardust/evals/reskin-content-fidelity/criteria.json
@@ -1,15 +1,56 @@
 {
-  "criteria": [
-    { "id": "donor_ingestion_design_source", "weight": 10, "description": "The donor is captured via stardust:extract --design-source into stardust/canon-source/ without modifying extract; multi-design-system donors get one pinned reference page per module family, recorded in the reskin artifacts." },
-    { "id": "content_model_capture", "weight": 15, "description": "stardust/reskin/content-model/<slug>.json exists with slot-granular text, CTAs with absolute hrefs, ordered visible images, and full SEO metadata; it declares the content-root scope and the executable normalization ledger used at capture time." },
-    { "id": "scope_coverage_guard", "weight": 10, "description": "The content-root scope is validated with the coverage diagnostic (body-vs-scope ratio / h1-in-scope); no whole section of the source page is silently absent from the model." },
-    { "id": "mapping_brief_contract", "weight": 15, "description": "stardust/reskin/mapping.md maps every content slot to a donor module with rationale and status (mapped/new-module/chrome); at least 80% of slots are mapped; new modules are explicitly composed from donor tokens; no silent improvisation." },
-    { "id": "programmatic_render", "weight": 10, "description": "The reskin page is generated from content-model.json by a renderer that interpolates model strings; no content string in the output was hand-retyped or paraphrased." },
-    { "id": "content_gate_passes", "weight": 15, "description": "dom-equality (text bytes + ordered image set, structure informational, shared normalization at both ends) and slot-coverage (every slot present, metadata verbatim) run and pass, with results recorded; any delta is a documented chrome swap or ledger normalization." },
-    { "id": "design_adoption_gate", "weight": 10, "description": "donor-probe token assertions run against the rendered page and pass (selector-missing treated as FAIL, token-missing as SKIP); overflow sanity holds at 1440 and 360." },
-    { "id": "iteration_discipline", "weight": 5, "description": "At most one fix iteration after measurement; remaining deltas land in the residual ledger rather than silently accepted." },
-    { "id": "standard_handoff_no_core_changes", "weight": 5, "description": "Scale/delivery is handed to migrate (donor-pinned, sibling tier) / deploy / rollout unchanged; reskin state stays under stardust/reskin/; no existing skill or the core state machine is modified." },
-    { "id": "provenance", "weight": 5, "description": "Content and donor captures carry live-render provenance; no invented sections, placeholder text, or synthesized facts appear in the reskin." }
-  ],
-  "total": 100
+  "context": "Entry point (reskin): tests a donor via --design-source, content-model capture with a scope guard, the mapping-brief contract (at least 80% mapped), programmatic render, and the dual content/design-adoption gates.",
+  "type": "weighted_checklist",
+  "checklist": [
+    {
+      "name": "donor_ingestion_design_source",
+      "max_score": 10,
+      "description": "The donor is captured via stardust:extract --design-source into stardust/canon-source/ without modifying extract; multi-design-system donors get one pinned reference page per module family, recorded in the reskin artifacts."
+    },
+    {
+      "name": "content_model_capture",
+      "max_score": 15,
+      "description": "stardust/reskin/content-model/<slug>.json exists with slot-granular text, CTAs with absolute hrefs, ordered visible images, and full SEO metadata; it declares the content-root scope and the executable normalization ledger used at capture time."
+    },
+    {
+      "name": "scope_coverage_guard",
+      "max_score": 10,
+      "description": "The content-root scope is validated with the coverage diagnostic (body-vs-scope ratio / h1-in-scope); no whole section of the source page is silently absent from the model."
+    },
+    {
+      "name": "mapping_brief_contract",
+      "max_score": 15,
+      "description": "stardust/reskin/mapping.md maps every content slot to a donor module with rationale and status (mapped/new-module/chrome); at least 80% of slots are mapped; new modules are explicitly composed from donor tokens; no silent improvisation."
+    },
+    {
+      "name": "programmatic_render",
+      "max_score": 10,
+      "description": "The reskin page is generated from content-model.json by a renderer that interpolates model strings; no content string in the output was hand-retyped or paraphrased."
+    },
+    {
+      "name": "content_gate_passes",
+      "max_score": 15,
+      "description": "dom-equality (text bytes + ordered image set, structure informational, shared normalization at both ends) and slot-coverage (every slot present, metadata verbatim) run and pass, with results recorded; any delta is a documented chrome swap or ledger normalization."
+    },
+    {
+      "name": "design_adoption_gate",
+      "max_score": 10,
+      "description": "donor-probe token assertions run against the rendered page and pass (selector-missing treated as FAIL, token-missing as SKIP); overflow sanity holds at 1440 and 360."
+    },
+    {
+      "name": "iteration_discipline",
+      "max_score": 5,
+      "description": "At most one fix iteration after measurement; remaining deltas land in the residual ledger rather than silently accepted."
+    },
+    {
+      "name": "standard_handoff_no_core_changes",
+      "max_score": 5,
+      "description": "Scale/delivery is handed to migrate (donor-pinned, sibling tier) / deploy / rollout unchanged; reskin state stays under stardust/reskin/; no existing skill or the core state machine is modified."
+    },
+    {
+      "name": "provenance",
+      "max_score": 5,
+      "description": "Content and donor captures carry live-render provenance; no invented sections, placeholder text, or synthesized facts appear in the reskin."
+    }
+  ]
 }


### PR DESCRIPTION
… schema

The Release Skills workflow's `tessl plugin publish` step began enforcing the new criteria.json schema between 2026-07-04 and 2026-07-07, failing the stardust plugin publish with:

  Invalid criteria.json (in migrate-self-contained-bundle):
    context: expected string, received undefined
    type:    expected "weighted_checklist"
    checklist: expected array, received undefined

Failed actions:
https://github.com/adobe/skills/actions/runs/28875097726/job/85647927305

All 9 stardust eval criteria.json still used the legacy {name, total, criteria:[{id, weight, description}]} shape. Convert them to the {context, type: "weighted_checklist", checklist:[{name, max_score, description}]} shape the other Adobe-skills plugins already use.

- id -> name (identifier preserved, lossless)
- weight -> max_score (sums to 100 per eval, unchanged)
- description kept verbatim
- context authored per eval from the README coverage table
- README Format/Running sections updated to describe the new shape

Item counts and weight sums verified unchanged for all 9 evals.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
