### PR TITLE
chore(code-assessment): GA the code-assessment skill and its beta sub-skills

### DIFF
--- a/plugins/aem/cloud-service/skills/code-assessment/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-assessment
 description: |
-  [BETA] Detect, review, and fix code-quality and correctness issues in an AEM as a Cloud Service
+  Detect, review, and fix code-quality and correctness issues in an AEM as a Cloud Service
   project — locally, with no external services or network calls. Use whenever a user wants to
   check, review, assess, audit, scan, modernize, upgrade, or fix AEM Java, Sling Models, OSGi,
   or Maven code — for example: "check my Sling Models are implemented correctly", "review my
@@ -10,15 +10,8 @@ description: |
   it to scan the repo; it detects issues, plans, and — only when you ask — applies surgical
   edits on a branch or in place, then verifies with mvn compile. It recognises the intent and
   handles each issue type itself, reporting anything it cannot yet fix.
-  This skill is in beta. Verify all outputs before applying them to production projects.
-metadata:
-  status: beta
 license: Apache-2.0
 ---
-
-> **Beta Skill**: This skill is in beta and under active development.
-> Results should be reviewed carefully before use in production.
-> Report issues at https://github.com/adobe/skills/issues
 
 # AEM as a Cloud Service — Code Assessment
 

--- a/plugins/aem/cloud-service/skills/code-assessment/inject-in-sling-model/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/inject-in-sling-model/SKILL.md
@@ -1,16 +1,9 @@
 ---
 name: inject-in-sling-model
 description: |
-  [BETA] AEM Cloud Service expert skill — migrate javax.inject.@Inject fields in Sling Model (@Model) classes to injector-specific annotations (@ValueMapValue / @OSGiService / @SlingObject). Self-discoverable (scan for @Model classes with field-level @Inject); the replacement is chosen deterministically from each field's declared type. Use for "fix @Inject in HeroModel.java", "modernize my Sling Models", or when scanning an AEM project for @Inject misuse. Detailed decision table, companion-annotation handling, import management, and file-level skip policy are in recipe.md.
-  This skill is in beta. Verify all outputs before applying them to production projects.
-metadata:
-  status: beta
+  AEM Cloud Service expert skill — migrate javax.inject.@Inject fields in Sling Model (@Model) classes to injector-specific annotations (@ValueMapValue / @OSGiService / @SlingObject). Self-discoverable (scan for @Model classes with field-level @Inject); the replacement is chosen deterministically from each field's declared type. Use for "fix @Inject in HeroModel.java", "modernize my Sling Models", or when scanning an AEM project for @Inject misuse. Detailed decision table, companion-annotation handling, import management, and file-level skip policy are in recipe.md.
 license: Apache-2.0
 ---
-
-> **Beta Skill**: This skill is in beta and under active development.
-> Results should be reviewed carefully before use in production.
-> Report issues at https://github.com/adobe/skills/issues
 
 # @Inject in Sling Models — AEM as a Cloud Service
 

--- a/plugins/aem/cloud-service/skills/code-assessment/outbound-call-timeouts/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/outbound-call-timeouts/SKILL.md
@@ -1,14 +1,8 @@
 ---
 name: outbound-call-timeouts
-description: "[BETA] AEM Cloud Service expert skill — add explicit connect/read/socket timeouts to outbound HTTP clients constructed without one (Apache HttpClient 4.x/5.x, OkHttp, JDK java.net.http.HttpClient), including the JDK per-request read timeout on HttpRequest. Use for \"add HTTP timeouts\", \"this external/outbound call has no timeout\", or a scan that flags a timeout-less client. Highest-frequency CSO outage cause: a client on default (effectively infinite) timeouts holds request threads on a slow upstream until the Jetty pool saturates and the site goes down. The analyzer locates timeout-less construction sites; mechanical per-library remediation applies CSO-backed default timeouts (recipe.md). This skill is in beta. Verify all outputs before applying them to production projects."
-metadata:
-  status: beta
+description: "AEM Cloud Service expert skill — add explicit connect/read/socket timeouts to outbound HTTP clients constructed without one (Apache HttpClient 4.x/5.x, OkHttp, JDK java.net.http.HttpClient), including the JDK per-request read timeout on HttpRequest. Use for \"add HTTP timeouts\", \"this external/outbound call has no timeout\", or a scan that flags a timeout-less client. Highest-frequency CSO outage cause: a client on default (effectively infinite) timeouts holds request threads on a slow upstream until the Jetty pool saturates and the site goes down. The analyzer locates timeout-less construction sites; mechanical per-library remediation applies CSO-backed default timeouts (recipe.md)."
 license: Apache-2.0
 ---
-
-> **Beta Skill**: This skill is in beta and under active development.
-> Results should be reviewed carefully before use in production.
-> Report issues at https://github.com/adobe/skills/issues
 
 # Outbound HTTP calls without a timeout — AEM as a Cloud Service
 

