### PR TITLE
feat(migration): full-coverage migration runbook with BPA wiring

### DIFF
--- a/plugins/aem/cloud-service/skills/code-assessment/references/git-workflow.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/references/git-workflow.md
@@ -106,7 +106,7 @@ The skill writes a single JSON record to `.autofix/last-run.json` at the working
   "abort_reason": "<string, only present when status=aborted>",
   "pattern": "outdated-dependencies",
   "edit_mode": "git | in_place",
-  "invocation": "with_findings | discover",
+  "invocation": "with_findings | with_findings_preresolved | discover",
   "base_branch": "main",
   "base_sha": "<7-char short hash, null when in_place>",
   "branch": "autofix/outdated-dependencies/2026-04-21-a1b2c3d",
@@ -165,13 +165,13 @@ The skill writes a single JSON record to `.autofix/last-run.json` at the working
 - **`discovery_warnings[]`** — strings from Step 3 discover-time checks (e.g. duplicate pom locator). Mirror the **Discover warnings** section of the Step 7 report template in `runbook.md`.
 - **`pattern`** — the expert skill (pattern slug) fixed this session.
 - **`edit_mode`** — `git` or `in_place` for the whole run.
-- **`invocation`** — `with_findings` (paths/coordinates supplied by the user) or `discover` (repo scan).
+- **`invocation`** — `with_findings` (paths/coordinates supplied by the user), `with_findings_preresolved` (an upstream caller supplied a complete `{pattern, file, line, snippet}` finding list; see [`runbook.md`](runbook.md) "with_findings (pre-resolved)"), or `discover` (repo scan).
 - **`branch`** — `null` when `edit_mode=in_place`, or `status=aborted` before branch creation.
 - **`base_branch` / `base_sha`** — `null` when `edit_mode=in_place`.
 - **`compile.baseline`** — `skipped` only when `status=aborted` before reaching baseline (e.g. unsupported pattern, user declined) or when no Maven project is present.
 - **`compile.verification`** — `skipped` when `status=aborted` (no edits applied) or when zero findings were applicable.
 - **`applied[].finding`** — human-readable identifier for the finding. For `outdated-dependencies` use `<groupId>:<artifactId>@<currentVersion> -> <targetVersion>`. For `inject-in-sling-model` use the file path.
-- **`skipped[].reason`** — must be one of the exact strings the active expert skill defines under "Unlocatable" (`literal-not-found: …`, `property-missing: …`, `inject-ambiguous-field: …`, `ambiguous-locator: …`, `discovery-no-match: …`). No free-form text.
+- **`skipped[].reason`** — must be one of the exact strings the active expert skill defines under "Unlocatable" (`literal-not-found: …`, `property-missing: …`, `inject-ambiguous-field: …`, `ambiguous-locator: …`, `discovery-no-match: …`), or `stale-finding: snippet at <file>:<line> no longer matches — re-scan recommended` for `with_findings_preresolved` runs where a cached finding's `(file, line)` no longer matches the live file. No free-form text.
 - **`deferred[]`** — patterns found but **not fixed this session**. Two reason variants:
   - `not-selected: user chose <other-pattern>` — the user picked a different pattern this session (one-pattern-per-session rule).
   - `no-recipe: no expert skill at ../<pattern-slug>/` — the issue has no expert skill yet.

--- a/plugins/aem/cloud-service/skills/code-assessment/references/runbook.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/references/runbook.md
@@ -9,6 +9,7 @@ For design *why*, see [`shared-principles.md`](shared-principles.md). For git br
 | Mode | How it starts | Findings `files[]` | Target versions (deps) |
 |---|---|---|---|
 | **with_findings** | User named paths or coordinates | Provided — use only these paths | User-supplied target versions before planning. |
+| **with_findings (pre-resolved)** | An upstream caller already supplies a finding list in the canonical `{pattern, file, line, snippet}` shape | Provided directly — see **Step 3, with_findings (pre-resolved)** below | Same as with_findings — ask if missing |
 | **discover** | User asks to scan/fix project without a file list | Empty — run **Discovery** in the active expert skill's `SKILL.md` + recipe under `../<pattern-name>/` (e.g. `../inject-in-sling-model/`, `../outdated-dependencies/`) inside workspace roots | Ask user for coordinates + target versions before building dep plans |
 
 ## Git vs in-place
@@ -59,6 +60,13 @@ Read the chosen expert skill's `SKILL.md` in full, then its `recipe.md` / `path-
 
 **with_findings:** Build the work list from user-named paths/coordinates. For outdated dependencies, merge user-supplied fields with local pom inspection for `shape` / `propertyName`. For Sling Model inject migration, use the resolved Java paths only.
 Pass the named paths to the analyzer with `--files a.java,b.java` so detection runs only on them.
+
+**with_findings (pre-resolved):** When an upstream caller already supplies findings in the canonical `{pattern, file, line, snippet}` shape:
+
+- If a finding already has `line` **and** `snippet` populated, **do not** invoke `analyze.sh` for it — treat the supplied array exactly as if it were the analyzer's `findings[]` output and proceed directly to **Discover-time checks** and Step 6.
+- If a finding has `file` but `line`/`snippet` are `null`, run `analyze.sh --files <paths>` once over the named files to resolve `line`/`snippet` before building the plan.
+- If a finding is tagged `"confidence": "heuristic"`, it is a candidate match (e.g. from a regex or config scan, not the analyzer), **not** analyzer-validated — re-confirm each against the matching pattern reference before editing, and call this out in the plan/report so the user knows these are proactive-discovery matches. A heuristic finding may also deliberately omit detail (e.g. a key name only, no value); never assume it is complete.
+- **Re-validate `(file, line)` against the live file when building the plan regardless of source.** If the snippet at that location no longer matches (the workspace changed since the findings were produced), record it as `skipped` with reason `stale-finding: snippet at <file>:<line> no longer matches — re-scan recommended` (see [`git-workflow.md`](git-workflow.md) for the full skip-reason vocabulary) rather than guessing or silently re-locating it.
 
 **discover:** Run the analyzer — it is the detection engine:
 

--- a/plugins/aem/cloud-service/skills/migration/SKILL.md
+++ b/plugins/aem/cloud-service/skills/migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: migration
-description: Migrates legacy AEM (6.x, AMS, on-prem) to AEM as a Cloud Service using BPA CSV or cache, CAM/MCP target discovery, and a one-pattern-per-session workflow. Use for BPA/CAM findings, Cloud Service blockers, or fixes for scheduler, ResourceChangeListener, replication, EventListener, OSGi EventHandler, DAM AssetManager, HTL data-sly-test lint, Classic UI dialog migration (lui — ExtJS/Coral 2 → Coral 3), and Custom Design Widgets (cdw). OSGi configs → Cloud Manager — scan ui.config, .cfg.json, secrets, $[secret:]/$[env:] — agent follows references/osgi-cfg-json-cloud-manager.md when prompted. After BPA/CAM discovery, migration hands off each (pattern, file) pair to the code-assessment skill for scheduler/resource-change-listener/replication/event-migration/asset-manager guides and shared SCR→DS/ResourceResolver/HTL-lint references. Template modernization runs a per-template context → execute → validate pipeline. Legacy UI migration (dialog and CDW) follows references/legacy-ui/ modules.
+description: Migrates legacy AEM (6.x, AMS, on-prem) to AEM as a Cloud Service using BPA CSV/cache, CAM/MCP discovery, and a one-pattern-per-session workflow. Use to review/scan a project for AEMaaCS migration (generates a read-only migration-runbook.md covering all patterns via per-pattern detection strategies), for BPA/CAM findings, Cloud Service blockers, or fixes for scheduler, ResourceChangeListener, replication, EventListener, OSGi EventHandler, DAM AssetManager, HTL data-sly-test lint, Classic UI dialog migration (lui — ExtJS/Coral 2 → Coral 3), Custom Design Widgets (cdw), and static→editable template modernization. OSGi configs → Cloud Manager — scan ui.config/.cfg.json for secrets and $[secret:]/$[env:] placeholders. After discovery, migration hands off each (pattern, file) pair to the code-assessment skill for the pattern guides and shared references; template modernization and legacy UI (dialog/CDW) follow references/ modules.
 license: Apache-2.0
 ---
 
@@ -18,6 +18,7 @@ This skill drives the **migration workflow**: BPA data, CAM/MCP, **one pattern p
 
 | You have… | Say something like… | What happens |
 |-----------|---------------------|--------------|
+| **A whole project to assess** | *"Review my code for AEMaaCS migration"* | Generates read-only `migration-runbook.md` — **all** migration patterns (Java cascade + `htlLint` + `osgiConfig`), affected files, sample prompts. **No edits.** |
 | A **BPA CSV** | *"Fix **scheduler** findings using `./path/to/bpa.csv`"* | Fastest path: CSV → cached collection → files |
 | **CAM + MCP** only | *"Get **scheduler** findings from CAM; I'll pick the project when you list them."* | Agent lists projects → you confirm → MCP fetch ([cam-mcp.md](references/cam-mcp.md)) |
 | **Just a few files** | *"Migrate **scheduler** in `core/.../MyJob.java`"* | Manual flow: no BPA required |
@@ -29,6 +30,7 @@ This skill drives the **migration workflow**: BPA data, CAM/MCP, **one pattern p
 
 **Starter prompts (copy-paste):**
 
+- *"Review my code for AEMaaCS migration"* — **start here** for a full runbook before changing anything.
 - *"Use the migration skill: **scheduler** only, BPA CSV at `./reports/bpa.csv`, then apply the code-assessment pattern guide before editing."*
 - *"**Replication** only from CAM; list projects first, I'll pick one."*
 - *"**Manual:** **event listener** migration for `.../Listener.java` — read the code-assessment pattern guide first."*
@@ -231,6 +233,64 @@ Do **not** duplicate the pattern table here. Use **`{code-assessment}/SKILL.md` 
 
 ## Workflow
 
