### PR TITLE
chore(code-assessment): GA the remove-deprecated-api skill and trim detection scaffolding

### DIFF
--- a/plugins/aem/cloud-service/skills/code-assessment/references/patterns.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/references/patterns.md
@@ -46,7 +46,7 @@ Adding a pattern: add a row here, then build the expert skill from
 | `unbounded-recursion` | add a depth guard to self-recursive / tree-traversal methods (incl. navigation & breadcrumb) | medium | planned | - | - |
 | `unbounded-graphql` | add pagination (`first` / `limit`) to GraphQL queries | medium | planned | - | - |
 | `logging-in-loops` | move logging out of hot loops / add level guards | low | planned | - | - |
-| [`remove-deprecated-api`](../remove-deprecated-api/SKILL.md) | migrate deprecated and removed Java APIs to comply with AEM as a Cloud Service enforcement; rules loaded dynamically from a preflight-produced cache (AEM Analyser Maven Plugin's `region-deprecated-api` output) — fixes driven by the plugin's hint (successor package from `deprecated.msg`), with Experience League as fallback | high | ready | analyzer | guided |
+| [`remove-deprecated-api`](../remove-deprecated-api/SKILL.md) | migrate deprecated and removed Java APIs to comply with AEM as a Cloud Service enforcement | high | ready | analyzer | guided |
 
 > Out-of-memory / leak incidents — a frequent symptom — are usually caused by
 > the patterns above (unbounded queries, unclosed resources, in-process image work, heavy init).

--- a/plugins/aem/cloud-service/skills/code-assessment/remove-deprecated-api/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/remove-deprecated-api/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: remove-deprecated-api
 description: |
-  [BETA] AEM Cloud Service expert skill — migrate deprecated and removed Java APIs to
+  AEM Cloud Service expert skill — migrate deprecated and removed Java APIs to
   comply with AEM as a Cloud Service enforcement policies. Detection is **plugin-driven,
   not table-driven**: the skill runs the AEM Analyser Maven Plugin
   (`com.adobe.aem:aemanalyser-maven-plugin`) at its latest published version against the
@@ -11,15 +11,8 @@ description: |
   auditing deprecated APIs, fixing Cloud Manager pipeline failures citing
   `region-deprecated-api` / `api-regions-check` / `Import-Package not satisfied`, or
   proactively modernizing AEM projects before enforcement deadlines.
-  This skill is in beta. Verify all outputs before applying them to production projects.
-metadata:
-  status: beta
 license: Apache-2.0
 ---
-
-> **Beta Skill**: This skill is in beta and under active development.
-> Results should be reviewed carefully before use in production.
-> Report issues at https://github.com/adobe/skills/issues
 
 # Remove Deprecated API — AEM as a Cloud Service
 

--- a/plugins/aem/cloud-service/skills/code-assessment/remove-deprecated-api/recipe.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/remove-deprecated-api/recipe.md
@@ -203,7 +203,7 @@ bash "$SKILL_DIR/remove-deprecated-api/scripts/detect.sh" "$PROJECT_ROOT"
 4. **Writes the rules cache TSV** — `<package>\t<hint>\t<for_removal>` per line —
    at `$AEM_DEPRECATED_API_RULES` (env override) or the default path
    `$TMPDIR/aem-code-assessment/deprecated-api-rules.tsv`.
-5. Emits a JSON summary on stdout (plugin version, rule count, sample findings —
+5. Emits a JSON run-summary on stdout (plugin/SDK version, rule count, maven exit —
    useful for the run log; the authoritative findings come from Phase 2).
 
 **If `detect.sh` exits non-zero** — inspect the reason:

--- a/plugins/aem/cloud-service/skills/code-assessment/remove-deprecated-api/scripts/detect.sh
+++ b/plugins/aem/cloud-service/skills/code-assessment/remove-deprecated-api/scripts/detect.sh
@@ -17,12 +17,11 @@
 # Each rule is one line:  <package>\t<hint>\t<for_removal>
 # Lines starting with # are comments (plugin version, generation timestamp).
 #
-# For callers that also want per-file findings (without invoking analyze.sh),
-# a JSON summary is emitted on stdout, mirroring the shared analyzer's shape.
+# A JSON run-summary (plugin/SDK version, rule count, maven exit) is emitted on
+# stdout. The authoritative per-file findings come from the shared analyzer
+# (analyze.sh), which reads the same rules cache.
 #
-# Usage:
-#   detect.sh <project-root> [--pin-plugin <version>] [--rules-out <path>]
-#             [--goal <goal>] [--log <path>] [--keep-log]
+# Usage: see usage() below (run with -h).
 #
 # Requires: bash, curl, Maven (project's ./mvnw or system `mvn`), a JDK.
 # Network access to Maven Central is required.
@@ -33,7 +32,7 @@ usage() {
   cat >&2 <<'EOF'
 usage: detect.sh <project-root> [--pin-plugin <version>] [--pin-sdk <version>]
                  [--respect-pom-sdk] [--rules-out <path>] [--goal <goal>]
-                 [--log <path>] [--keep-log]
+                 [--log <path>]
 
   <project-root>       Absolute or relative path to the Maven project root.
   --pin-plugin <ver>   Pin aemanalyser-maven-plugin to a specific version
@@ -55,7 +54,6 @@ usage: detect.sh <project-root> [--pin-plugin <version>] [--pin-sdk <version>]
                        (root-scoped fallback); ignored when a module is
                        auto-detected, which always runs a plain `install` first.
   --log <path>         Write the Maven log to <path> (default: /tmp/aem-analyser.log).
-  --keep-log           Do not remove the Maven log at end (for debugging).
 EOF
   exit 2
 }
@@ -68,7 +66,6 @@ RESPECT_POM_SDK=0
 RULES_OUT="${AEM_DEPRECATED_API_RULES:-${TMPDIR:-/tmp}/aem-code-assessment/deprecated-api-rules.tsv}"
 GOAL="package"
 LOG_PATH="/tmp/aem-analyser.log"
-KEEP_LOG=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --pin-plugin)        PIN_PLUGIN="$2"; shift 2 ;;
@@ -77,7 +74,6 @@ while [ $# -gt 0 ]; do
     --rules-out)         RULES_OUT="$2"; shift 2 ;;
     --goal)              GOAL="$2"; shift 2 ;;
     --log)               LOG_PATH="$2"; shift 2 ;;
