### PR TITLE
Remove .claude-plugin/ from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,5 @@ drafts/tmp/
 *.skill
 dist/
 
-# Claude plugin config
-.claude-plugin/
-
 # OMC state
 .omc/


### PR DESCRIPTION
## Summary

Removes `.claude-plugin/` from `.gitignore`. This pattern (no leading/middle slash) matches at any directory depth, not just the repo root, so it also matches every plugin's `plugins/*/**/.claude-plugin/plugin.json` — the actual manifest file each plugin needs.

## Why

The rule was added incidentally in #212 ("refactor(ops): improve ops skill documentation...", bundled into an unrelated docs refactor with no explanation). Every existing plugin category (`adobe-analytics`, `aem/*`, `app-builder`, `stardust`, `web`, etc.) already has its `.claude-plugin/plugin.json` tracked in git — that only works because those files were committed before this rule existed. For any newly added plugin, `git add .` silently drops this file from the commit with no error, since it's both untracked and gitignored, leaving the plugin missing its manifest with no visible failure.

Found while promoting Commerce plugins from `adobe/aio-commerce-sdk` for the first time (see PR #275) — the automation's `git add .` step silently excluded `.claude-plugin/plugin.json` for both new plugins.

## Testing

Confirmed locally that `git check-ignore -v plugins/commerce/app-management/.claude-plugin/plugin.json` no longer matches after this change.