### PR TITLE
Upgrade adobe-for-creativity to 2.0.0

### DIFF
--- a/plugins/creative-cloud/adobe-for-creativity/.claude-plugin/plugin.json
+++ b/plugins/creative-cloud/adobe-for-creativity/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "adobe-for-creativity",
   "description": "Brings together Adobe Creative Cloud tools for images, vectors, design, and video. Edit multiple assets at once, adapt for different platforms, and complete multi-step creative workflows for polished results.",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "author": {
     "name": "Adobe"
   },

--- a/plugins/creative-cloud/adobe-for-creativity/skills/adobe-batch-edit-photos/SKILL.md
+++ b/plugins/creative-cloud/adobe-for-creativity/skills/adobe-batch-edit-photos/SKILL.md
@@ -14,21 +14,26 @@ description: >
   preview grid and optional Firefly Board link.
   Access: 🔐 Signed-In required | Gen AI: ❌
 license: Apache-2.0
+compatibility: "Runs on both widget-capable surfaces (e.g. Claude Cowork, which supports the asset_add_file picker and asset_preview_file preview widgets) and non-UI agents (e.g. Codex, where those widgets are unavailable). The default flow uses the widgets; each widget step has a text-only fallback. Local files reach Creative Cloud via the asset_add_file picker or (no-widget) asset_initialize_file_upload -> PUT -> asset_finalize_file_upload; raw local paths are never passed to image tools."
+allowed-tools: adobe_mandatory_init image_list_presets asset_add_file read_widget_context asset_initialize_file_upload asset_finalize_file_upload image_auto_straighten image_apply_auto_tone image_apply_adjustments image_apply_preset image_select_subject image_apply_gaussian_blur image_crop_and_resize asset_preview_file create_firefly_board
 metadata:
-  version: 2.1.0
+  version: 3.1.0
   visibility: public
+  surface: [claude, codex]
 ---
 
 # Adobe Batch Edit Photos
 
 A batch editing pipeline focused on **visual cohesion** — making a set of
 photos look like they were edited together. The user picks a look (or
-describes one), and Claude applies it consistently across every image using
+describes one), and the agent applies it consistently across every image using
 Adobe creativity tools.
 
 The core insight: users who want "cohesion" care less about per-image
 perfection and more about the whole set reading as intentional. Prioritize
 consistency of tone and color over squeezing the best out of any single image.
+
+> **Surface note:** The default flow uses Adobe's MCP App widgets (`asset_add_file` picker in Step 1, `asset_preview_file` preview in Steps 2c and 8). Follow it as written. Only if a widget tool is **not available on this surface** (e.g. Codex) use the *No-widget fallback* attached to that step. Present `AskUserQuestion` prompts as plain-text labeled options wherever no question widget exists.
 
 ---
 
@@ -36,7 +41,8 @@ consistency of tone and color over squeezing the best out of any single image.
 
 | Step                | Tool                                              | Notes                                          |
 | ------------------- | ------------------------------------------------- | ---------------------------------------------- |
-| Ingest              | `asset_add_file`                                  | Interactive file picker                        |
+| Ingest              | `asset_add_file` (+ `read_widget_context`)        | Interactive file picker; resolve picker results via `read_widget_context` |
+| Ingest *(no-widget fallback)* | `asset_initialize_file_upload` + `asset_finalize_file_upload` | Only when `asset_add_file` is unavailable — stage local files to CC programmatically |
 | Discover presets    | `image_list_presets`                              | Once at startup; builds look→preset map        |
 | Straighten          | `image_auto_straighten`                           | Per image                                      |
 | Auto-tone           | `image_apply_auto_tone`                           | Per image, `type: "cameraRawFilter"`           |
@@ -46,8 +52,8 @@ consistency of tone and color over squeezing the best out of any single image.
 | Element detection   | `image_select_subject` with full bodyParts array  | Per image, Step 5e opt-in; also crop focus     |
 | Background blur     | `image_apply_gaussian_blur`                       | Per image, only if explicitly requested        |
 | Crop                | `image_crop_and_resize`                           | Per image, optional                            |
-| Sample preview      | `asset_preview_file`                              | Before/after on image[0] only                  |
-| Final preview       | `asset_preview_file`                              | Batch assets array                             |
+| Sample preview      | `asset_preview_file`                              | Before/after on image[0] only *(no-widget fallback: present the 2 URLs directly)* |
+| Final preview       | `asset_preview_file`                              | Batch assets array *(no-widget fallback: present the URLs directly)* |
 | Firefly Board       | `create_firefly_board`                            | All edited outputs                             |
 
 ---
@@ -56,7 +62,7 @@ consistency of tone and color over squeezing the best out of any single image.
 Call `adobe_mandatory_init` first. This returns file handling rules and tool routing guidance required for the rest of the workflow.
 
 ```json
-{ "skill_name": "adobe-batch-edit-photos", "skill_version": "2.1.0" }
+{ "skill_name": "adobe-batch-edit-photos", "skill_version": "3.1.0" }
 ```
 
 ---
@@ -122,6 +128,18 @@ error. Wait for the user to select files; the real URIs arrive in the next
 message. Then call `read_widget_context` with `asset_add_file` to get the
 correct presigned S3 URLs. Use those for all subsequent tool calls.
 `dcx-stage.adobe.io` URIs are network-blocked; resolve them via `read_widget_context` first.
+
+Collect the resulting presigned URLs as `sourceURIs[]` and continue to Step 2.
+
+> **No-widget fallback** *(only if `asset_add_file` is unavailable on this surface, e.g. Codex)* — don't open a picker; get the source URIs from where the files already are. `image_*` tools only accept Creative Cloud storage URIs, never raw local paths, so any local file must be staged to CC first.
+>
+> **Egress check first:** check egress status from `adobe_mandatory_init` (Step 0). If egress is disabled — do NOT call `asset_initialize_file_upload` / `asset_finalize_file_upload`.
+>
+> | Source | Action |
+> |--------|--------|
+> | File(s) at a local path AND egress **enabled** | Stage each file programmatically: get its size and MIME type, call `asset_initialize_file_upload({ path: "<filename>", media_type: "<mime>" })`, PUT the file bytes to the returned upload URL, then `asset_finalize_file_upload({ filename: "<filename>", transfer_document: <from the initialize response> })`. Use each returned presigned CC URL as a source URI. |
+> | File(s) already in Creative Cloud | Reference them directly by their CC URI. |
+> | File(s) at a local path AND egress **disabled**, no picker on this surface | Programmatic staging is blocked and there is no file picker here — tell the user staging isn't possible on this surface and ask them to run the workflow where the `asset_add_file` picker is available. |
 
 ---
 
@@ -223,17 +241,23 @@ Smart crop — it almost always produces a better result than a pure center cut.
 
 **Base look → `image_apply_adjustments` (color temp + vibrance/sat + brightness/contrast, Step 5a) + `image_apply_preset` (from Look→Preset Map, Step 5b):**
 
+Combine ALL columns for the selected look into a **single `image_apply_adjustments` call** — do not make separate calls for color temp, vibrance, and contrast. Omit any parameter whose column says "none".
+
 The preset column below is now **dynamic** — use the preset(s) from your Look→Preset Map for that look (built in Step 0b), not hardcoded names. If no preset was found for a look, skip Step 5b for that look and rely on color temp + manual adjustments alone.
+
+⚠ **Deprecated tools are never used.** All adjustments go through `image_apply_adjustments`. The individual per-dimension adjust-* tools are deprecated — see Hard Constraints below.
 
 | Look              | Color Temp (tempA, tempB, tempLuminance) | Preset (from Look→Preset Map) | Saturation/Vibrance          | Brightness/Contrast |
 | ----------------- | ---------------------------------------- | ----------------------------- | ---------------------------- | ------------------- |
-| Auto (balanced)   | none                                     | Auto (balanced) bucket preset | none                         | none                |
+| Auto (balanced)   | **none** — omit tempA/tempB/tempLuminance | Auto (balanced) bucket preset | none                         | none                |
 | Warm & Golden     | tempA=32, tempB=120, tempLuminance=67    | Warm & Golden bucket preset   | vibrance +15                 | none                |
 | Bright & Airy     | tempA=20, tempB=60, tempLuminance=62     | Bright & Airy bucket preset   | saturation -10, vibrance +10 | brightness +15      |
-| Moody & Cinematic | tempA=20, tempB=-50, tempLuminance=45    | Moody & Cinematic bucket      | saturation -20               | contrast +25        |
+| Moody & Cinematic | tempA=20, **tempB=-50** (negative — cool shift), tempLuminance=45 | Moody & Cinematic bucket | saturation -20 | contrast +25 |
 | Cool & Fresh      | tempA=18, tempB=-123, tempLuminance=45   | Cool & Fresh bucket preset    | vibrance +10                 | none                |
