### PR TITLE
feat(aem): add cloud-service and 6.5-lts plugin READMEs, consolidate top-level README

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -53,12 +53,51 @@
     {
       "name": "aem-cloud-service",
       "source": "./plugins/aem/cloud-service",
-      "description": "All AEM as a Cloud Service skills: component development and Dispatcher, workflows"
+      "description": "All AEM as a Cloud Service skills: component development, Dispatcher config authoring and hardening, workflow design and debugging, code assessment and migration from legacy AEM, content distribution, and Rapid Development Environment (RDE) support.",
+      "version": "1.0.0",
+      "category": "aem",
+      "keywords": [
+        "adobe",
+        "aem",
+        "aemaacs",
+        "cloud-service",
+        "dispatcher",
+        "component",
+        "workflow",
+        "rde",
+        "code-assessment",
+        "migration",
+        "content-distribution"
+      ],
+      "author": {
+        "name": "Adobe"
+      },
+      "homepage": "https://github.com/adobe/skills",
+      "repository": "https://github.com/adobe/skills",
+      "license": "Apache-2.0"
     },
     {
       "name": "aem-6-5-lts",
       "source": "./plugins/aem/6.5-lts",
-      "description": "All AEM 6.5 LTS skills: Dispatcher, workflows for AEM 6.5 LTS and AMS environment"
+      "description": "All AEM 6.5 LTS and AMS skills: Dispatcher config authoring and hardening, workflow design and debugging, replication agent configuration and troubleshooting, and project bootstrap.",
+      "version": "1.0.0",
+      "category": "aem",
+      "keywords": [
+        "adobe",
+        "aem",
+        "aem6.5",
+        "6.5-lts",
+        "ams",
+        "dispatcher",
+        "workflow",
+        "replication"
+      ],
+      "author": {
+        "name": "Adobe"
+      },
+      "homepage": "https://github.com/adobe/skills",
+      "repository": "https://github.com/adobe/skills",
+      "license": "Apache-2.0"
     },
     {
       "name": "aem-project-management",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -79,7 +79,7 @@
     {
       "name": "aem-6-5-lts",
       "source": "./plugins/aem/6.5-lts",
-      "description": "All AEM 6.5 LTS and AMS skills: Dispatcher config authoring and hardening, workflow design and debugging, replication agent configuration and troubleshooting, and project bootstrap.",
+      "description": "All AEM 6.5 LTS and AMS skills: Dispatcher config authoring and hardening, workflow design and debugging, replication agent configuration, content activation, programmatic Replication API, lifecycle orchestration, and troubleshooting, and project bootstrap.",
       "version": "1.0.0",
       "category": "aem",
       "keywords": [

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ All AEM 6.5 LTS and Adobe Managed Services (AMS) skills — Dispatcher, workflow
 | `ensure-agents-md` | Bootstrap skill — auto-generates `AGENTS.md` and `CLAUDE.md` for AEM 6.5 LTS projects when missing |
 | `dispatcher` | Config authoring, technical advisory, incident response, performance tuning, and security hardening for AEM 6.5 LTS and AMS. Requires Dispatcher MCP (`AEM_DEPLOYMENT_MODE=ams`) |
 | `aem-workflow` | Workflow model design, development, triggering, launchers, debugging, and triaging — with JMX, Felix Console, and direct log access for 6.5 LTS/AMS |
-| `aem-replication` | Replication agent configuration, content activation/deactivation, Replication API usage (49 Java examples), and troubleshooting blocked queues and distribution failures |
+| `aem-replication` | Replication agent configuration, content activation/deactivation, Replication API usage (57 Java examples), lifecycle orchestration, and troubleshooting blocked queues and distribution failures |
 
 See the [`aem-6-5-lts` plugin README](plugins/aem/6.5-lts/README.md) for sub-skill details.
 
@@ -359,31 +359,10 @@ plugins/
 │       │   └── plugin.json
 │       ├── README.md
 │       └── skills/
-│           ├── aem-workflow/
-│           │   ├── SKILL.md
-│           │   ├── workflow-model-design/
-│           │   ├── workflow-development/
-│           │   ├── workflow-triggering/
-│           │   ├── workflow-launchers/
-│           │   ├── workflow-debugging/
-│           │   ├── workflow-triaging/
-│           │   └── workflow-orchestrator/
-│           ├── aem-replication/
-│           │   ├── README.md
-│           │   ├── SKILL.md
-│           │   ├── configure-replication-agent/
-│           │   ├── replicate-content/
-│           │   ├── replication-api/
-│           │   └── troubleshoot-replication/
 │           ├── ensure-agents-md/
-│           └── dispatcher/
-│               ├── SKILL.md
-│               ├── config-authoring/
-│               ├── technical-advisory/
-│               ├── incident-response/
-│               ├── performance-tuning/
-│               ├── security-hardening/
-│               └── workflow-orchestrator/
+│           ├── dispatcher/
+│           ├── aem-workflow/
+│           └── aem-replication/
 ├── app-builder/
 │   ├── .claude-plugin/
 │   │   └── plugin.json

--- a/README.md
+++ b/README.md
@@ -173,107 +173,43 @@ Handover documentation and PDF guides generation for AEM Edge Delivery Services 
 | `whitepaper`  | Create professional PDF whitepapers from Markdown          |
 | `auth`        | Authenticate with AEM Config Service API                   |
 
-### AEM as a Cloud Service — Create Component
+##### AEM as a Cloud Service
 
-The `create-component` skill creates complete AEM components following Adobe best practices for AEM Cloud Service and AEM 6.5. It covers:
+All AEM as a Cloud Service skills — component development, Dispatcher, workflows, code assessment, migration, content distribution, RDE, and project bootstrap. Available via the [`aem-cloud-service`](plugins/aem/cloud-service/README.md) plugin.
 
-- Component definition, dialog XML, and HTL template
-- Sling Model and optional child item model (multifield)
-- Unit tests for models and servlets
-- Clientlibs (component and dialog)
-- Optional Sling Servlet for dynamic content
+```bash
+/plugin install aem-cloud-service@adobe-skills
+```
 
-See `plugins/aem/cloud-service/skills/create-component/` for the skill and its reference files.
+| Skill | Description |
+|-------|-------------|
+| `create-component` | Create complete AEM components: definition, dialog XML, HTL template, Sling Model, unit tests, clientlibs, and optional servlet |
+| `ensure-agents-md` | Bootstrap skill — auto-generates `AGENTS.md` and `CLAUDE.md` from `pom.xml` when missing, tailored to the project's modules and add-ons |
+| `dispatcher` | Config authoring, technical advisory, incident response, performance tuning, security hardening, and lifecycle orchestration for the Dispatcher. Requires Dispatcher MCP (`AEM_DEPLOYMENT_MODE=cloud`) |
+| `aem-workflow` | Workflow model design, process step development, launcher configuration, triggering, debugging stuck/failed workflows, and incident triaging for the Granite Workflow Engine |
+| `code-assessment` | Detect and fix AEM CS code-quality issues locally — Sling Model patterns, deprecated APIs, scheduler, replication, resource listeners, unbounded queries, outbound call timeouts, and more. Verifies with `mvn compile` |
+| `migration` | Migrate legacy AEM (6.x, AMS, on-prem) to AEM CS using BPA/CAM data — scheduler, replication, event handlers, HTL lint, dialog migration, template modernization, OSGi config. Delegates refactors to `code-assessment` |
+| `content-distribution` | Programmatic content publishing via the Replication API and distribution event monitoring via Sling Distribution events |
+| `aem-rde` *(beta)* | Expert assistance for `aio aem rde` — deploy, inspect, log-tail, snapshot, and troubleshoot Rapid Development Environments |
 
-### AEM as a Cloud Service — Ensure AGENTS.md (bootstrap)
+See the [`aem-cloud-service` plugin README](plugins/aem/cloud-service/README.md) for sub-skill details and MCP requirements.
 
-The `ensure-agents-md` skill is a **bootstrap skill** that runs first, before any other work. When a
-customer opens their AEM Cloud Service project and asks the agent anything, this skill checks whether
-`AGENTS.md` exists at the repo root. If missing, it:
+##### AEM 6.5 LTS
 
-- Reads root `pom.xml` to resolve the project name and discover actual modules
-- Detects add-ons (CIF, Forms, SPA type, precompiled scripts)
-- Generates a tailored `AGENTS.md` with only the modules that exist, correct frontend variant, conditional
-  Dispatcher MCP section, and the right resource links
-- Creates `CLAUDE.md` (`@AGENTS.md`) so Claude-based tools also discover the guidance
+All AEM 6.5 LTS and Adobe Managed Services (AMS) skills — Dispatcher, workflows, replication, and project bootstrap. Available via the [`aem-6-5-lts`](plugins/aem/6.5-lts/README.md) plugin.
 
-If `AGENTS.md` already exists it is never overwritten.
+```bash
+/plugin install aem-6-5-lts@adobe-skills
+```
 
-See `plugins/aem/cloud-service/skills/ensure-agents-md/` for the skill, template, and module catalog.
+| Skill | Description |
+|-------|-------------|
+| `ensure-agents-md` | Bootstrap skill — auto-generates `AGENTS.md` and `CLAUDE.md` for AEM 6.5 LTS projects when missing |
+| `dispatcher` | Config authoring, technical advisory, incident response, performance tuning, and security hardening for AEM 6.5 LTS and AMS. Requires Dispatcher MCP (`AEM_DEPLOYMENT_MODE=ams`) |
+| `aem-workflow` | Workflow model design, development, triggering, launchers, debugging, and triaging — with JMX, Felix Console, and direct log access for 6.5 LTS/AMS |
+| `aem-replication` | Replication agent configuration, content activation/deactivation, Replication API usage (49 Java examples), and troubleshooting blocked queues and distribution failures |
 
-### AEM Workflow
-
-Workflow skills cover the full AEM Granite Workflow Engine lifecycle — from designing and implementing workflows to production debugging and incident triaging. Like Dispatcher, they are split by runtime flavor:
-
-- `plugins/aem/cloud-service/skills/aem-workflow` — Cloud Service variant (no JMX, Cloud Manager logs, pipeline deploy)
-- `plugins/aem/6.5-lts/skills/aem-workflow` — 6.5 LTS / AMS variant (JMX, Felix Console, direct log access)
-
-Each flavor contains the same specialist sub-skills:
-
-| Sub-Skill                 | Purpose                                                                |
-| ------------------------- | ---------------------------------------------------------------------- |
-| `workflow-model-design` | Design workflow models, step types, OR/AND splits, variables           |
-| `workflow-development`  | Implement WorkflowProcess steps, ParticipantStepChooser, OSGi services |
-| `workflow-triggering`   | Start workflows from UI, code, HTTP API, or Manage Publication         |
-| `workflow-launchers`    | Configure automatic workflow launchers on JCR events                   |
-| `workflow-debugging`    | Debug stuck, failed, or stale workflows in production                  |
-| `workflow-triaging`     | Classify incidents, determine log patterns, Splunk queries             |
-| `workflow-orchestrator` | Full lifecycle orchestration across all sub-skills                     |
-
-### AEM Dispatcher
-
-Dispatcher skills are split by runtime flavor to avoid mode auto-detection and keep installation explicit.
-Install only one dispatcher flavor in a workspace (`cloud-service` or `6.5-lts`).
-
-Current dispatcher flavors:
-
-- `plugins/aem/cloud-service/skills/dispatcher`
-- `plugins/aem/6.5-lts/skills/dispatcher`
-
-Each flavor contains parallel capability groups (workflow orchestration, config authoring, technical advisory, incident response, performance tuning, and security hardening).
-Shared advisory logic is centralized under each flavor's `dispatcher/shared/references/` to reduce duplication and drift.
-
-### AEM Replication
-
-Replication skills for AEM 6.5 LTS cover the full content distribution lifecycle from agent configuration to troubleshooting.
-
-**Location:** `plugins/aem/6.5-lts/skills/aem-replication`
-
-The aem-replication skill contains four specialist sub-skills:
-
-| Sub-Skill                       | Purpose                                                                                |
-| ------------------------------- | -------------------------------------------------------------------------------------- |
-| `configure-replication-agent` | Configure replication agents for publishing, dispatcher flush, and reverse replication |
-| `replicate-content`           | Activate and deactivate content using UI, workflows, and package manager               |
-| `replication-api`             | Use the Replication API programmatically in custom code with complete Java examples    |
-| `troubleshoot-replication`    | Diagnose and fix blocked queues, connectivity failures, and distribution problems      |
-
-**Key features:**
-
-- All skills based on official AEM 6.5 LTS documentation
-- Complete coverage of public Replication API (Replicator, ReplicationOptions, AgentManager, ReplicationQueue, etc.)
-- 49 Java code examples for OSGi services, servlets, and workflow steps
-- 12+ troubleshooting scenarios with step-by-step resolution
-- 3,575 lines of comprehensive documentation
-
-### AEM as a Cloud Service — Rapid Development Environment (RDE) *(beta)*
-
-The `aem-rde` skill provides expert assistance for the Adobe I/O CLI plugin `@adobe/aio-cli-plugin-aem-rde` — used to deploy, inspect, log-tail, snapshot, and troubleshoot AEM Rapid Development Environments via `aio aem rde …` commands. The skill activates only on explicit RDE references; generic AEMaaCS deployment requests are deferred to Cloud Manager skills.
-
-| Skill                  | Description                                                                                                                                                                                                       |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `aem-rde` *(beta)* | Translate goals into the right `aio aem rde` commands (deploy, status, history, logs, inspect, snapshot, setup); diagnose RDE problems; guide setup, experimental feature flags, and CI/build-environment usage |
-
-See `plugins/aem/cloud-service/skills/aem-rde/` for the skill and its reference files (commands, configuration, deployment types, troubleshooting, workflows).
-
-### AEM as a Cloud Service — Best Practices & Migration
-
-Under `plugins/aem/cloud-service/skills/`, **`best-practices/`** is the **general-purpose** Cloud Service skill: pattern modules, Java baseline references (SCR→OSGi DS, resolver/logging, and related refs), and day-to-day Cloud Service alignment. Use it **without** loading **migration** for greenfield or maintainability work. **`migration/`** (BPA/CAM orchestration) is **scoped to legacy AEM → AEM as a Cloud Service** (not Edge Delivery or 6.5 LTS); it **delegates** concrete refactors to **`best-practices`** (`references/`). **Installing the AEM as a Cloud Service plugin** (`aem-cloud-service`, or the `plugins/aem/cloud-service` path with `npx skills` / `gh upskill`) **includes both**; the agent should load the appropriate `SKILL.md` for the task. Use **`gh upskill` / `npx skills` with `--skill`** when you need a specific bundled skill (see **Installation** above).
-
-**Key features:**
-
-- **Best practices:** one skill for patterns, SCR→OSGi DS, and resolver/logging — applicable to Cloud Service projects generally, not only migration
-- **Migration:** orchestration-only; pattern and transformation content lives in **`best-practices`**
+See the [`aem-6-5-lts` plugin README](plugins/aem/6.5-lts/README.md) for sub-skill details.
 
 ### App Builder
 
@@ -346,12 +282,6 @@ Migrate an Adobe Commerce App Builder project started from the Integration Start
 
 See the [`commerce-app-migration`](plugins/commerce/app-migration/README.md) doc for the full migration workflow and documentation-cleanup recommendations.
 
-### AEM as a Cloud Service — Code Assessment
-
-**`code-assessment`** (under `plugins/aem/cloud-service/skills/`) detects and fixes AEM CS code-quality issues entirely against the local workspace — no external services. Name the files to fix or ask it to scan the repo; it plans, applies surgical edits (git branch or in-place), and verifies with `mvn compile`. Each issue type is a self-contained expert skill.
-
-See `plugins/aem/cloud-service/skills/code-assessment/SKILL.md` for routing and classification. **Installing the AEM as a Cloud Service plugin** (`aem-cloud-service`) includes this skill.
-
 ### Creativity & Design
 
 | Skill                              | Description                                                                                                           |
@@ -414,45 +344,20 @@ plugins/
 │   ├── cloud-service/
 │   │   ├── .claude-plugin/
 │   │   │   └── plugin.json
+│   │   ├── README.md
 │   │   └── skills/
-│   │       ├── best-practices/
-│   │       │   ├── README.md
-│   │       │   ├── SKILL.md
-│   │       │   └── references/
-│   │       ├── migration/
-│   │       │   ├── README.md
-│   │       │   ├── SKILL.md
-│   │       │   ├── references/
-│   │       │   └── scripts/
-│   │       ├── ensure-agents-md/
-│   │       │   ├── SKILL.md
-│   │       │   └── references/
-│   │       │       ├── AGENTS.md.template
-│   │       │       └── module-catalog.md
 │   │       ├── create-component/
-│   │       │   ├── SKILL.md
-│   │       │   ├── assets/
-│   │       │   └── references/
+│   │       ├── ensure-agents-md/
+│   │       ├── dispatcher/
 │   │       ├── aem-workflow/
-│   │       │   ├── SKILL.md
-│   │       │   ├── workflow-model-design/
-│   │       │   ├── workflow-development/
-│   │       │   ├── workflow-triggering/
-│   │       │   ├── workflow-launchers/
-│   │       │   ├── workflow-debugging/
-│   │       │   ├── workflow-triaging/
-│   │       │   └── workflow-orchestrator/
-│   │       └── dispatcher/
-│   │           ├── SKILL.md
-│   │           ├── config-authoring/
-│   │           ├── technical-advisory/
-│   │           ├── incident-response/
-│   │           ├── performance-tuning/
-│   │           ├── security-hardening/
-│   │           └── workflow-orchestrator/
+│   │       ├── code-assessment/
+│   │       ├── migration/
+│   │       ├── content-distribution/
+│   │       └── aem-rde/
 │   └── 6.5-lts/
 │       ├── .claude-plugin/
 │       │   └── plugin.json
+│       ├── README.md
 │       └── skills/
 │           ├── aem-workflow/
 │           │   ├── SKILL.md

--- a/plugins/aem/6.5-lts/README.md
+++ b/plugins/aem/6.5-lts/README.md
@@ -120,13 +120,18 @@ Skills for developing and operating AEM 6.5 LTS and Adobe Managed Services (AMS)
 </tr>
 <tr>
   <td><a href="skills/aem-replication/replication-api/SKILL.md">replication-api</a></td>
-  <td>Use the Replication API programmatically in custom code — 49 Java examples for OSGi services, servlets, and workflow steps</td>
+  <td>Use the Replication API programmatically in custom code — 57 Java examples for OSGi services, servlets, and workflow steps</td>
   <td><ul><li><code>Publish content programmatically from a servlet</code></li><li><code>Show me bulk replication examples</code></li></ul></td>
 </tr>
 <tr>
   <td><a href="skills/aem-replication/troubleshoot-replication/SKILL.md">troubleshoot-replication</a></td>
   <td>Diagnose and fix blocked queues, connectivity failures, and distribution problems — 12+ troubleshooting scenarios</td>
   <td><ul><li><code>My replication queue is blocked</code></li><li><code>Content is not appearing on publish</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/aem-replication/replication-orchestrator/SKILL.md">replication-orchestrator</a></td>
+  <td>End-to-end replication lifecycle orchestration across all sub-skills — new environment setup, production incidents, performance optimization, and migration preparation</td>
+  <td><ul><li><code>Set up replication for a new AEM 6.5 environment end-to-end</code></li></ul></td>
 </tr>
 </tbody>
 </table>

--- a/plugins/aem/6.5-lts/README.md
+++ b/plugins/aem/6.5-lts/README.md
@@ -17,121 +17,47 @@ Skills for developing and operating AEM 6.5 LTS and Adobe Managed Services (AMS)
 
 ## Skills
 
-<table>
-<thead>
-<tr>
-  <th>Skill</th>
-  <th>Description</th>
-  <th>Try it</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-  <th colspan="3" align="left">Bootstrap</th>
-</tr>
-<tr>
-  <td><a href="skills/ensure-agents-md/SKILL.md">ensure-agents-md</a></td>
-  <td>Auto-generates <code>AGENTS.md</code> and <code>CLAUDE.md</code> for AEM 6.5 LTS projects when missing — tailored to discovered modules, add-ons, and Dispatcher layout. Runs first, before any other work.</td>
-  <td><ul><li><code>Set up my AEM 6.5 project for AI agents</code></li></ul></td>
-</tr>
-<tr>
-  <th colspan="3" align="left">Dispatcher — <em>Config authoring, advisory, performance, security, and incident response. Requires <a href="https://github.com/AdobeDocs/aem-dispatcher-mcp">Dispatcher MCP</a> (<code>AEM_DEPLOYMENT_MODE=ams</code>).</em></th>
-</tr>
-<tr>
-  <td><a href="skills/dispatcher/config-authoring/SKILL.md">config-authoring</a></td>
-  <td>Create, modify, review, and harden Dispatcher config files (<code>.any</code>, vhost, rewrite, cache, filter) for AEM 6.5 LTS and AMS</td>
-  <td><ul><li><code>Add a new vhost for my AMS site</code></li><li><code>Review my dispatcher cache rules</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/dispatcher/technical-advisory/SKILL.md">technical-advisory</a></td>
-  <td>Conceptual guidance on <code>statfileslevel</code>, filter rules, URL decomposition, cache invalidation, rewrite behavior, and security headers</td>
-  <td><ul><li><code>Explain statfileslevel for my AMS setup</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/dispatcher/incident-response/SKILL.md">incident-response</a></td>
-  <td>Investigate runtime incidents, failures, and cache anomalies on AMS Dispatcher</td>
-  <td><ul><li><code>My pages are returning 403 on the AMS dispatcher</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/dispatcher/performance-tuning/SKILL.md">performance-tuning</a></td>
-  <td>Optimize Dispatcher cache efficiency, latency, and throughput for AMS environments</td>
-  <td><ul><li><code>Tune my AMS dispatcher cache</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/dispatcher/security-hardening/SKILL.md">security-hardening</a></td>
-  <td>Security audits, threat models, exposure control, and header hardening for AMS Dispatcher</td>
-  <td><ul><li><code>Harden my AMS dispatcher security headers</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/dispatcher/workflow-orchestrator/SKILL.md">workflow-orchestrator</a></td>
-  <td>Orchestrate complete Dispatcher lifecycle from design through validation and incident troubleshooting</td>
-  <td><ul><li><code>Walk me through AMS dispatcher setup end-to-end</code></li></ul></td>
-</tr>
-<tr>
-  <th colspan="3" align="left">Workflow — <em>Granite Workflow Engine lifecycle with JMX, Felix Console, and direct log access.</em></th>
-</tr>
-<tr>
-  <td><a href="skills/aem-workflow/workflow-model-design/SKILL.md">workflow-model-design</a></td>
-  <td>Design workflow models — step types, variables, OR/AND splits</td>
-  <td><ul><li><code>Design an approval workflow with OR split</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/aem-workflow/workflow-development/SKILL.md">workflow-development</a></td>
-  <td>Implement custom WorkflowProcess steps, ParticipantStepChooser, OSGi service registration</td>
-  <td><ul><li><code>Create a custom workflow process step</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/aem-workflow/workflow-triggering/SKILL.md">workflow-triggering</a></td>
-  <td>Start workflows via Timeline UI, WorkflowSession API, HTTP API, Manage Publication, or replication triggers</td>
-  <td><ul><li><code>How do I trigger a workflow on content activation?</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/aem-workflow/workflow-launchers/SKILL.md">workflow-launchers</a></td>
-  <td>Configure Workflow Launchers that auto-start workflows on JCR content changes</td>
-  <td><ul><li><code>Set up a launcher for asset uploads</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/aem-workflow/workflow-debugging/SKILL.md">workflow-debugging</a></td>
-  <td>Debug stuck workflows, failed steps, missing Inbox tasks, thread pool exhaustion, queue backlogs — with JMX and direct log access</td>
-  <td><ul><li><code>My workflow is stuck — help debug</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/aem-workflow/workflow-triaging/SKILL.md">workflow-triaging</a></td>
-  <td>Classify workflow incidents, gather JMX/Splunk data, and map to runbooks</td>
-  <td><ul><li><code>Triage this workflow failure</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/aem-workflow/workflow-orchestrator/SKILL.md">workflow-orchestrator</a></td>
-  <td>End-to-end workflow lifecycle orchestration across all sub-skills</td>
-  <td><ul><li><code>Build a complete content approval workflow</code></li></ul></td>
-</tr>
-<tr>
-  <th colspan="3" align="left">Replication — <em>Content distribution lifecycle from agent configuration to troubleshooting.</em></th>
-</tr>
-<tr>
-  <td><a href="skills/aem-replication/configure-replication-agent/SKILL.md">configure-replication-agent</a></td>
-  <td>Configure replication agents for publishing, dispatcher flush, and reverse replication</td>
-  <td><ul><li><code>Set up a dispatcher flush agent</code></li><li><code>Configure reverse replication</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/aem-replication/replicate-content/SKILL.md">replicate-content</a></td>
-  <td>Activate and deactivate content using UI, workflows, and package manager</td>
-  <td><ul><li><code>How do I activate a page tree?</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/aem-replication/replication-api/SKILL.md">replication-api</a></td>
-  <td>Use the Replication API programmatically in custom code — 57 Java examples for OSGi services, servlets, and workflow steps</td>
-  <td><ul><li><code>Publish content programmatically from a servlet</code></li><li><code>Show me bulk replication examples</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/aem-replication/troubleshoot-replication/SKILL.md">troubleshoot-replication</a></td>
-  <td>Diagnose and fix blocked queues, connectivity failures, and distribution problems — 12+ troubleshooting scenarios</td>
-  <td><ul><li><code>My replication queue is blocked</code></li><li><code>Content is not appearing on publish</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/aem-replication/replication-orchestrator/SKILL.md">replication-orchestrator</a></td>
-  <td>End-to-end replication lifecycle orchestration across all sub-skills — new environment setup, production incidents, performance optimization, and migration preparation</td>
-  <td><ul><li><code>Set up replication for a new AEM 6.5 environment end-to-end</code></li></ul></td>
-</tr>
-</tbody>
-</table>
+### Bootstrap
+
+| Skill | Description | Try it |
+|-------|-------------|--------|
+| [ensure-agents-md](skills/ensure-agents-md/SKILL.md) | Auto-generates `AGENTS.md` and `CLAUDE.md` for AEM 6.5 LTS projects when missing — tailored to discovered modules, add-ons, and Dispatcher layout. Runs first, before any other work. | `Set up my AEM 6.5 project for AI agents` |
+
+### Dispatcher
+
+Config authoring, advisory, performance, security, and incident response. Requires [Dispatcher MCP](https://github.com/AdobeDocs/aem-dispatcher-mcp) (`AEM_DEPLOYMENT_MODE=ams`).
+
+| Skill | Description | Try it |
+|-------|-------------|--------|
+| [config-authoring](skills/dispatcher/config-authoring/SKILL.md) | Create, modify, review, and harden Dispatcher config files (`.any`, vhost, rewrite, cache, filter) for AEM 6.5 LTS and AMS | `Add a new vhost for my AMS site` |
+| [technical-advisory](skills/dispatcher/technical-advisory/SKILL.md) | Conceptual guidance on `statfileslevel`, filter rules, URL decomposition, cache invalidation, rewrite behavior, and security headers | `Explain statfileslevel for my AMS setup` |
+| [incident-response](skills/dispatcher/incident-response/SKILL.md) | Investigate runtime incidents, failures, and cache anomalies on AMS Dispatcher | `My pages are returning 403 on the AMS dispatcher` |
+| [performance-tuning](skills/dispatcher/performance-tuning/SKILL.md) | Optimize Dispatcher cache efficiency, latency, and throughput for AMS environments | `Tune my AMS dispatcher cache` |
+| [security-hardening](skills/dispatcher/security-hardening/SKILL.md) | Security audits, threat models, exposure control, and header hardening for AMS Dispatcher | `Harden my AMS dispatcher security headers` |
+| [workflow-orchestrator](skills/dispatcher/workflow-orchestrator/SKILL.md) | Orchestrate complete Dispatcher lifecycle from design through validation and incident troubleshooting | `Walk me through AMS dispatcher setup end-to-end` |
+
+### Workflow
+
+Granite Workflow Engine lifecycle with JMX, Felix Console, and direct log access.
+
+| Skill | Description | Try it |
+|-------|-------------|--------|
+| [workflow-model-design](skills/aem-workflow/workflow-model-design/SKILL.md) | Design workflow models — step types, variables, OR/AND splits | `Design an approval workflow with OR split` |
+| [workflow-development](skills/aem-workflow/workflow-development/SKILL.md) | Implement custom WorkflowProcess steps, ParticipantStepChooser, OSGi service registration | `Create a custom workflow process step` |
+| [workflow-triggering](skills/aem-workflow/workflow-triggering/SKILL.md) | Start workflows via Timeline UI, WorkflowSession API, HTTP API, Manage Publication, or replication triggers | `How do I trigger a workflow on content activation?` |
+| [workflow-launchers](skills/aem-workflow/workflow-launchers/SKILL.md) | Configure Workflow Launchers that auto-start workflows on JCR content changes | `Set up a launcher for asset uploads` |
+| [workflow-debugging](skills/aem-workflow/workflow-debugging/SKILL.md) | Debug stuck workflows, failed steps, missing Inbox tasks, thread pool exhaustion, queue backlogs — with JMX and direct log access | `My workflow is stuck — help debug` |
+| [workflow-triaging](skills/aem-workflow/workflow-triaging/SKILL.md) | Classify workflow incidents, gather JMX/Splunk data, and map to runbooks | `Triage this workflow failure` |
+| [workflow-orchestrator](skills/aem-workflow/workflow-orchestrator/SKILL.md) | End-to-end workflow lifecycle orchestration across all sub-skills | `Build a complete content approval workflow` |
+
+### Replication
+
+Content distribution lifecycle from agent configuration to troubleshooting.
+
+| Skill | Description | Try it |
+|-------|-------------|--------|
+| [configure-replication-agent](skills/aem-replication/configure-replication-agent/SKILL.md) | Configure replication agents for publishing, dispatcher flush, and reverse replication | `Set up a dispatcher flush agent` |
+| [replicate-content](skills/aem-replication/replicate-content/SKILL.md) | Activate and deactivate content using UI, workflows, and package manager | `How do I activate a page tree?` |
+| [replication-api](skills/aem-replication/replication-api/SKILL.md) | Use the Replication API programmatically in custom code — 57 Java examples for OSGi services, servlets, and workflow steps | `Publish content programmatically from a servlet` |
+| [troubleshoot-replication](skills/aem-replication/troubleshoot-replication/SKILL.md) | Diagnose and fix blocked queues, connectivity failures, and distribution problems — 12+ troubleshooting scenarios | `My replication queue is blocked` |
+| [replication-orchestrator](skills/aem-replication/replication-orchestrator/SKILL.md) | End-to-end replication lifecycle orchestration across all sub-skills — new environment setup, production incidents, performance optimization, and migration preparation | `Set up replication for a new AEM 6.5 environment end-to-end` |

--- a/plugins/aem/6.5-lts/README.md
+++ b/plugins/aem/6.5-lts/README.md
@@ -1,0 +1,132 @@
+# AEM 6.5 LTS Plugin
+
+Skills for developing and operating AEM 6.5 LTS and Adobe Managed Services (AMS) projects — Dispatcher configuration, workflows, replication, and project bootstrap.
+
+---
+
+## Installation
+
+**Claude Code:**
+
+```bash
+/plugin marketplace add adobe/skills
+/plugin install aem-6-5-lts@adobe-skills
+```
+
+---
+
+## Skills
+
+<table>
+<thead>
+<tr>
+  <th>Skill</th>
+  <th>Description</th>
+  <th>Try it</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <th colspan="3" align="left">Bootstrap</th>
+</tr>
+<tr>
+  <td><a href="skills/ensure-agents-md/SKILL.md">ensure-agents-md</a></td>
+  <td>Auto-generates <code>AGENTS.md</code> and <code>CLAUDE.md</code> for AEM 6.5 LTS projects when missing — tailored to discovered modules, add-ons, and Dispatcher layout. Runs first, before any other work.</td>
+  <td><ul><li><code>Set up my AEM 6.5 project for AI agents</code></li></ul></td>
+</tr>
+<tr>
+  <th colspan="3" align="left">Dispatcher — <em>Config authoring, advisory, performance, security, and incident response. Requires <a href="https://github.com/AdobeDocs/aem-dispatcher-mcp">Dispatcher MCP</a> (<code>AEM_DEPLOYMENT_MODE=ams</code>).</em></th>
+</tr>
+<tr>
+  <td><a href="skills/dispatcher/config-authoring/SKILL.md">config-authoring</a></td>
+  <td>Create, modify, review, and harden Dispatcher config files (<code>.any</code>, vhost, rewrite, cache, filter) for AEM 6.5 LTS and AMS</td>
+  <td><ul><li><code>Add a new vhost for my AMS site</code></li><li><code>Review my dispatcher cache rules</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/dispatcher/technical-advisory/SKILL.md">technical-advisory</a></td>
+  <td>Conceptual guidance on <code>statfileslevel</code>, filter rules, URL decomposition, cache invalidation, rewrite behavior, and security headers</td>
+  <td><ul><li><code>Explain statfileslevel for my AMS setup</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/dispatcher/incident-response/SKILL.md">incident-response</a></td>
+  <td>Investigate runtime incidents, failures, and cache anomalies on AMS Dispatcher</td>
+  <td><ul><li><code>My pages are returning 403 on the AMS dispatcher</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/dispatcher/performance-tuning/SKILL.md">performance-tuning</a></td>
+  <td>Optimize Dispatcher cache efficiency, latency, and throughput for AMS environments</td>
+  <td><ul><li><code>Tune my AMS dispatcher cache</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/dispatcher/security-hardening/SKILL.md">security-hardening</a></td>
+  <td>Security audits, threat models, exposure control, and header hardening for AMS Dispatcher</td>
+  <td><ul><li><code>Harden my AMS dispatcher security headers</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/dispatcher/workflow-orchestrator/SKILL.md">workflow-orchestrator</a></td>
+  <td>Orchestrate complete Dispatcher lifecycle from design through validation and incident troubleshooting</td>
+  <td><ul><li><code>Walk me through AMS dispatcher setup end-to-end</code></li></ul></td>
+</tr>
+<tr>
+  <th colspan="3" align="left">Workflow — <em>Granite Workflow Engine lifecycle with JMX, Felix Console, and direct log access.</em></th>
+</tr>
+<tr>
+  <td><a href="skills/aem-workflow/workflow-model-design/SKILL.md">workflow-model-design</a></td>
+  <td>Design workflow models — step types, variables, OR/AND splits</td>
+  <td><ul><li><code>Design an approval workflow with OR split</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/aem-workflow/workflow-development/SKILL.md">workflow-development</a></td>
+  <td>Implement custom WorkflowProcess steps, ParticipantStepChooser, OSGi service registration</td>
+  <td><ul><li><code>Create a custom workflow process step</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/aem-workflow/workflow-triggering/SKILL.md">workflow-triggering</a></td>
+  <td>Start workflows via Timeline UI, WorkflowSession API, HTTP API, Manage Publication, or replication triggers</td>
+  <td><ul><li><code>How do I trigger a workflow on content activation?</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/aem-workflow/workflow-launchers/SKILL.md">workflow-launchers</a></td>
+  <td>Configure Workflow Launchers that auto-start workflows on JCR content changes</td>
+  <td><ul><li><code>Set up a launcher for asset uploads</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/aem-workflow/workflow-debugging/SKILL.md">workflow-debugging</a></td>
+  <td>Debug stuck workflows, failed steps, missing Inbox tasks, thread pool exhaustion, queue backlogs — with JMX and direct log access</td>
+  <td><ul><li><code>My workflow is stuck — help debug</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/aem-workflow/workflow-triaging/SKILL.md">workflow-triaging</a></td>
+  <td>Classify workflow incidents, gather JMX/Splunk data, and map to runbooks</td>
+  <td><ul><li><code>Triage this workflow failure</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/aem-workflow/workflow-orchestrator/SKILL.md">workflow-orchestrator</a></td>
+  <td>End-to-end workflow lifecycle orchestration across all sub-skills</td>
+  <td><ul><li><code>Build a complete content approval workflow</code></li></ul></td>
+</tr>
+<tr>
+  <th colspan="3" align="left">Replication — <em>Content distribution lifecycle from agent configuration to troubleshooting.</em></th>
+</tr>
+<tr>
+  <td><a href="skills/aem-replication/configure-replication-agent/SKILL.md">configure-replication-agent</a></td>
+  <td>Configure replication agents for publishing, dispatcher flush, and reverse replication</td>
+  <td><ul><li><code>Set up a dispatcher flush agent</code></li><li><code>Configure reverse replication</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/aem-replication/replicate-content/SKILL.md">replicate-content</a></td>
+  <td>Activate and deactivate content using UI, workflows, and package manager</td>
+  <td><ul><li><code>How do I activate a page tree?</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/aem-replication/replication-api/SKILL.md">replication-api</a></td>
+  <td>Use the Replication API programmatically in custom code — 49 Java examples for OSGi services, servlets, and workflow steps</td>
+  <td><ul><li><code>Publish content programmatically from a servlet</code></li><li><code>Show me bulk replication examples</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/aem-replication/troubleshoot-replication/SKILL.md">troubleshoot-replication</a></td>
+  <td>Diagnose and fix blocked queues, connectivity failures, and distribution problems — 12+ troubleshooting scenarios</td>
+  <td><ul><li><code>My replication queue is blocked</code></li><li><code>Content is not appearing on publish</code></li></ul></td>
+</tr>
+</tbody>
+</table>

--- a/plugins/aem/cloud-service/README.md
+++ b/plugins/aem/cloud-service/README.md
@@ -17,155 +17,55 @@ Skills for developing, assessing, migrating, and operating AEM as a Cloud Servic
 
 ## Skills
 
-<table>
-<thead>
-<tr>
-  <th>Skill</th>
-  <th>Description</th>
-  <th>Try it</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-  <th colspan="3" align="left">Bootstrap &amp; scaffolding</th>
-</tr>
-<tr>
-  <td><a href="skills/ensure-agents-md/SKILL.md">ensure-agents-md</a></td>
-  <td>Auto-generates <code>AGENTS.md</code> and <code>CLAUDE.md</code> from <code>pom.xml</code> when missing — tailored to the project's modules and add-ons (CIF, Forms, SPA, precompiled scripts). Runs first, before any other work.</td>
-  <td><ul><li><code>Set up my AEM project for AI agents</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/create-component/SKILL.md">create-component</a></td>
-  <td>Create complete AEM components following Adobe best practices: component definition, dialog XML, HTL template, Sling Model, unit tests, clientlibs (component and dialog), and optional Sling Servlet for dynamic content.</td>
-  <td>
-<ul>
-<li><code>Create a hero banner component with title, description, and CTA</code></li>
-<li><code>Create a multifield FAQ component</code></li>
-</ul>
-</td>
-</tr>
-<tr>
-  <th colspan="3" align="left">Dispatcher — <em>Config authoring, advisory, performance, security, and incident response. Requires <a href="https://github.com/AdobeDocs/aem-dispatcher-mcp">Dispatcher MCP</a> (<code>AEM_DEPLOYMENT_MODE=cloud</code>).</em></th>
-</tr>
-<tr>
-  <td><a href="skills/dispatcher/config-authoring/SKILL.md">config-authoring</a></td>
-  <td>Create, modify, review, and harden Dispatcher config files (<code>.any</code>, vhost, rewrite, cache, filter)</td>
-  <td><ul><li><code>Add a new vhost for my site</code></li><li><code>Review my cache rules</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/dispatcher/technical-advisory/SKILL.md">technical-advisory</a></td>
-  <td>Conceptual guidance on <code>statfileslevel</code>, filter rules, URL decomposition, cache invalidation, rewrite behavior, and security headers — with public-doc citations</td>
-  <td><ul><li><code>Explain statfileslevel for my site</code></li><li><code>How does cache invalidation work?</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/dispatcher/incident-response/SKILL.md">incident-response</a></td>
-  <td>Investigate runtime incidents, failures, probe regressions, and cache anomalies using Dispatcher MCP evidence</td>
-  <td><ul><li><code>Why are my pages returning 403?</code></li><li><code>Cache hit ratio dropped — investigate</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/dispatcher/performance-tuning/SKILL.md">performance-tuning</a></td>
-  <td>Optimize Dispatcher cache efficiency, latency, and throughput with cloud-specific baselines</td>
-  <td><ul><li><code>Tune my dispatcher cache for better hit ratios</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/dispatcher/security-hardening/SKILL.md">security-hardening</a></td>
-  <td>Security audits, threat models, exposure control, and header hardening</td>
-  <td><ul><li><code>Harden my dispatcher security headers</code></li><li><code>Audit my filter rules for exposure</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/dispatcher/workflow-orchestrator/SKILL.md">workflow-orchestrator</a></td>
-  <td>Orchestrate complete Dispatcher lifecycle from design through validation, release readiness, and incident troubleshooting</td>
-  <td><ul><li><code>Walk me through setting up dispatcher for a new site end-to-end</code></li></ul></td>
-</tr>
-<tr>
-  <th colspan="3" align="left">Workflow — <em>Granite Workflow Engine lifecycle: design, develop, deploy, debug.</em></th>
-</tr>
-<tr>
-  <td><a href="skills/aem-workflow/workflow-model-design/SKILL.md">workflow-model-design</a></td>
-  <td>Design workflow models — step types, variables, OR/AND splits, deployment through Cloud Manager pipeline</td>
-  <td><ul><li><code>Design an approval workflow with OR split</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/aem-workflow/workflow-development/SKILL.md">workflow-development</a></td>
-  <td>Implement custom WorkflowProcess steps, ParticipantStepChooser, OSGi DS R6 registration</td>
-  <td><ul><li><code>Create a custom workflow process step</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/aem-workflow/workflow-triggering/SKILL.md">workflow-triggering</a></td>
-  <td>Start workflows via Timeline UI, WorkflowSession API, HTTP API, or Manage Publication</td>
-  <td><ul><li><code>How do I trigger a workflow programmatically?</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/aem-workflow/workflow-launchers/SKILL.md">workflow-launchers</a></td>
-  <td>Configure Workflow Launchers that auto-start workflows on JCR content changes</td>
-  <td><ul><li><code>Set up a launcher for asset uploads</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/aem-workflow/workflow-debugging/SKILL.md">workflow-debugging</a></td>
-  <td>Debug stuck workflows, failed steps, missing Inbox tasks, thread pool exhaustion, queue backlogs, purge failures</td>
-  <td><ul><li><code>My workflow is stuck — help debug</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/aem-workflow/workflow-triaging/SKILL.md">workflow-triaging</a></td>
-  <td>Classify workflow incidents, determine required logs, and map to Splunk queries</td>
-  <td><ul><li><code>Triage this workflow failure from Cloud Manager logs</code></li></ul></td>
-</tr>
-<tr>
-  <td><a href="skills/aem-workflow/workflow-orchestrator/SKILL.md">workflow-orchestrator</a></td>
-  <td>End-to-end workflow lifecycle orchestration across all sub-skills</td>
-  <td><ul><li><code>Build a complete content approval workflow</code></li></ul></td>
-</tr>
-<tr>
-  <th colspan="3" align="left">Code quality &amp; migration</th>
-</tr>
-<tr>
-  <td><a href="skills/code-assessment/SKILL.md">code-assessment</a></td>
-  <td>Detect and fix AEM CS code-quality issues locally — Sling Model patterns (<code>@Inject</code> → injector-specific), deprecated APIs, scheduler, replication, resource listeners, unbounded queries, outbound call timeouts, event migration, asset manager API, outdated Maven dependencies. Verifies with <code>mvn compile</code>.</td>
-  <td>
-<ul>
-<li><code>Check my Sling Models are implemented correctly</code></li>
-<li><code>Scan this AEM project for code issues</code></li>
-<li><code>Are my Maven dependencies up to date?</code></li>
-</ul>
-</td>
-</tr>
-<tr>
-  <td><a href="skills/migration/SKILL.md">migration</a></td>
-  <td>Migrate legacy AEM (6.x, AMS, on-prem) to AEM CS using BPA CSV/cache or CAM/MCP discovery. Covers scheduler, ResourceChangeListener, replication, EventListener, OSGi EventHandler, DAM AssetManager, HTL lint, Classic UI dialog migration, Custom Design Widgets, static→editable template modernization, and OSGi config → Cloud Manager. One pattern per session; delegates refactors to <code>code-assessment</code>.</td>
-  <td>
-<ul>
-<li><code>Review my code for AEMaaCS migration</code></li>
-<li><code>Fix scheduler findings using my BPA CSV</code></li>
-<li><code>Migrate my static templates to editable templates</code></li>
-</ul>
-</td>
-</tr>
-<tr>
-  <th colspan="3" align="left">Content distribution</th>
-</tr>
-<tr>
-  <td><a href="skills/content-distribution/SKILL.md">content-distribution</a></td>
-  <td>Programmatic content publishing via the Replication API (single-path, bulk, preview-tier, async) and distribution event monitoring via Sling Distribution events</td>
-  <td>
-<ul>
-<li><code>Publish content programmatically</code></li>
-<li><code>Monitor distribution events in my workflow</code></li>
-</ul>
-</td>
-</tr>
-<tr>
-  <th colspan="3" align="left">Rapid Development Environment</th>
-</tr>
-<tr>
-  <td><a href="skills/aem-rde/SKILL.md">aem-rde</a> <em>(beta)</em></td>
-  <td>Expert assistance for <code>aio aem rde</code> — deploy bundles/configs/content/frontend, inspect artifacts, tail logs, create/restore snapshots, and troubleshoot RDE issues. Activates only on explicit RDE references.</td>
-  <td>
-<ul>
-<li><code>Deploy my bundle to the RDE</code></li>
-<li><code>Create a snapshot of my RDE environment</code></li>
-<li><code>Why is my RDE deploy failing?</code></li>
-</ul>
-</td>
-</tr>
-</tbody>
-</table>
+### Bootstrap & scaffolding
+
+| Skill | Description | Try it |
+|-------|-------------|--------|
+| [ensure-agents-md](skills/ensure-agents-md/SKILL.md) | Auto-generates `AGENTS.md` and `CLAUDE.md` from `pom.xml` when missing — tailored to the project's modules and add-ons (CIF, Forms, SPA, precompiled scripts). Runs first, before any other work. | `Set up my AEM project for AI agents` |
+| [create-component](skills/create-component/SKILL.md) | Create complete AEM components following Adobe best practices: component definition, dialog XML, HTL template, Sling Model, unit tests, clientlibs (component and dialog), and optional Sling Servlet for dynamic content. | `Create a hero banner component with title, description, and CTA` |
+
+### Dispatcher
+
+Config authoring, advisory, performance, security, and incident response. Requires [Dispatcher MCP](https://github.com/AdobeDocs/aem-dispatcher-mcp) (`AEM_DEPLOYMENT_MODE=cloud`).
+
+| Skill | Description | Try it |
+|-------|-------------|--------|
+| [config-authoring](skills/dispatcher/config-authoring/SKILL.md) | Create, modify, review, and harden Dispatcher config files (`.any`, vhost, rewrite, cache, filter) | `Add a new vhost for my site` |
+| [technical-advisory](skills/dispatcher/technical-advisory/SKILL.md) | Conceptual guidance on `statfileslevel`, filter rules, URL decomposition, cache invalidation, rewrite behavior, and security headers — with public-doc citations | `Explain statfileslevel for my site` |
+| [incident-response](skills/dispatcher/incident-response/SKILL.md) | Investigate runtime incidents, failures, probe regressions, and cache anomalies using Dispatcher MCP evidence | `Why are my pages returning 403?` |
+| [performance-tuning](skills/dispatcher/performance-tuning/SKILL.md) | Optimize Dispatcher cache efficiency, latency, and throughput with cloud-specific baselines | `Tune my dispatcher cache for better hit ratios` |
+| [security-hardening](skills/dispatcher/security-hardening/SKILL.md) | Security audits, threat models, exposure control, and header hardening | `Harden my dispatcher security headers` |
+| [workflow-orchestrator](skills/dispatcher/workflow-orchestrator/SKILL.md) | Orchestrate complete Dispatcher lifecycle from design through validation, release readiness, and incident troubleshooting | `Walk me through setting up dispatcher for a new site end-to-end` |
+
+### Workflow
+
+Granite Workflow Engine lifecycle: design, develop, deploy, debug.
+
+| Skill | Description | Try it |
+|-------|-------------|--------|
+| [workflow-model-design](skills/aem-workflow/workflow-model-design/SKILL.md) | Design workflow models — step types, variables, OR/AND splits, deployment through Cloud Manager pipeline | `Design an approval workflow with OR split` |
+| [workflow-development](skills/aem-workflow/workflow-development/SKILL.md) | Implement custom WorkflowProcess steps, ParticipantStepChooser, OSGi DS R6 registration | `Create a custom workflow process step` |
+| [workflow-triggering](skills/aem-workflow/workflow-triggering/SKILL.md) | Start workflows via Timeline UI, WorkflowSession API, HTTP API, or Manage Publication | `How do I trigger a workflow programmatically?` |
+| [workflow-launchers](skills/aem-workflow/workflow-launchers/SKILL.md) | Configure Workflow Launchers that auto-start workflows on JCR content changes | `Set up a launcher for asset uploads` |
+| [workflow-debugging](skills/aem-workflow/workflow-debugging/SKILL.md) | Debug stuck workflows, failed steps, missing Inbox tasks, thread pool exhaustion, queue backlogs, purge failures | `My workflow is stuck — help debug` |
+| [workflow-triaging](skills/aem-workflow/workflow-triaging/SKILL.md) | Classify workflow incidents, determine required logs, and map to Splunk queries | `Triage this workflow failure from Cloud Manager logs` |
+| [workflow-orchestrator](skills/aem-workflow/workflow-orchestrator/SKILL.md) | End-to-end workflow lifecycle orchestration across all sub-skills | `Build a complete content approval workflow` |
+
+### Code quality & migration
+
+| Skill | Description | Try it |
+|-------|-------------|--------|
+| [code-assessment](skills/code-assessment/SKILL.md) | Detect and fix AEM CS code-quality issues locally — Sling Model patterns (`@Inject` to injector-specific), deprecated APIs, scheduler, replication, resource listeners, unbounded queries, outbound call timeouts, event migration, asset manager API, outdated Maven dependencies. Verifies with `mvn compile`. | `Scan this AEM project for code issues` |
+| [migration](skills/migration/SKILL.md) | Migrate legacy AEM (6.x, AMS, on-prem) to AEM CS using BPA CSV/cache or CAM/MCP discovery. Covers scheduler, ResourceChangeListener, replication, EventListener, OSGi EventHandler, DAM AssetManager, HTL lint, Classic UI dialog migration, Custom Design Widgets, static to editable template modernization, and OSGi config to Cloud Manager. One pattern per session; delegates refactors to `code-assessment`. | `Review my code for AEMaaCS migration` |
+
+### Content distribution
+
+| Skill | Description | Try it |
+|-------|-------------|--------|
+| [content-distribution](skills/content-distribution/SKILL.md) | Programmatic content publishing via the Replication API (single-path, bulk, preview-tier, async) and distribution event monitoring via Sling Distribution events | `Publish content programmatically` |
+
+### Rapid Development Environment
+
+| Skill | Description | Try it |
+|-------|-------------|--------|
+| [aem-rde](skills/aem-rde/SKILL.md) *(beta)* | Expert assistance for `aio aem rde` — deploy bundles/configs/content/frontend, inspect artifacts, tail logs, create/restore snapshots, and troubleshoot RDE issues. Activates only on explicit RDE references. | `Deploy my bundle to the RDE` |

--- a/plugins/aem/cloud-service/README.md
+++ b/plugins/aem/cloud-service/README.md
@@ -1,0 +1,171 @@
+# AEM as a Cloud Service Plugin
+
+Skills for developing, assessing, migrating, and operating AEM as a Cloud Service projects — component development, Dispatcher configuration, workflows, code assessment, content distribution, migration from legacy AEM, and Rapid Development Environments.
+
+---
+
+## Installation
+
+**Claude Code:**
+
+```bash
+/plugin marketplace add adobe/skills
+/plugin install aem-cloud-service@adobe-skills
+```
+
+---
+
+## Skills
+
+<table>
+<thead>
+<tr>
+  <th>Skill</th>
+  <th>Description</th>
+  <th>Try it</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <th colspan="3" align="left">Bootstrap &amp; scaffolding</th>
+</tr>
+<tr>
+  <td><a href="skills/ensure-agents-md/SKILL.md">ensure-agents-md</a></td>
+  <td>Auto-generates <code>AGENTS.md</code> and <code>CLAUDE.md</code> from <code>pom.xml</code> when missing — tailored to the project's modules and add-ons (CIF, Forms, SPA, precompiled scripts). Runs first, before any other work.</td>
+  <td><ul><li><code>Set up my AEM project for AI agents</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/create-component/SKILL.md">create-component</a></td>
+  <td>Create complete AEM components following Adobe best practices: component definition, dialog XML, HTL template, Sling Model, unit tests, clientlibs (component and dialog), and optional Sling Servlet for dynamic content.</td>
+  <td>
+<ul>
+<li><code>Create a hero banner component with title, description, and CTA</code></li>
+<li><code>Create a multifield FAQ component</code></li>
+</ul>
+</td>
+</tr>
+<tr>
+  <th colspan="3" align="left">Dispatcher — <em>Config authoring, advisory, performance, security, and incident response. Requires <a href="https://github.com/AdobeDocs/aem-dispatcher-mcp">Dispatcher MCP</a> (<code>AEM_DEPLOYMENT_MODE=cloud</code>).</em></th>
+</tr>
+<tr>
+  <td><a href="skills/dispatcher/config-authoring/SKILL.md">config-authoring</a></td>
+  <td>Create, modify, review, and harden Dispatcher config files (<code>.any</code>, vhost, rewrite, cache, filter)</td>
+  <td><ul><li><code>Add a new vhost for my site</code></li><li><code>Review my cache rules</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/dispatcher/technical-advisory/SKILL.md">technical-advisory</a></td>
+  <td>Conceptual guidance on <code>statfileslevel</code>, filter rules, URL decomposition, cache invalidation, rewrite behavior, and security headers — with public-doc citations</td>
+  <td><ul><li><code>Explain statfileslevel for my site</code></li><li><code>How does cache invalidation work?</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/dispatcher/incident-response/SKILL.md">incident-response</a></td>
+  <td>Investigate runtime incidents, failures, probe regressions, and cache anomalies using Dispatcher MCP evidence</td>
+  <td><ul><li><code>Why are my pages returning 403?</code></li><li><code>Cache hit ratio dropped — investigate</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/dispatcher/performance-tuning/SKILL.md">performance-tuning</a></td>
+  <td>Optimize Dispatcher cache efficiency, latency, and throughput with cloud-specific baselines</td>
+  <td><ul><li><code>Tune my dispatcher cache for better hit ratios</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/dispatcher/security-hardening/SKILL.md">security-hardening</a></td>
+  <td>Security audits, threat models, exposure control, and header hardening</td>
+  <td><ul><li><code>Harden my dispatcher security headers</code></li><li><code>Audit my filter rules for exposure</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/dispatcher/workflow-orchestrator/SKILL.md">workflow-orchestrator</a></td>
+  <td>Orchestrate complete Dispatcher lifecycle from design through validation, release readiness, and incident troubleshooting</td>
+  <td><ul><li><code>Walk me through setting up dispatcher for a new site end-to-end</code></li></ul></td>
+</tr>
+<tr>
+  <th colspan="3" align="left">Workflow — <em>Granite Workflow Engine lifecycle: design, develop, deploy, debug.</em></th>
+</tr>
+<tr>
+  <td><a href="skills/aem-workflow/workflow-model-design/SKILL.md">workflow-model-design</a></td>
+  <td>Design workflow models — step types, variables, OR/AND splits, deployment through Cloud Manager pipeline</td>
+  <td><ul><li><code>Design an approval workflow with OR split</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/aem-workflow/workflow-development/SKILL.md">workflow-development</a></td>
+  <td>Implement custom WorkflowProcess steps, ParticipantStepChooser, OSGi DS R6 registration</td>
+  <td><ul><li><code>Create a custom workflow process step</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/aem-workflow/workflow-triggering/SKILL.md">workflow-triggering</a></td>
+  <td>Start workflows via Timeline UI, WorkflowSession API, HTTP API, or Manage Publication</td>
+  <td><ul><li><code>How do I trigger a workflow programmatically?</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/aem-workflow/workflow-launchers/SKILL.md">workflow-launchers</a></td>
+  <td>Configure Workflow Launchers that auto-start workflows on JCR content changes</td>
+  <td><ul><li><code>Set up a launcher for asset uploads</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/aem-workflow/workflow-debugging/SKILL.md">workflow-debugging</a></td>
+  <td>Debug stuck workflows, failed steps, missing Inbox tasks, thread pool exhaustion, queue backlogs, purge failures</td>
+  <td><ul><li><code>My workflow is stuck — help debug</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/aem-workflow/workflow-triaging/SKILL.md">workflow-triaging</a></td>
+  <td>Classify workflow incidents, determine required logs, and map to Splunk queries</td>
+  <td><ul><li><code>Triage this workflow failure from Cloud Manager logs</code></li></ul></td>
+</tr>
+<tr>
+  <td><a href="skills/aem-workflow/workflow-orchestrator/SKILL.md">workflow-orchestrator</a></td>
+  <td>End-to-end workflow lifecycle orchestration across all sub-skills</td>
+  <td><ul><li><code>Build a complete content approval workflow</code></li></ul></td>
+</tr>
+<tr>
+  <th colspan="3" align="left">Code quality &amp; migration</th>
+</tr>
+<tr>
+  <td><a href="skills/code-assessment/SKILL.md">code-assessment</a></td>
+  <td>Detect and fix AEM CS code-quality issues locally — Sling Model patterns (<code>@Inject</code> → injector-specific), deprecated APIs, scheduler, replication, resource listeners, unbounded queries, outbound call timeouts, event migration, asset manager API, outdated Maven dependencies. Verifies with <code>mvn compile</code>.</td>
+  <td>
+<ul>
+<li><code>Check my Sling Models are implemented correctly</code></li>
+<li><code>Scan this AEM project for code issues</code></li>
+<li><code>Are my Maven dependencies up to date?</code></li>
+</ul>
+</td>
+</tr>
+<tr>
+  <td><a href="skills/migration/SKILL.md">migration</a></td>
+  <td>Migrate legacy AEM (6.x, AMS, on-prem) to AEM CS using BPA CSV/cache or CAM/MCP discovery. Covers scheduler, ResourceChangeListener, replication, EventListener, OSGi EventHandler, DAM AssetManager, HTL lint, Classic UI dialog migration, Custom Design Widgets, static→editable template modernization, and OSGi config → Cloud Manager. One pattern per session; delegates refactors to <code>code-assessment</code>.</td>
+  <td>
+<ul>
+<li><code>Review my code for AEMaaCS migration</code></li>
+<li><code>Fix scheduler findings using my BPA CSV</code></li>
+<li><code>Migrate my static templates to editable templates</code></li>
+</ul>
+</td>
+</tr>
+<tr>
+  <th colspan="3" align="left">Content distribution</th>
+</tr>
+<tr>
+  <td><a href="skills/content-distribution/SKILL.md">content-distribution</a></td>
+  <td>Programmatic content publishing via the Replication API (single-path, bulk, preview-tier, async) and distribution event monitoring via Sling Distribution events</td>
+  <td>
+<ul>
+<li><code>Publish content programmatically</code></li>
+<li><code>Monitor distribution events in my workflow</code></li>
+</ul>
+</td>
+</tr>
+<tr>
+  <th colspan="3" align="left">Rapid Development Environment</th>
+</tr>
+<tr>
+  <td><a href="skills/aem-rde/SKILL.md">aem-rde</a> <em>(beta)</em></td>
+  <td>Expert assistance for <code>aio aem rde</code> — deploy bundles/configs/content/frontend, inspect artifacts, tail logs, create/restore snapshots, and troubleshoot RDE issues. Activates only on explicit RDE references.</td>
+  <td>
+<ul>
+<li><code>Deploy my bundle to the RDE</code></li>
+<li><code>Create a snapshot of my RDE environment</code></li>
+<li><code>Why is my RDE deploy failing?</code></li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>


### PR DESCRIPTION
## Summary

Closes #261

- Created plugin-level **README for `aem-cloud-service`** listing all 8 skills (create-component, ensure-agents-md, dispatcher, aem-workflow, code-assessment, migration, content-distribution, aem-rde) with sub-skill details, MCP requirements, and example prompts
- Created plugin-level **README for `aem-6-5-lts`** listing all 4 skills (ensure-agents-md, dispatcher, aem-workflow, aem-replication) with sub-skill details
- **Consolidated 7 scattered `###` sections** in the top-level README into 2 clean `#####` sub-sections under `#### Adobe Experience Manager` — previously create-component, ensure-agents-md, dispatcher, workflow, replication, RDE, best-practices/migration, and code-assessment were each their own top-level heading, making them hard to discover as a group
- **Updated `marketplace.json`** with accurate descriptions and keywords for both plugins (was missing code-assessment, migration, content-distribution, RDE for CS; missing replication for 6.5 LTS)
- Removed out-of-place Code Assessment section that was between Commerce and Creativity & Design
- Fixed stale `best-practices/` reference (skill was renamed to `code-assessment/`)
- Updated Repository Structure tree to reflect current skill layout

## What is NOT in scope

- EDS, App Builder, Commerce, Analytics, Creative Cloud, or Workfront plugins are not touched
- No skill code changes — this is documentation only
- The `aem-eds-content-ops` plugin (also missing README docs) is a separate effort


## Test plan

- [ ] Verify all 8 AEM CS skills appear in the top-level README under `##### AEM as a Cloud Service`
- [ ] Verify all 4 AEM 6.5 LTS skills appear under `##### AEM 6.5 LTS`
- [ ] Verify plugin-level READMEs render correctly on GitHub
- [ ] Verify marketplace.json is valid JSON with updated descriptions
- [ ] Verify no EDS/content-ops content leaked into the changes
- [ ] Verify heading hierarchy is correct (##### under #### Adobe Experience Manager)
- [ ] Verify Repository Structure tree includes code-assessment, content-distribution, aem-rde

🤖 Generated with [Claude Code](https://claude.com/claude-code)