### PR TITLE
ci(tessl-review): distinguish tooling failures from low scores

### DIFF
--- a/.github/workflows/tessl-review.yml
+++ b/.github/workflows/tessl-review.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: tessl-review-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tessl-review:
     runs-on: ubuntu-latest
@@ -23,17 +27,40 @@ jobs:
     steps:
       # Fork PRs: review the merged result via the PR merge ref.
       # Push to main: use the pushed commit.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
           fetch-depth: 0
 
-      - uses: tesslio/setup-tessl@v2
+      - name: Check prerequisites
+        id: prereq
+        env:
+          TESSL_TOKEN: ${{ secrets.TESSL_TOKEN }}
+        run: |
+          if [ -z "$TESSL_TOKEN" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "TESSL_TOKEN is not available — skipping review."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post skip summary (Tessl not configured)
+        if: steps.prereq.outputs.skip == 'true'
+        run: |
+          {
+            echo "## Skill Review"
+            echo ""
+            echo "Review skipped — \`TESSL_TOKEN\` is not configured for this repository."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
+        if: steps.prereq.outputs.skip != 'true'
         with:
           token: ${{ secrets.TESSL_TOKEN }}
 
       - name: Detect changed skills
         id: detect
+        if: steps.prereq.outputs.skip != 'true'
         run: |
           if [ "${{ github.event_name }}" = "pull_request_target" ]; then
             # base.sha/head.sha are hex SHAs (safe to interpolate) and both reachable
@@ -104,14 +131,16 @@ jobs:
           fi
 
       - name: Post skip summary
-        if: steps.detect.outputs.skip == 'true'
+        if: steps.prereq.outputs.skip != 'true' && steps.detect.outputs.skip == 'true'
         run: |
-          echo "## Skill Review" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "No skills changed — review skipped." >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Skill Review"
+            echo ""
+            echo "No skills changed — review skipped."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Review skills
-        if: steps.detect.outputs.skip != 'true'
+        if: steps.prereq.outputs.skip != 'true' && steps.detect.outputs.skip != 'true'
         run: |
           THRESHOLD=80
           # Tessl workspace to attribute review runs to (required when --json is set).
@@ -119,6 +148,7 @@ jobs:
           WORKSPACE=adobe
           PASS=0
           FAIL=0
+          ERROR=0
           SUMMARY_FILE=$(mktemp)
           ERRORS_FILE=$(mktemp)
 
@@ -159,14 +189,17 @@ jobs:
               echo "  ❌ $SKILL_NAME: ${SCORE}% (below ${THRESHOLD}%)" >> "$ERRORS_FILE"
               echo "| $SKILL_NAME | ${SCORE}% | ❌ |" >> "$SUMMARY_FILE"
             else
-              # Non-zero exit with no parseable score = tool/auth error.
-              echo "::warning::tessl review run failed for $SKILL_NAME (exit code $EXIT_CODE)"
-              FAIL=$((FAIL + 1))
-              echo "| $SKILL_NAME | error | ❌ |" >> "$SUMMARY_FILE"
+              # Non-zero exit with no parseable score = tool/auth error. The review
+              # never ran, so this is not a judgement on the skill — don't report it
+              # as a low score.
+              echo "::error::Review could not be run for $SKILL_NAME (tessl exit code $EXIT_CODE) — tooling/auth failure, not a low score"
+              ERROR=$((ERROR + 1))
+              echo "| $SKILL_NAME | not run | ⚠️ |" >> "$SUMMARY_FILE"
+              echo "  ⚠️ $SKILL_NAME: review could not be run (exit code $EXIT_CODE)" >> "$ERRORS_FILE"
             fi
           done < "$SKILL_LIST_FILE"
 
-          TOTAL=$((PASS + FAIL))
+          TOTAL=$((PASS + FAIL + ERROR))
 
           # Fail if no skills were reviewed but some were expected
           if [ "$TOTAL" -eq 0 ] && [ -n "$SKILL_DIRS_INPUT" ]; then
@@ -181,7 +214,12 @@ jobs:
             echo "| Skill | Score | Status |"
             echo "|-------|-------|--------|"
             cat "$SUMMARY_FILE"
-            echo "| **Total** | **$PASS/$TOTAL passed** | $([ "$FAIL" -eq 0 ] && echo '✅' || echo '❌') |"
+            echo "| **Total** | **$PASS/$TOTAL passed** | $([ "$((FAIL + ERROR))" -eq 0 ] && echo '✅' || echo '❌') |"
+            if [ "$ERROR" -gt 0 ]; then
+              echo ""
+              echo "> ⚠️ $ERROR skill(s) could not be reviewed because the Tessl CLI did not complete."
+              echo "> This is a tooling or authentication problem, not a quality result."
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
           # Stdout summary for logs
@@ -189,18 +227,21 @@ jobs:
           echo "============================="
           echo "  Skill Review Summary"
           echo "============================="
-          echo "  Total:  $TOTAL"
-          echo "  Passed: $PASS"
-          echo "  Failed: $FAIL"
+          echo "  Total:   $TOTAL"
+          echo "  Passed:  $PASS"
+          echo "  Failed:  $FAIL"
+          echo "  Errored: $ERROR"
           if [ -s "$ERRORS_FILE" ]; then
             echo ""
-            echo "  Failed skills:"
+            echo "  Problem skills:"
             cat "$ERRORS_FILE"
           fi
           echo "============================="
 
           if [ "$FAIL" -gt 0 ]; then
             echo "::error::$FAIL skill(s) scored below ${THRESHOLD}%"
+          fi
+          if [ "$((FAIL + ERROR))" -gt 0 ]; then
             exit 1
           fi
 


### PR DESCRIPTION
> **Rewritten.** The first version of this PR was written against a stale checkout of `main` and duplicated work that had already landed. It has been rebased and cut down to only what is actually still missing. See the note at the bottom.

## Problem

When the Tessl CLI fails to run *at all* — auth failure, network error, crash — the review job counts it as a review failure and reports:

```
##[error]N skill(s) scored below 80%
```

That is misleading. The skill was never scored. On #189 this surfaced as a red "below 80%" check on a skill that actually scores **85%**, which reads to a contributor as a quality rejection rather than a broken CI run. It cost a fair amount of time to work out that the real message buried in the log was:

```
✘ Please authenticate with Tessl to continue.
```

## Changes

**Tooling failures are no longer reported as low scores.** They get their own counter and are reported as *"review could not be run"*, with a ⚠️ row in the summary table and an explanatory note beneath it. They still fail the job — they're just no longer conflated with a below-threshold score.

**Skip cleanly when Tessl isn't configured.** If `TESSL_TOKEN` is absent, the job now skips with an explanatory step summary instead of installing an unauthenticated CLI and failing on the first review call.

**Pin actions to commit SHAs.** `actions/checkout` and `tesslio/setup-tessl` are pinned with `# vN` comments, so Renovate keeps tracking them.

**Add a concurrency group** so superseded runs are cancelled.

**Silence the one lint warning** in this file (SC2129) by using a single redirect block in the skip summary. `actionlint` is now clean on it.

Deliberately unchanged: the `pull_request_target` trigger, the fork-only `eval` environment gating, the merge-ref checkout, and the `tessl review run --workspace --json --threshold` invocation. Those are all already correct on `main`.

## Verification

`actionlint` is clean. The exit-code behaviour the error/score split relies on was checked against the real CLI, on a skill in this repo:

| Case | Exit code | Score parseable from output | Reported as |
|---|---|---|---|
| Score above threshold | `0` | yes (`89`) | ✅ pass |
| Score below threshold | `1` | yes (`89`) | ❌ below threshold |
| Not authenticated | `1` | no | ⚠️ review could not be run |

I also confirmed `main`'s existing score regex does correctly match the CLI's `"reviewScore": 89` field (the `-i` flag plus the optional underscore make `review[_]?score` match `reviewScore`), so that is left alone.

## Note on the first version of this PR

I originally believed the workflow still needed the fork-secrets fix and the migration off the deprecated `tessl skill review`. Both had already landed on `main` in e56e29f, 756e8d7 and 16184c2 on 2026-07-06/07 — I was diffing against a month-old local `main` and did not notice. The failing check on #189 is simply a stale run from `2026-07-07T08:49Z`, about 72 minutes before the fork fix merged.

That version has been discarded. What remains is the subset that is genuinely still missing, and it no longer touches the fork-gating logic — which is good, because my earlier version would have regressed 756e8d7 by requiring `eval` approval for same-repo PRs too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