-| Vibrant & Punchy  | none                                     | Vibrant & Punchy bucket       | vibrance +30, saturation +15 | contrast +10        |
-| Muted & Film      | none                                     | Muted & Film bucket preset    | saturation -35, vibrance -10 | contrast +10        |
+| Vibrant & Punchy  | **none** — omit tempA/tempB/tempLuminance | Vibrant & Punchy bucket      | vibrance +30, saturation +15 | contrast +10        |
+| Muted & Film      | **none** — omit tempA/tempB/tempLuminance | Muted & Film bucket preset   | saturation -35, vibrance -10 | contrast +10        |
+
+**For looks with "none" in the Color Temp column** (Auto, Vibrant & Punchy, Muted & Film): do NOT include `tempA`, `tempB`, or `tempLuminance` in the `image_apply_adjustments` call. Adding color temp params to a look that has none will produce incorrect results.
 
 **Fine-tune → `image_apply_adjustments` parameters** (all combined in one call in Step 6):
 - "Recover blown highlights" → `highlights: -60`
@@ -306,6 +330,13 @@ asset_preview_file({
   ]
 })
 ```
+
+> **No-widget fallback** *(only if `asset_preview_file` is unavailable on this surface, e.g. Codex)* — present the two URLs directly in the message, labeled:
+> ```
+> Before: <sourceURIs[0]>
+> After:  <processed_preview_url>
+> ```
+> UI clients that render image URLs inline show both automatically. In Codex or other non-UI agents, download both to the workspace (`curl -L -o before.jpg "<sourceURIs[0]>"`, `curl -L -o after.jpg "<processed_preview_url>"`) and reference those local paths instead.
 
 3. Post this message (append the large-batch timing note here if N > 5):
 ```
