### PR TITLE
feat(commerce): promote plugins from adobe/aio-commerce-sdk@6b69060

### DIFF
--- a/plugins/commerce/app-management/.claude-plugin/plugin.json
+++ b/plugins/commerce/app-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commerce-app-management",
   "description": "Skills for Adobe Commerce App Management — scaffold and configure Commerce apps using the aio-commerce-sdk.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": {
     "name": "Adobe"
   },

--- a/plugins/commerce/app-management/.tessl-plugin/plugin.json
+++ b/plugins/commerce/app-management/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe/commerce-app-management",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Skills for Adobe Commerce App Management — scaffold and configure Commerce apps using the aio-commerce-sdk.",
   "private": false,
   "skills": [

--- a/plugins/commerce/app-management/CHANGELOG.md
+++ b/plugins/commerce/app-management/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @adobe/aio-commerce-plugin-app-management
 
+## 1.3.2
+
+### Patch Changes
+
+- [#635](https://github.com/adobe/aio-commerce-sdk/pull/635) [`71bf666`](https://github.com/adobe/aio-commerce-sdk/commit/71bf66656ef1fc6dd272a0821e8b00aab5dc197e) Thanks [@iivvaannxx](https://github.com/iivvaannxx)! - Update the Admin UI skill guidance so it reflects that StrictMode runs only in development builds and is stripped from production.
+
 ## 1.3.1
 
 ### Patch Changes

--- a/plugins/commerce/app-management/skills/commerce-app-admin-ui/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-admin-ui/SKILL.md
@@ -292,7 +292,7 @@ A build failure with a validation error points directly to the offending `adminU
 - **View route `path`**: register the `{ path }` in `src/app.jsx` as the exact same string as the entry's config `path` — copy it verbatim, hash included, so the two line up.
 - **Menu `id` charset**: the menu `id` allows only letters, digits, `/`, `:`, and `_` — no hyphens or spaces.
 - **`defineConfig` not found**: import `defineConfig` from `@adobe/aio-commerce-lib-app/config`.
-- **Double renders/requests in development**: `createExtensionApp` wraps the app in React `<StrictMode>`, so under `aio app dev` or `aio app run` components render twice and effects run an extra setup + cleanup cycle on mount. Duplicate renders or effect-triggered requests in development are expected StrictMode behavior, not a bug to fix; production builds are unaffected.
+- **Double renders/requests in development**: local builds served by `aio app dev` and `aio app run` are development builds, where `createExtensionApp` wraps the app in React `<StrictMode>` — so components render twice and effects run an extra setup + cleanup cycle on mount. Duplicate renders or effect-triggered requests during local development are expected StrictMode behavior, not a bug to fix. `aio app build` and `aio app deploy` produce production builds, which render without `<StrictMode>` (it is stripped from the bundle).
 
 ## Quality Bar
 


### PR DESCRIPTION
## commerce-app-management v1.3.2

- [#635](https://github.com/adobe/aio-commerce-sdk/pull/635) [`71bf666`](https://github.com/adobe/aio-commerce-sdk/commit/71bf66656ef1fc6dd272a0821e8b00aab5dc197e) Thanks [@iivvaannxx](https://github.com/iivvaannxx)! - Update the Admin UI skill guidance so it reflects that StrictMode runs only in development builds and is stripped from production.