--- a/plugins/aem/cloud-service/skills/code-assessment/outdated-dependencies/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/outdated-dependencies/SKILL.md
@@ -1,14 +1,8 @@
 ---
 name: outdated-dependencies
-description: "[BETA] AEM Cloud Service expert skill — upgrade outdated Maven dependencies in pom.xml, both literal <version> and same-pom ${property} shapes. Use for \"update my aem-sdk-api\", \"upgrade mockito\", or scanning a project for stale dependency versions. Discovery can find <dependency> blocks but \"outdated\" needs a target version, which the user supplies. Pattern A/B locators and editing strategy are in recipe.md. This skill is in beta. Verify all outputs before applying them to production projects."
-metadata:
-  status: beta
+description: "AEM Cloud Service expert skill — upgrade outdated Maven dependencies in pom.xml, both literal <version> and same-pom ${property} shapes. Use for \"update my aem-sdk-api\", \"upgrade mockito\", or scanning a project for stale dependency versions. Discovery can find <dependency> blocks but \"outdated\" needs a target version, which the user supplies. Pattern A/B locators and editing strategy are in recipe.md."
 license: Apache-2.0
 ---
-
-> **Beta Skill**: This skill is in beta and under active development.
-> Results should be reviewed carefully before use in production.
-> Report issues at https://github.com/adobe/skills/issues
 
 # Outdated Maven dependencies — AEM as a Cloud Service
 

--- a/plugins/aem/cloud-service/skills/code-assessment/unbounded-query/SKILL.md
+++ b/plugins/aem/cloud-service/skills/code-assessment/unbounded-query/SKILL.md
@@ -1,14 +1,8 @@
 ---
 name: unbounded-query
-description: "[BETA] AEM Cloud Service expert skill — handle an explicitly-unbounded query (`p.limit=-1` predicate or JCR `setLimit(-1)`): bound it when capping is provably safe, otherwise flag it for human pagination. Use for \"bound my query\", \"unbounded query\", \"query causing OOM\", or a scan that flags `p.limit=-1`. Top CSO OOM cause: an unbounded result set traversed in a loop fills the heap and saturates the instance. The analyzer locates the explicit markers; the recipe triages each by how the result is consumed — single-result → 1, already-bounded list → N, iterate-all on the request path → escalate. Never silently cap a result the caller reads in full. This skill is in beta. Verify all outputs before applying them to production projects."
-metadata:
-  status: beta
+description: "AEM Cloud Service expert skill — handle an explicitly-unbounded query (`p.limit=-1` predicate or JCR `setLimit(-1)`): bound it when capping is provably safe, otherwise flag it for human pagination. Use for \"bound my query\", \"unbounded query\", \"query causing OOM\", or a scan that flags `p.limit=-1`. Top CSO OOM cause: an unbounded result set traversed in a loop fills the heap and saturates the instance. The analyzer locates the explicit markers; the recipe triages each by how the result is consumed — single-result → 1, already-bounded list → N, iterate-all on the request path → escalate. Never silently cap a result the caller reads in full."
 license: Apache-2.0
 ---
-
-> **Beta Skill**: This skill is in beta and under active development.
-> Results should be reviewed carefully before use in production.
-> Report issues at https://github.com/adobe/skills/issues
 
 # Unbounded query — AEM as a Cloud Service
 


### PR DESCRIPTION
## What

Removes beta status from the `code-assessment` orchestrator and the four sub-skills that were still marked beta.

Follows the same four-marker removal used when `remove-deprecated-api` went GA (50e16b6):

- `[BETA]` prefix in `description`
- the `This skill is in beta. Verify all outputs before applying them to production projects.` caveat line
- the `metadata:` block (`status: beta` was its only key, so the parent key goes too)
- the `> **Beta Skill**: ...` body blockquote

## Skills GA'd

| Skill | Path |
| --- | --- |
| `code-assessment` (orchestrator) | `plugins/aem/cloud-service/skills/code-assessment/SKILL.md` |
| `inject-in-sling-model` | `.../code-assessment/inject-in-sling-model/SKILL.md` |
| `outbound-call-timeouts` | `.../code-assessment/outbound-call-timeouts/SKILL.md` |
| `outdated-dependencies` | `.../code-assessment/outdated-dependencies/SKILL.md` |
| `unbounded-query` | `.../code-assessment/unbounded-query/SKILL.md` |

## Verification

- `skills-ref validate` passes on all 11 `code-assessment` skill directories.
- `git grep -ni beta` over the `code-assessment` tree returns zero hits.
- Frontmatter re-parsed with `js-yaml` for each edited file: keys are now exactly `name, description, license`; the multi-line `|` and quoted-string description forms are intact.


🤖 Generated with [Claude Code](https://claude.com/claude-code)