+### Step 0: Migration runbook (review / scan entry point)
+
+When the user opens with a **broad review/scan** request — *"review my code for AEMaaCS migration"*, *"scan my project for AEM migration"*, or similar — and does **not** name a single pattern, generate a **read-only migration runbook** before any apply work.
+
+The runbook covers **every pattern the migration skill can address**. Each pattern declares a **detection strategy** — CSV-eligible patterns run the priority cascade; the others keep their existing discovery behaviour:
+
+| Pattern(s) | Strategy | How it's detected |
+|---|---|---|
+| `scheduler`, `resourceChangeListener`, `event-migration`, `assetApi` | `cascade` | BPA/CAM → CSV → analyzer → LLM scan (priority list) |
+| `replication` | `cascade` | analyzer → LLM scan (no BPA/CSV subtype mapping) |
+| `htlLint` | `html-scan` | heuristic regex scan of `.html` (pure Node — no `rg` binary needed) |
+| `osgiConfig` | `config-scan` | heuristic scan of OSGi config files for secret-looking keys / `$[secret:]`/`$[env:]` placeholders — **key names + locations only, never secret values** |
+| `lui`, `cdw`, `templateModernization` | BPA `cascade` → `content-scan` fallback | When a BPA CSV/CAM source is present, these come from BPA (subtypes `custom.classic.widget`; `legacy.dialog.classic`/`.coral2`; `legacy.static.template` + `custom.static.template`). With no BPA source, a heuristic `.content.xml` scan is the fallback. Sample prompts route to **Branch D** (legacy-ui) / **Branch C** (templates), not code-assessment |
+
+`htlLint`, `osgiConfig`, and the content-scan **fallback** for `lui`/`cdw`/`templateModernization` are **heuristic** (tagged `confidence: heuristic` in the cache) — candidate matches, not compiler-validated. BPA-sourced `lui`/`cdw`/`templateModernization`/`replication` findings are authoritative. Out of scope: `inject-in-sling-model` and `outdated-dependencies` (those belong to code-assessment's own runbook, not migration).
+
+**BPA is the source of truth when a report is available.** `lui`/`cdw`/`templateModernization`/`replication` are read from the BPA CSV/CAM (the parser now extracts these subtypes and excludes `_COUNT_*`/`_STAT` summary rows), so the runbook counts match your BPA report's LUI-dialog / CDW / static-template / REP tallies. `lui` keeps only the dialog sub-types (`legacy.custom.component` → create-component; `legacy.static.template` is counted under `templateModernization`). The `.content.xml` scan is only the fallback when no BPA source is present — and it can **undercount** relative to BPA when the flagged legacy nodes live in packages (e.g. acs-commons) not in the project source. `replication`: BPA `replication.agent` findings when a report is present, else the analyzer detects `Replicator` usage from source.
+
+The script handles every deterministic strategy (`cascade` tiers 1–3, `html-scan`, `config-scan`); the agent handles only the LLM-scan tier for `cascade` patterns nothing else could scan.
+
+```javascript
+const { generateRunbook, renderRunbook, writeRunbookCache } = require('./scripts/runbook-generator.js');
+
+const result = await generateRunbook({
+  workspaceRoot: '<IDE workspace root>',     // analyzer + html-scan + config-scan
+  bpaFilePath: '<csv path or undefined>',     // cascade tier 2
+  collectionsDir: './unified-collections',
+  projectId, mcpFetcher,                      // cascade tier 1 (MCP), when configured
+  outputPath: './migration-runbook.md',
+});
+// result.needsLlmScan → cascade patterns no deterministic source could scan
+```
+
+**Tier 4 — LLM scan (last resort).** If `result.needsLlmScan` is non-empty (no BPA source **and** the analyzer could not run — e.g. no JDK), the agent scans those patterns itself: read each pattern guide's detection hints under `{code-assessment}/<pattern>/`, locate matches **inside the IDE workspace** (see **Workspace scope**). For **each** pattern the agent scans, update `result.gathered` so the re-render and cache stay consistent:
+
+- Build display findings in the `{ location, detail, severity }` shape and assign them to `result.gathered.findingsByPattern[<pattern>]`.
+- Build raw findings in the canonical `{ pattern, file, line, snippet }` shape and assign them to `result.gathered.rawFindingsByPattern[<pattern>]` (use `null` for `line`/`snippet` when a match can't be pinned to a line).
+- Set `result.gathered.sourceByPattern[<pattern>] = 'llm'`.
+- Remove the pattern from `result.gathered.needsLlmScan` (otherwise the re-render still shows it as _needs LLM scan_ **and** a findings table).
+
+Then re-render with `renderRunbook(result.gathered, ctx)`, overwrite the runbook file, and call `writeRunbookCache(result.gathered, ctx, result.cachePath)` so the sidecar cache reflects the merged findings.
+
+After writing the runbook, tell the user:
+
+> "I've written `migration-runbook.md` — **{totalFindings} findings** across **{N} patterns** (detected via {sources}). It's read-only. Reply with the pattern you want to migrate first (e.g. `scheduler`) and I'll reuse the findings already discovered for that pattern — no re-scan needed — and run the one-pattern-per-session apply workflow."
+
+`generateRunbook()` also writes a sidecar findings cache (default `./migration-runbook.json`, see `result.cachePath`) alongside the markdown, holding each pattern's raw findings and their source. **Step 3** below reads this cache first before falling back to a live BPA/analyzer/scan lookup.
+
+**Skip Step 0** when the user names a **specific pattern** up front (e.g. *"fix scheduler findings"*, *"fix htlLint in ui.apps"*, *"scan my config files for Cloud Manager secrets"*) — go straight to the relevant apply flow. Step 0 is only for a **broad review/scan** request with no single pattern named.
+
+**CLI (development):**
+
+```bash
+node scripts/runbook-generator.js <workspaceRoot> [--csv ./reports/bpa.csv] [--out ./migration-runbook.md]
+```
+
+---
+
 ### One pattern per session
 
 If the user asks to fix everything or BPA mixes patterns, **ask which pattern first**. Prefer one commit per pattern session.
@@ -251,7 +311,38 @@ If the id is missing from the code-assessment catalog ([`{code-assessment}/refer
 
 ### Step 3: Targets
 
-**For BPA patterns** (`scheduler`, `resourceChangeListener`, `replication`, `eventListener`, `eventHandler`, `assetApi`, `lui`, `cdw`): Run **`getBpaFindings`** (with `bpaFilePath` when provided). Internally: cache → CSV → MCP → manual **only when each step is applicable and succeeds**; if MCP fails, obey **MCP errors and fallback** (stop; no silent chain). For MCP details, [references/cam-mcp.md](references/cam-mcp.md).
+**Check for a cached runbook first.** If `./migration-runbook.json` (or the path passed to
+`generateRunbook`'s `cachePath` option) exists and its `findingsByPattern[<active pattern>]` array
+is non-empty, reuse it instead of re-deriving findings:
+
+- Load `{ generatedAt, workspaceRoot, sourceByPattern, findingsByPattern }` from the cache file.
+- Take `allFindings = findingsByPattern[<active pattern>]`. Each entry is
+  `{ pattern, file, line, snippet }` — `file` is **relative to the cache's `workspaceRoot`**
+  (resolve with `path.join(workspaceRoot, file)`); `line`/`snippet` are `null` when the pattern's
+  source was `mcp`/`csv` (BPA-sourced findings never carry line/snippet; only the `analyzer`,
+  `html-scan`, and `config-scan` sources do). `osgiConfig` findings additionally carry a `kind`
+  and, for `already-placeholdered` rows, `informational: true` — skip those when building the fix
+  work list.
+- Slice the batch with the same paginate helper used elsewhere in this file:
+  ```javascript
+  const { paginate } = require('./scripts/unified-collection-reader.js');
+  const { targets, paging } = paginate(allFindings, { offset, limit: 5 });
+  ```
+  This keeps the exact same `{ targets, paging }` envelope, batch-of-5 default, and
+  `paging.nextOffset` semantics as the live `getBpaFindings` path below — only the data source
+  differs. Do not bypass the batch-of-5 discipline just because the whole array is already in
+  memory.
+- Tell the user: *"Reusing N findings for `<pattern>` from the existing runbook (generated at
+  `<generatedAt>`)."*
+- Hand the batch to code-assessment as a **`with_findings (pre-resolved)`** invocation (see
+  `{code-assessment}/references/runbook.md`). Findings with `line`/`snippet` already populated skip
+  the analyzer re-run entirely; findings with only `file` populated (BPA-sourced) still trigger one
+  `analyze.sh --files <paths>` call inside code-assessment to resolve `line`/`snippet` before the
+  edit plan is built.
+- If the cache is missing, has no entries for the active pattern, or the user explicitly says
+  "re-scan" / "refresh", fall through to the live flow below unchanged.
+
+**For BPA patterns** (`scheduler`, `resourceChangeListener`, `replication`, `eventListener`, `eventHandler`, `assetApi`, `lui`, `cdw`) **when no usable cache exists**: Run **`getBpaFindings`** (with `bpaFilePath` when provided). Internally: cache → CSV → MCP → manual **only when each step is applicable and succeeds**; if MCP fails, obey **MCP errors and fallback** (stop; no silent chain). For MCP details, [references/cam-mcp.md](references/cam-mcp.md).
 
 For `lui` findings, the `identifier` in each target is the **JCR component path** (e.g. `/apps/myapp/components/content/mycomp`) — not a Java class name. Resolve it to the filesystem path using the [JCR → filesystem mapping](references/legacy-ui/dialog/context.md#jcr-path--filesystem-path) before opening files. **Note:** `luiCoral2` is not a standalone BPA pattern id — Coral 2 dialogs appear as the `legacy.dialog.coral2` sub-type within `lui` results. Do not call `getBpaFindings('luiCoral2', …)` independently; call `getBpaFindings('lui', …)` and filter by sub-type inside Branch D.
 
@@ -259,7 +350,17 @@ For `lui` findings, the `identifier` in each target is the **JCR component path*
 envelope. The agent processes that batch only; it does **not** request the next batch until
 the user says to continue. See **Batched processing (batch size 5)** below.
 
-**For `htlLint`**: Skip BPA/CSV/MCP — targets come from proactive `rg` discovery. See **htlLint flow** below.
+**For `htlLint`**: Skip BPA/CSV/MCP. If a cached runbook entry already has `htlLint` findings
+(they carry `"confidence": "heuristic"` — regex matches, not compiler-validated), reuse them per
+the cache-first rule above, but **re-open and re-confirm each hit** against the patterns in
+`{code-assessment}/references/data-sly-test-redundant-constant.md` before editing. If there is no
+cache, targets come from proactive `rg` discovery. See **htlLint flow** below.
+
+**For `osgiConfig`** (OSGi → Cloud Manager): the cache holds heuristic, review-only findings
+(`"confidence": "heuristic"`, key names + locations only — **no secret values**). Use them as a
+starting checklist, then follow **Branch A** and [references/osgi-cfg-json-cloud-manager.md](references/osgi-cfg-json-cloud-manager.md)
+to classify each value (real secret? Adobe-owned PID → `needs_user_review`) — never trust the
+heuristic `plaintext-secret` label without confirming.
 
 ### Step 4: Read before edits
 

--- a/plugins/aem/cloud-service/skills/migration/scripts/README.md
+++ b/plugins/aem/cloud-service/skills/migration/scripts/README.md
@@ -28,6 +28,64 @@ Collection already exists?              No CSV path given
 
 ## Scripts
 
+### `runbook-generator.js` (review / scan entry point)
+
+Generates a read-only `migration-runbook.md` covering **every pattern the migration skill can address**. Triggered by broad prompts like "review my code for AEMaaCS migration".
+
+Each pattern declares a **detection strategy** in `PATTERN_META`:
+
+| Pattern(s) | `strategy` | Engine |
+|---|---|---|
+| `scheduler`, `resourceChangeListener`, `event-migration`, `assetApi` | `cascade` | BPA/CAM → CSV → analyzer → LLM scan |
+| `replication` | `cascade` | BPA/CAM → CSV (`replication.agent`) → analyzer → LLM scan |
+| `htlLint` | `html-scan` | `htl-lint-runner.js` (pure-Node regex over `.html`) |
+| `osgiConfig` | `config-scan` | `osgi-config-runner.js` (config-file scan) |
+| `lui`, `cdw`, `templateModernization` | BPA + `content-scan` | BPA/CAM → CSV first (`legacy-ui-runner.js` / `template-scan-runner.js` as fallback) |
+
+`html-scan` / `config-scan` findings, and the `content-scan` fallback for `lui`/`cdw`/`templateModernization`, are **heuristic** and tagged `confidence: "heuristic"` in the cache. BPA-sourced findings are authoritative. `osgiConfig` reports key names + locations only — **never secret values**.
+
+```javascript
+const { generateRunbook, renderRunbook } = require('./scripts/runbook-generator.js');
+
+const result = await generateRunbook({
+  workspaceRoot: '/path/to/project',         // analyzer tier
+  bpaFilePath: './reports/bpa.csv',          // optional (CSV tier)
+  collectionsDir: './unified-collections',   // default
+  projectId, mcpFetcher,                     // optional (MCP tier)
+  outputPath: './migration-runbook.md',      // default
+});
+
+// result.totalFindings → total across patterns
+// result.patternCounts → { scheduler: 12, replication: 1, … }
+// result.needsLlmScan  → patterns no deterministic source could scan (tier 4)
+// result.gathered      → { findingsByPattern, sourceByPattern, … } for re-render after an LLM scan
+```
+
+**CLI:**
+```bash
+node scripts/runbook-generator.js <workspaceRoot> [--csv <bpaFilePath>] [--out <outputPath>]
+```
+
+### `analyzer-runner.js`
+
+Wraps the code-assessment deterministic analyzer (`../../code-assessment/scripts/analyze.sh`). Runs it once over a workspace, parses the `{ findings, warnings }` JSON, and normalizes analyzer slugs (`resource-change-listener`, `event-migration`, `asset-manager`, …) into the migration canonical pattern ids. Used internally by `runbook-generator.js` for `cascade` patterns. Returns `{ ok: false }` when the analyzer can't run (missing script, no JDK, compile error) so the cascade falls through to the LLM-scan tier.
+
+### `htl-lint-runner.js`
+
+The `html-scan` strategy for `htlLint`. Pure-Node fs walk + regex over `.html` files detecting `data-sly-test` redundant-constant anti-patterns (`== true`, `/apps/…` string, split `${} || ${}`, numeric literals) — mirrors the `rg` discovery in `{code-assessment}/references/data-sly-test-redundant-constant.md`, but with **no external `rg` dependency** so it runs anywhere Node does. Heuristic (a regex is not the HTL compiler); findings are re-confirmed before editing.
+
+### `osgi-config-runner.js`
+
+The `config-scan` strategy for `osgiConfig`. Scans OSGi config files (`.cfg.json`, legacy `.cfg`/`.config`) under `config*` folders for secret-looking keys and `$[secret:]`/`$[env:]` placeholders, per `{migration}/references/osgi-cfg-json-cloud-manager.md`. **Reports key names + locations only — never secret values** (the runbook is written to disk / often committed). Heuristic and review-only: classification (real secret? Adobe-owned PID?) is deferred to apply time.
+
+### `legacy-ui-runner.js`
+
+The `content-scan` **fallback** for `lui` (Classic UI `cq:Dialog`/`xtype="dialog"` and Coral 2 `granite/ui/components/foundation` dialogs) and `cdw` (custom `cq:Widget` xtypes not in the known-safe Coral 3 set). Pure-Node scan of `.content.xml` per `{migration}/references/legacy-ui/`. Used only when no BPA source is available; heuristic and can undercount vs BPA when legacy nodes live in packages (e.g. acs-commons) outside the project source.
+
+### `template-scan-runner.js`
+
+The `content-scan` **fallback** for `templateModernization` — static templates (`cq:Template`) under `apps/<appId>/templates/*`. Used only when no BPA source is available.
+
 ### `bpa-findings-helper.js` (main entry point)
 
 Orchestrates finding BPA data. Called by the skill internally.
@@ -113,3 +171,9 @@ Matches the cloud-adoption-service format with MongoDB-safe field names (dots �
 | eventListener | javax.jcr.observation.EventListener |
 | resourceChangeListener | org.apache.sling.api.resource.observation.ResourceChangeListener |
 | eventHandler | org.osgi.service.event.EventHandler |
+| cdw | custom.classic.widget |
+| lui | legacy.dialog.classic, legacy.dialog.coral2, legacy.custom.component, legacy.static.template |
+| templateModernization | legacy.static.template, custom.static.template |
+| replication | forward.replication, reverse.replication |
+
+Summary rows (`code` starting with `_`, e.g. `_COUNT_*`, `_STAT`) are excluded. Content/legacy-UI subtypes (cdw/lui/template/replication) are keyed by JCR node path (stored raw, not MongoDB-safed, so underscores like `design_dialog` survive).

--- a/plugins/aem/cloud-service/skills/migration/scripts/analyzer-runner.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/analyzer-runner.js
@@ -1,0 +1,127 @@
+/**
+ * Analyzer Runner
+ *
+ * Thin wrapper around the code-assessment deterministic analyzer
+ * (`code-assessment/scripts/analyze.sh`). Shells out once over a workspace,
+ * parses the `{ findings, warnings }` JSON, and normalizes the analyzer's
+ * pattern slugs into the migration skill's canonical pattern taxonomy.
+ *
+ * This is the "analyzer (local fallback)" tier of the runbook cascade — it can
+ * find every BPA-addressed pattern (including `replication`, which the BPA CSV
+ * parser cannot map) directly from source, with no BPA report or MCP needed.
+ */
+
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const { execFileSync } = require('child_process');
+
+// Default location of the code-assessment analyzer relative to this file:
+//   .../skills/migration/scripts/analyzer-runner.js
+//   .../skills/code-assessment/scripts/analyze.sh
+const DEFAULT_ANALYZE_SCRIPT = path.resolve(__dirname, '../../code-assessment/scripts/analyze.sh');
+
+// analyzer pattern slug → migration canonical pattern id.
+// event-migration covers both JCR EventListener and OSGi EventHandler, which the
+// migration apply flow routes to the same guide — so we keep them merged.
+const ANALYZER_TO_CANONICAL = {
+  'scheduler': 'scheduler',
+  'resource-change-listener': 'resourceChangeListener',
+  'event-migration': 'event-migration',
+  'replication': 'replication',
+  'asset-manager': 'assetApi',
+};
+
+/** Collapse a (possibly multi-line) code snippet into a single, table-safe cell. */
+function sanitizeSnippet(snippet, maxLen = 120) {
+  const oneLine = (snippet || '').replace(/\s+/g, ' ').trim();
+  return oneLine.length > maxLen ? `${oneLine.slice(0, maxLen - 1)}…` : oneLine;
+}
+
+/**
+ * Is the analyzer usable? Requires the analyze.sh script to exist on disk.
+ * (A missing JDK surfaces only at run time as a non-zero exit — handled in run().)
+ */
+function isAnalyzerAvailable(analyzeScript = DEFAULT_ANALYZE_SCRIPT) {
+  return fs.existsSync(analyzeScript);
+}
+
+/**
+ * Run the analyzer once over `workspaceRoot` and return normalized findings.
+ *
+ * @returns {{
+ *   ok: boolean,
+ *   findingsByPattern: Record<string, Array<{location: string, detail: string, severity: string}>>,
+ *   rawFindingsByPattern: Record<string, Array<{pattern: string, file: string, line: number, snippet: string}>>,
+ *   warnings: string[],
+ *   error?: string,
+ * }}
+ *   `findingsByPattern` is the display shape, keyed by canonical migration
+ *   pattern id, for rendering the runbook markdown. `rawFindingsByPattern`
+ *   preserves the analyzer's own `{pattern, file, line, snippet}` shape
+ *   verbatim (same keys) so the apply handoff can hand exact, re-locatable
+ *   findings to code-assessment without re-running the analyzer. `ok:false`
+ *   means the analyzer could not run (missing script, no JDK, compile/parse
+ *   failure) — the caller should treat the analyzer tier as unavailable.
+ */
+function runAnalyzer(workspaceRoot, options = {}) {
+  const { analyzeScript = DEFAULT_ANALYZE_SCRIPT } = options;
+
+  if (!isAnalyzerAvailable(analyzeScript)) {
+    return { ok: false, findingsByPattern: {}, rawFindingsByPattern: {}, warnings: [], error: `analyzer not found at ${analyzeScript}` };
+  }
+
+  let raw;
+  try {
+    raw = execFileSync('bash', [analyzeScript, workspaceRoot], {
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    // exit 3 (no JDK), 5 (compile error), etc. — analyzer tier unavailable.
+    const stderr = (err.stderr || '').toString().trim();
+    return {
+      ok: false,
+      findingsByPattern: {},
+      rawFindingsByPattern: {},
+      warnings: [],
+      error: stderr || `analyzer exited with code ${err.status}`,
+    };
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    return { ok: false, findingsByPattern: {}, rawFindingsByPattern: {}, warnings: [], error: `could not parse analyzer output: ${e.message}` };
+  }
+
+  const findingsByPattern = {};
+  const rawFindingsByPattern = {};
+  for (const f of parsed.findings || []) {
+    const canonical = ANALYZER_TO_CANONICAL[f.pattern];
+    if (!canonical) continue; // skip non-BPA patterns (inject-in-sling-model, outdated-dependencies, …)
+    (findingsByPattern[canonical] = findingsByPattern[canonical] || []).push({
+      location: f.line ? `${f.file}:${f.line}` : f.file,
+      detail: sanitizeSnippet(f.snippet),
+      severity: 'high',
+    });
+    (rawFindingsByPattern[canonical] = rawFindingsByPattern[canonical] || []).push({
+      pattern: f.pattern,
+      file: f.file,
+      line: f.line,
+      snippet: f.snippet,
+    });
+  }
+
+  return { ok: true, findingsByPattern, rawFindingsByPattern, warnings: parsed.warnings || [] };
+}
+
+module.exports = {
+  runAnalyzer,
+  isAnalyzerAvailable,
+  ANALYZER_TO_CANONICAL,
+  DEFAULT_ANALYZE_SCRIPT,
+};

--- a/plugins/aem/cloud-service/skills/migration/scripts/analyzer-runner.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/analyzer-runner.js
@@ -77,6 +77,10 @@ function runAnalyzer(workspaceRoot, options = {}) {
     raw = execFileSync('bash', [analyzeScript, workspaceRoot], {
       encoding: 'utf8',
       maxBuffer: 64 * 1024 * 1024,
+      // Cap runtime so a hung analyze.sh (e.g. a wedged JVM) can't block runbook
+      // generation forever — a timeout throws, and the catch below returns
+      // ok:false so the caller falls through to the LLM-scan tier.
+      timeout: 5 * 60 * 1000,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
   } catch (err) {

--- a/plugins/aem/cloud-service/skills/migration/scripts/bpa-local-parser.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/bpa-local-parser.js
@@ -33,6 +33,24 @@ const CSV_SUBTYPE_TO_PATTERN = {
 // Known scheduler identifier
 const SCHEDULER_IDENTIFIER = "org.apache.sling.commons.scheduler";
 
+// Content/legacy-UI subtypes whose findings are keyed by a JCR node path
+// (`identifier`), not a Java class name. Extracted generically into the
+// unified collection so the migration runbook + Branch C/D can consume them.
+//   cdw                    → custom.classic.widget
+//   lui (dialogs + more)   → legacy.dialog.classic / .coral2 / .custom.component / .static.template
+//   template modernization → legacy.static.template / custom.static.template
+//   replication            → forward.replication / reverse.replication
+const CONTENT_SUBTYPES = [
+  'custom.classic.widget',
+  'legacy.dialog.classic',
+  'legacy.dialog.coral2',
+  'legacy.custom.component',
+  'legacy.static.template',
+  'custom.static.template',
+  'forward.replication',
+  'reverse.replication',
+];
+
 /**
  * Parse command line arguments
  */
@@ -199,6 +217,29 @@ function processSchedulerFindings(findings) {
     subtype: PATTERN_TO_SUBTYPE.scheduler,
     identifiers: identifiers
   };
+}
+
+/**
+ * Process a content/legacy-UI subtype whose findings are keyed by JCR path.
+ * Groups by the `identifier` (node path); each finding contributes one entry
+ * (so the count matches the BPA report). Summary rows (code starting with `_`,
+ * e.g. `_COUNT_REP`, `_STAT`) are excluded — they share real subtype strings
+ * and would otherwise inflate counts.
+ *
+ * Returns { subtype, identifiers } where `identifiers` is keyed by the RAW JCR
+ * path (not MongoDB-safed): these paths contain underscores (`design_dialog`,
+ * `_cq_dialog`) that a dot→underscore round-trip would corrupt.
+ */
+function processContentSubtypeFindings(findings, subtype) {
+  const matched = findings.filter(f =>
+    f.subtype === subtype && !String(f.code || '').startsWith('_')
+  );
+  const identifiers = {};
+  matched.forEach(f => {
+    const key = f.identifier || f.context || subtype;
+    (identifiers[key] = identifiers[key] || []).push(f.context || f.message || key);
+  });
+  return { subtype, identifiers };
 }
 
 /**
@@ -487,7 +528,23 @@ function createUnifiedCollection(bpaData, outputDir) {
     
     console.log(`Found ${Object.values(eventHandlerCollection.identifiers).flat().length} event handler classes`);
   }
-  
+
+  // Process content / legacy-UI subtypes (cdw, lui, templates, replication).
+  // Keys are RAW JCR paths (not MongoDB-safed) to avoid corrupting underscores.
+  for (const subtype of CONTENT_SUBTYPES) {
+    const coll = processContentSubtypeFindings(findings, subtype);
+    const ids = Object.keys(coll.identifiers);
+    if (ids.length === 0) continue;
+    const mongoSafeSubtype = toMongoSafeFieldName(subtype);
+    subtypes[mongoSafeSubtype] = {};
+    ids.forEach(identifier => {
+      const values = coll.identifiers[identifier];
+      subtypes[mongoSafeSubtype][identifier] = values;
+      totalFindings += values.length;
+    });
+    console.log(`Found ${Object.values(coll.identifiers).flat().length} ${subtype} findings`);
+  }
+
   // Create unified collection structure with metadata
   const subtypeKeys = Object.keys(subtypes);
   const unifiedCollection = {

--- a/plugins/aem/cloud-service/skills/migration/scripts/htl-lint-runner.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/htl-lint-runner.js
@@ -1,0 +1,113 @@
+/**
+ * HTL Lint Runner
+ *
+ * The `html-scan` detection tier of the runbook cascade for the **htlLint**
+ * pattern — the AEM Cloud SDK HTL lint warning *"data-sly-test: redundant
+ * constant value comparison"*. Mirrors the proactive discovery documented in
+ * `{code-assessment}/references/data-sly-test-redundant-constant.md`.
+ *
+ * Implemented as a pure-Node fs walk + regex scan (no external `rg` binary):
+ * ripgrep is not guaranteed to be installed in a developer's environment, and
+ * the anti-patterns are simple line regexes, so a self-contained scan is more
+ * portable and deterministic.
+ *
+ * This is a **heuristic** detector: a regex is not the HTL compiler, so it can
+ * miss multi-line attributes and false-positive on legitimate expressions.
+ * Findings are tagged `confidence: 'heuristic'` by the caller and must be
+ * re-confirmed before editing.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// Anti-pattern classes searched inside a `data-sly-test="…"` attribute.
+// `\b` after true/false avoids matching identifiers like `trueFlag`; the
+// `apps` class stays within the attribute value (`[^"]*`) to avoid matching
+// `/apps/` in an unrelated attribute on the same line.
+const HTL_CLASSES = [
+  { label: 'boolean-literal', js: /data-sly-test="[^"]*(?:==|!=)\s*(?:true|false)\b/ },
+  { label: 'apps-string-as-test', js: /data-sly-test\s*=\s*["'][^"]*\/apps\// },
+  { label: 'split-logical-across-expr', js: /data-sly-test="[^"]*\}\s*(?:\|\||&&)\s*\$\{/ },
+  { label: 'numeric-literal', js: /data-sly-test="[^"]*==\s*[0-9]+\s*\}/ },
+];
+
+/** Classify a line into an HTL anti-pattern label, or null if it matches none. */
+function classify(line) {
+  for (const c of HTL_CLASSES) {
+    if (c.js.test(line)) return c.label;
+  }
+  return null;
+}
+
+/** Collapse a matched line into a single, table-safe snippet cell. */
+function sanitizeSnippet(snippet, maxLen = 120) {
+  const oneLine = (snippet || '').replace(/\s+/g, ' ').trim();
+  return oneLine.length > maxLen ? `${oneLine.slice(0, maxLen - 1)}…` : oneLine;
+}
+
+/** Recursively collect `.html` files under `dir`, skipping heavy/vendor dirs. */
+function collectHtmlFiles(dir, acc = []) {
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return acc; }
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (e.name === 'node_modules' || e.name === '.git' || e.name === 'target' || e.name === 'dist') continue;
+      collectHtmlFiles(full, acc);
+    } else if (e.isFile() && e.name.toLowerCase().endsWith('.html')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+/**
+ * Scan `.html` files under `workspaceRoot` for HTL `data-sly-test` anti-patterns.
+ *
+ * @returns {{
+ *   ok: boolean,
+ *   findings: Array<{location: string, detail: string, severity: string}>,
+ *   rawFindings: Array<{pattern: string, file: string, line: number, snippet: string}>,
+ *   warnings: string[],
+ *   error?: string,
+ * }}
+ *   A clean scan with no hits is `ok:true` with empty arrays. `ok:false` only
+ *   on an unexpected failure (e.g. unreadable root) — the caller then falls
+ *   through to the LLM-scan tier.
+ */
+function runHtlLint(workspaceRoot, options = {}) {
+  if (!workspaceRoot) {
+    return { ok: false, findings: [], rawFindings: [], warnings: [], error: 'no workspaceRoot' };
+  }
+
+  let files;
+  try {
+    files = collectHtmlFiles(workspaceRoot);
+  } catch (err) {
+    return { ok: false, findings: [], rawFindings: [], warnings: [], error: err.message };
+  }
+
+  const findings = [];
+  const rawFindings = [];
+  for (const file of files) {
+    let content;
+    try { content = fs.readFileSync(file, 'utf8'); } catch { continue; }
+    const lines = content.split('\n');
+    lines.forEach((line, i) => {
+      const label = classify(line);
+      if (!label) return;
+      findings.push({
+        location: `${file}:${i + 1}`,
+        detail: `${label} — ${sanitizeSnippet(line)}`,
+        severity: 'medium',
+      });
+      rawFindings.push({ pattern: 'htlLint', file, line: i + 1, snippet: line });
+    });
+  }
+
+  return { ok: true, findings, rawFindings, warnings: [] };
+}
+
+module.exports = { runHtlLint, collectHtmlFiles, classify, HTL_CLASSES };

--- a/plugins/aem/cloud-service/skills/migration/scripts/legacy-ui-runner.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/legacy-ui-runner.js
@@ -1,0 +1,114 @@
+/**
+ * Legacy UI Runner
+ *
+ * The `content-scan` detection tier of the runbook for the **lui** (Classic UI
+ * dialog) and **cdw** (Custom Design/Classic Widget) patterns. Mirrors the
+ * discovery documented in `{migration}/references/legacy-ui/dialog/context.md`
+ * and `.../cdw/context.md`.
+ *
+ * Pure-Node fs walk + attribute regex over `.content.xml` (no external tools).
+ * Heuristic — not the BPA analyzer — so hits are candidate matches the agent
+ * re-confirms in Branch D before converting.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// xtypes with a direct Coral 3 equivalent (dialog/context.md). Anything else on
+// a cq:Widget is a custom widget → cdw.
+const KNOWN_SAFE_XTYPES = new Set([
+  'textfield', 'editfield', 'textarea', 'htmleditor', 'richtext', 'checkbox', 'selection',
+  'combobox', 'pathfield', 'browsefield', 'smartfile', 'numberfield', 'datefield',
+  'multifield', 'dialogfieldset', 'tabpanel', 'panel', 'hidden', 'colorfield', 'tags',
+  'tagsfield', 'label', 'static', 'button', 'dialogbuttons', 'userpicker',
+]);
+
+/** Recursively collect `.content.xml` files, skipping vendor/build dirs. */
+function collectContentXml(dir, acc = []) {
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return acc; }
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (e.name === 'node_modules' || e.name === '.git' || e.name === 'target' || e.name === 'dist') continue;
+      collectContentXml(full, acc);
+    } else if (e.isFile() && e.name === '.content.xml') {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+/** Read a file, returning '' on failure. */
+function read(file) {
+  try { return fs.readFileSync(file, 'utf8'); } catch { return ''; }
+}
+
+/**
+ * CDW — custom Classic UI widgets. Flags `xtype="…"` attributes whose value is
+ * not a known-safe Coral 3 equivalent. One finding per (file, custom xtype).
+ *
+ * @returns {{ ok: boolean, findings: Array, rawFindings: Array, warnings: string[] }}
+ */
+function runCdwScan(workspaceRoot) {
+  if (!workspaceRoot) return { ok: false, findings: [], rawFindings: [], warnings: [], error: 'no workspaceRoot' };
+  const findings = [];
+  const rawFindings = [];
+  for (const file of collectContentXml(workspaceRoot)) {
+    const content = read(file);
+    if (!content.includes('xtype')) continue;
+    const seen = new Set();
+    const re = /xtype="([^"]+)"/g;
+    let m;
+    while ((m = re.exec(content)) !== null) {
+      const xtype = m[1];
+      if (KNOWN_SAFE_XTYPES.has(xtype) || seen.has(xtype)) continue;
+      seen.add(xtype);
+      findings.push({
+        location: file,
+        detail: `custom-xtype '${xtype}' — no direct Coral 3 equivalent; scaffold a Granite UI component`,
+        severity: 'high',
+      });
+      rawFindings.push({ pattern: 'cdw', file, line: null, snippet: `xtype="${xtype}"`, xtype });
+    }
+  }
+  return { ok: true, findings, rawFindings, warnings: [] };
+}
+
+/**
+ * LUI — Classic UI / Coral 2 dialogs. Flags:
+ *   - `legacy.dialog.classic`: a Classic dialog node (`jcr:primaryType="cq:Dialog"`
+ *     or `xtype="dialog"`).
+ *   - `legacy.dialog.coral2`: a Touch dialog using Coral 2 resourceTypes
+ *     (`granite/ui/components/foundation/…` without the Coral 3 `.../coral/…`).
+ * One finding per (file, sub-type).
+ *
+ * @returns {{ ok: boolean, findings: Array, rawFindings: Array, warnings: string[] }}
+ */
+function runLuiScan(workspaceRoot) {
+  if (!workspaceRoot) return { ok: false, findings: [], rawFindings: [], warnings: [], error: 'no workspaceRoot' };
+  const findings = [];
+  const rawFindings = [];
+  for (const file of collectContentXml(workspaceRoot)) {
+    const content = read(file);
+
+    const isClassic = /jcr:primaryType="cq:Dialog"/.test(content) || /xtype="dialog"/.test(content);
+    const usesFoundation = content.includes('granite/ui/components/foundation/');
+    const usesCoral3 = content.includes('granite/ui/components/coral/');
+    const isCoral2 = usesFoundation && !usesCoral3;
+
+    if (isClassic) {
+      findings.push({ location: file, detail: 'legacy.dialog.classic — Classic UI dialog; convert to Coral 3 (Touch UI)', severity: 'high' });
+      rawFindings.push({ pattern: 'lui', file, line: null, snippet: 'Classic UI dialog', subType: 'legacy.dialog.classic' });
+    }
+    if (isCoral2) {
+      findings.push({ location: file, detail: 'legacy.dialog.coral2 — Coral 2 resourceTypes; upgrade to Coral 3', severity: 'high' });
+      rawFindings.push({ pattern: 'lui', file, line: null, snippet: 'Coral 2 dialog', subType: 'legacy.dialog.coral2' });
+    }
+  }
+  return { ok: true, findings, rawFindings, warnings: [] };
+}
+
+module.exports = { runLuiScan, runCdwScan, collectContentXml, KNOWN_SAFE_XTYPES };

--- a/plugins/aem/cloud-service/skills/migration/scripts/osgi-config-runner.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/osgi-config-runner.js
@@ -35,9 +35,14 @@ const PLACEHOLDER_RE = /\$\[(secret|env):/;
 // secret keys for placeholder injection (see osgi-cfg-json-cloud-manager.md).
 const REPOINIT_RE = /RepositoryInitializer/i;
 
-/** A path segment starting with `config` scopes OSGi configuration folders. */
+// An OSGi config folder is `config` or a runmode variant `config.<runmode>`
+// (e.g. config.author.dev). Matches the whole segment — not any segment merely
+// starting with "config" (which would catch e.g. `configuration`).
+const CONFIG_FOLDER_RE = /^config(\.[a-z0-9-]+)*$/i;
+
+/** True if any path segment is a `config` / `config.<runmode>` folder. */
 function inConfigFolder(filePath) {
-  return filePath.split(path.sep).some(seg => seg.toLowerCase().startsWith('config'));
+  return filePath.split(path.sep).some(seg => CONFIG_FOLDER_RE.test(seg));
 }
 
 const CFG_JSON_RE = /\.cfg\.json$/i;
@@ -50,7 +55,7 @@ function collectConfigFiles(dir, acc = []) {
   for (const e of entries) {
     const full = path.join(dir, e.name);
     if (e.isDirectory()) {
-      if (e.name === 'node_modules' || e.name === '.git' || e.name === 'target') continue;
+      if (e.name === 'node_modules' || e.name === '.git' || e.name === 'target' || e.name === 'dist') continue;
       collectConfigFiles(full, acc);
     } else if (e.isFile()) {
       if (!inConfigFolder(full)) continue;

--- a/plugins/aem/cloud-service/skills/migration/scripts/osgi-config-runner.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/osgi-config-runner.js
@@ -1,0 +1,168 @@
+/**
+ * OSGi Config Runner
+ *
+ * The `config-scan` detection tier of the runbook cascade for the **osgiConfig**
+ * pattern — OSGi configuration values that should move to Cloud Manager
+ * environment secrets / variables. Mirrors the scan documented in
+ * `{migration}/references/osgi-cfg-json-cloud-manager.md`.
+ *
+ * This is a **heuristic, review-only** detector. It performs the cheap,
+ * deterministic part — finding config files and flagging secret-looking keys
+ * and `$[secret:]`/`$[env:]` placeholders — and defers all classification
+ * (is this really a secret? Adobe-owned PID?) to apply time. Findings are
+ * tagged `confidence: 'heuristic'`, `needsReview: true` by the caller.
+ *
+ * HARD SAFETY RULE: this detector never emits a secret *value*. It reports
+ * only the file path, the key *name*, and a `kind` label. The runbook is a
+ * file written to disk (often committed), so leaking a plaintext secret into
+ * it would defeat the entire migration.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// Keys whose plaintext string values are likely secrets and should move to
+// `$[secret:…]`. Matched case-insensitively against the JSON property name.
+const SECRET_KEY_RE = /(password|passwd|pwd|secret|token|api[-_]?key|access[-_]?key|private[-_]?key|credential|client[-_]?secret)/i;
+
+// A value already using a Cloud Manager placeholder — not actionable, just
+// informational ("already templated correctly").
+const PLACEHOLDER_RE = /\$\[(secret|env):/;
+
+// repoinit files: placeholders are not allowed there, so we do not flag
+// secret keys for placeholder injection (see osgi-cfg-json-cloud-manager.md).
+const REPOINIT_RE = /RepositoryInitializer/i;
+
+/** A path segment starting with `config` scopes OSGi configuration folders. */
+function inConfigFolder(filePath) {
+  return filePath.split(path.sep).some(seg => seg.toLowerCase().startsWith('config'));
+}
+
+const CFG_JSON_RE = /\.cfg\.json$/i;
+const LEGACY_RE = /\.(cfg|config)$/i;
+
+/** Recursively collect candidate config files under `dir`. Skips node_modules/.git/target. */
+function collectConfigFiles(dir, acc = []) {
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return acc; }
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (e.name === 'node_modules' || e.name === '.git' || e.name === 'target') continue;
+      collectConfigFiles(full, acc);
+    } else if (e.isFile()) {
+      if (!inConfigFolder(full)) continue;
+      if (CFG_JSON_RE.test(e.name) || LEGACY_RE.test(e.name)) acc.push(full);
+    }
+  }
+  return acc;
+}
+
+/**
+ * Extract **every** `"key": "value"` string property on a line, returning each
+ * key name and whether its value is already a placeholder — NEVER the value
+ * itself. Uses a global match so compact / multi-property lines (legal for
+ * `.cfg.json`, which is JSON) don't hide secrets after the first pair.
+ */
+function scanCfgJsonLine(line) {
+  const re = /"([^"]+)"\s*:\s*"((?:\\.|[^"\\])*)"/g;
+  const pairs = [];
+  let m;
+  while ((m = re.exec(line)) !== null) {
+    pairs.push({ key: m[1], isPlaceholder: PLACEHOLDER_RE.test(m[2]) });
+  }
+  return pairs;
+}
+
+/**
+ * Scan config files under `workspaceRoot`.
+ *
+ * @returns {{
+ *   ok: boolean,
+ *   findings: Array<{location: string, detail: string, severity: string}>,
+ *   rawFindings: Array<{pattern: string, file: string, line: number|null, snippet: string, kind: string}>,
+ *   warnings: string[],
+ *   error?: string,
+ * }}
+ */
+function runOsgiConfigScan(workspaceRoot, options = {}) {
+  if (!workspaceRoot) {
+    return { ok: false, findings: [], rawFindings: [], warnings: [], error: 'no workspaceRoot' };
+  }
+
+  let files;
+  try {
+    files = collectConfigFiles(workspaceRoot);
+  } catch (err) {
+    return { ok: false, findings: [], rawFindings: [], warnings: [], error: err.message };
+  }
+
+  const findings = [];
+  const rawFindings = [];
+  const warnings = [];
+
+  for (const file of files) {
+    const isRepoinit = REPOINIT_RE.test(file);
+
+    if (LEGACY_RE.test(file)) {
+      // Legacy .cfg/.config → must be converted to .cfg.json (Phase 0).
+      findings.push({
+        location: file,
+        detail: 'legacy-format — convert to .cfg.json (Phase 0)',
+        severity: 'high',
+      });
+      rawFindings.push({ pattern: 'osgiConfig', file, line: null, snippet: 'legacy config format', kind: 'legacy-format' });
+      continue;
+    }
+
+    let content;
+    try { content = fs.readFileSync(file, 'utf8'); } catch { continue; }
+    const lines = content.split('\n');
+    let filePlaceholdered = false;
+
+    lines.forEach((line, i) => {
+      for (const { key, isPlaceholder } of scanCfgJsonLine(line)) {
+        if (isPlaceholder) { filePlaceholdered = true; continue; }
+        if (isRepoinit) continue; // placeholders not allowed in repoinit — do not flag.
+        if (SECRET_KEY_RE.test(key)) {
+          // Report key NAME and location only — never the value.
+          findings.push({
+            location: `${file}:${i + 1}`,
+            detail: `plaintext-secret — key '${key}' should move to $[secret:…]`,
+            severity: 'high',
+          });
+          rawFindings.push({
+            pattern: 'osgiConfig',
+            file,
+            line: i + 1,
+            snippet: `"${key}": <redacted>`,
+            kind: 'plaintext-secret',
+          });
+        }
+      }
+    });
+
+    if (filePlaceholdered) {
+      findings.push({
+        location: file,
+        detail: 'already-placeholdered — uses $[secret:]/$[env:] (informational)',
+        severity: 'info',
+        informational: true, // already migrated — does not count as outstanding work
+      });
+      rawFindings.push({ pattern: 'osgiConfig', file, line: null, snippet: 'uses $[secret:]/$[env:]', kind: 'already-placeholdered', informational: true });
+    }
+  }
+
+  // XML sling:OsgiConfig nodes are in scope per the reference but are not
+  // scanned deterministically here — only surface this limitation when the
+  // project actually has config folders (otherwise it is noise).
+  if (files.length > 0) {
+    warnings.push('XML sling:OsgiConfig nodes are not scanned by this detector — review .content.xml config nodes manually.');
+  }
+
+  return { ok: true, findings, rawFindings, warnings };
+}
+
+module.exports = { runOsgiConfigScan, collectConfigFiles, SECRET_KEY_RE };

--- a/plugins/aem/cloud-service/skills/migration/scripts/package.json
+++ b/plugins/aem/cloud-service/skills/migration/scripts/package.json
@@ -6,7 +6,7 @@
     "parse-bpa": "node bpa-local-parser.js",
     "read-unified": "node unified-collection-reader.js",
     "check-sources": "node bpa-findings-helper.js",
-    "test": "node --test bpa-findings-helper.test.js"
+    "test": "node --test bpa-findings-helper.test.js runbook-generator.test.js"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/plugins/aem/cloud-service/skills/migration/scripts/runbook-generator.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/runbook-generator.js
@@ -1,0 +1,634 @@
+/**
+ * Migration Runbook Generator
+ *
+ * Produces a read-only `migration-runbook.md` covering every pattern the
+ * migration skill can address. Triggered by generic prompts like "review/scan
+ * my code for AEMaaCS migration" (no pattern named, no CSV required).
+ *
+ * Per-pattern detection STRATEGY — each pattern declares in `PATTERN_META` how
+ * it is detected:
+ *
+ *   'cascade'     — Java code patterns. Highest available source wins:
+ *                     BPA/CAM (MCP, if configured)
+ *                        → CSV (if uploaded / cached)
+ *                           → analyzer (local — code-assessment analyze.sh)
+ *                              → LLM scan (last resort — agent, not this script)
+ *                   `replication` has no BPA/CSV mapping, so it always falls
+ *                   through to the analyzer (or LLM scan).
+ *   'html-scan'   — `htlLint`: heuristic regex scan of `.html` templates.
+ *   'config-scan' — `osgiConfig`: heuristic scan of OSGi config files for
+ *                   secret-looking keys and `$[secret:]`/`$[env:]` placeholders
+ *                   (key names + locations only — never secret values).
+ *   'content-scan'— `lui` / `cdw` / `templateModernization`. These ALSO carry
+ *                   `bpaSlugs`, so when a BPA source is present they come from
+ *                   BPA (authoritative); the `.content.xml` scan (Classic/Coral 2
+ *                   dialogs, custom `cq:Widget` xtypes, static templates) is the
+ *                   heuristic fallback when no BPA source is available. Routed to
+ *                   migration Branches D / C, not code-assessment.
+ *
+ * `html-scan`/`config-scan`/`content-scan` (fallback) findings are tagged `confidence: 'heuristic'` in the
+ * cache. Patterns no available strategy could scan (e.g. a cascade pattern
+ * with no BPA source and no JDK) are returned in `needsLlmScan` for the agent.
+ *
+ * Alongside `migration-runbook.md`, this also writes a sidecar JSON cache
+ * (default `./migration-runbook.json`) holding each pattern's raw
+ * `{pattern, file, line, snippet}` findings. The apply handoff
+ * (migration/SKILL.md Step 3) reads this cache to avoid re-deriving findings
+ * via `getBpaFindings` or re-running the analyzer when the user picks a
+ * pattern to fix.
+ *
+ * Usage (CLI):
+ *   node scripts/runbook-generator.js <workspaceRoot> [--csv <bpaFilePath>] [--out <outputPath>] [--cache <cachePath>]
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { getBpaFindings, checkAvailableSources } = require('./bpa-findings-helper.js');
+const { runAnalyzer, isAnalyzerAvailable, DEFAULT_ANALYZE_SCRIPT } = require('./analyzer-runner.js');
+const { runHtlLint } = require('./htl-lint-runner.js');
+const { runOsgiConfigScan } = require('./osgi-config-runner.js');
+const { runLuiScan, runCdwScan } = require('./legacy-ui-runner.js');
+const { runTemplateScan } = require('./template-scan-runner.js');
+
+// Canonical pattern taxonomy for the runbook — every pattern the migration
+// skill can address. Each declares a detection `strategy`:
+//   'cascade'     — BPA/CAM → CSV → analyzer → LLM (Java code patterns)
+//   'rg'          — ripgrep heuristic scan (htlLint)
+//   'config-scan' — config-file heuristic scan (osgiConfig)
+// `bpaSlugs` applies only to 'cascade' patterns (empty = analyzer-only, e.g.
+// replication). (inject-in-sling-model and outdated-dependencies belong to
+// code-assessment's own runbook, not the migration runbook, so they stay out.)
+const PATTERN_META = {
+  scheduler: {
+    label: 'Scheduler',
+    severity: 'high',
+    strategy: 'cascade',
+    bpaSlugs: ['scheduler'],
+    description: 'Classes using `org.apache.sling.commons.scheduler.Scheduler` / implementing the legacy `Job` interface. Migrate to OSGi-property scheduling or Sling Jobs via `JobManager`.',
+    promptPattern: 'scheduler',
+  },
+  resourceChangeListener: {
+    label: 'Resource Change Listener',
+    severity: 'high',
+    strategy: 'cascade',
+    bpaSlugs: ['resourceChangeListener'],
+    description: 'Classes implementing `ResourceChangeListener` / `ExternalResourceChangeListener`. Migrate to a lightweight `ResourceChangeListener` + `JobConsumer` split.',
+    promptPattern: 'resourceChangeListener',
+  },
+  'event-migration': {
+    label: 'Event Migration (EventListener / EventHandler)',
+    severity: 'high',
+    strategy: 'cascade',
+    bpaSlugs: ['eventListener', 'eventHandler'],
+    description: 'Classes implementing JCR `javax.jcr.observation.EventListener` or OSGi `org.osgi.service.event.EventHandler`. Migrate to a lightweight handler + `JobConsumer` split, with `TopologyEventListener` for leader-only work.',
+    promptPattern: 'eventListener',
+  },
+  assetApi: {
+    label: 'Asset Manager API',
+    severity: 'high',
+    strategy: 'cascade',
+    bpaSlugs: ['assetApi'],
+    description: 'Calls to `com.day.cq.dam.api.AssetManager` create/upload/delete methods not available on Cloud Service. Migrate to Direct Binary Access and in-JVM `resolver.delete()`.',
+    promptPattern: 'assetApi',
+  },
+  replication: {
+    label: 'Replication',
+    severity: 'high',
+    strategy: 'cascade',
+    // BPA reports replication agents under replication.agent / forward|reverse.
+    // When no CSV is present, the analyzer detects Replicator usage from source.
+    bpaSlugs: ['replication'],
+    description: 'Usage of `com.day.cq.replication.Replicator` / Sling Replication Agent. Migrate to the Sling Distribution API (`Distributor` + `SimpleDistributionRequest`).',
+    promptPattern: 'replication',
+  },
+  htlLint: {
+    label: 'HTL data-sly-test Lint',
+    severity: 'medium',
+    strategy: 'html-scan',
+    bpaSlugs: [],
+    heuristic: true,
+    description: 'HTL `data-sly-test` redundant constant comparisons (`== true`, `/apps/…` string as test, split `${} || ${}`, numeric literals). Detected heuristically by a regex scan — not the HTL compiler — so re-confirm each hit before editing.',
+    promptPattern: 'htlLint',
+  },
+  osgiConfig: {
+    label: 'OSGi → Cloud Manager Config',
+    severity: 'high',
+    strategy: 'config-scan',
+    bpaSlugs: [],
+    heuristic: true,
+    needsReview: true,
+    description: 'OSGi config values that should move to Cloud Manager environment secrets/variables — plaintext secret-looking keys, legacy `.cfg`/`.config` formats, and existing `$[secret:]`/`$[env:]` placeholders. Heuristic, review-only: classification (real secret? Adobe-owned PID?) happens at apply time. Secret values are never written to the runbook.',
+    promptPattern: 'osgi config',
+    // Override — the OSGi → Cloud Manager branch uses a natural-language prompt,
+    // not a `<pattern> only` invocation.
+    sampleOverride: 'Use the migration skill: scan my config files and create Cloud Manager environment secrets or variables.',
+  },
+  lui: {
+    label: 'Classic UI / Coral 2 Dialogs (LUI)',
+    severity: 'high',
+    strategy: 'content-scan',
+    // BPA `lui` returns all legacy.user.interface sub-types; the runbook keeps
+    // only the dialog ones (custom.component → create-component, static.template
+    // → templateModernization, handled elsewhere).
+    bpaSlugs: ['lui'],
+    bpaSubtypeFilter: ['legacy.dialog.classic', 'legacy.dialog.coral2'],
+    heuristic: true,
+    description: 'Classic UI dialogs (`cq:Dialog` / `xtype="dialog"`) and Coral 2 dialogs (`granite/ui/components/foundation/…` resourceTypes) that must move to Coral 3 Touch UI. Detected heuristically by scanning `.content.xml`; the dialog migration (Branch D — legacy-ui/dialog) re-confirms and converts each.',
+    promptPattern: 'lui',
+    sampleOverride: 'Use the migration skill: fix my LUI dialog findings — convert Classic UI / ExtJS dialogs and upgrade Coral 2 dialogs to Coral 3.',
+  },
+  cdw: {
+    label: 'Custom Classic Widgets (CDW)',
+    severity: 'high',
+    strategy: 'content-scan',
+    bpaSlugs: ['cdw'],
+    heuristic: true,
+    description: 'Custom `cq:Widget` xtypes with no direct Coral 3 equivalent. Detected heuristically by scanning `.content.xml` for non-standard `xtype` values; the custom-widget migration (Branch D — legacy-ui/cdw) inventories each xtype and maps or scaffolds a Granite UI component. Run CDW before dialog migration when both are present.',
+    promptPattern: 'cdw',
+    sampleOverride: 'Use the migration skill: fix my CDW findings — migrate custom ExtJS widgets to Coral 3.',
+  },
+  templateModernization: {
+    label: 'Static → Editable Templates',
+    severity: 'medium',
+    strategy: 'content-scan',
+    bpaSlugs: ['templateModernization'],
+    heuristic: true,
+    description: 'Static templates under `apps/<appId>/templates/*` (`cq:Template`) that should become editable templates. Detected heuristically by globbing template `.content.xml`; the template modernization pipeline (Branch C) runs per-template context → execute → validate.',
+    promptPattern: 'template modernization',
+    sampleOverride: 'Use the migration skill: migrate my static templates to editable templates and generate the AEM Modernize Tools rewrite rules.',
+  },
+};
+
+// content-scan strategy → the runner that produces that pattern's findings.
+const CONTENT_SCANNERS = {
+  lui: runLuiScan,
+  cdw: runCdwScan,
+  templateModernization: runTemplateScan,
+};
+
+const CANONICAL_PATTERNS = Object.keys(PATTERN_META);
+
+/** Normalize a BPA target into the runbook's display shape. */
+function normalizeBpaTarget(t) {
+  return {
+    location: t.className || t.filePath || '—',
+    detail: t.identifier || t.issue || '',
+    severity: t.severity || 'high',
+  };
+}
+
+/**
+ * Normalize a BPA target into the raw handoff shape. BPA/CSV/MCP sources
+ * carry no line number or code snippet — only `pattern` and `file` are
+ * populated, so the apply handoff knows it must still run
+ * `analyze.sh --files <path>` once to resolve `line`/`snippet` before
+ * building an edit plan (see code-assessment/references/runbook.md,
+ * with_findings (pre-resolved) mode).
+ */
+function rawBpaTarget(pattern, t) {
+  return {
+    pattern,
+    file: t.filePath || t.className || null,
+    line: null,
+    snippet: null,
+  };
+}
+
+/**
+ * Gather findings for every canonical pattern via the per-pattern cascade.
+ *
+ * @returns {Promise<{
+ *   findingsByPattern: Record<string, Array<object>>,
+ *   rawFindingsByPattern: Record<string, Array<{pattern: string, file: string, line: number|null, snippet: string|null}>>,
+ *   sourceByPattern: Record<string, string>,   // 'mcp' | 'csv' | 'analyzer'
+ *   needsLlmScan: string[],                      // patterns no deterministic source could scan
+ *   analyzerWarnings: string[],
+ *   bpaMode: string|null,
+ *   analyzerUsed: boolean,
+ * }>}
+ */
+async function gatherFindings(options = {}) {
+  const {
+    bpaFilePath,
+    collectionsDir = './unified-collections',
+    projectId,
+    mcpFetcher,
+    workspaceRoot = process.cwd(),
+    analyzeScript = DEFAULT_ANALYZE_SCRIPT,
+  } = options;
+
+  const sources = checkAvailableSources({ bpaFilePath, collectionsDir, projectId, mcpFetcher });
+  const bpaMode = sources.mcpServer.available
+    ? 'mcp'
+    : (sources.bpaFile.available || sources.unifiedCollection.available)
+      ? 'csv'
+      : null;
+
+  const findingsByPattern = {};
+  const rawFindingsByPattern = {};
+  const sourceByPattern = {};
+  const scannedBy = {};
+  CANONICAL_PATTERNS.forEach(p => { findingsByPattern[p] = []; rawFindingsByPattern[p] = []; });
+
+  const cascadePatterns = CANONICAL_PATTERNS.filter(p => PATTERN_META[p].strategy === 'cascade');
+  const bpaPatterns = CANONICAL_PATTERNS.filter(p => (PATTERN_META[p].bpaSlugs || []).length > 0);
+
+  // ── BPA tier (MCP or CSV) — any pattern with bpaSlugs. When a BPA source is
+  //    available it owns the verdict; the pattern's local detector (analyzer /
+  //    content scan) only runs as a fallback when no BPA source scanned it. ──
+  if (bpaMode) {
+    for (const pattern of bpaPatterns) {
+      const { bpaSlugs, bpaSubtypeFilter } = PATTERN_META[pattern];
+      const merged = [];
+      const mergedRaw = [];
+      for (const slug of bpaSlugs) {
+        const res = await getBpaFindings(slug, {
+          bpaFilePath, collectionsDir, projectId, mcpFetcher, limit: null, offset: 0,
+        });
+        if (res.success && Array.isArray(res.targets)) {
+          // A pattern may map to a broader BPA pattern (e.g. `lui` returns all
+          // legacy.user.interface sub-types); keep only the ones this runbook
+          // pattern owns.
+          const targets = bpaSubtypeFilter
+            ? res.targets.filter(t => bpaSubtypeFilter.includes(t.identifier))
+            : res.targets;
+          merged.push(...targets.map(normalizeBpaTarget));
+          mergedRaw.push(...targets.map(t => rawBpaTarget(pattern, t)));
+        }
+      }
+      // Mark the pattern scanned by the BPA source even when `merged` is empty.
+      // For CSV, a pattern's absence from the report means BPA found no
+      // instances — a legitimate "clean" result, not a gap to fill from the
+      // analyzer. For MCP, a fetch error must NOT silently chain to the
+      // analyzer either (see migration/SKILL.md "MCP errors and fallback":
+      // stop, don't chain). So once a BPA source is available for a pattern,
+      // it owns the verdict and we do not fall through to the analyzer.
+      findingsByPattern[pattern] = merged;
+      rawFindingsByPattern[pattern] = mergedRaw;
+      sourceByPattern[pattern] = bpaMode;
+      scannedBy[pattern] = bpaMode;
+    }
+  }
+
+  // ── Cascade tier 3: analyzer (fills replication always; fills the other
+  //    cascade patterns only when no BPA source scanned them) ──────────────
+  let analyzerWarnings = [];
+  let analyzerUsed = false;
+  const analyzerCanRun = isAnalyzerAvailable(analyzeScript) && !!workspaceRoot;
+  const patternsNeedingAnalyzer = cascadePatterns.filter(p => !scannedBy[p]);
+
+  if (analyzerCanRun && patternsNeedingAnalyzer.length > 0) {
+    const result = runAnalyzer(workspaceRoot, { analyzeScript });
+    if (result.ok) {
+      analyzerUsed = true;
+      analyzerWarnings = result.warnings;
+      for (const pattern of patternsNeedingAnalyzer) {
+        findingsByPattern[pattern] = result.findingsByPattern[pattern] || [];
+        rawFindingsByPattern[pattern] = result.rawFindingsByPattern[pattern] || [];
+        sourceByPattern[pattern] = 'analyzer';
+        scannedBy[pattern] = 'analyzer';
+      }
+    }
+  }
+
+  // ── Strategy 'html-scan': htlLint (independent of the cascade) ───────────
+  if (CANONICAL_PATTERNS.includes('htlLint') && workspaceRoot) {
+    const res = runHtlLint(workspaceRoot);
+    if (res.ok) {
+      findingsByPattern.htlLint = res.findings;
+      rawFindingsByPattern.htlLint = res.rawFindings;
+      sourceByPattern.htlLint = 'html-scan';
+      scannedBy.htlLint = 'html-scan';
+    }
+  }
+
+  // ── Strategy 'config-scan': osgiConfig (independent of the cascade) ──────
+  if (CANONICAL_PATTERNS.includes('osgiConfig') && workspaceRoot) {
+    const res = runOsgiConfigScan(workspaceRoot);
+    if (res.ok) {
+      findingsByPattern.osgiConfig = res.findings;
+      rawFindingsByPattern.osgiConfig = res.rawFindings;
+      sourceByPattern.osgiConfig = 'config';
+      scannedBy.osgiConfig = 'config';
+      if (res.warnings && res.warnings.length) analyzerWarnings = analyzerWarnings.concat(res.warnings);
+    }
+  }
+
+  // ── Strategy 'content-scan': lui / cdw / templateModernization (fallback
+  //    when no BPA source scanned the pattern) ──────────────────────────────
+  if (workspaceRoot) {
+    for (const pattern of CANONICAL_PATTERNS) {
+      if (PATTERN_META[pattern].strategy !== 'content-scan') continue;
+      if (scannedBy[pattern]) continue; // BPA already provided findings
+      const scan = CONTENT_SCANNERS[pattern];
+      if (!scan) continue;
+      const res = scan(workspaceRoot);
+      if (res.ok) {
+        findingsByPattern[pattern] = res.findings;
+        rawFindingsByPattern[pattern] = res.rawFindings;
+        sourceByPattern[pattern] = 'content-scan';
+        scannedBy[pattern] = 'content-scan';
+        if (res.warnings && res.warnings.length) analyzerWarnings = analyzerWarnings.concat(res.warnings);
+      }
+    }
+  }
+
+  // ── Tier 4: anything still unscanned → LLM scan (agent handles it) ───────
+  const needsLlmScan = CANONICAL_PATTERNS.filter(p => !scannedBy[p]);
+
+  return { findingsByPattern, rawFindingsByPattern, sourceByPattern, needsLlmScan, analyzerWarnings, bpaMode, analyzerUsed };
+}
+
+/** Build the per-pattern copy-paste sample prompt. */
+function samplePrompt(pattern, ctx) {
+  const meta = PATTERN_META[pattern];
+  if (meta.sampleOverride) return meta.sampleOverride;
+  const csvClause = ctx.bpaFilePath ? ` BPA CSV at \`${ctx.bpaFilePath}\`,` : '';
+  return `Use the migration skill: **${meta.promptPattern}** only,${csvClause} then read the code-assessment pattern guide before editing.`;
+}
+
+/**
+ * Strip a leading `workspaceRoot` prefix from a `file` or `file:line` string so
+ * the committed runbook shows portable, workspace-relative paths and does not
+ * leak the local filesystem layout. Leaves non-path values untouched (e.g. a
+ * BPA `className` FQN, or an already-relative path), so it is safe to apply to
+ * every source's output.
+ */
+function relPath(value, workspaceRoot) {
+  if (!value || !workspaceRoot || typeof value !== 'string') return value;
+  const prefix = workspaceRoot.endsWith(path.sep) ? workspaceRoot : workspaceRoot + path.sep;
+  return value.startsWith(prefix) ? value.slice(prefix.length) : value;
+}
+
+/** Findings that represent outstanding work (excludes informational rows). */
+function actionable(findings) {
+  return findings.filter(f => !f.informational);
+}
+
+/** Render the runbook markdown. */
+function renderRunbook(gathered, ctx = {}) {
+  const { findingsByPattern, sourceByPattern, needsLlmScan, analyzerWarnings } = gathered;
+  const root = ctx.workspaceRoot;
+  const lines = [];
+
+  const total = CANONICAL_PATTERNS.reduce((n, p) => n + actionable(findingsByPattern[p]).length, 0);
+  const withFindings = CANONICAL_PATTERNS.filter(p => actionable(findingsByPattern[p]).length > 0);
+
+  lines.push('# AEM Cloud Service — Migration Runbook');
+  lines.push('');
+  lines.push('> **Read-only planning document.** It lists the migration findings discovered');
+  lines.push('> across your project. Use a pattern\'s sample prompt to start the');
+  lines.push('> one-pattern-per-session apply workflow. No code was changed to produce this.');
+  lines.push('');
+
+  lines.push('## Summary');
+  lines.push('');
+  lines.push('| Field | Value |');
+  lines.push('|-------|-------|');
+  lines.push(`| Generated | ${ctx.generatedAt || new Date().toISOString().replace('T', ' ').slice(0, 19)} UTC |`);
+  lines.push(`| Total findings | **${total}** |`);
+  lines.push(`| Patterns with findings | **${withFindings.length}** of ${CANONICAL_PATTERNS.length} |`);
+  lines.push('');
+
+  lines.push('### Findings by pattern');
+  lines.push('');
+  lines.push('| Pattern | Severity | Findings | Detected via |');
+  lines.push('|---------|----------|----------|--------------|');
+  for (const p of CANONICAL_PATTERNS) {
+    const meta = PATTERN_META[p];
+    const count = actionable(findingsByPattern[p]).length;
+    const src = needsLlmScan.includes(p)
+      ? '_needs LLM scan_'
+      : SOURCE_LABEL[sourceByPattern[p]] || '—';
+    lines.push(`| ${meta.label} | ${meta.severity} | ${count === 0 ? '—' : `**${count}**`} | ${src} |`);
+  }
+  lines.push('');
+
+  if (needsLlmScan.length > 0) {
+    lines.push(`> ⚠️ No deterministic source could scan: **${needsLlmScan.map(p => PATTERN_META[p].label).join(', ')}**. `);
+    lines.push('> Provide a BPA CSV, open the project workspace for the analyzer, or ask the agent to run an LLM scan for these.');
+    lines.push('');
+  }
+
+  lines.push('---');
+  lines.push('');
+
+  for (const p of CANONICAL_PATTERNS) {
+    const targets = findingsByPattern[p];
+    if (targets.length === 0) continue;
+    const meta = PATTERN_META[p];
+
+    const actCount = actionable(targets).length;
+    const infoCount = targets.length - actCount;
+    lines.push(`## ${meta.label} (\`${p}\`)`);
+    lines.push('');
+    lines.push(`**Severity:** ${meta.severity} | **Findings:** ${actCount}${infoCount > 0 ? ` (+${infoCount} informational)` : ''} | **Detected via:** ${SOURCE_LABEL[sourceByPattern[p]] || '—'}`);
+    lines.push('');
+    lines.push(meta.description);
+    lines.push('');
+    if (meta.heuristic) {
+      lines.push(`> ⚠️ **Heuristic detection** (${SOURCE_LABEL[sourceByPattern[p]] || 'non-deterministic'}) — these are candidate matches, not compiler/BPA-validated findings. Re-confirm each one before editing.`);
+      if (meta.needsReview) {
+        lines.push('> Secret **values** are intentionally omitted from this runbook — only key names and locations are shown. Classification happens at apply time.');
+      }
+      lines.push('');
+    }
+    lines.push('### Affected');
+    lines.push('');
+    lines.push('| Location | Detail | Severity |');
+    lines.push('|----------|--------|----------|');
+    for (const t of targets) {
+      const detail = (t.detail || '').replace(/\|/g, '\\|');
+      const location = relPath(t.location, root);
+      lines.push(`| \`${location}\` | \`${detail || '—'}\` | ${t.severity || 'high'} |`);
+    }
+    lines.push('');
+    lines.push('### Sample prompt');
+    lines.push('');
+    lines.push('```');
+    lines.push(samplePrompt(p, ctx));
+    lines.push('```');
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+  }
+
+  const clean = CANONICAL_PATTERNS.filter(p => findingsByPattern[p].length === 0 && !needsLlmScan.includes(p));
+  if (clean.length > 0) {
+    lines.push('## Scanned — no findings');
+    lines.push('');
+    for (const p of clean) lines.push(`- **${PATTERN_META[p].label}** (\`${p}\`)`);
+    lines.push('');
+  }
+
+  if (analyzerWarnings && analyzerWarnings.length > 0) {
+    lines.push('## Scan warnings');
+    lines.push('');
+    for (const w of analyzerWarnings) lines.push(`- ${w}`);
+    lines.push('');
+  }
+
+  lines.push('---');
+  lines.push('');
+  lines.push('*Generated by the AEM Cloud Service migration skill — runbook-generator.js*');
+  return lines.join('\n');
+}
+
+const SOURCE_LABEL = {
+  mcp: 'BPA / CAM',
+  csv: 'BPA CSV',
+  analyzer: 'analyzer',
+  'html-scan': 'HTL scan',
+  config: 'config scan',
+  'content-scan': 'content scan',
+  llm: 'LLM scan',
+};
+
+/**
+ * Default path for the runbook's raw-findings sidecar cache, written next to
+ * the markdown so the apply handoff (migration/SKILL.md Step 3) can reuse
+ * already-computed findings for a pattern instead of re-deriving them via
+ * `getBpaFindings` or re-running the analyzer.
+ */
+const DEFAULT_CACHE_PATH = './migration-runbook.json';
+
+/**
+ * Write the raw-findings sidecar cache. Kept as a separate function (rather
+ * than inlined in generateRunbook) so a caller re-rendering after an LLM/rg
+ * scan (Tier 4) can refresh the cache without re-running the whole cascade.
+ */
+function writeRunbookCache(gathered, ctx, cachePath = DEFAULT_CACHE_PATH) {
+  const root = ctx.workspaceRoot;
+  const cache = {
+    generatedAt: ctx.generatedAt,
+    // `file` fields below are relative to this root — the apply handoff
+    // resolves them with `path.join(workspaceRoot, file)`.
+    workspaceRoot: root || null,
+    sourceByPattern: gathered.sourceByPattern,
+    findingsByPattern: {},
+  };
+  // Copy raw findings, relativizing `file` and tagging heuristic patterns
+  // (regex-scanned htlLint, config-scanned osgiConfig) so the apply handoff
+  // knows they are candidate matches, not analyzer/BPA-grade findings, and
+  // must re-confirm each one.
+  for (const [pattern, findings] of Object.entries(gathered.rawFindingsByPattern)) {
+    const meta = PATTERN_META[pattern];
+    const heuristic = !!(meta && meta.heuristic);
+    cache.findingsByPattern[pattern] = findings.map(f => {
+      const rel = { ...f, file: relPath(f.file, root) };
+      if (heuristic) rel.confidence = 'heuristic';
+      return rel;
+    });
+  }
+  fs.writeFileSync(cachePath, JSON.stringify(cache, null, 2), 'utf8');
+  return cachePath;
+}
+
+/**
+ * Generate the runbook end to end.
+ *
+ * @returns {Promise<{
+ *   success: boolean, outputPath?: string, cachePath?: string, message: string,
+ *   totalFindings: number, patternCounts: object,
+ *   needsLlmScan: string[], gathered: object,
+ * }>}
+ *   When `needsLlmScan` is non-empty, the agent should LLM-scan those patterns,
+ *   merge them into `gathered.findingsByPattern` (and `gathered.rawFindingsByPattern`
+ *   using the same `{pattern, file, line, snippet}` shape where locatable),
+ *   re-render via `renderRunbook`, and call `writeRunbookCache` again so the
+ *   cache reflects the merged findings.
+ */
+async function generateRunbook(options = {}) {
+  const { outputPath = './migration-runbook.md', cachePath = DEFAULT_CACHE_PATH, bpaFilePath, workspaceRoot } = options;
+
+  const gathered = await gatherFindings(options);
+  const ctx = {
+    bpaFilePath,
+    workspaceRoot,
+    generatedAt: new Date().toISOString().replace('T', ' ').slice(0, 19),
+  };
+
+  const markdown = renderRunbook(gathered, ctx);
+  fs.writeFileSync(outputPath, markdown, 'utf8');
+  writeRunbookCache(gathered, ctx, cachePath);
+
+  // Counts reflect outstanding work — informational findings (e.g. OSGi
+  // configs already using placeholders) are excluded from the headline.
+  const patternCounts = {};
+  let totalFindings = 0;
+  for (const p of CANONICAL_PATTERNS) {
+    patternCounts[p] = actionable(gathered.findingsByPattern[p]).length;
+    totalFindings += patternCounts[p];
+  }
+
+  return {
+    success: true,
+    outputPath,
+    cachePath,
+    message: `Runbook written to ${outputPath} — ${totalFindings} findings across ${CANONICAL_PATTERNS.filter(p => patternCounts[p] > 0).length} pattern(s).`,
+    totalFindings,
+    patternCounts,
+    needsLlmScan: gathered.needsLlmScan,
+    gathered,
+  };
+}
+
+// CLI
+function parseArgs(argv) {
+  const out = { workspaceRoot: undefined, bpaFilePath: undefined, outputPath: './migration-runbook.md', cachePath: DEFAULT_CACHE_PATH };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--csv') out.bpaFilePath = argv[++i];
+    else if (a === '--out') out.outputPath = argv[++i];
+    else if (a === '--cache') out.cachePath = argv[++i];
+    else if (!out.workspaceRoot) out.workspaceRoot = a;
+  }
+  if (!out.workspaceRoot) out.workspaceRoot = process.cwd();
+  return out;
+}
+
+async function main() {
+  const { workspaceRoot, bpaFilePath, outputPath, cachePath } = parseArgs(process.argv.slice(2));
+
+  console.log('Migration Runbook Generator');
+  console.log('===========================');
+  console.log(`Workspace:  ${workspaceRoot}`);
+  if (bpaFilePath) console.log(`BPA CSV:    ${bpaFilePath}`);
+  console.log(`Output:     ${outputPath}`);
+  console.log(`Cache:      ${cachePath}`);
+  console.log('');
+
+  const result = await generateRunbook({ workspaceRoot, bpaFilePath, outputPath, cachePath });
+
+  console.log(`✅ ${result.message}`);
+  console.log(`   Findings cache: ${result.cachePath}`);
+  console.log('');
+  console.log('Pattern breakdown:');
+  for (const [pattern, count] of Object.entries(result.patternCounts)) {
+    const src = result.gathered.needsLlmScan.includes(pattern)
+      ? 'needs-llm-scan'
+      : (result.gathered.sourceByPattern[pattern] || '—');
+    console.log(`  ${pattern.padEnd(25)} ${String(count).padStart(3)}  (${src})`);
+  }
+  if (result.needsLlmScan.length > 0) {
+    console.log('');
+    console.log(`⚠️  Needs LLM scan: ${result.needsLlmScan.join(', ')}`);
+  }
+}
+
+if (require.main === module) {
+  main().catch(err => { console.error(err); process.exit(1); });
+}
+
+module.exports = {
+  generateRunbook,
+  gatherFindings,
+  renderRunbook,
+  writeRunbookCache,
+  samplePrompt,
+  CANONICAL_PATTERNS,
+  PATTERN_META,
+  DEFAULT_CACHE_PATH,
+};

--- a/plugins/aem/cloud-service/skills/migration/scripts/runbook-generator.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/runbook-generator.js
@@ -13,8 +13,8 @@
  *                        → CSV (if uploaded / cached)
  *                           → analyzer (local — code-assessment analyze.sh)
  *                              → LLM scan (last resort — agent, not this script)
- *                   `replication` has no BPA/CSV mapping, so it always falls
- *                   through to the analyzer (or LLM scan).
+ *                   `replication` maps to the BPA `replication.agent` subtype;
+ *                   with no BPA source it falls through to the analyzer (or LLM).
  *   'html-scan'   — `htlLint`: heuristic regex scan of `.html` templates.
  *   'config-scan' — `osgiConfig`: heuristic scan of OSGi config files for
  *                   secret-looking keys and `$[secret:]`/`$[env:]` placeholders
@@ -54,11 +54,14 @@ const { runTemplateScan } = require('./template-scan-runner.js');
 
 // Canonical pattern taxonomy for the runbook — every pattern the migration
 // skill can address. Each declares a detection `strategy`:
-//   'cascade'     — BPA/CAM → CSV → analyzer → LLM (Java code patterns)
-//   'rg'          — ripgrep heuristic scan (htlLint)
-//   'config-scan' — config-file heuristic scan (osgiConfig)
-// `bpaSlugs` applies only to 'cascade' patterns (empty = analyzer-only, e.g.
-// replication). (inject-in-sling-model and outdated-dependencies belong to
+//   'cascade'      — BPA/CAM → CSV → analyzer → LLM (Java code patterns)
+//   'html-scan'    — pure-Node regex scan of .html (htlLint)
+//   'config-scan'  — config-file heuristic scan (osgiConfig)
+//   'content-scan' — .content.xml / template scan (lui, cdw, templateModernization)
+// `bpaSlugs` maps a pattern to its BPA subtype(s): the Java 'cascade' patterns,
+// plus replication (replication.agent) and lui/cdw/templateModernization. When a
+// BPA source is present it is authoritative; html/config/content scans are the
+// local fallback. (inject-in-sling-model and outdated-dependencies belong to
 // code-assessment's own runbook, not the migration runbook, so they stay out.)
 const PATTERN_META = {
   scheduler: {
@@ -234,6 +237,7 @@ async function gatherFindings(options = {}) {
 
   const cascadePatterns = CANONICAL_PATTERNS.filter(p => PATTERN_META[p].strategy === 'cascade');
   const bpaPatterns = CANONICAL_PATTERNS.filter(p => (PATTERN_META[p].bpaSlugs || []).length > 0);
+  const scanWarnings = [];
 
   // ── BPA tier (MCP or CSV) — any pattern with bpaSlugs. When a BPA source is
   //    available it owns the verdict; the pattern's local detector (analyzer /
@@ -243,6 +247,7 @@ async function gatherFindings(options = {}) {
       const { bpaSlugs, bpaSubtypeFilter } = PATTERN_META[pattern];
       const merged = [];
       const mergedRaw = [];
+      let realError = false; // a genuine fetch failure (not "pattern absent")
       for (const slug of bpaSlugs) {
         const res = await getBpaFindings(slug, {
           bpaFilePath, collectionsDir, projectId, mcpFetcher, limit: null, offset: 0,
@@ -256,15 +261,28 @@ async function gatherFindings(options = {}) {
             : res.targets;
           merged.push(...targets.map(normalizeBpaTarget));
           mergedRaw.push(...targets.map(t => rawBpaTarget(pattern, t)));
+        } else if (res.availablePatterns) {
+          // Benign: the report parsed fine but this pattern is absent — a
+          // legitimate "clean" result. Stay silent.
+        } else {
+          // Real failure (mcp-error / mcp-server / bpa-file-error / no-source /
+          // "no CSV path"). Do NOT report as clean.
+          realError = true;
+          scanWarnings.push(
+            `BPA fetch failed for \`${pattern}\` (slug \`${slug}\`, source: ${res.source || 'unknown'}): ${res.error || res.message || 'unknown error'}`
+          );
         }
       }
-      // Mark the pattern scanned by the BPA source even when `merged` is empty.
-      // For CSV, a pattern's absence from the report means BPA found no
-      // instances — a legitimate "clean" result, not a gap to fill from the
-      // analyzer. For MCP, a fetch error must NOT silently chain to the
-      // analyzer either (see migration/SKILL.md "MCP errors and fallback":
-      // stop, don't chain). So once a BPA source is available for a pattern,
-      // it owns the verdict and we do not fall through to the analyzer.
+
+      if (realError && merged.length === 0) {
+        // Nothing usable from BPA and the fetch genuinely failed — leave the
+        // pattern UNSCANNED so its local detector runs as a fallback (and, if
+        // that can't run either, it surfaces in needsLlmScan). Never mark it
+        // as a clean BPA scan.
+        continue;
+      }
+      // Either the fetch succeeded (possibly zero findings = genuinely clean)
+      // or we still got some findings despite a partial error — BPA owns it.
       findingsByPattern[pattern] = merged;
       rawFindingsByPattern[pattern] = mergedRaw;
       sourceByPattern[pattern] = bpaMode;
@@ -274,7 +292,6 @@ async function gatherFindings(options = {}) {
 
   // ── Cascade tier 3: analyzer (fills replication always; fills the other
   //    cascade patterns only when no BPA source scanned them) ──────────────
-  let analyzerWarnings = [];
   let analyzerUsed = false;
   const analyzerCanRun = isAnalyzerAvailable(analyzeScript) && !!workspaceRoot;
   const patternsNeedingAnalyzer = cascadePatterns.filter(p => !scannedBy[p]);
@@ -283,7 +300,7 @@ async function gatherFindings(options = {}) {
     const result = runAnalyzer(workspaceRoot, { analyzeScript });
     if (result.ok) {
       analyzerUsed = true;
-      analyzerWarnings = result.warnings;
+      if (result.warnings && result.warnings.length) scanWarnings.push(...result.warnings);
       for (const pattern of patternsNeedingAnalyzer) {
         findingsByPattern[pattern] = result.findingsByPattern[pattern] || [];
         rawFindingsByPattern[pattern] = result.rawFindingsByPattern[pattern] || [];
@@ -310,9 +327,9 @@ async function gatherFindings(options = {}) {
     if (res.ok) {
       findingsByPattern.osgiConfig = res.findings;
       rawFindingsByPattern.osgiConfig = res.rawFindings;
-      sourceByPattern.osgiConfig = 'config';
-      scannedBy.osgiConfig = 'config';
-      if (res.warnings && res.warnings.length) analyzerWarnings = analyzerWarnings.concat(res.warnings);
+      sourceByPattern.osgiConfig = 'config-scan';
+      scannedBy.osgiConfig = 'config-scan';
+      if (res.warnings && res.warnings.length) scanWarnings.push(...res.warnings);
     }
   }
 
@@ -330,7 +347,7 @@ async function gatherFindings(options = {}) {
         rawFindingsByPattern[pattern] = res.rawFindings;
         sourceByPattern[pattern] = 'content-scan';
         scannedBy[pattern] = 'content-scan';
-        if (res.warnings && res.warnings.length) analyzerWarnings = analyzerWarnings.concat(res.warnings);
+        if (res.warnings && res.warnings.length) scanWarnings.push(...res.warnings);
       }
     }
   }
@@ -338,7 +355,7 @@ async function gatherFindings(options = {}) {
   // ── Tier 4: anything still unscanned → LLM scan (agent handles it) ───────
   const needsLlmScan = CANONICAL_PATTERNS.filter(p => !scannedBy[p]);
 
-  return { findingsByPattern, rawFindingsByPattern, sourceByPattern, needsLlmScan, analyzerWarnings, bpaMode, analyzerUsed };
+  return { findingsByPattern, rawFindingsByPattern, sourceByPattern, needsLlmScan, analyzerWarnings: scanWarnings, bpaMode, analyzerUsed };
 }
 
 /** Build the per-pattern copy-paste sample prompt. */
@@ -481,7 +498,7 @@ const SOURCE_LABEL = {
   csv: 'BPA CSV',
   analyzer: 'analyzer',
   'html-scan': 'HTL scan',
-  config: 'config scan',
+  'config-scan': 'config scan',
   'content-scan': 'content scan',
   llm: 'LLM scan',
 };

--- a/plugins/aem/cloud-service/skills/migration/scripts/runbook-generator.test.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/runbook-generator.test.js
@@ -10,6 +10,7 @@ const { runHtlLint, classify } = require('./htl-lint-runner.js');
 const { runOsgiConfigScan } = require('./osgi-config-runner.js');
 const { runLuiScan, runCdwScan } = require('./legacy-ui-runner.js');
 const { runTemplateScan } = require('./template-scan-runner.js');
+const { runAnalyzer } = require('./analyzer-runner.js');
 const {
   gatherFindings, generateRunbook, renderRunbook, writeRunbookCache,
   samplePrompt, CANONICAL_PATTERNS, PATTERN_META,
@@ -27,10 +28,18 @@ function write(root, rel, content) {
 
 // ── Pattern registry ────────────────────────────────────────────────────────
 
-test('registry includes all migration patterns with a strategy', () => {
-  for (const key of ['scheduler', 'resourceChangeListener', 'event-migration', 'assetApi', 'replication', 'htlLint', 'osgiConfig']) {
+test('registry includes all 10 migration patterns with a valid strategy', () => {
+  const expected = [
+    'scheduler', 'resourceChangeListener', 'event-migration', 'assetApi', 'replication',
+    'htlLint', 'osgiConfig', 'lui', 'cdw', 'templateModernization',
+  ];
+  assert.strictEqual(CANONICAL_PATTERNS.length, expected.length, 'no unexpected patterns');
+  for (const key of expected) {
     assert.ok(CANONICAL_PATTERNS.includes(key), `${key} in CANONICAL_PATTERNS`);
-    assert.ok(['cascade', 'html-scan', 'config-scan'].includes(PATTERN_META[key].strategy), `${key} has a valid strategy`);
+    assert.ok(
+      ['cascade', 'html-scan', 'config-scan', 'content-scan'].includes(PATTERN_META[key].strategy),
+      `${key} has a valid strategy`
+    );
   }
 });
 
@@ -120,7 +129,7 @@ test('gatherFindings dispatches rg + config-scan and tags heuristic in cache', a
 
   assert.strictEqual(gathered.sourceByPattern.htlLint, 'html-scan');
   assert.ok(gathered.findingsByPattern.htlLint.length >= 1);
-  assert.strictEqual(gathered.sourceByPattern.osgiConfig, 'config');
+  assert.strictEqual(gathered.sourceByPattern.osgiConfig, 'config-scan');
   assert.ok(gathered.findingsByPattern.osgiConfig.length >= 1);
 
   const cachePath = path.join(root, 'cache.json');
@@ -283,6 +292,49 @@ test('lui/cdw/template sample prompts route to the migration branches', () => {
   assert.match(samplePrompt('templateModernization', {}), /editable templates/i);
 });
 
+// ── analyzer-runner: slug normalization + ok:false branches (stub analyze.sh) ─
+
+function writeAnalyzeStub(root, body) {
+  const p = path.join(root, 'analyze.sh');
+  fs.writeFileSync(p, body, 'utf8');
+  return p;
+}
+
+test('runAnalyzer normalizes analyzer slugs and skips non-migration patterns', () => {
+  const root = mkworkspace();
+  const payload = { findings: [
+    { pattern: 'scheduler', file: 'A.java', line: 3, snippet: 'Scheduler s;' },
+    { pattern: 'resource-change-listener', file: 'B.java', line: 5, snippet: 'impl RCL' },
+    { pattern: 'asset-manager', file: 'C.java', line: 7, snippet: 'AssetManager.createAsset' },
+    { pattern: 'inject-in-sling-model', file: 'D.java', line: 9, snippet: '@Inject' },
+  ], warnings: ['w1'] };
+  const stub = writeAnalyzeStub(root, `#!/usr/bin/env bash\ncat <<'JSON'\n${JSON.stringify(payload)}\nJSON\n`);
+  const res = runAnalyzer(root, { analyzeScript: stub });
+  assert.strictEqual(res.ok, true);
+  assert.ok(res.findingsByPattern.scheduler, 'scheduler kept');
+  assert.ok(res.findingsByPattern.resourceChangeListener, 'resource-change-listener → resourceChangeListener');
+  assert.ok(res.findingsByPattern.assetApi, 'asset-manager → assetApi');
+  assert.ok(!res.findingsByPattern['inject-in-sling-model'], 'non-migration slug dropped');
+  assert.deepStrictEqual(res.warnings, ['w1']);
+  assert.strictEqual(res.rawFindingsByPattern.scheduler[0].line, 3);
+});
+
+test('runAnalyzer returns ok:false on non-zero exit', () => {
+  const root = mkworkspace();
+  const stub = writeAnalyzeStub(root, '#!/usr/bin/env bash\necho "compile error" >&2\nexit 5\n');
+  const res = runAnalyzer(root, { analyzeScript: stub });
+  assert.strictEqual(res.ok, false);
+  assert.match(res.error, /compile error|code 5/);
+});
+
+test('runAnalyzer returns ok:false on unparseable output', () => {
+  const root = mkworkspace();
+  const stub = writeAnalyzeStub(root, '#!/usr/bin/env bash\necho "not json at all"\n');
+  const res = runAnalyzer(root, { analyzeScript: stub });
+  assert.strictEqual(res.ok, false);
+  assert.match(res.error, /parse/i);
+});
+
 // ── BPA parsing of the new subtypes (parser + reader) ───────────────────────
 
 const { getBpaFindings } = require('./bpa-findings-helper.js');
@@ -323,6 +375,39 @@ test('BPA parser extracts cdw/lui/template/replication and excludes _COUNT rows'
 
   const tpl = await getBpaFindings('templateModernization', opts);
   assert.strictEqual(tpl.targets.length, 2, 'legacy.static.template + custom.static.template');
+});
+
+test('a real BPA fetch failure is surfaced (warning + needsLlmScan), NOT reported clean', async () => {
+  const root = mkworkspace();
+  const gathered = await gatherFindings({
+    workspaceRoot: root,
+    collectionsDir: path.join(root, 'uc'),                 // no cached collection
+    projectId: 'proj-1',                                   // + mcpFetcher ⇒ bpaMode='mcp'
+    mcpFetcher: async () => { throw new Error('MCP down'); },
+    analyzeScript: path.join(root, 'missing-analyze.sh'),  // analyzer unavailable
+  });
+  // scheduler is a cascade BPA pattern; the fetch threw — it must NOT be marked
+  // as cleanly scanned by BPA, and must be surfaced for follow-up.
+  assert.notStrictEqual(gathered.sourceByPattern.scheduler, 'mcp');
+  assert.ok(gathered.needsLlmScan.includes('scheduler'), 'failed pattern surfaced in needsLlmScan');
+  assert.ok(
+    gathered.analyzerWarnings.some(w => /BPA fetch failed.*scheduler/.test(w)),
+    'a Scan-warnings entry names the failed pattern'
+  );
+});
+
+test('benign "pattern not in CSV" stays silent and counts as clean', async () => {
+  const root = mkworkspace();
+  const csv = writeBpaCsv(root); // has cdw/lui/etc but NOT scheduler
+  const gathered = await gatherFindings({
+    workspaceRoot: root, bpaFilePath: csv, collectionsDir: path.join(root, 'uc'),
+    analyzeScript: path.join(root, 'missing-analyze.sh'),
+  });
+  // scheduler is absent from the report → genuinely clean, sourced from csv, no warning.
+  assert.strictEqual(gathered.sourceByPattern.scheduler, 'csv');
+  assert.strictEqual(gathered.findingsByPattern.scheduler.length, 0);
+  assert.ok(!gathered.needsLlmScan.includes('scheduler'));
+  assert.ok(!gathered.analyzerWarnings.some(w => /scheduler/.test(w)), 'no warning for a benign absence');
 });
 
 test('runbook lui is filtered to dialog sub-types when sourced from BPA', async () => {

--- a/plugins/aem/cloud-service/skills/migration/scripts/runbook-generator.test.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/runbook-generator.test.js
@@ -1,0 +1,341 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { runHtlLint, classify } = require('./htl-lint-runner.js');
+const { runOsgiConfigScan } = require('./osgi-config-runner.js');
+const { runLuiScan, runCdwScan } = require('./legacy-ui-runner.js');
+const { runTemplateScan } = require('./template-scan-runner.js');
+const {
+  gatherFindings, generateRunbook, renderRunbook, writeRunbookCache,
+  samplePrompt, CANONICAL_PATTERNS, PATTERN_META,
+} = require('./runbook-generator.js');
+
+function mkworkspace() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'runbook-test-'));
+}
+function write(root, rel, content) {
+  const full = path.join(root, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, 'utf8');
+  return full;
+}
+
+// ── Pattern registry ────────────────────────────────────────────────────────
+
+test('registry includes all migration patterns with a strategy', () => {
+  for (const key of ['scheduler', 'resourceChangeListener', 'event-migration', 'assetApi', 'replication', 'htlLint', 'osgiConfig']) {
+    assert.ok(CANONICAL_PATTERNS.includes(key), `${key} in CANONICAL_PATTERNS`);
+    assert.ok(['cascade', 'html-scan', 'config-scan'].includes(PATTERN_META[key].strategy), `${key} has a valid strategy`);
+  }
+});
+
+test('inject-in-sling-model and outdated-dependencies stay out of scope', () => {
+  assert.ok(!CANONICAL_PATTERNS.includes('inject-in-sling-model'));
+  assert.ok(!CANONICAL_PATTERNS.includes('outdated-dependencies'));
+});
+
+// ── htl-lint-runner ───────────────────────────────────────────────────────
+
+test('classify labels each anti-pattern class', () => {
+  assert.strictEqual(classify('<div data-sly-test="${x == true}">'), 'boolean-literal');
+  assert.strictEqual(classify("<div data-sly-test='/apps/foo'>"), 'apps-string-as-test');
+  assert.strictEqual(classify('<div data-sly-test="${a} || ${b}">'), 'split-logical-across-expr');
+  assert.strictEqual(classify('<div data-sly-test="${x == 5}">'), 'numeric-literal');
+});
+
+test('runHtlLint finds data-sly-test anti-patterns in .html', () => {
+  const root = mkworkspace();
+  write(root, 'ui.apps/jcr_root/apps/comp/hero.html', '<div data-sly-test="${properties.x == true}">hi</div>\n');
+  write(root, 'ui.apps/jcr_root/apps/comp/clean.html', '<div data-sly-test="${properties.enabled}">ok</div>\n');
+  const res = runHtlLint(root);
+  assert.strictEqual(res.ok, true);
+  assert.strictEqual(res.findings.length, 1);
+  assert.match(res.findings[0].detail, /boolean-literal/);
+  assert.strictEqual(res.rawFindings[0].pattern, 'htlLint');
+  assert.ok(res.rawFindings[0].line > 0);
+});
+
+test('runHtlLint returns empty (ok) when nothing matches', () => {
+  const root = mkworkspace();
+  write(root, 'ui.apps/jcr_root/apps/comp/clean.html', '<div data-sly-test="${properties.enabled}">ok</div>\n');
+  const res = runHtlLint(root);
+  assert.strictEqual(res.ok, true);
+  assert.strictEqual(res.findings.length, 0);
+});
+
+// ── osgi-config-runner ──────────────────────────────────────────────────────
+
+test('runOsgiConfigScan flags plaintext secret keys WITHOUT leaking the value', () => {
+  const root = mkworkspace();
+  const secretValue = 'sup3rSecretP@ss';
+  write(root, 'ui.config/src/main/content/jcr_root/apps/my/config/com.my.Svc.cfg.json',
+    `{\n  "api-key": "${secretValue}",\n  "endpoint": "https://example.com"\n}\n`);
+  const res = runOsgiConfigScan(root);
+  assert.strictEqual(res.ok, true);
+  const secretFinding = res.rawFindings.find(f => f.kind === 'plaintext-secret');
+  assert.ok(secretFinding, 'a plaintext-secret finding is produced');
+  assert.match(secretFinding.snippet, /<redacted>/);
+  // The value must never appear anywhere in the output.
+  const blob = JSON.stringify(res);
+  assert.ok(!blob.includes(secretValue), 'secret value must not leak into findings');
+});
+
+test('runOsgiConfigScan flags already-placeholdered files and legacy formats', () => {
+  const root = mkworkspace();
+  write(root, 'ui.config/src/main/content/jcr_root/apps/my/config.publish/com.my.Placeheld.cfg.json',
+    '{\n  "password": "$[secret:my-pw]"\n}\n');
+  write(root, 'ui.config/src/main/content/jcr_root/apps/my/config/com.my.Legacy.config',
+    'my.prop="value"\n');
+  const res = runOsgiConfigScan(root);
+  const kinds = res.rawFindings.map(f => f.kind);
+  assert.ok(kinds.includes('already-placeholdered'));
+  assert.ok(kinds.includes('legacy-format'));
+  // A key already using a placeholder is NOT flagged as plaintext-secret.
+  assert.ok(!kinds.includes('plaintext-secret'));
+});
+
+test('runOsgiConfigScan ignores non-config folders and repoinit secret keys', () => {
+  const root = mkworkspace();
+  write(root, 'ui.apps/jcr_root/apps/my/components/notaconfig.cfg.json', '{ "password": "x" }\n');
+  write(root, 'ui.config/jcr_root/apps/my/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-my.cfg.json',
+    '{ "scripts": ["create user with password abc"] }\n');
+  const res = runOsgiConfigScan(root);
+  assert.ok(!res.rawFindings.some(f => f.kind === 'plaintext-secret'),
+    'files outside config folders and repoinit files are not flagged for plaintext secrets');
+});
+
+// ── orchestrator dispatch + cache tagging ────────────────────────────────────
+
+test('gatherFindings dispatches rg + config-scan and tags heuristic in cache', async () => {
+  const root = mkworkspace();
+  write(root, 'ui.apps/jcr_root/apps/comp/hero.html', '<div data-sly-test="${x == false}">x</div>\n');
+  write(root, 'ui.config/jcr_root/apps/my/config/com.my.Svc.cfg.json', '{ "secret-token": "abc123" }\n');
+  // No BPA source, no Java project → cascade patterns go to needsLlmScan or analyzer(empty).
+  const gathered = await gatherFindings({ workspaceRoot: root });
+
+  assert.strictEqual(gathered.sourceByPattern.htlLint, 'html-scan');
+  assert.ok(gathered.findingsByPattern.htlLint.length >= 1);
+  assert.strictEqual(gathered.sourceByPattern.osgiConfig, 'config');
+  assert.ok(gathered.findingsByPattern.osgiConfig.length >= 1);
+
+  const cachePath = path.join(root, 'cache.json');
+  writeRunbookCache(gathered, { generatedAt: 'now' }, cachePath);
+  const cache = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+  for (const f of cache.findingsByPattern.osgiConfig) {
+    assert.strictEqual(f.confidence, 'heuristic');
+  }
+  for (const f of cache.findingsByPattern.htlLint) {
+    assert.strictEqual(f.confidence, 'heuristic');
+  }
+});
+
+test('cascade findings are NOT tagged heuristic', async () => {
+  const root = mkworkspace();
+  const gathered = await gatherFindings({ workspaceRoot: root });
+  const cachePath = path.join(root, 'cache.json');
+  writeRunbookCache(gathered, { generatedAt: 'now' }, cachePath);
+  const cache = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+  for (const f of cache.findingsByPattern.scheduler || []) {
+    assert.notStrictEqual(f.confidence, 'heuristic');
+  }
+});
+
+test('samplePrompt uses the OSGi natural-language override', () => {
+  assert.match(samplePrompt('osgiConfig', {}), /scan my config files/i);
+  assert.match(samplePrompt('scheduler', {}), /migration skill: \*\*scheduler\*\* only/);
+});
+
+test('renderRunbook shows a heuristic note and never emits secret values', async () => {
+  const root = mkworkspace();
+  write(root, 'ui.config/jcr_root/apps/my/config/com.my.Svc.cfg.json', '{ "password": "leakme-please-9000" }\n');
+  const gathered = await gatherFindings({ workspaceRoot: root });
+  const md = renderRunbook(gathered, { generatedAt: 'now' });
+  assert.match(md, /Heuristic detection/);
+  assert.ok(!md.includes('leakme-please-9000'), 'secret value must not appear in the rendered runbook');
+});
+
+// ── regression: compact / multi-property JSON must not hide secrets ─────────
+
+test('runOsgiConfigScan catches a secret that is not the first property on a line', () => {
+  const root = mkworkspace();
+  write(root, 'ui.config/jcr_root/apps/my/config/com.my.Svc.cfg.json',
+    '{"endpoint":"https://x","apiPassword":"HUNTER2_LEAK","token":"$[secret:t]"}');
+  const res = runOsgiConfigScan(root);
+  assert.ok(res.rawFindings.some(f => f.kind === 'plaintext-secret' && /apiPassword/.test(f.snippet)),
+    'secret after the first property on a compact line must be caught');
+  assert.ok(!JSON.stringify(res).includes('HUNTER2_LEAK'), 'secret value must not leak');
+});
+
+test('runOsgiConfigScan emits no XML warning when there are no config files', () => {
+  const root = mkworkspace();
+  write(root, 'core/src/main/java/J.java', 'class J {}\n');
+  const res = runOsgiConfigScan(root);
+  assert.strictEqual(res.warnings.length, 0);
+});
+
+// ── already-placeholdered is informational, not counted as work ─────────────
+
+test('already-placeholdered findings do not count as outstanding work', async () => {
+  const root = mkworkspace();
+  write(root, 'ui.config/jcr_root/apps/my/config/com.my.Done.cfg.json', '{ "password": "$[secret:pw]" }\n');
+  const out = path.join(root, 'rb.md');
+  const cache = path.join(root, 'rb.json');
+  const result = await generateRunbook({ workspaceRoot: root, outputPath: out, cachePath: cache });
+  // informational only → zero actionable findings for osgiConfig
+  assert.strictEqual(result.patternCounts.osgiConfig, 0);
+  // but the informational row is still present in the gathered findings + cache
+  assert.ok(result.gathered.findingsByPattern.osgiConfig.some(f => f.informational));
+  const cached = JSON.parse(fs.readFileSync(cache, 'utf8'));
+  assert.ok(cached.findingsByPattern.osgiConfig.some(f => f.kind === 'already-placeholdered' && f.informational));
+});
+
+// ── paths are workspace-relative in both the runbook and the cache ──────────
+
+test('generateRunbook writes workspace-relative paths, not absolute', async () => {
+  const root = mkworkspace();
+  write(root, 'ui.apps/jcr_root/apps/comp/hero.html', '<div data-sly-test="${x == true}">x</div>\n');
+  const out = path.join(root, 'rb.md');
+  const cache = path.join(root, 'rb.json');
+  await generateRunbook({ workspaceRoot: root, outputPath: out, cachePath: cache });
+
+  const md = fs.readFileSync(out, 'utf8');
+  assert.ok(!md.includes(root), 'rendered runbook must not contain the absolute workspace path');
+  assert.match(md, /ui\.apps\/jcr_root\/apps\/comp\/hero\.html/);
+
+  const cached = JSON.parse(fs.readFileSync(cache, 'utf8'));
+  assert.strictEqual(cached.workspaceRoot, root);
+  for (const f of cached.findingsByPattern.htlLint) {
+    assert.ok(!path.isAbsolute(f.file), 'cache file paths must be relative');
+  }
+});
+
+// ── htlLint word boundary: identifiers starting with true/false not flagged ─
+
+test('classify does not flag identifiers like trueFlag / falseHood', () => {
+  assert.strictEqual(classify('<div data-sly-test="${x == trueFlag}">'), null);
+  assert.strictEqual(classify('<div data-sly-test="${x != falseHood}">'), null);
+  assert.strictEqual(classify('<div data-sly-test="${x == true}">'), 'boolean-literal');
+});
+
+// ── content-scan: lui / cdw / template ──────────────────────────────────────
+
+test('runCdwScan flags custom xtypes but not known-safe ones', () => {
+  const root = mkworkspace();
+  write(root, 'ui.apps/jcr_root/apps/my/components/c/dialog/.content.xml',
+    '<jcr:root><items><a jcr:primaryType="cq:Widget" xtype="textfield"/><b jcr:primaryType="cq:Widget" xtype="my-colorpicker"/></items></jcr:root>');
+  const res = runCdwScan(root);
+  const xtypes = res.rawFindings.map(f => f.xtype);
+  assert.ok(xtypes.includes('my-colorpicker'), 'custom xtype flagged');
+  assert.ok(!xtypes.includes('textfield'), 'known-safe xtype not flagged');
+});
+
+test('runLuiScan flags classic and coral2 dialogs, not coral3', () => {
+  const root = mkworkspace();
+  write(root, 'a/dialog/.content.xml', '<jcr:root jcr:primaryType="cq:Dialog"/>');
+  write(root, 'b/_cq_dialog/.content.xml', '<jcr:root sling:resourceType="granite/ui/components/foundation/container"/>');
+  write(root, 'c/_cq_dialog/.content.xml', '<jcr:root sling:resourceType="granite/ui/components/coral/foundation/container"/>');
+  const res = runLuiScan(root);
+  const subs = res.rawFindings.map(f => f.subType);
+  assert.ok(subs.includes('legacy.dialog.classic'));
+  assert.ok(subs.includes('legacy.dialog.coral2'));
+  assert.strictEqual(res.rawFindings.length, 2, 'coral3 dialog must not be flagged');
+});
+
+test('runTemplateScan flags static templates under apps/*/templates/*', () => {
+  const root = mkworkspace();
+  write(root, 'ui.apps/jcr_root/apps/my/templates/content-page/.content.xml',
+    '<jcr:root jcr:primaryType="cq:Template"/>');
+  write(root, 'ui.apps/jcr_root/apps/my/components/foo/.content.xml',
+    '<jcr:root jcr:primaryType="cq:Template"/>'); // not under templates/ → ignored
+  const res = runTemplateScan(root);
+  assert.strictEqual(res.rawFindings.length, 1);
+  assert.strictEqual(res.rawFindings[0].subType, 'legacy.static.template');
+  assert.match(res.findings[0].detail, /content-page/);
+});
+
+test('gatherFindings dispatches content-scan patterns as heuristic', async () => {
+  const root = mkworkspace();
+  write(root, 'ui.apps/jcr_root/apps/my/components/c/dialog/.content.xml',
+    '<jcr:root jcr:primaryType="cq:Dialog"><items><w jcr:primaryType="cq:Widget" xtype="my-widget"/></items></jcr:root>');
+  write(root, 'ui.apps/jcr_root/apps/my/templates/t/.content.xml', '<jcr:root jcr:primaryType="cq:Template"/>');
+  // Isolate collectionsDir so no ambient BPA collection pre-empts content-scan.
+  const gathered = await gatherFindings({ workspaceRoot: root, collectionsDir: path.join(root, 'no-collections') });
+  for (const p of ['lui', 'cdw', 'templateModernization']) {
+    assert.strictEqual(gathered.sourceByPattern[p], 'content-scan', `${p} scanned via content-scan`);
+    assert.ok(gathered.findingsByPattern[p].length >= 1, `${p} has a finding`);
+  }
+  const cache = path.join(root, 'c.json');
+  writeRunbookCache(gathered, { generatedAt: 'now', workspaceRoot: root }, cache);
+  const cached = JSON.parse(fs.readFileSync(cache, 'utf8'));
+  for (const p of ['lui', 'cdw', 'templateModernization']) {
+    for (const f of cached.findingsByPattern[p]) assert.strictEqual(f.confidence, 'heuristic');
+  }
+});
+
+test('lui/cdw/template sample prompts route to the migration branches', () => {
+  assert.match(samplePrompt('lui', {}), /LUI dialog|Coral 3/i);
+  assert.match(samplePrompt('cdw', {}), /CDW|custom ExtJS/i);
+  assert.match(samplePrompt('templateModernization', {}), /editable templates/i);
+});
+
+// ── BPA parsing of the new subtypes (parser + reader) ───────────────────────
+
+const { getBpaFindings } = require('./bpa-findings-helper.js');
+
+function writeBpaCsv(root) {
+  const rows = [
+    'code,type,subtype,importance,identifier,message,context',
+    // CDW — note underscore in path (design_dialog) must survive round-trip.
+    'CDW,custom.dialog.widget,custom.classic.widget,MAJOR,/apps/x/components/c/design_dialog/items/w1,Custom widget,ctx',
+    'CDW,custom.dialog.widget,custom.classic.widget,MAJOR,/apps/x/components/c/dialog/items/w2,Custom widget,ctx',
+    // LUI — dialogs + a static-template sub-type (should NOT count under lui).
+    'LUI,legacy.user.interface,legacy.dialog.classic,MAJOR,/apps/x/components/c/dialog,Classic dialog,ctx',
+    'LUI,legacy.user.interface,legacy.dialog.coral2,MAJOR,/apps/x/components/c/_cq_dialog,Coral2 dialog,ctx',
+    'LUI,legacy.user.interface,legacy.static.template,MINOR,/apps/x/templates/t1,Static template,ctx',
+    // CTEM — another static template.
+    'CTEM,custom.template,custom.static.template,MINOR,/apps/x/templates/t2,Static template,ctx',
+    // REP — one real forward finding + a summary row that must be excluded.
+    'REP,replication.agent,forward.replication,MAJOR,agent-1,Forward replication agent,ctx',
+    '_COUNT_REP,_count.replication.agent,forward.replication,INFO,\\N,summary,ctx',
+  ];
+  const p = path.join(root, 'bpa.csv');
+  fs.writeFileSync(p, rows.join('\n') + '\n', 'utf8');
+  return p;
+}
+
+test('BPA parser extracts cdw/lui/template/replication and excludes _COUNT rows', async () => {
+  const root = mkworkspace();
+  const csv = writeBpaCsv(root);
+  const opts = { bpaFilePath: csv, collectionsDir: path.join(root, 'uc'), limit: null, offset: 0 };
+
+  const cdw = await getBpaFindings('cdw', opts);
+  assert.strictEqual(cdw.targets.length, 2);
+  // Underscore path must survive the unified round-trip (no design_dialog → design.dialog).
+  assert.ok(cdw.targets.some(t => t.className.includes('design_dialog')), 'underscore path preserved');
+
+  const rep = await getBpaFindings('replication', opts);
+  assert.strictEqual(rep.targets.length, 1, '_COUNT_REP summary row excluded');
+
+  const tpl = await getBpaFindings('templateModernization', opts);
+  assert.strictEqual(tpl.targets.length, 2, 'legacy.static.template + custom.static.template');
+});
+
+test('runbook lui is filtered to dialog sub-types when sourced from BPA', async () => {
+  const root = mkworkspace();
+  const csv = writeBpaCsv(root);
+  const out = path.join(root, 'rb.md');
+  const cache = path.join(root, 'rb.json');
+  const result = await generateRunbook({
+    workspaceRoot: root, bpaFilePath: csv, collectionsDir: path.join(root, 'uc'),
+    outputPath: out, cachePath: cache,
+  });
+  assert.strictEqual(result.patternCounts.lui, 2, 'only classic + coral2, not static.template');
+  assert.strictEqual(result.patternCounts.cdw, 2);
+  assert.strictEqual(result.patternCounts.templateModernization, 2);
+  assert.strictEqual(result.gathered.sourceByPattern.lui, 'csv');
+});

--- a/plugins/aem/cloud-service/skills/migration/scripts/template-scan-runner.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/template-scan-runner.js
@@ -1,0 +1,68 @@
+/**
+ * Template Scan Runner
+ *
+ * The `content-scan` detection tier of the runbook for the
+ * **templateModernization** pattern — static templates that should become
+ * editable templates. Mirrors the discovery in
+ * `{migration}/references/template-modernization/template-modernization-context.md`
+ * (static templates live under `**​/jcr_root/apps/<appId>/templates/*​/.content.xml`).
+ *
+ * Pure-Node fs walk (no external tools). Heuristic — the agent runs the full
+ * per-template context → execute → validate pipeline (Branch C) to confirm and
+ * modernize each one.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Recursively find static-template `.content.xml` files: a `.content.xml`
+ * whose path contains `.../apps/<appId>/templates/<name>/.content.xml` and
+ * whose content declares a `cq:Template` (the static-template marker).
+ */
+function collectStaticTemplates(dir, acc = []) {
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return acc; }
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (e.name === 'node_modules' || e.name === '.git' || e.name === 'target' || e.name === 'dist') continue;
+      collectStaticTemplates(full, acc);
+    } else if (e.isFile() && e.name === '.content.xml') {
+      // Path shape: .../jcr_root/apps/<appId>/templates/<templateName>/.content.xml
+      const parts = full.split(path.sep);
+      const ti = parts.lastIndexOf('templates');
+      const inAppsTemplates = ti > 0 && parts[ti - 2] === 'apps' && parts.length === ti + 3;
+      if (!inAppsTemplates) continue;
+      let content = '';
+      try { content = fs.readFileSync(full, 'utf8'); } catch { continue; }
+      if (/jcr:primaryType="cq:Template"/.test(content)) acc.push(full);
+    }
+  }
+  return acc;
+}
+
+/**
+ * Scan for static templates under `workspaceRoot`.
+ *
+ * @returns {{ ok: boolean, findings: Array, rawFindings: Array, warnings: string[] }}
+ */
+function runTemplateScan(workspaceRoot) {
+  if (!workspaceRoot) return { ok: false, findings: [], rawFindings: [], warnings: [], error: 'no workspaceRoot' };
+  const findings = [];
+  const rawFindings = [];
+  for (const file of collectStaticTemplates(workspaceRoot)) {
+    const templateName = file.split(path.sep).slice(-2, -1)[0];
+    findings.push({
+      location: file,
+      detail: `static-template '${templateName}' — modernize to an editable template (Branch C)`,
+      severity: 'medium',
+    });
+    rawFindings.push({ pattern: 'templateModernization', file, line: null, snippet: 'static template (cq:Template)', subType: 'legacy.static.template' });
+  }
+  return { ok: true, findings, rawFindings, warnings: [] };
+}
+
+module.exports = { runTemplateScan, collectStaticTemplates };

--- a/plugins/aem/cloud-service/skills/migration/scripts/unified-collection-reader.js
+++ b/plugins/aem/cloud-service/skills/migration/scripts/unified-collection-reader.js
@@ -30,6 +30,30 @@ const MONGO_SAFE_TO_PATTERN = {
   "org_osgi_service_event_EventHandler": "eventHandler"
 };
 
+// Pattern → subtype(s), 1:many. Covers the Java patterns above plus the
+// content/legacy-UI patterns whose findings are keyed by JCR path. A subtype
+// may belong to more than one pattern (e.g. legacy.static.template is both a
+// LUI sub-type and a template-modernization candidate).
+const PATTERN_TO_SUBTYPES = {
+  scheduler: ["sling.commons.scheduler"],
+  assetApi: ["unsupported.asset.api"],
+  eventListener: ["javax.jcr.observation.EventListener"],
+  resourceChangeListener: ["org.apache.sling.api.resource.observation.ResourceChangeListener"],
+  eventHandler: ["org.osgi.service.event.EventHandler"],
+  cdw: ["custom.classic.widget"],
+  lui: ["legacy.dialog.classic", "legacy.dialog.coral2", "legacy.custom.component", "legacy.static.template"],
+  templateModernization: ["legacy.static.template", "custom.static.template"],
+  replication: ["forward.replication", "reverse.replication"],
+};
+
+// Patterns whose findings are keyed by JCR path (raw keys, generic processor).
+const CONTENT_PATTERNS = new Set(["cdw", "lui", "templateModernization", "replication"]);
+
+/** MongoDB-safe subtype key: dots → underscores (matches the parser). */
+function toMongoSafeSubtype(subtype) {
+  return subtype ? subtype.replace(/\./g, '_') : null;
+}
+
 // Known scheduler identifier
 const SCHEDULER_IDENTIFIER = "org.apache.sling.commons.scheduler";
 
@@ -126,10 +150,12 @@ function getAvailablePatterns(collectionsDir = './unified-collections') {
       return [];
     }
     
-    const patterns = Object.keys(unifiedCollection.subtypes)
-      .map(mongoSafeSubtype => MONGO_SAFE_TO_PATTERN[mongoSafeSubtype])
-      .filter(pattern => pattern);
-    
+    const present = new Set(Object.keys(unifiedCollection.subtypes));
+    // A pattern is available if ANY of its subtypes is present in the collection.
+    const patterns = Object.keys(PATTERN_TO_SUBTYPES).filter(pattern =>
+      PATTERN_TO_SUBTYPES[pattern].some(st => present.has(toMongoSafeSubtype(st)))
+    );
+
     return patterns;
   } catch (error) {
     console.error('Error reading unified collection:', error.message);
@@ -297,6 +323,31 @@ function processEventHandlerFromUnified(subtypeData, targets) {
 }
 
 /**
+ * Process a content/legacy-UI subtype whose unified data is keyed by RAW JCR
+ * path (no MongoDB round-trip). Emits one target per finding, with the JCR path
+ * as `className` (so downstream `location`/`file` resolve to the path) and the
+ * BPA sub-type as `identifier`.
+ */
+function processContentFromUnified(subtypeData, targets, pattern, subtype) {
+  let count = 0;
+  const pathKeys = Object.keys(subtypeData || {}).sort();
+  for (const jcrPath of pathKeys) {
+    const values = subtypeData[jcrPath] || [];
+    for (let i = 0; i < values.length; i++) {
+      count++;
+      targets.push(new BpaTarget(
+        pattern,
+        jcrPath,                       // className → runbook location/file
+        subtype,                       // identifier → runbook detail (the sub-type)
+        `${pattern} finding (${subtype}): ${jcrPath}`,
+        "high"
+      ));
+    }
+  }
+  return count;
+}
+
+/**
  * Fetch findings from unified collection (mimics cam-bpa-fetcher behavior).
  *
  * The full ordered list for the requested `pattern` is assembled, then
@@ -371,42 +422,34 @@ function fetchUnifiedBpaFindings(pattern = "all", collectionsDir = './unified-co
   
   console.log(`[Unified Collection Reader] Reading patterns: ${patternsToFetch.join(', ')}`);
   
-  // Process each pattern
+  // Processors for the Java patterns (keyed by class name). Content/legacy-UI
+  // patterns use the generic JCR-path processor.
+  const JAVA_PROCESSORS = {
+    scheduler: processSchedulerFromUnified,
+    assetApi: processAssetApiFromUnified,
+    eventListener: processEventListenerFromUnified,
+    resourceChangeListener: processResourceChangeListenerFromUnified,
+    eventHandler: processEventHandlerFromUnified,
+  };
+
+  // Process each pattern — a pattern may map to more than one subtype.
   for (const pat of patternsToFetch) {
-    const mongoSafeSubtype = Object.keys(MONGO_SAFE_TO_PATTERN).find(key => 
-      MONGO_SAFE_TO_PATTERN[key] === pat
-    );
-    
-    if (!mongoSafeSubtype) {
+    const subtypes = PATTERN_TO_SUBTYPES[pat];
+    if (!subtypes) {
       console.warn(`[Unified Collection Reader] Unknown pattern: ${pat}, skipping`);
       continue;
     }
-    
-    const subtypeData = unifiedCollection.subtypes[mongoSafeSubtype];
-    if (!subtypeData) {
-      console.warn(`[Unified Collection Reader] No data for pattern: ${pat}, skipping`);
-      continue;
-    }
-    
-    // Process data based on pattern type
+
     let count = 0;
-    if (pat === "scheduler") {
-      count = processSchedulerFromUnified(subtypeData, result.targets);
-      result.summary.schedulerCount = count;
-    } else if (pat === "assetApi") {
-      count = processAssetApiFromUnified(subtypeData, result.targets);
-      result.summary.assetApiCount = count;
-    } else if (pat === "eventListener") {
-      count = processEventListenerFromUnified(subtypeData, result.targets);
-      result.summary.eventListenerCount = count;
-    } else if (pat === "resourceChangeListener") {
-      count = processResourceChangeListenerFromUnified(subtypeData, result.targets);
-      result.summary.resourceChangeListenerCount = count;
-    } else if (pat === "eventHandler") {
-      count = processEventHandlerFromUnified(subtypeData, result.targets);
-      result.summary.eventHandlerCount = count;
+    for (const subtype of subtypes) {
+      const subtypeData = unifiedCollection.subtypes[toMongoSafeSubtype(subtype)];
+      if (!subtypeData) continue;
+      count += CONTENT_PATTERNS.has(pat)
+        ? processContentFromUnified(subtypeData, result.targets, pat, subtype)
+        : JAVA_PROCESSORS[pat](subtypeData, result.targets);
     }
-    
+    result.summary[`${pat}Count`] = count;
+
     console.log(`[Unified Collection Reader] Processed ${count} findings for pattern: ${pat}`);
   }
   


### PR DESCRIPTION
## What

Adds a **read-only migration runbook** to the AEM Cloud Service `migration` skill and evolves it to cover **every pattern the skill can address**. A broad prompt like *"review my code for AEMaaCS migration"* now generates `migration-runbook.md` (+ a sidecar findings cache) listing findings, locations, and per-pattern sample prompts — with no edits.

The runbook generator is a **per-pattern detection strategy registry** rather than a single hardcoded cascade:

| Strategy | Patterns | Engine |
|---|---|---|
| `cascade` | scheduler, resourceChangeListener, event-migration, assetApi, replication | BPA/CAM → CSV → analyzer → LLM scan |
| `html-scan` | htlLint | `htl-lint-runner.js` (pure-Node regex over `.html`) |
| `config-scan` | osgiConfig | `osgi-config-runner.js` (OSGi config scan) |

## Why

- CSV-eligible patterns keep the BPA priority cascade; the others keep their existing discovery behaviour (HTL regex scan, OSGi config scan) — so the runbook is complete without changing how any individual pattern is detected.
- `html-scan` avoids an external `rg` binary dependency (ripgrep isn't guaranteed to be installed) by scanning in pure Node.
- `config-scan` reports **key names + locations only — never secret values**, because the runbook is written to disk and often committed.

## Key design points for reviewers

- **`html-scan` / `config-scan` findings are heuristic** — tagged `confidence: heuristic` in the cache and rendered with a "re-confirm before editing" note. Classification for `osgiConfig` (real secret? Adobe-owned PID?) is deferred to apply time.
- **Secret-leak safety:** the OSGi runner redacts values; there are explicit tests asserting a planted secret never appears in findings or the rendered runbook.
- **Layering / decoupling:** `migration` depends on `code-assessment`, not the reverse. The `with_findings (pre-resolved)` handoff in `code-assessment/references/{runbook,git-workflow}.md` is written in generic "upstream caller" terms with **no** mention of the migration skill, its cache, or htlLint/osgiConfig. All migration-specific handoff knowledge lives in `migration/SKILL.md`.
- Also fixes defects found while reviewing the initial runbook work: a dead htlLint cache block, a stale Tier-4 (LLM-scan) re-render, and unclear cascade fall-through semantics.

## Testing

- New `runbook-generator.test.js` — **31 tests total** pass via `node --test`: strategy dispatch, both new runners, heuristic cache tagging, the OSGi natural-language sample prompt, and two secret-leak assertions.
- End-to-end run on a fixture project produces the expected 7-pattern runbook; a grep confirms the planted secret is absent from both the runbook and the cache.

> Note: `npm test` fails locally with `bad option: --test` due to a pre-existing environment quirk (npm's subshell resolves an older `node`); `node --test` is the reliable path and all tests pass there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)