-    --keep-log)          KEEP_LOG=1; shift ;;
     -h|--help)           usage ;;
     *)                   echo "unknown arg: $1" >&2; usage ;;
   esac
@@ -324,10 +320,7 @@ mkdir -p "$(dirname "$RULES_OUT")"
 } > "$RULES_OUT"
 log "rules cache written: $RULES_OUT ($RULE_COUNT rules)"
 
-# ---- 5. Correlate to source (JSON summary for direct callers) --------------
-
-TMP_FINDINGS="$(mktemp)"
-: > "$TMP_FINDINGS"
+# ---- 5. Emit JSON run-summary ----------------------------------------------
 
 emit_json_str() {
   local s="$1"
@@ -339,50 +332,8 @@ emit_json_str() {
   printf '"%s"' "$s"
 }
 
-emit_finding() {
-  local file="$1" line="$2" snippet="$3" pkg="$4" hint="$5" removal="$6"
-  {
-    printf '{"pattern":"remove-deprecated-api","file":'
-    emit_json_str "$file"
-    printf ',"line":%s,"snippet":' "$line"
-    emit_json_str "$snippet"
-    printf ',"package":'
-    emit_json_str "$pkg"
-    printf ',"hint":'
-    emit_json_str "$hint"
-    printf ',"for_removal":'
-    emit_json_str "$removal"
-    printf '}'
-  } >> "$TMP_FINDINGS"
-  printf '\n' >> "$TMP_FINDINGS"
-}
-
-while IFS=$'\t' read -r PKG HINT REMOVAL; do
-  [ -n "$PKG" ] || continue
-  while IFS=: read -r F L SNIP; do
-    [ -n "$F" ] || continue
-    REL="${F#$PROJECT_ROOT/}"
-    emit_finding "$REL" "$L" "$SNIP" "$PKG" "$HINT" "$REMOVAL"
-  done < <(
-    grep -rn --include='*.java' \
-      --exclude-dir=target --exclude-dir=.git \
-      --exclude-dir=node_modules --exclude-dir=generated-sources \
-      -E "^[[:space:]]*import[[:space:]]+(static[[:space:]]+)?${PKG}[.;]" \
-      "$PROJECT_ROOT" 2>/dev/null || true
-  )
-done < "$TMP_HINTS"
-
-# ---- 6. Emit JSON summary --------------------------------------------------
-
 {
-  printf '{"findings":['
-  first=1
-  while IFS= read -r line; do
-    [ -n "$line" ] || continue
-    if [ $first -eq 1 ]; then first=0; else printf ','; fi
-    printf '%s' "$line"
-  done < "$TMP_FINDINGS"
-  printf '],"warnings":['
+  printf '{"warnings":['
   if [ "$MVN_EXIT" -ne 0 ]; then
     emit_json_str "mvn-exit-nonzero: $MVN_EXIT — see $LOG_PATH"
   fi
@@ -398,7 +349,6 @@ done < "$TMP_HINTS"
   printf ',"rule_count":%s}}\n' "$RULE_COUNT"
 }
 
-rm -f "$TMP_HINTS" "$TMP_FINDINGS"
-if [ "$KEEP_LOG" -eq 0 ]; then :; fi
+rm -f "$TMP_HINTS"
 
 exit 0


### PR DESCRIPTION
Follow-up cleanup on top of the dynamic detection feature merged in #266. Scope is limited to the `remove-deprecated-api` skill.

### Changes
- **GA the skill** — remove beta markers from `remove-deprecated-api/SKILL.md` only (`[BETA]` prefix, caveat line, `status: beta`, beta blockquote). The umbrella `code-assessment` skill and the other expert sub-skills remain beta, intentionally.
- **Patterns catalog** — shorten the `remove-deprecated-api` row to a one-line description; the plugin-driven detection detail already lives in the skill's SKILL.md / recipe.md / README.md.
- **`detect.sh` cleanup** — drop the dead `--keep-log` flag (it was only ever a no-op), the stale duplicated usage header comment, and the redundant per-package source-correlation pass. The JSON run-summary (plugin/SDK version, rule count, maven exit) is kept.
- **`recipe.md`** — describe the trimmed JSON run-summary.

No behavior change to the analyzer or the rules cache; the script's product (the rules TSV) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
