### PR TITLE
feat(commerce): promote plugins from adobe/aio-commerce-sdk@88b6b06

### DIFF
--- a/plugins/commerce/app-management/.claude-plugin/plugin.json
+++ b/plugins/commerce/app-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commerce-app-management",
   "description": "Skills for Adobe Commerce App Management — scaffold and configure Commerce apps using the aio-commerce-sdk.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "Adobe"
   },

--- a/plugins/commerce/app-management/.tessl-plugin/plugin.json
+++ b/plugins/commerce/app-management/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe/commerce-app-management",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Skills for Adobe Commerce App Management — scaffold and configure Commerce apps using the aio-commerce-sdk.",
   "private": false,
   "skills": [

--- a/plugins/commerce/app-management/skills/commerce-app-admin-ui/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-admin-ui/SKILL.md
@@ -119,6 +119,14 @@ The build derives the extension's `ext.config.yaml` from your `adminUi` config: 
 
 When a `view` operation is present, init/generate also scaffolds the web frontend automatically (skipped if `web-src/index.html` already exists). It generates `src/commerce-backend-ui-2/web-src/` — `index.html`, `src/app.jsx`, `src/pages/main-page.jsx`, `src/components/welcome.jsx` (`.tsx` plus a `tsconfig.json` when the app config is TypeScript) — adds the `#web/*` import alias to `package.json`, and declares and installs pinned versions of `react`, `react-dom`, `@react-spectrum/s2`, and `@adobe/aio-commerce-lib-admin-ui` (React and Spectrum S2 are optional peer dependencies of the admin-ui library), plus some `devDependencies` for proper TypeScript support/config. Do not hand-pick different versions of these dependencies; the scaffold fails if incompatible versions are already installed.
 
+If the scaffold is skipped because `web-src` already exists, check its `package.json` for classic React Spectrum (`@adobe/react-spectrum` or `@react-spectrum/<component>` without `s2`) instead of `@react-spectrum/s2`. The two are compatible, but S2 is the version Adobe recommends moving to and the one this scaffold targets — suggest upgrading. This skill only configures the Admin UI extension, it doesn't drive the upgrade itself, so point the user to the `commerce-app-migrate` skill for the actual migration:
+
+```sh
+npx skills add adobe/skills --skill commerce-app-migrate
+```
+
+Do not install it or perform the upgrade yourself unless the user asks.
+
 ## Step 4 — Implement the handlers
 
 What you implement depends on the variant. Examples below are in TypeScript; if the project uses JavaScript, omit type imports and annotations.

--- a/plugins/commerce/app-management/skills/commerce-app-admin-ui/evals/evals.json
+++ b/plugins/commerce/app-management/skills/commerce-app-admin-ui/evals/evals.json
@@ -4,7 +4,7 @@
     {
       "id": 0,
       "name": "order-grid-column",
-      "prompt": "I've got a base Commerce app scaffolded with the aio-commerce-sdk (app.commerce.config.ts exists and the project is initialized). I need to add a 'Fulfillment' column to the Admin order grid — the value for each order comes from our warehouse API. Wire up the config and the runtime action handler.",
+      "prompt": "I've got a base Commerce app scaffolded with the aio-commerce-sdk (app.commerce.config.ts exists and the project is initialized). I need to add a 'Fulfillment' column to the Admin order grid, the value for each order comes from our warehouse API. Wire up the config and the runtime action handler.",
       "expected_output": "adminUi.order.gridColumns declared in app.commerce.config.ts with a single column (id, label, type, align) and a runtimeAction in <package>/<action> form. A handler under src/commerce-backend-ui-2/actions/ using parseGridRequest + okGridResponse/errorGridResponse from @adobe/aio-commerce-sdk/admin-ui/grid-columns, with row keys matching the column id. The action registered under runtimeManifest in src/commerce-backend-ui-2/ext.config.yaml with function: actions/<action>/index.js, require-adobe-auth: true, and final: true. Uses the v2 adminUi schema, does not use adminUiSdk.registration or commerce/backend-ui/1, and mentions running npx @adobe/aio-commerce-lib-app init and aio app build.",
       "files": [],
       "assertions": [
@@ -93,7 +93,7 @@
       "assertions": [
         "Declares adminUi.menu (single object) with id, label, and description",
         "Sets parentMenu to MENU_SALES imported from @adobe/aio-commerce-sdk/admin-ui/menu",
-        "Menu id uses only valid characters (letters, digits, /, :, _) — no hyphens or spaces",
+        "Menu id uses only valid characters (letters, digits, /, :, _), no hyphens or spaces",
         "Recognizes the menu has no runtime action handler; does not scaffold a menu-specific action under src/commerce-backend-ui-2/actions/",
         "Declares adminUi.order.viewButtons with a type: \"worker\" entry containing id, label, and runtimeAction",
         "View button handler imports parseOrderViewButtonRequest and okOrderViewButtonResponse/orderViewButtonErrorResponse from @adobe/aio-commerce-sdk/admin-ui/order-view-buttons",
@@ -138,6 +138,34 @@
         "Both worker action sources live under src/commerce-backend-ui-2/actions/<action>/index.ts",
         "Both worker actions are registered under runtimeManifest with function paths, require-adobe-auth: true, and final: true",
         "Notes mention running npx @adobe/aio-commerce-lib-app init and aio app build"
+      ]
+    },
+    {
+      "id": 8,
+      "name": "existing-web-src-classic-react-spectrum-suggestion",
+      "prompt": "My initialized Commerce app already has an adminUi.menu entry wired up (commerce/backend-ui/2), with src/commerce-backend-ui-2/web-src/ already scaffolded. Its package.json lists \"@adobe/react-spectrum\": \"^3.34.2\" as a dependency (no @react-spectrum/s2). Add a new order view button 'Sync inventory' as a view (iframe) variant.",
+      "expected_output": "The order view button is added to app.commerce.config.ts (adminUi.order.viewButtons) as a type: \"view\" entry with a path, and a new placeholder page plus route are added to the existing web-src without touching the existing menu page/route. Separately, the agent notices the existing web-src's package.json depends on classic React Spectrum (@adobe/react-spectrum) instead of @react-spectrum/s2, explains the two are compatible but S2 is the version Adobe recommends moving to, and suggests installing/using the commerce-app-migrate skill (npx skills add adobe/skills --skill commerce-app-migrate) to run the upgrade, offering to help but not installing packages or rewriting components itself unless asked.",
+      "files": [
+        {
+          "path": "app.commerce.config.ts",
+          "content": "import { defineConfig } from \"@adobe/aio-commerce-lib-app/config\";\nimport { MENU_SALES } from \"@adobe/aio-commerce-sdk/admin-ui/menu\";\n\nexport default defineConfig({\n  adminUi: {\n    menu: {\n      id: \"acme_dashboard\",\n      label: \"Acme Dashboard\",\n      description: \"Acme app dashboard.\",\n      parentMenu: MENU_SALES,\n    },\n  },\n});\n"
+        },
+        {
+          "path": "src/commerce-backend-ui-2/web-src/package.json",
+          "content": "{\n  \"name\": \"acme-web-src\",\n  \"dependencies\": {\n    \"react\": \"^18.2.0\",\n    \"react-dom\": \"^18.2.0\",\n    \"@adobe/react-spectrum\": \"^3.34.2\",\n    \"@adobe/aio-commerce-lib-admin-ui\": \"^1.0.0\"\n  }\n}\n"
+        },
+        {
+          "path": "src/commerce-backend-ui-2/web-src/src/app.jsx",
+          "content": "import { createExtensionApp } from \"@adobe/aio-commerce-lib-admin-ui/web\";\nimport \"@react-spectrum/s2/page.css\";\n\nimport config from \"#app.commerce.config\";\nimport { MainPage } from \"#web/pages/main-page.jsx\";\n\ncreateExtensionApp({\n  metadata: { extensionId: config.metadata.id },\n  routes: [{ index: true, element: <MainPage /> }],\n});\n"
+        }
+      ],
+      "assertions": [
+        "Adds adminUi.order.viewButtons with a type: \"view\" entry (id, label, path) without touching the existing adminUi.menu entry",
+        "Creates a new placeholder page under web-src/src/pages/ and registers its route in app.jsx as the exact path string from the config, keeping the existing index route and menu page/route untouched",
+        "Detects that web-src's package.json depends on @adobe/react-spectrum (classic React Spectrum) rather than @react-spectrum/s2",
+        "States classic React Spectrum and S2 are compatible, but recommends moving to S2 without claiming classic React Spectrum is unmaintained",
+        "Suggests installing/using the commerce-app-migrate skill (e.g. npx skills add adobe/skills --skill commerce-app-migrate) to run the S1-to-S2 migration, offering to help",
+        "Does not run the codemod, install packages, or rewrite Spectrum components itself unless the user explicitly asks it to proceed"
       ]
     }
   ]

--- a/plugins/commerce/app-migration/.claude-plugin/plugin.json
+++ b/plugins/commerce/app-migration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commerce-app-migration",
   "description": "Migrate an Adobe Commerce App Builder project from the Integration Starter Kit or Checkout Starter Kit to the new App Management approach.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "Adobe",
     "email": "commerce-app-management@adobe.com"

--- a/plugins/commerce/app-migration/.tessl-plugin/plugin.json
+++ b/plugins/commerce/app-migration/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe/commerce-app-migration",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Migrate an Adobe Commerce App Builder project from the Integration Starter Kit or Checkout Starter Kit to the new App Management approach. Run from the root of the App Builder project to be migrated. Pass --auto to skip confirmation prompts (suitable for CI or batch use).",
   "private": false,
   "skills": ["skills/commerce-app-migrate"]

--- a/plugins/commerce/app-migration/skills/commerce-app-migrate/SKILL.md
+++ b/plugins/commerce/app-migration/skills/commerce-app-migrate/SKILL.md
@@ -303,8 +303,18 @@ export default defineConfig({
   Max 50 chars.
 - `version`: Use `package.json` `version`. Default: `"1.0.0"`.
 - `description`: Use `package.json` `description` if present.
-  If the description exceeds 255 characters, truncate it to 252 characters and append `"..."`.
-  If absent or empty, check `extension-manifest.json` `description` field (truncate to 255 if needed).
+  If the description exceeds 255 characters, do NOT truncate it mid-sentence.
+  Instead, rewrite it: read the full description and compose a shorter one that
+  fits in 255 characters while preserving the essential meaning — what the app
+  does, which systems it connects, and its key capabilities. Prefer complete
+  sentences; drop secondary detail (deployment notes, exhaustive feature lists)
+  before core purpose. Never end with `"..."` — the rewritten description must
+  read as intentional, not cut off.
+  The rewritten value applies only to the config: the Executor records the original
+  `package.json` description before init and restores it afterwards (init writes the
+  config value back into `package.json`).
+  If absent or empty, check `extension-manifest.json` `description` field (apply the
+  same rewrite rule).
   If neither has a description: `"Commerce App Builder application"`.
 
 **productDependencies comment:**

--- a/plugins/commerce/app-migration/skills/commerce-app-migrate/agents/executor.md
+++ b/plugins/commerce/app-migration/skills/commerce-app-migrate/agents/executor.md
@@ -26,8 +26,8 @@ Triggered when the orchestrating skill detects an already-migrated project.
 
 - **Skip:** Steps 1–3 (no branch, no file writes, no script migration)
 - **Run:** Step 3a with modified inputs (see Step 3a for details)
-- **Skip:** Steps 4–9
-- **Run:** Step 10 with a restricted output (documentation recommendations only)
+- **Skip:** Steps 4–7
+- **Run:** Step 8 with a restricted output (documentation recommendations only)
 
 In doc-scan-only mode the `assembled config` parameter is `null`. When Step 3a
 reads the config to build migration context, it reads the **existing config file**
@@ -41,7 +41,7 @@ from disk — `app.commerce.config.ts` if it exists, otherwise `app.commerce.con
   and extract the quoted string value as a script path. If none found, use `[]`
 - `convertedYamlFiles`: `[]` (no YAML conversion happened in this mode)
 
-The Step 10 report header is also modified for doc-scan-only mode — see Step 10.
+The Step 8 report header is also modified for doc-scan-only mode — see Step 8.
 
 ---
 
@@ -178,7 +178,7 @@ If the script reads a data file via `fs.readFileSync` (e.g. a YAML or JSON confi
   The `require()` string must be a **static literal** (not a variable) so webpack can
   analyse it at build time.
 
-  **Bookkeeping for Step 10:** Each time you create a `.json` sibling for a `.yaml`
+  **Bookkeeping for Step 8:** Each time you create a `.json` sibling for a `.yaml`
   file, record the original YAML path in an internal list called `convertedYamlFiles`.
   For example, converting `shipping-carriers.yaml` → add `"shipping-carriers.yaml"` to
   `convertedYamlFiles`. This list is used to populate the "Files that can be safely
@@ -435,36 +435,36 @@ Private helpers (e.g. `formatErrorMessage`) are removed — errors now throw dir
 
 **Run this step immediately after Step 3, before init.** Both Category C and
 Category D analyze static files that exist before any install command. Computing them
-now ensures the recommendations are always available in Step 10 regardless of whether
+now ensures the recommendations are always available in Step 8 regardless of whether
 Step 4 succeeds, times out, or is blocked.
 
 In **doc-scan-only mode**, run this step using the modified inputs described in the
 "Operating Modes" section above. Skip Steps 1–3 entirely and begin here.
 
-Apply all computation rules defined below in Step 10 (Categories A, B, C, D). Those rules
-are written in Step 10 for readability but execute here, before npm install.
+Apply all computation rules defined below in Step 8 (Categories A, B, C, D). Those rules
+are written in Step 8 for readability but execute here, before npm install.
 
 - `convertedYamlFiles` for Category B is the list built during Step 3
   (empty `[]` in doc-scan-only mode)
 - All other inputs are drawn from the assembled config and `ProjectSnapshot`
-  as described in Step 10
+  as described in Step 8
 
 Store all results in memory, then:
 
 - **Normal mode:** also print the "Documentation recommendations" block **immediately now**,
-  before Steps 4–9 run. Use the same format as defined in Step 10's
+  before Steps 4–7 run. Use the same format as defined in Step 8's
   "── Documentation recommendations" section. Prefix the block with:
 
       ── Documentation recommendations (computed before install) ────────
 
   This ensures recommendations are visible if a later step (init, commit)
-  blocks, hangs, or fails. Step 10 includes the same block again — that is intentional.
+  blocks, hangs, or fails. Step 8 includes the same block again — that is intentional.
 
 - **Doc-scan-only mode:** store results only. Do **not** print here. There are no risky
-  commands between Step 3a and Step 10, so printing twice would be pure noise. Print once
-  in Step 10's abbreviated report.
+  commands between Step 3a and Step 8, so printing twice would be pure noise. Print once
+  in Step 8's abbreviated report.
 
-Proceed to Step 4 (or Step 10 in doc-scan-only mode) after storing.
+Proceed to Step 4 (or Step 8 in doc-scan-only mode) after storing.
 
 ---
 
@@ -475,7 +475,7 @@ Proceed to Step 4 (or Step 10 in doc-scan-only mode) after storing.
 ### Node version detection
 
 Before running init, detect the Node.js runtime version to use when scaffolding action
-handlers in Step 5a. Apply in order — first match wins:
+handlers in Step 5. Apply in order — first match wins:
 
 1. Scan all `ext.config.yaml` files in the project for a `runtime: nodejs:XX` declaration
    in any action definition. Use the value found (e.g. `nodejs:24`).
@@ -485,7 +485,7 @@ handlers in Step 5a. Apply in order — first match wins:
    Format as `nodejs:<major>`.
 4. Default: `nodejs:24`
 
-Store as `detectedNodeRuntime`. Used only in Step 5a.
+Store as `detectedNodeRuntime`. Used only in Step 5.
 
 ### Pre-flight: ensure `.env` exists
 
@@ -500,16 +500,71 @@ Before running init, check whether `.env` exists at the project root:
 This is required because the init CLI unconditionally reads `.env` during
 the configuration-schema generation sub-step.
 
+### Pre-flight: record the original package.json description
+
+Read `package.json` and store its `description` value as `originalPackageDescription`
+(may be absent). `init` writes the config's `metadata.description` back into
+`package.json` — if that value was rewritten during config assembly to fit the
+255-char limit, the original description would be silently replaced. Step 6
+restores it.
+
+### Pre-flight (pnpm only): approve the esbuild build script
+
+pnpm 10 blocks dependency build scripts by default. `init` runs `pnpm add` inside
+the project to install its dependencies, and the `--allow-build` flag on the outer
+`dlx` command does **not** carry over to that inner install — without persistent
+approval it fails with `ERR_PNPM_IGNORED_BUILDS: Ignored build scripts: esbuild@...`.
+
+Before running init on a pnpm project, approve esbuild persistently. Write the
+approval **where the project already keeps its pnpm configuration** — inspect
+both files and pick the first matching rule:
+
+1.  If either file already has an `onlyBuiltDependencies` list (`pnpm.onlyBuiltDependencies`
+    in `package.json`, or top-level `onlyBuiltDependencies` in `pnpm-workspace.yaml`):
+    merge `esbuild` into **that existing list**. Never create a second list in the
+    other file — pnpm reads only one of them, and a duplicate misleads.
+2.  Else, if `package.json` has a `pnpm` section: add the list there —
+
+        "pnpm": { "onlyBuiltDependencies": ["esbuild"] }
+
+    (This mirrors pnpm's own `approve-builds` behavior: when pnpm settings live in
+    `package.json`, it keeps writing them there.)
+
+3.  Else, if `pnpm-workspace.yaml` exists: add a top-level list there —
+
+        onlyBuiltDependencies:
+          - esbuild
+
+4.  Else (neither location holds pnpm settings): add the `pnpm` section to
+    `package.json` as in rule 2. Do not create `pnpm-workspace.yaml` on a project
+    that does not already have one — its presence declares a pnpm workspace.
+
+If `esbuild` is already present in the list, make no change.
+
+Record which file was modified (or that no change was needed) — it is reported in
+Step 8's "Modified" section.
+
 ### Run init
 
 Run the appropriate command for the `packageManager` from `ProjectSnapshot`:
 
-| packageManager | command                               |
-| -------------- | ------------------------------------- |
-| `npm`          | `npx aio-commerce-lib-app init`       |
-| `pnpm`         | `pnpm exec aio-commerce-lib-app init` |
-| `yarn`         | `yarn exec aio-commerce-lib-app init` |
-| `bun`          | `bunx aio-commerce-lib-app init`      |
+| packageManager | command                                                                  |
+| -------------- | ------------------------------------------------------------------------ |
+| `npm`          | `npx --yes @adobe/aio-commerce-lib-app@latest init`                      |
+| `pnpm`         | `pnpm --allow-build=esbuild dlx @adobe/aio-commerce-lib-app@latest init` |
+| `yarn`         | `yarn dlx @adobe/aio-commerce-lib-app@latest init`                       |
+| `bun`          | `bunx @adobe/aio-commerce-lib-app@latest init`                           |
+
+The scoped package name (`@adobe/aio-commerce-lib-app`) is required: on a project
+where the package is not yet a local dependency, the unscoped bin name
+(`npx aio-commerce-lib-app init`) fails with
+`npm error could not determine executable to run`.
+
+For pnpm, `--allow-build=esbuild` covers the temporary `dlx` install of the CLI
+itself. The flag must come **before** `dlx` — `pnpm dlx --allow-build=...` fails
+with `ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER` on several pnpm versions.
+The install init runs inside the project is covered by the pre-flight approval
+above, not by this flag.
 
 The `init` command installs required dependencies and generates the full `src/` extension
 structure from `app.commerce.config.ts` in one step.
@@ -517,23 +572,22 @@ structure from `app.commerce.config.ts` in one step.
 **If the init command is denied or blocked (permission error, sandbox rejection,
 or non-zero exit with no network output):**
 
-Do NOT retry. Record the failure and emit the following manual instruction in Step 10:
+Do NOT retry. Record the failure and emit the following manual instruction in Step 8,
+substituting the command matching the project's package manager from the table above:
 
     ✗ aio-commerce-lib-app init BLOCKED (Claude Code sandbox restriction)
 
     Run this manually in your terminal before continuing:
-        npx aio-commerce-lib-app init
+        npx --yes @adobe/aio-commerce-lib-app@latest init
 
-    Then update app.config.yaml and install.yaml per the Next steps section.
-
-Continue to Step 5a even if init failed.
+Continue to Step 5 even if init failed.
 
 **Diagnosing init failures:**
 
 If the command exits with an error, inspect the output:
 
 1.  **"CLI was not built!"** — The installed package is missing its compiled `dist/`
-    directory (packaging defect). Record this specific error. In Step 10, emit:
+    directory (packaging defect). Record this specific error. In Step 8, emit:
 
         ✗ aio-commerce-lib-app init FAILED: CLI was not built! (dist/ missing from aio-commerce-lib-app)
 
@@ -543,13 +597,29 @@ If the command exits with an error, inspect the output:
                  npm view @adobe/aio-commerce-lib-app versions --json
           2. Install a newer version that includes dist/:
                  npm install @adobe/aio-commerce-lib-app@<latest>
-          3. Re-run: npx aio-commerce-lib-app init
+          3. Re-run: npx --yes @adobe/aio-commerce-lib-app@latest init
 
-2.  **Schema validation errors** — Record the error and report it in Step 10 so
+2.  **`ERR_PNPM_IGNORED_BUILDS` (pnpm only)** — pnpm 10 blocked a dependency's build
+    script (the output names the package, e.g. `Ignored build scripts: esbuild@...`).
+    This means the blocked package is not covered by the project's persistent
+    approval (the pre-flight above covers `esbuild`; a different package may be
+    named). Add the named package to the same `onlyBuiltDependencies` list the
+    pre-flight wrote, then re-run init **once**. If it still fails, record the
+    failure and emit in Step 8:
+
+        ✗ aio-commerce-lib-app init FAILED: ERR_PNPM_IGNORED_BUILDS (<package> build script blocked)
+
+        pnpm blocks dependency build scripts by default. Approve the build for
+        this project, then re-run init:
+          1. Add <package> to the onlyBuiltDependencies list in <file the
+             pre-flight chose>, or run: pnpm approve-builds
+          2. Re-run: pnpm --allow-build=esbuild dlx @adobe/aio-commerce-lib-app@latest init
+
+3.  **Schema validation errors** — Record the error and report it in Step 8 so
     the developer can fix the config and re-run init manually.
 
-3.  **Any other error** — Record the failure message and skip Step 5a.
-    Report the error in Step 10.
+4.  **Any other error** — Record the failure message and skip Step 5.
+    Report the error in Step 8.
 
 After this command completes successfully, check which directories were created:
 
@@ -560,11 +630,11 @@ After this command completes successfully, check which directories were created:
   it also contains a generated `web-src/` frontend (mounted with `createExtensionApp`
   from `@adobe/aio-commerce-lib-admin-ui/web`), plus additional dependencies installed (if not already present and compatible) needed by the frontend (`react`, `react-dom`, `@react-spectrum/s2`, and some `devDependencies` needed for proper TypeScript support/config).
 
-Note which directories exist — you will need this in Steps 5a and 6.
+Note which directories exist — you will need this in Steps 5 and 6.
 
 ---
 
-## Step 5a: Scaffold Admin UI SDK handlers
+## Step 5: Scaffold Admin UI SDK handlers
 
 Runs immediately after Step 4 init succeeds and `src/commerce-backend-ui-2/` exists.
 Skip this step entirely if the assembled config has no `adminUi` section.
@@ -728,12 +798,21 @@ is no longer generated by `commerce/backend-ui/2` and the hook will fail the bui
 `install.yml` (or merge its extra entries into `install.yaml` first) so only one
 install file remains.
 
+**4. Restore the original `package.json` description.**
+`init` writes the config's `metadata.description` back into `package.json`. If the
+config value was rewritten during assembly, this silently replaces the original.
+Compare `package.json`'s current `description` with the `originalPackageDescription`
+recorded in Step 4 — if they differ, restore `originalPackageDescription`. The
+rewritten value belongs only in `app.commerce.config.ts` (App Management's 255-char
+limit); the full description stays in `package.json`. Record whether a restore
+happened — it is reported in Step 8's "Modified" section.
+
 **Do not modify any other content in `app.config.yaml`, the install file, or
 `package.json`.**
 
 ---
 
-## Step 9: Stage changes and ask to commit
+## Step 7: Stage changes and ask to commit
 
 Stage all migration-related files:
 
@@ -763,15 +842,15 @@ without prompting.
 
       git commit -m "feat: migrate to App Management"
 
-Then proceed to Step 10. Do not wait for the developer to commit before printing the summary.
+Then proceed to Step 8. Do not wait for the developer to commit before printing the summary.
 
 ---
 
-## Step 10: Print migration summary
+## Step 8: Print migration summary
 
 **Use the pre-computed results stored in Step 3a. The computation rules for
 Categories A–D are defined below — they run in Step 3a, not here.
-Step 10 only assembles and prints the report.**
+Step 8 only assembles and prints the report.**
 
 **Category A — Onboarding scripts not in `customInstallationSteps`:**
 
@@ -996,9 +1075,17 @@ constraints, Next steps) when in doc-scan-only mode.
     ║             App Management Migration — Complete                  ║
     ╚══════════════════════════════════════════════════════════════════╝
 
+    TL;DR: staged <N> files · init <✓ ok / ✗ failed / ✗ blocked> · <K> manual follow-up(s)
+
+       ← N = number of files staged in Step 7; K = total count of items requiring
+          developer action across "Safe to delete", "Removable files",
+          "Documentation recommendations" (Category C + D entries), and any failed
+          command that must be re-run manually. Print "no manual follow-ups" if K is 0 →
+
     ── Files written ──────────────────────────────────────────────────
       ✓  app.commerce.config.ts                          new
-      ✓  install.yaml                                    new / updated
+      [✓  install.yaml                                   new / updated]
+         ← omit if init failed →
       [✓  scripts/<name>.js                              migrated → defineCustomInstallationStep]
          ← one line per migrated script; omit section if none were migrated →
 
@@ -1047,6 +1134,12 @@ constraints, Next steps) when in doc-scan-only mode.
       If adminUi is worker-only (no view entries), react and react-dom are
       removable as well.
 
+      Each `view` entry only gets a placeholder page. Porting the old
+      iframe's UI content into it is out of scope for this migration —
+      suggest it to the user, targeting @react-spectrum/s2 (not
+      @adobe/react-spectrum; see ../references/spectrum-s2-upgrade.md),
+      but do not port it yourself unless the user explicitly asks.
+
       Runtime packages replaced by @adobe/aio-commerce-sdk:
         @adobe/aio-sdk  cloudevents  got  node-fetch  oauth-1.0a  uuid
 
@@ -1062,9 +1155,15 @@ constraints, Next steps) when in doc-scan-only mode.
     ← end conditional →
 
     ── Modified ───────────────────────────────────────────────────────
-         ← omit app.config.yaml line if init failed →
+         ← omit the next two lines if init failed →
       app.config.yaml    added extensions block
       package.json       added postinstall hook
+      [package.json      description restored — init wrote the shortened config value back;
+                         the original full description was kept (see Step 6)]
+         ← include only if Step 6 restored the description →
+      [pnpm-workspace.yaml   approved esbuild build script (onlyBuiltDependencies)]
+      [package.json          approved esbuild build script (pnpm.onlyBuiltDependencies)]
+         ← include only the line matching the file the Step 4 pnpm pre-flight modified →
 
     ── Installation steps ─────────────────────────────────────────────
          ← omit this entire section if no customInstallationSteps →
@@ -1219,7 +1318,7 @@ constraints, Next steps) when in doc-scan-only mode.
     ← end conditional block →
 
     ── Next steps ─────────────────────────────────────────────────────
-      [1. npx aio-commerce-lib-app init]   ← include ONLY if Step 4 failed
+      [1. npx --yes @adobe/aio-commerce-lib-app@latest init]   ← include ONLY if Step 4 failed
        2. Review src/commerce-extensibility-1/.generated/ before deploying
        3. aio app deploy
 

--- a/plugins/commerce/app-migration/skills/commerce-app-migrate/evals/evals.json
+++ b/plugins/commerce/app-migration/skills/commerce-app-migrate/evals/evals.json
@@ -38,7 +38,7 @@
       "id": 1,
       "name": "order-mass-action-view-sandbox",
       "prompt": "I have a Commerce App Builder project using Admin UI SDK v1. The registration at src/commerce-backend-ui-1/registration.js has an iframe mass action on the order grid with a space-separated sandbox string that includes an invalid value. Migrate it to App Management v2.",
-      "expected_output": "adminUi.order.massActions in app.commerce.config.ts with type: \"view\", path kept, sandbox string split into sandboxPermissions array — only valid values retained (allow-downloads, allow-modals, allow-popups). The invalid value allow-scripts is dropped.",
+      "expected_output": "adminUi.order.massActions in app.commerce.config.ts with type: \"view\", path kept, sandbox string split into sandboxPermissions array, only valid values retained (allow-downloads, allow-modals, allow-popups). The invalid value allow-scripts is dropped.",
       "files": [
         {
           "path": "app.config.yaml",
@@ -57,7 +57,7 @@
         "Produces adminUi.order.massActions with type: \"view\"",
         "Renames actionId to id (value: \"review-orders\")",
         "Keeps path as path (value: \"#/review\")",
-        "Converts sandbox string to sandboxPermissions array [\"allow-downloads\", \"allow-modals\"] — dropping \"allow-scripts\" as an invalid value",
+        "Converts sandbox string to sandboxPermissions array [\"allow-downloads\", \"allow-modals\"], dropping \"allow-scripts\" as an invalid value",
         "Does not include runtimeAction on the view entry"
       ]
     },
@@ -264,6 +264,90 @@
         "Converts sandbox string \"allow-popups allow-modals\" to sandboxPermissions array [\"allow-popups\", \"allow-modals\"]",
         "Does not include runtimeAction on the view entry",
         "Does not emit an unresolved question for runtimeAction"
+      ]
+    },
+    {
+      "id": 9,
+      "name": "classic-react-spectrum-upgrade-suggestion",
+      "prompt": "I have a Commerce App Builder project using Admin UI SDK v1. The registration at src/commerce-backend-ui-1/registration.js has a menuItems array with a single non-section item. The project's src/commerce-backend-ui-1/web-src/package.json lists \"@adobe/react-spectrum\": \"^3.34.2\" as a dependency. Migrate it to App Management v2.",
+      "expected_output": "adminUi.menu produced in app.commerce.config.ts from the non-section menu item. The v2 init scaffolds a fresh src/commerce-backend-ui-2/web-src/ pinned to @react-spectrum/s2. The migration report flags @adobe/react-spectrum under v1 frontend packages superseded by the v2 scaffold, notes that porting any existing iframe UI content is a manual follow-up that should target @react-spectrum/s2 rather than reinstalling classic React Spectrum, and offers to help run that S1-to-S2 upgrade, without actually rewriting UI components unless the user asks.",
+      "files": [
+        {
+          "path": "app.config.yaml",
+          "content": "application:\n  extensions:\n    commerce/backend-ui/1:\n      $include: src/commerce-backend-ui-1/ext.config.yaml\n"
+        },
+        {
+          "path": "package.json",
+          "content": "{\"name\": \"acme-app\", \"version\": \"1.0.0\"}\n"
+        },
+        {
+          "path": "src/commerce-backend-ui-1/registration.js",
+          "content": "module.exports = {\n  menuItems: [\n    {\n      id: 'dashboard',\n      title: 'Dashboard'\n    }\n  ]\n}\n"
+        },
+        {
+          "path": "src/commerce-backend-ui-1/web-src/package.json",
+          "content": "{\n  \"name\": \"acme-web-src\",\n  \"dependencies\": {\n    \"react\": \"^18.2.0\",\n    \"react-dom\": \"^18.2.0\",\n    \"@adobe/react-spectrum\": \"^3.34.2\",\n    \"@adobe/exc-app\": \"^1.0.0\",\n    \"@adobe/uix-guest\": \"^1.0.0\"\n  }\n}\n"
+        }
+      ],
+      "assertions": [
+        "Produces a single adminUi.menu object from the non-section item (id: \"dashboard\")",
+        "Lists @adobe/react-spectrum among v1 frontend packages superseded by the v2 web-src scaffold in the migration report",
+        "States that the v2 scaffold pins @react-spectrum/s2 for the new web-src, not classic React Spectrum",
+        "Notes that porting any existing iframe UI content into the new web-src is a manual follow-up that should target @react-spectrum/s2",
+        "Offers to help run the S1-to-S2 upgrade rather than only describing it",
+        "Does not rewrite or port any UI component code itself without the user explicitly asking"
+      ]
+    },
+    {
+      "id": 10,
+      "name": "description-rewrite-preserves-package-json",
+      "prompt": "I have a Commerce App Builder project with a package.json description longer than 255 characters. Migrate it to App Management.",
+      "expected_output": "metadata.description in app.commerce.config.ts is a rewritten summary of the original that fits in 255 characters, reads as complete sentences preserving the app's core purpose (Commerce-to-ERP sync of orders, customers, inventory), and does not end with \"...\" or cut off mid-sentence. The original full description in package.json is preserved: the executor records it before init and restores it if init writes the shortened config value back, reporting the restore in the migration summary.",
+      "files": [
+        {
+          "path": "app.config.yaml",
+          "content": "application:\n  runtimeManifest:\n    packages:\n      acme-app:\n        license: Apache-2.0\n        actions:\n          sync-orders:\n            function: actions/sync-orders/index.js\n            web: \"yes\"\n            runtime: nodejs:22\n"
+        },
+        {
+          "path": "package.json",
+          "content": "{\"name\": \"acme-app\", \"version\": \"1.0.0\", \"description\": \"Acme Commerce integration for Adobe App Builder that synchronizes orders, customers, and product inventory between Adobe Commerce and the Acme ERP platform, including bidirectional event-driven updates, scheduled reconciliation jobs, configurable field mappings, and audit logging for enterprise deployments.\"}\n"
+        },
+        {
+          "path": "actions/sync-orders/index.js",
+          "content": "async function main (params) {\n  return { statusCode: 200, body: { success: true } }\n}\n\nmodule.exports = { main }\n"
+        }
+      ],
+      "assertions": [
+        "metadata.description in app.commerce.config.ts is at most 255 characters",
+        "The description is a coherent rewrite, not a mechanical cut: it does not end with \"...\", does not stop mid-word or mid-sentence, and preserves the core purpose (synchronizing orders, customers, and inventory between Adobe Commerce and the Acme ERP)",
+        "The original full description remains in package.json after migration (restored if init wrote the shortened config value back)",
+        "If the description was restored after init, the migration summary's Modified section mentions the restore"
+      ]
+    },
+    {
+      "id": 11,
+      "name": "init-scoped-package-and-tldr-summary",
+      "prompt": "I have a Commerce App Builder project (npm) that has never used @adobe/aio-commerce-lib-app — it is not a dependency in package.json. Migrate it to App Management with --auto.",
+      "expected_output": "The executor runs init with the scoped package name (npx --yes @adobe/aio-commerce-lib-app@latest init), not the unscoped bin name (npx aio-commerce-lib-app init), which fails with \"could not determine executable to run\" when the package is not installed. The migration summary starts with a one-line TL;DR stating the number of staged files, the init outcome, and the number of manual follow-ups.",
+      "files": [
+        {
+          "path": "app.config.yaml",
+          "content": "application:\n  runtimeManifest:\n    packages:\n      acme-app:\n        license: Apache-2.0\n        actions:\n          sync-orders:\n            function: actions/sync-orders/index.js\n            web: \"yes\"\n            runtime: nodejs:22\n"
+        },
+        {
+          "path": "package.json",
+          "content": "{\"name\": \"acme-app\", \"version\": \"1.0.0\", \"description\": \"Acme order sync app.\", \"dependencies\": {\"@adobe/aio-sdk\": \"^6.0.0\"}}\n"
+        },
+        {
+          "path": "actions/sync-orders/index.js",
+          "content": "async function main (params) {\n  return { statusCode: 200, body: { success: true } }\n}\n\nmodule.exports = { main }\n"
+        }
+      ],
+      "assertions": [
+        "Runs init using the scoped package name: npx --yes @adobe/aio-commerce-lib-app@latest init",
+        "Does not run init with the unscoped bin name (npx aio-commerce-lib-app init)",
+        "The migration summary begins with a one-line TL;DR containing the staged file count, the init outcome, and the manual follow-up count",
+        "The TL;DR appears before the Files written section"
       ]
     }
   ]

--- a/plugins/commerce/app-migration/skills/commerce-app-migrate/references/spectrum-s2-upgrade.md
+++ b/plugins/commerce/app-migration/skills/commerce-app-migrate/references/spectrum-s2-upgrade.md
@@ -1,0 +1,40 @@
+# Upgrading `web-src` from React Spectrum (v3) to Spectrum 2 (S2)
+
+Applies to any Admin UI `web-src` iframe frontend (view mass actions, order view buttons, menu) that still uses classic React Spectrum (v3) instead of `@react-spectrum/s2`.
+
+**This is guidance only.** Detect the situation, tell the user what to do next, and offer to help run the migration — do not run the codemod, install packages, or rewrite components yourself unless the user says to go ahead.
+
+## Detecting classic React Spectrum
+
+Check the app's root `package.json` for:
+
+- `@adobe/react-spectrum`, or
+- `@react-spectrum/<component>` packages **without** an `s2` in the name (e.g. `@react-spectrum/button`, `@react-spectrum/provider`)
+
+If ONLY `@react-spectrum/s2` dependencies are present, no action is needed, but the user might also be using a mix of the two, in which case you should offer to migrate the remaining ones.
+
+To be sure, check also the `import` statements in the source code; some users might have the dependencies but not actually use them.
+
+## Why recommend upgrading
+
+The two are functionally compatible — they can even be mounted together in the same tree (S2's `Provider` must be the inner-most provider if nested). Classic React Spectrum (v3) is still maintained, but S2 is the version Adobe recommends moving to: smaller bundles via atomic/macro-based CSS, ongoing feature work, and the version this scaffold generates all new `web-src` code against. Recommend the upgrade so the extension's UI stays on one consistent system instead of drifting to two.
+
+## Next steps to give the user
+
+Point the user at the official migration guide rather than relying on a list of breaking changes here — it drifts out of date as S2 evolves, while the source stays current: **https://react-spectrum.adobe.com/migrating.md**
+
+That guide documents both ways to migrate:
+
+1. **AI-assisted migration** — install the Agent Skill so an AI tool can drive the migration:
+
+   ```sh
+   npx skills add https://react-spectrum.adobe.com --skill migrate-react-spectrum-v3-to-s2 --skill react-spectrum-s2
+   ```
+
+2. **Automated codemod** — works standalone, without an AI tool:
+
+   ```sh
+   npx @react-spectrum/codemods s1-to-s2
+   ```
+
+Either way, the guide is the source of truth for scope, options (e.g. `--components`, `--dry`, `--agent`), and the component-by-component breaking changes — fetch it (or have the installed skill/codemod surface it) rather than guessing from memory. Offer to run either route for the user, but it's their choice whether to do it now, later, or themselves. After migrating (if done), test the extension's iframe pages for visual and behavioral regressions.


### PR DESCRIPTION
## commerce-app-management v1.3.0

- [#593](https://github.com/adobe/aio-commerce-sdk/pull/593) [`554bc21`](https://github.com/adobe/aio-commerce-sdk/commit/554bc21fdaf745447ce0685bb7735da974f06904) Thanks [@iivvaannxx](https://github.com/iivvaannxx)! - commerce-app-admin-ui now detects existing `web-src` frontends still on classic React Spectrum (v3) and suggests upgrading to Spectrum 2.

## commerce-app-migration v1.3.0

- [#593](https://github.com/adobe/aio-commerce-sdk/pull/593) [`554bc21`](https://github.com/adobe/aio-commerce-sdk/commit/554bc21fdaf745447ce0685bb7735da974f06904) Thanks [@iivvaannxx](https://github.com/iivvaannxx)! - `commerce-app-migrate` gains a `spectrum-s2-upgrade` reference so the migration executor can detect classic React Spectrum (v3) in a project's Admin UI `web-src` and offer to run the S1-to-S2 migration for the user.
- [#594](https://github.com/adobe/aio-commerce-sdk/pull/594) [`a947231`](https://github.com/adobe/aio-commerce-sdk/commit/a9472317626df39adcef9258a8bcaa2885b64826) Thanks [@iivvaannxx](https://github.com/iivvaannxx)! - Improved the `commerce-app-migrate` skill:
- `init` runs with the scoped package name (`npx --yes @adobe/aio-commerce-lib-app@latest init`) so first runs work without the library installed.
- pnpm projects get esbuild's build script approved (`onlyBuiltDependencies`) before init, with recovery guidance for `ERR_PNPM_IGNORED_BUILDS`.
- Descriptions over 255 characters are rewritten into a coherent shorter summary instead of truncated mid-sentence.
- The original `package.json` description is restored if `init` writes back the shortened config value.
- The migration summary opens with a one-line TL;DR.