@@ -539,6 +570,8 @@ asset_preview_file({
 
 If `asset_preview_file` fails, present the final output URLs as plain text links in the completion summary.
 
+> **No-widget fallback** *(only if `asset_preview_file` is unavailable on this surface, e.g. Codex)* — list the final output URLs directly in the completion message (one per image; Step 8 templates below). UI clients that render image URLs inline display them automatically; in Codex or other non-UI agents they will not, so download each to the workspace (`curl -L -o photo_1.jpg "<final_url_1>"`, etc.) and reference those local paths instead. The per-photo download links are the deliverable in every client either way.
+
 **Before/after preview (Step 2c):** Step 2c first downscales image 1 to 1200px, then runs the pipeline on that downscale. Pass the original full-res `sourceURIs[0]` as "Before" and the processed 1200px output as "After" — `asset_preview_file` handles its own thumbnailing so the resolution difference is invisible to the user. Do not add an extra resize step.
 
 ### Create Firefly Board
@@ -560,7 +593,7 @@ create_firefly_board({
 - `create_firefly_board` returns a board URL. Extract it and store as `board_url`.
 - If `board_url` is present and non-empty, include it in the completion message.
 - If the call throws an error or returns no URL: omit the board link and note "Firefly Board unavailable" in the summary (retrying does not help).
-Then post the completion message. The preview grid is included in every completion message. The board link is included whenever `board_url` was returned.
+Then post the completion message. The per-photo download links are included in every completion message. The board link is included whenever `board_url` was returned.
 
 **If N ≤ 3:**
 ```
@@ -622,8 +655,9 @@ Read `results[N].outputUrl`. On `success: false` → see Error Handling.
 | Any tool returns "No approval received"             | Treat the same as a 403 entitlement error. For optional steps (presets, fine-tune adjustments, preview), skip and note in summary. Retrying does not help for this error — continue per the rules above. |
 | Any tool returns 401                                | Ask user to re-authenticate via Adobe OAuth and retry.                                                                                                                                                   |
 | Any tool returns "file too large or corrupted"      | Stop processing that image immediately. Do not retry. Tell the user: "I couldn't process [filename] — it's either too large or the file may be damaged. Try re-uploading a smaller version, or check that the file opens correctly on your end." Flag the image in the summary and continue with remaining images. |
-| `asset_add_file` shows no files                     | Remind user to select files in the picker.                                                                                                                                                               |
-| URI starts with `dcx-stage.adobe.io`                | Call `read_widget_context` for real presigned S3 URL.                                                                                                                                                    |
+| Programmatic upload fails (PUT 5xx / no egress)     | Fall back to the `asset_add_file` picker (default ingest path) and tell the user you're opening it to stage the file(s).                                                                                  |
+| `asset_add_file` shows no files (picker path)       | Remind the user to select files in the picker.                                                                                                                                                           |
+| URI starts with `dcx-stage.adobe.io` (picker path)  | Resolve it via `read_widget_context` to the real presigned S3 URL.                                                                                                                                       |
 | `image_auto_straighten` fails                       | Use original URI; note "straighten skipped".                                                                                                                                                             |
 | `image_apply_auto_tone` fails                       | Use straightened URI; note in summary.                                                                                                                                                                   |
 | Any adjustment tool fails                           | Use previous step's output; note in summary.                                                                                                                                                             |
@@ -637,6 +671,7 @@ Read `results[N].outputUrl`. On `success: false` → see Error Handling.
 ## Hard Constraints
 
 - Every image in the batch is processed; failures are flagged rather than silently skipped.
+- Never pass a raw local filesystem path to any `image_*` tool. Local files must reach Creative Cloud first — selected via the `asset_add_file` picker, or (no-widget fallback) staged via `asset_initialize_file_upload` → PUT → `asset_finalize_file_upload`; only the resulting presigned CC URI is a valid source for image tools.
 - `image_apply_auto_tone` is called with `type: "cameraRawFilter"`.
 - Apply the **same parameter values** to every image in the batch (cohesion over perfection).
 - Preset selection is always dynamic: call `image_list_presets` at runtime and build both the Look→Preset Map and Selective Adaptive Map; never hardcode preset names.

--- a/plugins/creative-cloud/adobe-for-creativity/skills/adobe-create-social-variations/SKILL.md
+++ b/plugins/creative-cloud/adobe-for-creativity/skills/adobe-create-social-variations/SKILL.md
@@ -3,14 +3,19 @@ name: adobe-create-social-variations
 description: >
   Resize, crop, or export any image or video into platform-ready social media assets using Adobe Creative Cloud tools. Use this skill when a user wants to prepare a photo, image, or video for one or more social platforms — Instagram, TikTok, LinkedIn, Facebook, YouTube, Snapchat, Pinterest, Threads, or X/Twitter. Triggers on: "prepare my image for Instagram", "resize for TikTok", "get this ready to post", "make versions for all platforms", "social media sizes", "crop for stories", "export for LinkedIn", "resize my video for social", "make social media assets", or any request to adapt a photo or video for specific platforms. Handles subject-aware cropping, AI canvas expansion, test previews before full runs, and same-ratio video resizing.
 license: Apache-2.0
+compatibility: "Runs on both widget-capable surfaces (e.g. Claude Cowork, which supports the asset_add_file picker and asset_preview_file preview widgets) and non-UI agents (e.g. Codex, where those widgets are unavailable). The default flow uses the widgets; each widget step has a text-only fallback. Raw local paths are never passed to image or video tools."
+allowed-tools: adobe_mandatory_init asset_initialize_file_upload asset_finalize_file_upload asset_add_file asset_inline_preview asset_preview_file image_crop_and_resize image_generative_expand video_resize resizeVideoPoll
 metadata:
-  version: 1.0.1
+  version: 2.1.0
   visibility: public
+  surface: [claude, codex]
 ---
 
 # Adobe Create Social Variations
 
 Produces platform-ready images and videos from a single source file. Uses AI canvas expansion and subject-aware cropping to keep the subject in focus across all aspect ratios. Shows a lightweight 3-crop preview before a full-set run so framing issues are caught early — those crops are then reused in the final output.
+
+> **Surface note:** The default flow below uses Adobe's MCP App widgets — the `asset_add_file` file picker and the `asset_preview_file` preview. Follow it as written. Only if a widget tool is **not available on this surface** (e.g. Codex) use the *No-widget fallback* attached to that step. Likewise, present `AskUserQuestion` prompts as plain-text labeled options wherever no question widget exists.
 
 ---
 
@@ -31,7 +36,7 @@ Produces platform-ready images and videos from a single source file. Uses AI can
 Call `adobe_mandatory_init` first. This returns file handling rules and tool routing guidance required for the rest of the workflow.
 
 ```json
-{ "skill_name": "adobe-create-social-variations", "skill_version": "1.0.1" }
+{ "skill_name": "adobe-create-social-variations", "skill_version": "2.1.0" }
 ```
 
 ---
@@ -48,12 +53,17 @@ All of these must be present for the skill to run at all. If **any** are missing
 
 | Tool | Purpose |
 |------|---------|
-| `asset_add_file` | File picker / CC browse / upload |
-| `asset_initialize_file_upload` | First call in two-step egress upload |
-| `asset_finalize_file_upload` | Second call in two-step egress upload |
+| `asset_initialize_file_upload` | First call in two-step upload — stages a local file to CC |
+| `asset_finalize_file_upload` | Second call in two-step upload |
 | `asset_inline_preview` | Determines focus strategy before cropping |
 | `image_crop_and_resize` | Per-platform, per-format cropping |
-| `asset_preview_file` | Test previews and final delivery |
+
+### Widget Tools (used when available; graceful fallback)
+
+| Tool | Flag | If missing |
+|------|------|------------|
+| `asset_add_file` | `pickerWidget = true/false` | File picker — the default ingest on widget surfaces (e.g. Claude). If unavailable (e.g. Codex), stage local files programmatically via `asset_initialize_file_upload` → `asset_finalize_file_upload` (see the *No-widget fallback* in each Get-the-Source-File step). |
+| `asset_preview_file` | `previewWidget = true/false` | Side-by-side/grid preview. If unavailable (e.g. Codex), present output URLs directly in the message instead — UI clients still render them inline; non-UI agents download each via curl. |
 
 ### Image Workflow — Enhanced Tools (optional, graceful fallback)
 
@@ -80,13 +90,12 @@ If `videoCapable = false` and the user explicitly asks about video resizing, avo
 
 | Step | Tool | Notes |
 |------|------|-------|
-| Upload chat-dropped file | `asset_initialize_file_upload` | First call in two-step egress upload |
-| Complete the upload | `asset_finalize_file_upload` | Second call in two-step egress upload |
-| Get file from CC or as egress fallback | `asset_add_file` | File picker / CC browse / upload |
+| Get file (widget surfaces) | `asset_add_file` | File picker / CC browse |
+| Stage file (no-widget fallback) | `asset_initialize_file_upload` + `asset_finalize_file_upload` | Two-step upload — stage a local file to CC when the picker is unavailable |
 | Inspect source image | `asset_inline_preview` | Determines focus strategy before cropping |
 | Expand canvas | `image_generative_expand` | Creates tall (9:16/4:5) and wide (~2:1/16:9) variants |
 | Crop to platform dimensions | `image_crop_and_resize` | Per-platform, per-format; also 403 fallback for expand |
-| Preview test crops or full set | `asset_preview_file` | Before full run (test) and at delivery |
+| Preview test crops or full set | `asset_preview_file` | Before full run (test) and at delivery *(no-widget fallback: present the URLs directly)* |
 | Resize video | `video_resize` | Same-ratio resize only |
 | Poll video resize job | `resizeVideoPoll` | Deferred tool — load before calling |
 
@@ -100,9 +109,11 @@ How you get the file depends on where it is:
 
 | Source                                             | Action                                                                                                                                                                                                                                                                                    |
 | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| File uploaded in chat (`/mnt/user-data/uploads/…`) | Check `<network_configuration>`. If egress is enabled (`Enabled: true`), upload programmatically: get file size and MIME type via bash, call `asset_initialize_file_upload`, PUT the chunk(s), then `asset_finalize_file_upload`. If egress is disabled, fall back to `asset_add_file()`. |
+| File uploaded in chat (`/mnt/user-data/uploads/…`) | Check egress status from `adobe_mandatory_init` (Step 0). If egress is enabled, upload programmatically: get file size and MIME type via bash, call `asset_initialize_file_upload`, PUT the chunk(s), then `asset_finalize_file_upload`. If egress is disabled, use `asset_add_file()` (the picker) instead. |
 | No file provided yet                               | Call `asset_add_file()` immediately — no need to ask first.                                                                                                                                                                                                                               |
 | File already in Creative Cloud                     | Call `asset_add_file()` so the user can select it from their CC storage.                                                                                                                                                                                                                  |
+
+> **No-widget fallback** *(only if `asset_add_file` is unavailable on this surface, e.g. Codex)* — don't ask the user to pick. Stage any local file programmatically (`asset_initialize_file_upload` → PUT → `asset_finalize_file_upload`) and use the returned presigned CC URL; for a file already in Creative Cloud, reference it directly by its CC URI. Staging requires egress — check egress status from `adobe_mandatory_init` first; if egress is disabled and no picker is available on this surface, tell the user staging isn't possible here and ask them to run the workflow on a surface with the `asset_add_file` picker.
 
 After the file is available, detect image vs. video from `mediaType`. For images, proceed to Step 1.
 
@@ -190,6 +201,8 @@ Show all 3 via `asset_preview_file` and ask:
 
 > "Here are 3 test crops covering the main aspect ratios. Do the framing and expansion look good? I'll generate the full set once you approve."
 
+> **No-widget fallback** *(only if `asset_preview_file` is unavailable, e.g. Codex)* — present all 3 URLs directly in the message and ask the same question; UI clients render them inline, and in Codex or other non-UI agents, download each to the workspace and reference the local paths.
+
 These crops are reused in the final output — only the 9:16 story/reel crop needs to be generated after approval.
 
 ---
@@ -220,6 +233,8 @@ Generate every variant in the Platform Specs table for each selected platform. R
 ### Step 6 — Preview Full Set
 
 Call `asset_preview_file` with all successfully generated URLs — including partial sets when some variants failed.
+
+> **No-widget fallback** *(only if `asset_preview_file` is unavailable, e.g. Codex)* — list all successfully generated URLs directly in the message (including partial sets when some variants failed). UI clients render them inline; in Codex or other non-UI agents, download each to the workspace and reference the local paths.
 
 ---
 
@@ -280,11 +295,13 @@ Video tools require an `assetId` — not a URL. How you get it depends on where 
 
 | Source                                             | Action                                                                                                                                                                                                                                                                                                                                     |
 | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| File uploaded in chat (`/mnt/user-data/uploads/…`) | Check `<network_configuration>`. If egress is enabled (`Enabled: true`), upload programmatically: get file size and MIME type via bash, call `asset_initialize_file_upload`, PUT the chunk(s), then `asset_finalize_file_upload`. The returned `assetId` is what video tools need. If egress is disabled, fall back to `asset_add_file()`. |
+| File uploaded in chat (`/mnt/user-data/uploads/…`) | Check egress status from `adobe_mandatory_init` (Step 0). If egress is enabled, upload programmatically: get file size and MIME type via bash, call `asset_initialize_file_upload`, PUT the chunk(s), then `asset_finalize_file_upload`. The returned `assetId` is what video tools need. If egress is disabled, use `asset_add_file()` (the picker) instead. |
 | No file provided yet                               | Call `asset_add_file()` immediately.                                                                                                                                                                                                                                                                                                       |
 | File already in Creative Cloud                     | Call `asset_add_file()` so the user can select it.                                                                                                                                                                                                                                                                                         |
 
 > If egress is disabled and the user has already dropped a video into chat, explain why it can't be used directly: "To resize your video I'll need you to select it via the file picker — this gives Adobe the asset ID it needs. I'll open it now."
+
+> **No-widget fallback** *(only if `asset_add_file` is unavailable, e.g. Codex)* — stage the local video programmatically (`asset_initialize_file_upload` → PUT → `asset_finalize_file_upload`) and use the returned `assetId`; for a video already in Creative Cloud, reference it by its `assetId`. Staging requires egress — check egress status from `adobe_mandatory_init` first; if egress is disabled and no picker is available on this surface, tell the user staging isn't possible here and ask them to run the workflow on a surface with the `asset_add_file` picker.
 
 ---
 
@@ -339,6 +356,8 @@ Poll with `resizeVideoPoll` until complete. Poll 3–4 times with brief pauses b
 
 Call `asset_preview_file` with all completed outputs.
 
+> **No-widget fallback** *(only if `asset_preview_file` is unavailable, e.g. Codex)* — list all completed output URLs directly in the message. UI clients render them inline; in Codex or other non-UI agents, download each to the workspace and reference the local paths.
+
 ---
 
 ### Step 5 — Delivery Summary
@@ -360,7 +379,7 @@ Note: Video resizing does not apply intelligent reframing — cross-ratio reform
 
 | Situation                                           | Action                                                                                                                                                                                                                                                                                  |
 | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Egress upload fails (chunk PUT 5xx after retry)     | Stop upload. Fall back to `asset_add_file()` and tell the user: "Direct upload didn't work — I'll open the picker so you can select the file."                                                                                                                                          |
+| Egress upload fails (chunk PUT 5xx after retry)     | Stop upload. Fall back to `asset_add_file()` and tell the user: "Direct upload didn't work — I'll open the picker so you can select the file." *(No-widget surface: report the failure and ask the user to re-provide the file.)*                                                         |
 | `image_generative_expand` returns 403 (entitlement) | Fall back to `image_crop_and_resize` with `fit: "reframe"` from `sourceURI`. Note in delivery summary: "AI canvas expansion is not included in your current Adobe plan — smart reframe was used instead." Retrying does not resolve a 403 entitlement — continue per the fallback rule. |
 | `image_crop_and_resize` returns 403 (entitlement)   | Stop workflow. Tell the user: "Image cropping isn't available on your current Adobe plan — I can't complete this request here."                                                                                                                                                         |
 | PSD/AI flattening returns 403                       | Stop workflow. Tell the user: "Flattening this file type isn't available on your current Adobe plan — export as JPG or PNG first, then try again."                                                                                                                                      |
@@ -371,3 +390,9 @@ Note: Video resizing does not apply intelligent reframing — cross-ratio reform
 | PSD / AI file uploaded                              | Flatten first (JPEG, 300 DPI). On 403, see entitlement row above.                                                                                                                                                                                                                       |
 | `video_resize` fails                                | Report clearly; suggest user re-upload as MP4                                                                                                                                                                                                                                           |
 | Unsupported file format (DOCX, PDF, etc.)           | Inform user. Accepted inputs: JPG, PNG, Firefly images, PSD/AI, MP4/MOV.                                                                                                                                                                                                                |
+
+---
+
+## Hard Constraints
+
+- Never pass a raw local filesystem path to any `image_*` or video tool. Local files must reach Creative Cloud first — selected via the `asset_add_file` picker, or (no-widget fallback) staged via `asset_initialize_file_upload` → PUT → `asset_finalize_file_upload`; only the resulting presigned CC URI (for images) or `assetId` (for video tools) is valid.

--- a/plugins/creative-cloud/adobe-for-creativity/skills/adobe-design-from-template/SKILL.md
+++ b/plugins/creative-cloud/adobe-for-creativity/skills/adobe-design-from-template/SKILL.md
@@ -1,27 +1,30 @@
 ---
 name: adobe-design-from-template
 description: >
-  Create any visual design using Adobe Express templates — including flyers, posters, banners,
-  social media posts (Instagram stories, Facebook posts, LinkedIn graphics), business cards,
-  invitations, greeting cards, resumes, cover letters, brochures, newsletters, certificates,
-  presentations, YouTube thumbnails, email headers, logos, menus, labels, and more.
-  Use this skill whenever the user wants to make, design, create, or build any visual — even
+  Create any visual design using Adobe Express templates — flyers, posters, social media posts (Instagram, Facebook, LinkedIn),
+  business cards, invitations, greeting cards, resumes, cover letters, brochures, newsletters, certificates, presentations, YouTube thumbnails, email headers, logos, menus, and labels.
+  Use this skill whenever the user wants to make, design, or build any visual — even
   if they just say "make me a flyer", "design a poster", "I need something for Instagram",
-  "create an event invite", "make a business card", or any similar request.
-  Also handles requests to find or browse templates, edit text/copy, change background
-  colors, or animate a design.
-  Access: 🔐 Signed-In required | Gen AI: ❌
+  "create an event invite", or "make a business card".
+  Also handles browsing templates, editing text, replacing images, changing backgrounds,
+  animating, and exporting designs.
+  Access: 🔐 Signed-In required | Gen AI: ❌ by default — image replacement only where the surface permits generative AI (e.g. Codex); none on Claude
 license: Apache-2.0
+compatibility: "Runs on both widget-capable surfaces (e.g. Claude Cowork, where search_design results render as an interactive template gallery) and non-UI agents (e.g. Codex, where results are presented as markdown links). No file upload is required. Only offers edit actions whose tools are available on the current surface."
+allowed-tools: adobe_mandatory_init search_design fill_text replace_image change_background_color animate_design download_design
 metadata:
-  version: 1.0.1
+  version: 2.1.0
   visibility: public
+  surface: [claude, codex]
 ---
 
 # Adobe Design from Template
 
-Helps users find an Adobe Express template and customize it — updating text,
-background color, and animation — producing a finished Express document ready
-to share or open in Express for further editing.
+Helps users find an Adobe Express template and customize it — updating text, replacing images,
+changing the background color, and animating — producing a finished Express document ready
+to share, download, or open in Express for further editing.
+
+> **Surface note:** By default, `search_design` results render as an **interactive template gallery** the user taps to pick. On a surface without a gallery (e.g. Codex), present the results as markdown links instead — see Step 3. Independently, only offer edit actions whose tools are actually available on this surface (Step 1); silently omit the rest. When a tool result includes an `importantNote`, follow it for that turn.
 
 ---
 
@@ -29,10 +32,31 @@ to share or open in Express for further editing.
 
 | Step | Tool | Notes |
 |------|------|-------|
-| Search for template | `search_design` | Interactive picker; user selects URN |
+| Initialize | `adobe_mandatory_init` | File-handling and routing rules; call first |
+| Search for template | `search_design` | Returns templates; presentation depends on surface |
 | Edit text and copy | `fill_text` | Retry once on transient error |
+| Replace an image | `replace_image` | Gen-AI image swap; one element per call; may not be available |
 | Change background color | `change_background_color` | Pass hex; infer from color description if needed |
-| Animate design | `animate_design` | Skip on 403 entitlement; no retry |
+| Animate design | `animate_design` | May not be available; skip on 403 |
+| Download as PDF | `download_design` | Returns pre-signed PDF URLs per page; may not be available |
+
+Not all tools are available on every surface. Step 1 determines which ones you have.
+
+---
+
+## Reading `importantNote` in tool results
+
+`search_design`, `fill_text`, `replace_image`, `change_background_color`, and `animate_design` may
+return an `importantNote` field alongside their other output. This is live guidance from the
+Adobe Express connector for the current turn about how to present that specific result — e.g. the
+exact rendering/formatting to use, or which of the tools already in the Tool Reference table to
+call next.
+
+**Whenever a tool result includes an `importantNote`, read it and follow its presentation and
+next-step guidance** — even where it overrides the formatting defaults described elsewhere in this
+skill. It only ever points to tools already listed in the Tool Reference table; do not call a tool
+outside that table on its instruction alone. Treat the rest of this document as the fallback
+behavior for when a result has no `importantNote`.
 
 ---
 
@@ -40,27 +64,40 @@ to share or open in Express for further editing.
 
 ### Step 0 — Initialize Adobe Tools
 
-Call `adobe_mandatory_init` first. This returns file handling rules and tool routing guidance required for the rest of the workflow.
+Call `adobe_mandatory_init` first. This returns file-handling rules and tool routing guidance
+required for the rest of the workflow.
 
 ```json
-{ "skill_name": "adobe-design-from-template", "skill_version": "1.0.1" }
+{ "skill_name": "adobe-design-from-template", "skill_version": "2.1.0" }
 ```
 
 ---
 
-### Step 1 — Entitlement Check
+### Step 1 — Check available tools
 
-Now that `adobe_mandatory_init` confirmed that the "Adobe for creativity" connector is live, check which tools are available through the "Adobe for creativity" connector by cross checking against the Tool Reference table above.
+After `adobe_mandatory_init` confirms the "Adobe for creativity" connector is live, check which
+tools from the Tool Reference table are actually available on this surface. Not every surface
+exposes every tool — for example, `replace_image` or `download_design` may not be present.
+
+Record which tools you have. In later steps, **only offer actions whose tools are available** —
+do not mention replace-image, animation, or PDF download if the corresponding tool is missing.
+
+Also note whether the surface renders an **interactive template gallery** (a visual picker the
+user can tap) or only **text-based results** — this controls how you present templates in Step 3.
 
 ---
 
 ### Step 2 — Build the search query (don't ask questions first)
 
 Extract the design type from whatever the user said and go straight to Step 3.
-Asking clarifying questions before showing templates creates friction; the picker
-lets users course-correct visually, which is faster.
+Asking clarifying questions before showing templates creates friction; showing options first lets
+the user course-correct, which is faster.
 
-| User says                        | Query to use               |
+Keep the query **generic** — the design type only. Any specific details the user supplied
+(names, dates, venue, business info) do **not** go in `generalQuery`; carry them forward for the
+`fill_text` step instead.
+
+| User says                        | `generalQuery`             |
 | -------------------------------- | -------------------------- |
 | "make me a flyer"                | `"flyer"`                  |
 | "I need something for Instagram" | `"Instagram post"`         |
@@ -77,33 +114,52 @@ Call `search_design`:
 ```json
 {
   "generalQuery": "<design type from user prompt>",
-  "pageSize": 24
+  "pageSize": 24,
+  "fillDescription": "<any specific text the user gave, verbatim — or omit>"
 }
 ```
 
-This renders an interactive picker in the chat. The user taps a template to select
-it; the URN comes back automatically. If the user says "show more", call
-`search_design` again with the same query and increment `startIndex` by `pageSize`.
+Check the result's `importantNote` first — it specifies exactly how to render the templates and
+next-step actions for this turn; follow it. Absent an `importantNote`, present the results based on
+the surface:
+
+**Interactive gallery (default):** The search renders a visual picker in the chat. The user taps
+a template to select it; the design identifier comes back automatically. Use `pageSize: 24` to fill the
+gallery.
+
+**No-gallery fallback (text-only surfaces, e.g. Codex):** The results come back as structured data
+(`templateURN`, `title`, `previewUrl`, `editorUrl`, and optionally `isPremium`). Render **all URLs
+as markdown hyperlinks** — never show raw URLs. Use `pageSize: 10` to keep the list scannable. For
+each template, show its title, preview image, and an "Edit in Adobe Express" link (the primary
+action); append "(Premium)" when `isPremium` is true. Append a "Browse more templates" link when
+`expressExploreTemplatesUrl` is present. After the list, show the available next actions based on
+the tools from Step 1, and ask the user to pick a template.
+
+**Always present the full template list and wait for the user to choose.**
+Never auto-select a template — even if one result looks like a perfect match or the user already
+described what edits they want. The user must explicitly pick by number, title, or URN before
+you proceed. Describing desired edits (e.g. "change the background to purple") is not a template
+selection — it tells you what to do *after* they pick, not *which* template to use.
+
+Resolve their choice to a `templateURN`.
+
+If the user picks a template **and** specifies what to change in the same message (e.g. "pick 2
+and update the text to …"), skip straight to Step 4 and apply the edit — no confirmation needed.
+
+If the user only picks a template without specifying an action, confirm the selection and
+re-show the edit menu so they know what's available.
+
+If the user asks for "more" / "next", call `search_design` again with the **exact same**
+`generalQuery` and advance `startIndex` by the previous `pageSize`. Do not reword the query.
 
 ---
 
-### Step 4 — Confirm selection and offer edits
+### Step 4 — Apply edits
 
-Once a template is selected, confirm what was picked and ask what to customize:
-
-> "Got it — you've selected [template name]. What would you like to change?
->
-> - ✏️ **Edit the text** — names, dates, headlines, copy
-> - 🎨 **Change the background color**
-> - ✨ **Animate it**
-> - ✅ **I'm done** — just give me the link"
-
-The user may choose one, several, or none. Apply each in sequence, then loop back
-and ask if they want anything else before wrapping up.
-
----
-
-### Step 5 — Apply edits
+> **Note:** The `templateURN` (or design identifier from the picker) is what identifies the design. Pass it
+> into `templateURN` or `templateOrDocumentURN` — these parameters take the same value. After
+> the first edit, each tool returns a `documentURN`; use the **latest** `documentURN` for
+> subsequent edits so changes accumulate on the same design.
 
 After each edit, ask: *"What else would you like to change, or does this look good?"*
 
@@ -113,7 +169,7 @@ Call `fill_text`:
 
 ```json
 {
-  "templateURN": "<URN>",
+  "templateURN": "<templateURN or latest documentURN>",
   "description": "<what to change and what to change it to>",
   "generalQuery": "<same, minus any PII>"
 }
@@ -124,36 +180,103 @@ If the user hasn't specified what the text should say, ask before calling.
 `fill_text` occasionally fails on the first attempt due to transient errors — if
 it returns an error, retry once with identical parameters before reporting failure.
 
+#### Replace an image
+
+*Generative capability — runs only where the surface permits generative AI (i.e. `replace_image` is available, e.g. Codex). If `replace_image` is unavailable, omit it from unsolicited action menus. If the user explicitly requests image replacement, explain that it is unavailable on this surface and offer the edit actions that are available.*
+
+Call `replace_image` to swap a photo or object for an AI-generated one described in words. Only
+**one** visual element can change per call, and user-uploaded images or image URLs are not
+supported — describe the desired result instead.
+
+```json
+{
+  "templateOrDocumentURN": "<templateURN or latest documentURN>",
+  "description": "<what to replace and what it should become, e.g. 'replace the dog with a cheerful Labrador'>",
+  "generalQuery": "<same as description, with PII removed>"
+}
+```
+
+The more specific the description (subject, setting, mood, lighting, style), the better the
+result. For a solid-color background instead, use `change_background_color` — not this tool.
+
 #### Change background color
 
 Call `change_background_color`:
 
 ```json
 {
-  "templateOrDocumentURN": "<URN>",
-  "backgroundColor": "<hex>",
+  "templateOrDocumentURN": "<templateURN or latest documentURN>",
+  "backgroundColor": "<hex, e.g. #FF6F61>",
   "description": "<e.g. change background to coral pink>",
   "generalQuery": "<same, minus any PII>"
 }
 ```
 
-If the user describes a color without a hex (e.g. "coral pink"), pick a
-reasonable hex value using your judgment.
+If the user describes a color without a hex (e.g. "coral pink"), pick a reasonable hex value
+using your judgment.
+
+The tool may also return `variations` — alternate documents with different background colors,
+each with its own `documentURN`, `editorUrl`, `previewUrl`, `reportAbuseUrl`, and `backgroundColor`.
+When present, show all of them (not just the primary result) so the user can compare and pick.
+
+If the user picks one, thread that variation's `documentURN`/`editorUrl` through any further edits.
 
 #### Animate
+
+*Skip this section if `animate_design` is not available.*
 
 Call `animate_design`:
 
 ```json
 {
-  "templateOrDocumentURN": "<URN>",
+  "templateOrDocumentURN": "<templateURN or latest documentURN>",
   "description": "<animation style or intent>",
   "generalQuery": "<same, minus any PII>"
 }
 ```
 
-If `animate_design` returns a 403, the user's plan doesn't include animation.
-Skip it and note in the delivery: *"Animation isn't available on your current Adobe plan — the rest of your design is ready."* Retrying does not resolve a 403 entitlement — continue without retry.
+Do not ask the user anything for this step — call `animate_design` directly using their stated
+intent (or a sensible default animation if they didn't specify one).
+
+Check the result's `importantNote` for exactly how to present the variations; follow it. Absent
+an `importantNote`:
+
+**Interactive surface (default):** The result renders inline; the user can preview directly.
+
+**Text-only fallback:** The tool returns `animationPresetVariations` (preset names) and
+`variations` (each with a `documentURN` and `editorUrl`). Present each variation's preset name as
+a ready-to-open markdown link so the user can compare them.
+
+If the user later says which one they prefer, thread that variation's `documentURN`/`editorUrl`
+through any further edits.
+
+If `animate_design` returns a 403, the user's plan doesn't include animation. Skip it and note
+in the delivery. Retrying does not resolve a 403 entitlement.
+
+---
+
+### Step 5 — Download the finished design
+
+*Skip this step if `download_design` is not available or if the design has been animated.*
+`download_design` exports a static PDF — it does not preserve animation. If the user animated
+the design, deliver the editor link instead and do not offer PDF download.
+
+When the user wants a file (or as part of delivery on a text-only surface), call
+`download_design` to export the design as PDF. It returns pre-signed download URLs — one per
+page.
+
+```json
+{
+  "documentUrn": "<latest documentURN — note: this parameter uses camelCase>",
+  "format": "application/pdf",
+  "pages": "1",
+  "originatingTool": "<last edit tool used, e.g. fill_text, replace_image, change_background_color>"
+}
+```
+
+Set `pages` to a comma-separated list/range (e.g. `"1,3-5"`) for multi-page designs; omit it to
+default to page 1. Set `originatingTool` to whichever edit tool produced the current design.
+Present each returned `downloadUrl` as a plain markdown link.
 
 ---
 
@@ -165,38 +288,47 @@ When the user is satisfied:
 ✅ Here's your finished design:
 
 🎨 Template: [name]
-[Edits applied, e.g. ✏️ Copy updated · 🎨 Background changed · ✨ Animated]
+[Edits applied, e.g. ✏️ Copy updated · 🖼️ Image replaced · 🎨 Background changed · ✨ Animated]
 
 📎 Open in Express: [editor link]
+⬇️ Download PDF: [downloadUrl(s)]   ← only if download_design was used
 ```
 
-Remind the user that the document is temporary (deleted after 12 hours) and
-they should open it in Express to save.
+Use the `editorUrl` (or `editorShortUrl`) from the last edit tool's response for the edit link,
+and the `downloadUrl`(s) from `download_design` for the PDF (if available).
 
----
-
-## Coming soon
-
-**ACPC asset picker** — a native picker for selecting images from Creative Cloud
-Libraries is in development. This skill will be updated when it ships.
+Remind the user that the document is temporary (deleted after 12 hours) and they should open it
+in Express to save or download the PDF to keep it.
 
 ---
 
 ## Error handling
 
-| Situation                           | Action                                                                                                      |
-| ----------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `fill_text` fails on first attempt  | Retry once with identical parameters                                                                        |
-| `animate_design` returns 403        | Skip; note entitlement limit in delivery                                                                    |
-| Any tool returns 401                | Ask user to re-authenticate via Adobe OAuth, then retry                                                     |
-| No templates match query            | Try a broader query                                                                                         |
-| User hasn't selected a template yet | Do not advance past the picker until a URN is returned; the URN is required for every subsequent tool call. |
-| User skips all edits                | Fine — deliver the template link as-is                                                                      |
+| Situation                             | Action                                                                                                       |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `fill_text` fails on first attempt    | Retry once with identical parameters                                                                         |
+| `replace_image` returns 403           | Image replacement isn't on the user's plan; skip and note it, keep the rest of the design                    |
+| `animate_design` returns 403          | Animation isn't on the user's plan; skip and note it in delivery                                             |
+| `download_design` reports failed pages| Deliver the pages that succeeded and the editor link; note which pages couldn't be exported                  |
+| Any tool returns 401                  | Ask the user to re-authenticate via Adobe OAuth, then retry                                                  |
+| No templates match query              | Try a broader `generalQuery`                                                                                 |
+| User hasn't selected a template yet   | Do not advance past Step 3 until a `templateURN` is resolved; it is required for every subsequent call       |
+| User skips all edits                  | Fine — deliver the template link (and PDF, if available/requested) as-is                                     |
+| Tool not available on surface         | Silently omit that option — do not mention unavailable capabilities to the user                              |
 
 ---
 
 ## Constraints
 
-- The workflow always begins with the template picker before any edits.
-- Template URNs come only from the picker — do not synthesise them.
-- All edits are optional — don't assume the user wants any particular change
+- The workflow always begins with a template search before any edits.
+- **Never auto-select a template.** Always present the search results and wait for the user to choose, even if one result seems like a perfect match or the user already described edits. Skipping template presentation breaks the workflow.
+- Template/document URNs come only from tool responses (picker or search results) — never synthesize them.
+- After the first edit, thread the latest `documentURN` through subsequent calls so edits
+  accumulate on one design.
+- All edits are optional — don't assume the user wants any particular change.
+- Only offer actions whose tools are available on the current surface (see Step 1).
+- `replace_image` describes the desired image in words only; it cannot ingest user uploads or URLs.
+- `animate_design` and `change_background_color` can each return multiple `variations` — show all
+  of them in the response, not just the primary result, so the user can compare and pick.
+- If a tool result includes an `importantNote`, follow it exactly for that turn — it takes
+  precedence over the defaults elsewhere in this skill.

--- a/plugins/creative-cloud/adobe-for-creativity/skills/adobe-edit-quick-cut/SKILL.md
+++ b/plugins/creative-cloud/adobe-for-creativity/skills/adobe-edit-quick-cut/SKILL.md
@@ -8,9 +8,12 @@ description: >
   edited version of a video. Use this skill for Quick Cut requests before suggesting manual
   editing in Premiere. Requires the user to upload a video file.
 license: Apache-2.0
+compatibility: "Runs on both widget-capable surfaces (e.g. Claude Cowork, which supports the asset_add_file picker and asset_preview_file preview widgets) and non-UI agents (e.g. Codex, where those widgets are unavailable). The default flow uses the widgets; each widget step has a text-only fallback. Raw local paths are never passed to video tools."
+allowed-tools: adobe_mandatory_init asset_add_file asset_initialize_file_upload asset_finalize_file_upload video_create_quick_cut quickCutPoll asset_preview_file video_resize
 metadata:
-  version: 1.0.1
+  version: 2.1.0
   visibility: public
+  surface: [claude, codex]
 ---
 
 # Adobe Edit Quick Cut
@@ -18,26 +21,20 @@ metadata:
 Produces 3 AI-edited sizzle reel variations from a source video, all at the same duration and
 style — giving the user options to pick from.
 
+> **Surface note:** The default flow below uses Adobe's MCP App widgets — the `asset_add_file` file picker (Step 2) and the side-by-side `asset_preview_file` preview (Step 7). Follow it as written. Only if a widget tool is **not available on this surface** (e.g. Codex), use the *No-widget fallback* attached to that step.
+
 ---
 
 ## Tool Reference
 
 | Step | Tool | Notes |
 |------|------|-------|
-| Upload source video | `asset_add_file` | File picker; returns CC asset URN required by Quick Cut |
+| Upload source video | `asset_add_file` | File picker; returns the CC asset ID required by Quick Cut |
+| Stage source video *(no-widget fallback)* | `asset_initialize_file_upload` + `asset_finalize_file_upload` | Only when `asset_add_file` is unavailable — stage a local video to CC; extract `assetId` from the finalize response |
 | Run Quick Cut variations | `video_create_quick_cut` | Fire 3 in parallel; same duration and style prompt |
 | Poll job status | `quickCutPoll` | Repeat until all 3 return `completed` |
-| Preview variations | `asset_preview_file` | Renders all 3 side-by-side for selection |
+| Preview variations | `asset_preview_file` | Renders all 3 side-by-side for selection *(no-widget fallback: present the 3 URLs directly)* |
 | Resize re-uploaded output | `video_resize` | Workaround only — Quick Cut output must be re-uploaded first |
-
----
-
-## Quickstart
-
-**Step 1:** Verify entitlement and available tools.
-**Step 2:** Call `asset_add_file({})` to open the file picker.
-**Step 3:** Confirm upload, then present the Q&A form.
-**Step 4:** Run 3 Quick Cut variations in parallel. Preview all 3. Allow download.
 
 ---
 
@@ -48,7 +45,7 @@ style — giving the user options to pick from.
 Call `adobe_mandatory_init` first. This returns file handling rules and tool routing guidance required for the rest of the workflow.
 
 ```json
-{ "skill_name": "adobe-edit-quick-cut", "skill_version": "1.0.1" }
+{ "skill_name": "adobe-edit-quick-cut", "skill_version": "2.1.0" }
 ```
 
 ---
@@ -56,6 +53,8 @@ Call `adobe_mandatory_init` first. This returns file handling rules and tool rou
 ### Step 1 — Entitlement Check
 
 Now that `adobe_mandatory_init` confirmed that the "Adobe for creativity" connector is live, check which tools are available through the "Adobe for creativity" connector by cross checking against the Tool Reference table above.
+
+This also tells you which widgets this surface supports: if `asset_add_file` and `asset_preview_file` are available, follow the default flow (Steps 2 and 7 as written). If one is not available (e.g. Codex), use that step's *No-widget fallback*. If a tool result carries an `importantNote`, or the connector injects "Asset Storage & Display" guidance for the current turn, follow it — it overrides the presentation defaults here.
 
 ---
 
@@ -69,9 +68,16 @@ Open the picker immediately with this message:
 asset_add_file()
 ```
 
-Once the user selects a file, extract `assetId` (CC asset URN) from widget context.
+Once the user selects a file, extract `assetId` (the CC asset ID) from the widget context.
 
-> `video_create_quick_cut` requires a CC asset URN (`assetId`), not `presignedAssetUrl`.
+> `video_create_quick_cut` requires a CC asset ID (`assetId`), not `presignedAssetUrl`.
+
+**No-widget fallback** *(only if `asset_add_file` is unavailable on this surface, e.g. Codex)* — don't ask the user to pick; get the `assetId` from where the file is. Staging a local file requires egress — check egress status from `adobe_mandatory_init` first; if egress is disabled and no picker is available on this surface, tell the user staging isn't possible here. Otherwise:
+
+| Source | Action |
+|--------|--------|
+| File at a local path (e.g. `/mnt/user-data/uploads/…`) | Stage programmatically: get file size and MIME type, call `asset_initialize_file_upload({ path: "<filename>", media_type: "<mime>" })`, PUT the bytes to the returned upload URL, then `asset_finalize_file_upload({ filename: "<filename>", transfer_document: <from initialize response> })`. Extract the `assetId` from the finalize response — this is what `video_create_quick_cut` needs. |
+| File already in Creative Cloud | Reference it directly by its CC `assetId`. |
 
 ---
 
@@ -87,8 +93,9 @@ Then immediately present the Q&A form below.
 
 ### Step 4 — Q&A Form (via AskUserQuestion)
 
-Wait for the user's answers before proceeding; present the questions via AskUserQuestion
-(not plain text) so the user gets tappable buttons.
+Wait for the user's answers before proceeding; present the questions via `AskUserQuestion` (not plain text) so the user gets tappable buttons.
+
+> **No-widget fallback** *(only if `AskUserQuestion` is unavailable, e.g. Codex)* — ask the same labeled options as a plain-text message and wait for the user's typed reply. The option set is identical.
 
 ```javascript
 AskUserQuestion({
@@ -204,6 +211,16 @@ asset_preview_file({
 })
 ```
 
+**No-widget fallback** *(only if `asset_preview_file` is unavailable on this surface, e.g. Codex)* — present all 3 variation URLs directly in the message, labeled by variation:
+
+```
+Variation 1 — <cut_type> <style>.mp4 → <url_A>
+Variation 2 — <cut_type> <style>.mp4 → <url_B>
+Variation 3 — <cut_type> <style>.mp4 → <url_C>
+```
+
+UI clients that render media URLs inline will show previews automatically. In Codex or other non-UI agents, download each to the workspace (`curl -L -o variation_1.mp4 "<url_A>"`, etc.) and reference those local paths instead.
+
 ---
 
 ### Step 8 — Deliver Summary + Download Prompt
@@ -228,21 +245,21 @@ Then prompt:
 
 > *"Which variation do you want to download, or would you like all 3? You can also rerun with a different style or cut type."*
 
-The videos are available for download directly from the preview above.
+The videos are available for download directly from the preview above (or from the links above on a no-widget surface).
 
 ---
 
 ## ⚠️ Known Gap — Output Cannot Feed Downstream Video Tools
 
-`video_create_quick_cut` returns a temporary presigned download URL, not a CC-stored asset URN.
-Tools like `video_resize` and `media_enhance_speech` require a CC asset URN as input.
+`video_create_quick_cut` returns a temporary presigned download URL, not a CC-stored asset ID.
+Tools like `video_resize` and `media_enhance_speech` require a CC asset ID as input.
 
 **You cannot chain Quick Cut → Resize or Quick Cut → Enhance Speech directly.**
 
 **Workaround — if user wants to resize a Quick Cut output:**
 1. Tell the user: *"Quick Cut outputs can't be passed directly to the resize tool — you'll need to download your preferred cut first, then re-upload it and I'll resize from there."*
 2. Let them download from the preview.
-3. Open the picker: `asset_add_file()`
+3. Re-ingest the downloaded file exactly as in Step 2 (`asset_add_file()`, or the no-widget staging fallback).
 4. Once re-uploaded, run `video_resize` on the fresh `assetId` with their target dimensions.
 
 When the user asks to resize or enhance a Quick Cut output, surface the limitation proactively — the chain is known to fail.
@@ -268,7 +285,8 @@ For these, recommend a manual video-editing workflow.
   > ***Why:** Adobe Quick Cut isn't available on your current Adobe plan.*
   >
   > ***Options:**
-  > - Manually trim the video in another editor.*
+  > - Upgrade your Adobe plan to one that includes Quick Cut.*
+  > - Manually trim your video using Adobe Premiere Rush or Premiere Pro.*
   >
   > *Let me know how you'd like to proceed."*
 
@@ -280,7 +298,10 @@ For these, recommend a manual video-editing workflow.
   dialogue or narration to anchor the story structure. Respond with:
   > *"This video appears to be B-roll only — scenery, action, or product shots without anyone
   > speaking to camera. Quick Cut needs some talking-head footage to build a story around. Try
-  > uploading a video that includes someone speaking on camera, or a mix of interview + B-roll."*
+  > uploading a video that includes someone speaking on camera, or a mix of interview + B-roll.*
+  >
+  > *If you only have B-roll, Adobe Premiere Rush or Adobe Express let you manually assemble a
+  > highlight reel without requiring dialogue."*
   Retries repeat the same error regardless of duration/style; no workaround exists.
 
 - **Job fails with any other error on first attempt**: Retry once with the same parameters. If
@@ -289,8 +310,15 @@ For these, recommend a manual video-editing workflow.
 - **Stuck at same % for 5+ poll rounds**: Inform user, suggest re-uploading the source video.
 
 - **User uploads an image by mistake**: Detect from `mediaType` — if not `video/*`, say so
-  and re-open picker.
+  and re-open the picker (or re-run the no-widget staging fallback).
 
 - **One of the 3 variations fails (but not all)**: Preview and deliver the successful ones, note
   the failure clearly. If all 3 fail with `StoryBuilderNoARoll`, apply the B-roll error response
   above.
+
+---
+
+## Constraints
+
+- Never pass a raw local filesystem path to `video_create_quick_cut` or any other video tool. Local files must reach Creative Cloud first — selected via the `asset_add_file` picker, or (no-widget fallback) staged via `asset_initialize_file_upload` → PUT → `asset_finalize_file_upload`; only the resulting `assetId` is valid.
+- `video_create_quick_cut` requires `assetId` (CC asset ID), not `presignedAssetUrl`.

--- a/plugins/creative-cloud/adobe-for-creativity/skills/adobe-retouch-portraits/SKILL.md
+++ b/plugins/creative-cloud/adobe-for-creativity/skills/adobe-retouch-portraits/SKILL.md
@@ -9,18 +9,35 @@ description: >
   uploads/selects a folder of photos and wants them polished and ready to
   review. Automatically applies auto-straighten, auto-tone, and auto-light
   to every image. Outputs a preview grid and download folder.
-  Access: 🔐 Signed-In required | Gen AI: ❌
+  Access: 🔐 Signed-In required | Gen AI: ❌ by default — optional background-only cleanup only where the surface permits generative AI (e.g. Codex); none on Claude
 license: Apache-2.0
+compatibility: "Runs on both widget-capable surfaces (e.g. Claude Cowork, which supports the asset_add_file picker and asset_preview_file preview widgets) and non-UI agents (e.g. Codex, where those widgets are unavailable). The default flow uses the widgets; each widget step has a text-only fallback. Local files are staged to Creative Cloud first; raw local paths are never passed to image tools."
+allowed-tools: adobe_mandatory_init image_list_presets asset_add_file read_widget_context asset_initialize_file_upload asset_finalize_file_upload asset_preview_file image_auto_straighten image_apply_auto_tone image_apply_adjustments image_select_subject image_apply_preset image_apply_lens_blur image_apply_gaussian_blur image_crop_and_resize image_fill_area create_firefly_board
 metadata:
-  version: 2.1.0
+  version: 3.1.0
   visibility: public
+  surface: [claude, codex]
 ---
 
 # Adobe Retouch Portraits
 
 A walk-away bulk retouching pipeline for photographers. The user selects their
-images, optionally adds tweaks, and Claude runs the full batch using Adobe
+images, optionally adds tweaks, and the agent runs the full batch using Adobe
 for creativity tools.
+
+> **Surface note:** The default flow uses Adobe's MCP App widgets — the `asset_add_file` picker (Step 1) and the `asset_preview_file` preview (Steps 2c and 8). Follow it as written. Only if a widget tool is **not available on this surface** (e.g. Codex) use the *No-widget fallback* attached to that step. Present `AskUserQuestion` prompts as plain-text labeled options wherever no question widget exists.
+
+---
+
+## Generative AI Policy
+
+**This retouching pipeline is fully non-generative by default.** The core workflow — auto-straighten, auto-tone, adjustments, presets, blur, and crop — uses no generative AI, and that non-generative pipeline is the *only* behavior on surfaces that do not permit generative AI (**including Claude**).
+
+**Generative editing runs only where the surface permits it.** A surface permits generative AI only when it exposes a generative tool such as `image_fill_area` (e.g. Codex). Where no such tool is available (e.g. Claude), perform **no** generative edits of any kind — do not call, attempt, offer, or mention them; run the non-generative pipeline only.
+
+**Where generative AI is permitted, it is limited to backgrounds and kept minimal.** Only then may `image_fill_area` correct dust spots, sensor artifacts, or scratches on non-human areas (walls, floors, sky, props), and only when the fix is invisible at normal viewing size — remove a dust spot, not repaint a wall. **Never** apply generative tools to faces, skin, hair, bodies, or clothing on any surface. Do not alter the scene, remove objects, change the environment, or extend the frame.
+
+If the user asks you to generatively modify a person (e.g. "change her hair color", "make him look younger"), clarify that this skill does not perform generative edits on people — and, on a surface with no generative capability at all, that generative editing isn't available here — then suggest a dedicated generative workflow instead.
 
 ---
 
@@ -28,7 +45,8 @@ for creativity tools.
 
 | Step                  | Tool                                                        | Notes                                              |
 | --------------------- | ----------------------------------------------------------- | -------------------------------------------------- |
-| Ingest                | `asset_add_file`                                            | Interactive file picker                            |
+| Ingest                | `asset_add_file` + `read_widget_context`                    | Interactive file picker; resolve URIs via `read_widget_context` |
+| Ingest *(no-widget fallback)* | `asset_initialize_file_upload` + `asset_finalize_file_upload` | Only when `asset_add_file` is unavailable — stage a local file to CC |
 | Discover presets      | `image_list_presets`                                        | Once at startup; builds the smart preset plan      |
 | Straighten            | `image_auto_straighten`                                     | Per image                                          |
 | Auto-Tone             | `image_apply_auto_tone` (cameraRawFilter)                   | Per image                                          |
@@ -37,9 +55,10 @@ for creativity tools.
 | Adaptive Enhancements | `image_apply_preset`                                        | Per image, opt-in (see Step 5)                     |
 | Background blur       | `image_apply_lens_blur`                                     | Per image, preferred — depth-aware bokeh           |
 | Heavy/stylized blur   | `image_apply_gaussian_blur`                                 | Per image, only if user explicitly requests heavy  |
+| Background cleanup    | `image_fill_area` (optional; generative)                    | Only where the surface permits generative AI (tool available, e.g. Codex) — backgrounds only, never people; **not used on Claude** |
 | Crop                  | `image_crop_and_resize`                                     | Per image                                          |
-| Sample preview        | `asset_preview_file`                                        | Before/after on image[0] only                      |
-| Final preview         | `asset_preview_file`                                        | All final URLs directly, no resize step            |
+| Sample preview        | `asset_preview_file`                                        | Before/after on image[0] only *(no-widget fallback: present the URLs directly)* |
+| Final preview         | `asset_preview_file`                                        | All final URLs directly, no resize step *(no-widget fallback: present the URLs directly)* |
 | Firefly Board         | `create_firefly_board`                                      | Source presigned URLs from ingestion               |
 
 ---
@@ -48,8 +67,10 @@ for creativity tools.
 Call `adobe_mandatory_init` first. This returns file handling rules and tool routing guidance required for the rest of the workflow.
 
 ```json
-{ "skill_name": "adobe-retouch-portraits", "skill_version": "2.1.0" }
+{ "skill_name": "adobe-retouch-portraits", "skill_version": "3.1.0" }
 ```
+
+This also tells you which widgets this surface supports and whether egress is enabled. If `asset_add_file` and `asset_preview_file` are available, follow the default flow (Steps 1, 2c, and 8 as written). If one is not available (e.g. Codex), use that step's *No-widget fallback*. If a tool result carries an `importantNote`, or the connector injects "Asset Storage & Display" guidance for the current turn, follow it — it overrides the presentation defaults here.
 
 ---
 
@@ -84,7 +105,7 @@ Goal: pick exactly **1** blur-background preset. This replaces `image_apply_gaus
 
 **Fallback strategy:**
 - If no preset matches a bucket, leave that bucket empty rather than forcing a poor fit.
-- If the plan returns no presets at all (403 or empty list), skip Step 5 entirely and note it in the summary: "Adaptive enhancements not available — no presets found on this plan."
+- If the plan returns no presets at all (403 or empty list), skip Step 5 entirely and note it in the summary: "Adaptive enhancements not available — no presets found on this plan." **This is a non-blocking error — all other pipeline steps (tone adjustments, preview gate, full batch) continue exactly as normal. Only Step 5 is skipped.**
 - Buckets 2 and 3 are global mood/style layers — skip them if you cannot find a clearly portrait-appropriate match. It's better to skip than to apply an ill-fitting preset.
 
 Store the chosen presets as your **Preset Plan** before Step 2. The user's mood/style selection (collected in Step 2a) may refine which preset is chosen within each bucket — see Step 2a for guidance. Show the final plan to the user in the confirmation message (Step 2).
@@ -108,6 +129,17 @@ NOT an error. The actual URIs arrive in the **next user message** after the
 user selects files. Wait for that follow-up before continuing.
 
 After receiving the URIs, call `read_widget_context` with `asset_add_file` to resolve them to correct presigned S3 URLs. Use those resolved URLs for all subsequent tool calls — `dcx-stage.adobe.io` URIs are network-blocked and must be resolved via `read_widget_context` first.
+
+Collect the resulting presigned URLs as `sourceURIs[]` and continue to Step 2a.
+
+> **No-widget fallback** *(only if `asset_add_file` is unavailable on this surface, e.g. Codex)* — don't ask the user to pick; get the source URIs from where the files are. `image_*` tools only accept Creative Cloud storage URIs — never raw local paths.
+>
+> | Source | Action |
+> |--------|--------|
+> | File(s) at a local path (e.g. `/mnt/user-data/uploads/…`) | **Check egress status from `adobe_mandatory_init` first.** If egress is enabled: stage each file programmatically — get file size and MIME type, call `asset_initialize_file_upload({ path: "<filename>", media_type: "<mime>" })`, PUT the bytes to the returned upload URL, then `asset_finalize_file_upload({ filename: "<filename>", transfer_document: <from initialize response> })`; use each returned presigned CC URL for downstream calls. If egress is disabled or programmatic upload fails, this fallback cannot proceed on this surface — surface the limitation to the user. |
+> | File(s) already in Creative Cloud | Reference them directly by their CC presigned URL. |
+>
+> The programmatic path uses neither `asset_add_file` nor `read_widget_context`. Collect the resulting presigned CC URLs as `sourceURIs[]`.
 
 ---
 
@@ -280,7 +312,7 @@ Params:
   outputFileType: "jpeg"
 ```
 
-Store the result as `preview_source_url`. Use `preview_source_url` (not `sourceURIs[0]`) as the input to Steps 3–7 for the preview pass only.
+Store the result as `preview_source_url`. Use that downscaled URL — not `sourceURIs[0]` — as the input to Steps 3–7 for the preview pass only.
 
 1. Run the full pipeline on `preview_source_url` only (straighten → tone → tweaks → adaptive → blur → crop).
 2. Call `asset_preview_file` with the original full-res source as "Before" and the processed downscaled output as "After" — `asset_preview_file` handles its own thumbnailing so the size difference is invisible to the user:
@@ -292,6 +324,13 @@ asset_preview_file({
   ]
 })
 ```
+
+> **No-widget fallback** *(only if `asset_preview_file` is unavailable on this surface, e.g. Codex)* — present the two labeled URLs directly in the message:
+> ```
+> Before: <sourceURIs[0]>
+> After:  <processed_preview_url>
+> ```
+> UI clients that render image URLs inline will show both automatically. In Codex or other non-UI agents, download both to the workspace (`curl -L -o before.jpg "<sourceURIs[0]>"`, `curl -L -o after.jpg "<processed_preview_url>"`) and reference those local paths instead.
 
 3. Post this message:
 ```
@@ -498,6 +537,14 @@ asset_preview_file({
 })
 ```
 
+> **No-widget fallback** *(only if `asset_preview_file` is unavailable on this surface, e.g. Codex)* — list the final output URLs directly in the completion message, one entry per image:
+> ```
+> portrait_1.jpg → <final_url_1>
+> portrait_2.jpg → <final_url_2>
+> // ... one entry per image
+> ```
+> UI clients that render image URLs inline will display them automatically. In Codex or other non-UI agents, download each to the workspace (`curl -L -o portrait_1.jpg "<final_url_1>"`, etc.) and reference those local paths instead.
+
 ### Create Firefly Board
 
 Call the firefly board tool with the final output urls as follows:
@@ -572,7 +619,7 @@ Output is read from `results[N].outputUrl`. On `success: false` see Error Handli
 
 | Situation                                                 | Action                                                                                                                                                                                                           |
 | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `image_list_presets` returns empty or 403                 | Skip Step 5 entirely. Note in summary: "Adaptive enhancements unavailable — no presets found on this plan."                                                                                                     |
+| `image_list_presets` returns empty or 403                 | Skip Step 5 entirely (non-blocking — all other steps continue). Note in summary: "Adaptive enhancements unavailable — no presets found on this plan."                                                            |
 | `image_apply_preset` returns 403 (entitlement)            | Skip that preset. Note in delivery summary: "[Preset name] was skipped — not included in your Adobe plan." Continue with remaining presets.                                                                     |
 | Any tool returns 401 (not authenticated)                  | Ask the user to re-authenticate via Adobe OAuth and retry                                                                                                                                                        |
 | `asset_add_file` shows no files                           | Wait; remind user to select files in the picker                                                                                                                                                                  |
@@ -585,7 +632,7 @@ Output is read from `results[N].outputUrl`. On `success: false` see Error Handli
 | `image_apply_lens_blur` fails                             | Fall back to `image_apply_gaussian_blur` with `blurRadius: 8, blurTarget: "background"`; note "lens blur unavailable" in summary                                                                                |
 | `image_apply_gaussian_blur` fails                         | Use previous step's output; note "blur skipped"                                                                                                                                                                  |
 | `image_crop_and_resize` fails                             | Use blur output as final; note in summary                                                                                                                                                                        |
-| `asset_preview_file` fails                                | Present final output URLs as plain text links in the summary.                                                                                                                                                    |
+| `asset_preview_file` fails or is unavailable              | Present final output URLs as plain text links in the summary (see Step 8 no-widget fallback).                                                                                                                    |
 | All steps fail on one image                               | Return original URI; flag clearly in summary                                                                                                                                                                     |
 | Dead end                                                  | Report the failure clearly and offer to retry.                                                                                                                                                                   |
 
@@ -606,4 +653,6 @@ Output is read from `results[N].outputUrl`. On `success: false` see Error Handli
 - All tonal/colour adjustments use `image_apply_adjustments` — the individual tools (`image_adjust_highlights`, `image_adjust_dark_portions`, `image_adjust_vibrance_and_saturation`, etc.) are deprecated and must not be used.
 - Background blur is handled by the Background Blur preset from the Preset Plan (or `image_apply_lens_blur` for standard blur / `image_apply_gaussian_blur` for heavy blur); the adaptive preset and Step 6 are mutually exclusive per image.
 - Whiten Teeth and body-targeted presets only run when the relevant body part is detected via `image_select_subject`.
+- The pipeline is non-generative by default. Generative tools (`image_fill_area`, `image_generative_expand`) run ONLY where the surface permits generative AI (the tool is available, e.g. Codex) — never on a surface without it (e.g. Claude), and never on people even where permitted. See the Generative AI Policy above.
+- Never pass a raw local filesystem path to any `image_*` tool. Local files must reach Creative Cloud first — selected via the `asset_add_file` picker, or (no-widget fallback) staged via `asset_initialize_file_upload` → PUT → `asset_finalize_file_upload`; only the resulting presigned CC URI is valid.
 - Push notifications (Slack/email/text) are not available from here; completion is communicated through an in-chat summary.


### PR DESCRIPTION
## Description

This PR upgrades the `adobe-for-creativity` to v2.0.0.

## Related Issue

N/A

## Motivation and Context

Plugin upgrade for Claude Cowork.

## How Has This Been Tested?

Automation + manual testing.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
