### PR TITLE
stardust: figma-to-eds — Figma web-kit donor adapter + EDS gate suite

### DIFF
--- a/plugins/stardust/CHANGELOG.md
+++ b/plugins/stardust/CHANGELOG.md
@@ -431,3 +431,16 @@ learnings digest.
   carry one version, and the impeccable dependency is declared consistently
   as **hard** everywhere (tile.json previously listed it as a soft
   dependency).
+
+## figma-to-eds (new skill)
+
+Implements the reskin `--donor-figma` adapter contract
+(donor-sources.md § 3, provenance class `figma-mcp`) and extends it
+with an EDS apply/gate layer: token probe (byte-equality), geometry
+gate (variant matrix from Figma metadata with gap semantics), pixel
+gate (scaled component diffs with recorded crops), full-suite sweep,
+and a divergence-attribution register. Ships a synthetic self-eval
+(eval/run-eval.mjs, 4 checks, no Figma connection needed) and method
+references distilled from a full production validation run: 35 modules
+gated (~2,700 geometry checks, ~120 pixel gates, functional gates for
+interactive chrome), 13 page archetypes register-audited.

--- a/plugins/stardust/skills/figma-to-eds/SKILL.md
+++ b/plugins/stardust/skills/figma-to-eds/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: figma-to-eds
+description: Apply a design system defined in Figma — a component web kit or sample page designs — to an AEM Edge Delivery Services (EDS) site as reusable blocks, with design fidelity gated against Figma at the token and component level. Implements the stardust:reskin Figma donor contract (donor-sources.md § 3, provenance class figma-mcp) and extends it with an EDS block target. Use when a site must adopt a Figma-defined design system ("make the blocks match the Figma web kit", "build these Figma pages as EDS blocks", "the design system source of truth is Figma"), the Figma file is reachable via the Figma desktop MCP, and the output is an EDS code repo (styles + blocks). NOT for content migration (that's stardust extract/replica/migrate — content fidelity is gated upstream) and NOT for redesigning from intent (that's stardust direct/prototype).
+license: Apache-2.0
+---
+
+# figma-to-eds — Figma design system, EDS blocks
+
+The user has an EDS site (or an EDS migration in progress) and a design
+system that lives in Figma. This skill captures the Figma source into
+stardust's canon-source artifacts, curates a probe-able token sheet,
+maps the Figma module vocabulary onto EDS blocks, applies it, and gates
+the result **against Figma, not against any live site**.
+
+The division of contracts mirrors stardust:reskin:
+
+- **Content is out of scope here.** Text, images, metadata fidelity are
+  gated by the upstream migration (replica/reskin content gates). This
+  skill never edits content; it edits `styles/` and `blocks/`.
+- **Design is gated against Figma.** Where an existing live site and
+  the Figma kit disagree, **Figma wins**. Live-vs-new visual diffs are
+  demoted to a *divergence report* in which every delta must be
+  attributable to a Figma node id — never a design gate.
+
+## Donor modes
+
+- **`web-kit`** — the Figma file is a component library (foundation
+  token pages + a module/component inventory). Page composition is
+  inherited from the existing site's structure; every block's surface
+  comes from the kit. The gate surface is per-component.
+- **`sample-pages`** — the Figma file contains full page designs.
+  Composition AND surface come from Figma; the gate surface is
+  per-page frames plus per-component. (Contract defined; harden this
+  mode on its first real run.)
+
+## Inputs
+
+- The Figma file **open and focused in the Figma desktop app** with
+  the local MCP server enabled (server `figma-desktop`). Verify with a
+  no-argument `get_metadata` call — it returns the file's page list.
+  If it errors, relay the seat/permission/file checklist in
+  `reference/figma-mcp-recipes.md` § Connection and stop.
+- An EDS project checkout (the target `styles/` + `blocks/` tree), or
+  a decision to bootstrap one.
+- Optional: an explicit scope contract inside the kit (e.g. a
+  "future / do not develop" section) — honor it verbatim.
+
+## Phases
+
+### 1. Capture → `stardust/canon-source/`
+
+Produce the same artifacts as reskin's other donor types, per the
+fixed contract in stardust `skills/reskin/reference/donor-sources.md`
+§ 3 — provenance class `figma-mcp`, every derived value cites the
+Figma node id it came from, `_crawl-log.json` records
+`fetchTechnique: "figma-mcp"` and states explicitly that no
+`renderedBy: "playwright"` pages exist:
+
+1. **Inventory** — no-arg `get_metadata` for the page list; classify
+   pages (foundation / brand / atoms / modules / excluded / meta).
+2. **Foundation tokens** — extract palette, type ramp, spacing,
+   borders, shadows, motion into
+   `canon-source/foundation/*.json` + `_brand-extraction.json`.
+   Follow `reference/figma-mcp-recipes.md` exactly — the MCP has
+   sharp edges (usage-scoped variables, oversized dumps) and the
+   recipes encode the reliable paths. **Never retype a value**;
+   parse dumps programmatically so exactness holds by construction.
+3. **Module vocabulary** — enumerate module/component pages into
+   `canon-source/donor-modules.md`: one row per module, node id,
+   family, variants, status. Excluded sections are listed with status
+   `excluded — do not develop`.
+4. **Vision references** — `get_screenshot` per module frame →
+   `canon-source/assets/screenshots/<module-slug>.png`.
+
+### 2. Curate → `stardust/reskin/donor-tokens.json`
+
+The probe-able token sheet: exact strings for colors, type, radii,
+borders, shadows, spacing. Figma has no computed styles, so values
+are authored from variables/spec tables rather than sampled — the
+probe still works because the tokens are exact either way (the
+contract's acknowledged gap). Semantic variables map to CSS custom
+properties by a declared, mechanical naming transform (see
+`reference/eds-mapping.md` § Token transform) recorded in the file
+itself, so the probe can assert both name and value.
+
+### 3. Map → `stardust/figma-to-eds/mapping.md`
+
+The module ↔ EDS block mapping brief: for each Figma module, the
+target block (existing block to restyle / new block to build /
+variant of another), the variant model (EDS block classes), and the
+atoms it composes. Existing blocks with no Figma counterpart go to
+the divergence register with a proposed resolution, they are never
+silently restyled by taste. Method in `reference/eds-mapping.md`.
+
+### 4. Apply
+
+Tokens first, then blocks: `styles/styles.css` gets the custom
+properties and element type ramp (per the kit's HTML mapping, if it
+publishes one); each block's CSS/JS is then written against tokens
+only — a block that hardcodes a hex or px that exists as a token is
+a defect even if it renders identically.
+
+### 5. Gate → `stardust/figma-to-eds/gates/`
+
+Three gates, in order:
+
+1. **Token probe** — computed styles of rendered blocks assert
+   byte-equal token values against `donor-tokens.json`.
+2. **Component diff** — each block rendered at the Figma frame's
+   width, screenshot-diffed against the exported Figma frame.
+   Structural mismatch fails; anti-aliasing/text-raster noise is
+   declared in a per-gate tolerance note, not silently absorbed.
+3. **Divergence attribution** — if there is a pre-existing live
+   site: for each visual delta live-vs-new, a register row citing
+   the Figma node id that mandates it. A delta with no node id is a
+   defect (unmandated drift).
+
+Details in `reference/gates.md`.
+
+## Artifacts
+
+| artifact | contract |
+|---|---|
+| `stardust/canon-source/` | Figma capture: foundation JSONs, `_brand-extraction.json`, `donor-modules.md`, screenshots, `_crawl-log.json` (reskin donor contract, `figma-mcp`) |
+| `stardust/reskin/donor-tokens.json` | probe-able exact-string token sheet |
+| `stardust/figma-to-eds/mapping.md` | module ↔ block mapping brief |
+| `stardust/figma-to-eds/gates/` | token probe results, component diffs, divergence register |
+
+## Relationship to stardust
+
+This skill is the implementation of reskin's `--donor-figma` adapter
+(capture + curate phases are upstreamable into `skills/reskin`
+verbatim) plus an EDS-target apply/gate layer. It assumes content
+fidelity is handled by the stardust migration flow it runs alongside.
+
+## Eval policy
+
+Eval fixtures for this skill MUST be synthetic or public design
+systems. Client web kits, client tokens, client screenshots, and
+client node ids never enter the skill tree or its evals — validation
+runs against real clients stay in the client project's `stardust/`
+directory. Before any upstream PR, grep the skill tree for the client
+vocabulary of every project it was hardened on.

--- a/plugins/stardust/skills/figma-to-eds/eval/fixture/donor-tokens.json
+++ b/plugins/stardust/skills/figma-to-eds/eval/fixture/donor-tokens.json
@@ -1,0 +1,34 @@
+{
+ "provenance": { "class": "figma-mcp", "note": "SYNTHETIC eval fixture — invented design system, no client data" },
+ "normalizations": [
+  { "rule": "lineHeight percent -> unitless" },
+  { "rule": "fontWeight names -> numeric" }
+ ],
+ "tokens": {
+  "colors": {
+   "--color-surface-canvas": { "value": "#fdfdfb", "figma": "color/surface/canvas", "src": "1:100" },
+   "--color-surface-panel": { "value": "#e4ecf7", "figma": "color/surface/panel", "src": "1:100" },
+   "--color-content-ink": { "value": "#101a2e", "figma": "color/content/ink", "src": "1:100" },
+   "--color-action-core": { "value": "#3355aa", "figma": "color/action/core", "src": "1:100" },
+   "--color-action-core-hover": { "value": "#223c80", "figma": "color/action/coreHover", "src": "1:100" }
+  },
+  "radii": { "--border-radius-soft": { "value": "6px", "figma": "borderRadius/soft", "src": "1:101" } },
+  "borderWidths": { "--border-width-hairline": { "value": "1px", "figma": "borderWidth/hairline", "src": "1:101" } },
+  "shadows": { "--shadow-lift": { "value": "0 2px 8px 0 #101a2e1f", "figma": "shadow.lift", "src": "1:102" } },
+  "spacing": { "--spacing-unit-2": { "value": "16px", "figma": "spacing.unit-2", "src": "1:103" }, "--spacing-unit-4": { "value": "32px", "figma": "spacing.unit-4", "src": "1:103" } },
+  "sizing": {}, "spaceSemantic": {}, "sizeSemantic": {},
+  "durations": { "--motion-quick": { "value": "150ms", "figma": "motion.quick", "src": "1:104" } },
+  "easings": { "--motion-ease-out": { "value": "cubic-bezier(0.2, 0, 0, 1)", "figma": "motion.easeOut", "src": "1:104" } },
+  "grid": { "src": "1:105", "desktop": { "pageWidth": "1200px", "pageMargin": "40px", "extendedContainer": { "width": "1120px", "padding": "40px" }, "contentContainer": { "columns": 12, "width": "1040px", "gutter": "24px", "column": "auto" } }, "tablet": { "pageWidth": "800px", "pageMargin": "24px", "extendedContainer": { "width": "752px", "padding": "24px" }, "contentContainer": { "columns": 8, "width": "704px", "gutter": "16px", "column": "auto" } }, "mobile": { "pageWidth": "400px", "pageMargin": "16px", "extendedContainer": { "width": "368px", "padding": "16px" }, "contentContainer": { "columns": 4, "width": "336px", "gutter": "12px", "column": "auto" } } },
+  "typography": {
+   "families": { "primary": "Georgia" },
+   "familyEquivalences": [["Georgia", "georgia"]],
+   "htmlMapping": { "h1": "Display/Big", "p": "Body/Base" },
+   "htmlMappingSrc": "1:106",
+   "styles": {
+    "display-big": { "figma": "Display/Big", "src": "1:106", "props": { "desktop": { "font-family": "Georgia", "font-weight": "400", "font-style": "normal", "font-size": "44px", "line-height": "1.1", "letter-spacing": "0" }, "mobile": { "font-family": "Georgia", "font-weight": "400", "font-style": "normal", "font-size": "32px", "line-height": "1.1", "letter-spacing": "0" }, "tablet": { "font-family": "Georgia", "font-weight": "400", "font-style": "normal", "font-size": "38px", "line-height": "1.1", "letter-spacing": "0" } } },
+    "body-base": { "figma": "Body/Base", "src": "1:106", "props": { "all": { "font-family": "Georgia", "font-weight": "400", "font-style": "normal", "font-size": "17px", "line-height": "1.4", "letter-spacing": "0" } } }
+   }
+  }
+ }
+}

--- a/plugins/stardust/skills/figma-to-eds/eval/fixture/geometry-spec.json
+++ b/plugins/stardust/skills/figma-to-eds/eval/fixture/geometry-spec.json
@@ -1,0 +1,15 @@
+{
+ "_comment": "SYNTHETIC eval spec — asserts the fixture page against its own intended geometry",
+ "page": "FIXTURE_PAGE_URL",
+ "origin": "main",
+ "cases": [
+  { "name": "desktop", "viewport": { "width": 1200, "height": 800 },
+    "checks": [
+     { "name": "h1", "selector": "h1", "expect": { "top": 0, "left": 0, "height": 48.4 }, "tol": { "default": 1 }, "source": "1:106" },
+     { "name": "panel", "selector": ".panel", "expect": { "width": 400 }, "tol": { "default": 1 }, "source": "1:102" },
+     { "name": "panel-gap", "selector": ".panel", "gapFrom": "p", "expect": { "gap": 32 }, "tol": { "default": 1 }, "source": "1:103" }
+    ] },
+  { "name": "mobile", "viewport": { "width": 400, "height": 800 },
+    "checks": [ { "name": "h1", "selector": "h1", "expect": { "height": 35.2 }, "tol": { "default": 1 }, "source": "1:106" } ] }
+ ]
+}

--- a/plugins/stardust/skills/figma-to-eds/eval/fixture/page.html
+++ b/plugins/stardust/skills/figma-to-eds/eval/fixture/page.html
@@ -1,0 +1,3 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="styles.css"></head>
+<body><main><h1>Specimen Display</h1><p>Specimen body copy for the synthetic design system.</p>
+<div class="panel"><p>Panel content.</p></div></main></body></html>

--- a/plugins/stardust/skills/figma-to-eds/eval/fixture/styles.css
+++ b/plugins/stardust/skills/figma-to-eds/eval/fixture/styles.css
@@ -1,0 +1,27 @@
+/* synthetic stylesheet consuming the fixture token sheet */
+:root {
+  --color-surface-canvas: #fdfdfb;
+  --color-surface-panel: #e4ecf7;
+  --color-content-ink: #101a2e;
+  --color-action-core: #3355aa;
+  --color-action-core-hover: #223c80;
+  --border-radius-soft: 6px;
+  --border-width-hairline: 1px;
+  --shadow-lift: 0 2px 8px 0 #101a2e1f;
+  --spacing-unit-2: 16px;
+  --spacing-unit-4: 32px;
+  --motion-quick: 150ms;
+  --motion-ease-out: cubic-bezier(0.2, 0, 0, 1);
+  --type-display-big-font-size: 32px;
+  --type-display-big-line-height: 1.1;
+  --type-body-base-font-size: 17px;
+  --type-body-base-line-height: 1.4;
+}
+
+@media (width >= 700px) { :root { --type-display-big-font-size: 38px; } }
+@media (width >= 1100px) { :root { --type-display-big-font-size: 44px; } }
+
+body { margin: 0; font-family: georgia, serif; color: var(--color-content-ink); background: var(--color-surface-canvas); }
+h1 { margin: 0; font-family: georgia, serif; font-weight: 400; font-style: normal; font-size: var(--type-display-big-font-size); line-height: var(--type-display-big-line-height); letter-spacing: 0; }
+p { margin: 0; font-family: georgia, serif; font-weight: 400; font-style: normal; font-size: var(--type-body-base-font-size); line-height: var(--type-body-base-line-height); letter-spacing: 0; }
+.panel { box-sizing: border-box; margin: var(--spacing-unit-4) auto 0; width: 400px; padding: var(--spacing-unit-2); border-radius: var(--border-radius-soft); background: var(--color-surface-panel); box-shadow: var(--shadow-lift); }

--- a/plugins/stardust/skills/figma-to-eds/eval/run-eval.mjs
+++ b/plugins/stardust/skills/figma-to-eds/eval/run-eval.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// Self-contained eval for the figma-to-eds gate scripts. Runs on a
+// SYNTHETIC design system (fixture/) — no Figma connection, no client
+// data. Proves: token probe (positive + negative), geometry gate, and
+// component-diff round-trip (self-reference = 0.00%).
+// Usage: NODE_MODULES_DIR=<node_modules with playwright/pixelmatch/pngjs> node run-eval.mjs
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, cpSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const scripts = resolve(here, '..', 'scripts');
+const work = mkdtempSync(join(tmpdir(), 'figma-to-eds-eval-'));
+cpSync(join(here, 'fixture'), work, { recursive: true });
+const page = 'file://' + join(work, 'page.html');
+let pass = 0; let fail = 0;
+const check = (name, ok) => { console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}`); ok ? pass++ : fail++; };
+const run = (script, args) => spawnSync('node', [join(scripts, script), ...args], { encoding: 'utf8' });
+
+// 1. token probe — positive
+let r = run('token-probe.mjs', ['--tokens', join(work, 'donor-tokens.json'), '--css', join(work, 'styles.css'), '--out', join(work, 'probe.json')]);
+check('token-probe positive (all synthetic tokens byte-match)', r.status === 0);
+
+// 2. token probe — negative (perturb one value; probe must FAIL)
+const sheet = JSON.parse(readFileSync(join(work, 'donor-tokens.json'), 'utf8'));
+sheet.tokens.colors['--color-action-core'].value = '#3355ab';
+writeFileSync(join(work, 'donor-tokens-bad.json'), JSON.stringify(sheet));
+r = run('token-probe.mjs', ['--tokens', join(work, 'donor-tokens-bad.json'), '--css', join(work, 'styles.css'), '--out', join(work, 'probe-bad.json')]);
+check('token-probe negative (single-hex perturbation detected)', r.status === 1);
+
+// 3. geometry gate
+const spec = readFileSync(join(work, 'geometry-spec.json'), 'utf8').replace('FIXTURE_PAGE_URL', page);
+writeFileSync(join(work, 'geometry-spec.json'), spec);
+r = run('geometry-gate.mjs', ['--spec', join(work, 'geometry-spec.json'), '--out', join(work, 'geometry-report.json')]);
+check('geometry gate (boxes + gapFrom on the fixture page)', r.status === 0);
+
+// 4. component-diff round trip: seed a reference screenshot of the page,
+// then diff the page against it — must be ~0.00%
+const boot = spawnSync('node', ['--input-type=module', '-e', `
+  import { createRequire } from 'node:module';
+  const req = createRequire(process.env.NODE_MODULES_DIR + '/x.cjs');
+  const { chromium } = req('playwright');
+  const b = await chromium.launch();
+  const p = await b.newPage({ viewport: { width: 1200, height: 800 } });
+  await p.goto(${JSON.stringify(page)});
+  await p.evaluate(() => document.fonts.ready);
+  await p.locator('main').screenshot({ path: ${JSON.stringify(join(work, 'seed.png'))} });
+  await b.close();
+`], { encoding: 'utf8', env: process.env });
+if (boot.status !== 0) console.error(boot.stderr);
+r = run('component-diff.mjs', ['--figma', join(work, 'seed.png'), '--page', page, '--width', '1200', '--selector', 'main', '--out', join(work, 'diff-out'), '--threshold', '0.05']);
+check('component-diff round-trip (self-reference ~0.00%)', r.status === 0);
+
+console.log(`\neval: ${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/plugins/stardust/skills/figma-to-eds/reference/eds-mapping.md
+++ b/plugins/stardust/skills/figma-to-eds/reference/eds-mapping.md
@@ -1,0 +1,83 @@
+# Mapping a Figma design system onto EDS
+
+How the captured canon-source becomes an EDS `styles/` + `blocks/`
+tree. The invariant throughout: **blocks consume tokens; only
+`styles.css` states raw values.**
+
+## Token transform (variables → CSS custom properties)
+
+Declare one mechanical transform and record it in
+`donor-tokens.json` so the probe can assert names, not just values:
+
+- Figma variable path → custom property: lowercase, `/` → `-`,
+  spaces and camelCase humps → `-`.
+  `color/surface/light` → `--color-surface-light`;
+  `color/action/primary/surface/hover` →
+  `--color-action-primary-surface-hover`.
+- Keep BOTH layers when the kit has them: the global scale
+  (`--color-<hue>-<step>`) and the semantic layer
+  (`--color-surface-*`, `--color-action-*`). Blocks use the semantic
+  layer; the global scale exists so the semantic layer can be
+  expressed as references, mirroring the kit's own aliasing.
+- Composite type styles become per-style custom-property groups
+  (`--type-<style>-size/-line-height/-weight/-letter-spacing`) plus
+  element rules per the kit's HTML mapping (below).
+- Numeric-only tokens get their unit from the kit's resolved spec
+  (`24` + `paragraphSpacing` context → `24px`; `130%` line-height →
+  unitless `1.3` is a **declared normalization**, listed in
+  `donor-tokens.json#normalizations`, never an ad-hoc conversion).
+
+## Element type ramp
+
+If the kit publishes an HTML-usage mapping (text style → `h1…h6`,
+`p`, captions), apply it verbatim in `styles.css` element rules and
+record the mapping's source node id. If it doesn't, propose a mapping
+from the ramp's hierarchy, write it to `mapping.md`, and flag it as
+authored-not-mandated — it is a divergence candidate, not kit law.
+
+## Module ↔ block mapping brief (`stardust/figma-to-eds/mapping.md`)
+
+One row per Figma module, joined against the existing block inventory
+(when restyling an existing EDS site) or empty (greenfield):
+
+| column | meaning |
+|---|---|
+| module | kit name + node id |
+| target | `restyle <block>` / `new block <name>` / `variant of <block> (<class>)` / `chrome` (header/footer) / `element styles` (no block needed) |
+| variants | the kit's variant axes → EDS block classes (`block-name (variant)` rows in the content model) |
+| atoms | which atom components it composes (buttons, cards, badges) — atoms map to shared CSS, not blocks |
+| gate frame | the Figma frame id the component diff will render against |
+
+Mapping rules validated in practice:
+
+- **Atoms are not blocks.** Buttons, links, badges, inputs map to
+  shared styles (`styles.css` or a shared stylesheet) consumed by
+  every block. Making an atom a block fragments the token surface.
+- **Navigation modules map to chrome** (header/footer blocks +
+  their fragment content), not to page blocks.
+- **The kit's exclusion list is a scope contract.** Modules marked
+  "future / do not develop" (or equivalent) are listed in
+  `mapping.md` with target `excluded` and never built, even when
+  they look useful.
+- **Orphans go to the register.** An existing block with no kit
+  counterpart, or a kit module with no content need, is recorded in
+  the divergence register with a proposed resolution (keep-as-is /
+  retire / request-design). Silent restyling-by-taste is the failure
+  mode this table exists to prevent.
+- **One reference component per module** (reskin's pinned-reference
+  rule transposed): when a module appears in several kit contexts
+  with token disagreements, pick the component-set's main variant as
+  the token source and demote the rest to corroboration; record the
+  pick in `mapping.md`.
+
+## Apply order
+
+1. `styles.css`: custom properties, fonts, element ramp — then run
+   the token probe on a bare page before touching any block.
+2. Shared atoms (buttons, cards, form controls).
+3. Blocks, one module family at a time, gating each with its
+   component diff before starting the next family.
+
+Fonts: the kit names families; licensing/serving (self-hosted,
+a hosted font service, fallback stacks) is a project decision recorded in the
+project's divergence register, not in this skill.

--- a/plugins/stardust/skills/figma-to-eds/reference/figma-mcp-recipes.md
+++ b/plugins/stardust/skills/figma-to-eds/reference/figma-mcp-recipes.md
@@ -1,0 +1,103 @@
+# Figma desktop MCP — validated capture recipes
+
+The Figma desktop MCP (`figma-desktop`) serves whatever file is open
+and focused in the desktop app. These recipes were validated against a
+real component web kit; follow them instead of improvising — the tool
+surface has sharp edges that silently under-report if used naively.
+
+Always pass `clientFrameworks` and `clientLanguages` on every call
+(logging-only, but required by the schema).
+
+## Connection
+
+A no-argument `get_metadata` call is the health check. Success with no
+selection returns the file's **top-level page list** (id + name) — the
+inventory starting point. On error, relay to the user before anything
+else: (1) paid seat with Dev Mode access, (2) file permissions,
+(3) file open AND focused in the desktop app, (4) "Enable local MCP
+Server" toggled in preferences (resets after some app updates),
+(5) it's a `/design/` file, not FigJam/Slides. A retry after the user
+selects any frame on the canvas often resolves a first-call failure.
+
+## Quirk ledger (each one costs a wrong capture if ignored)
+
+1. **`get_variable_defs` is usage-scoped, not collection-scoped.** It
+   returns only variables *bound on the queried node*. A foundation
+   page whose swatch tables bind every color variable yields the full
+   color set; a typography page whose specimens use text *styles*
+   (not variables) yields almost nothing. Never treat one call as
+   "the variables of the file". Union calls across foundation pages
+   and drill into frames until counts stop growing.
+2. **Composite variables come through as pseudo-values.** Font-type
+   variables serialize like
+   `Font(family: "...", style: ..., size: ..., weight: 350, lineHeight: 1.15, letterSpacing: 0)`
+   and effects like `Effect(type: DROP_SHADOW, color: <token>, offset: (x, y), radius: <token>, spread: 0)`.
+   Parse these; they carry both token references and resolved numbers.
+3. **Page-level `get_metadata` dumps are huge** (hundreds of KB) and
+   the harness saves oversized results to a `tool-results/*.txt` file
+   as a JSON array `[{type, text}]`. Never read them whole. Extract:
+   `jq -r '.[0].text' <file> | grep -E '^\s{0,6}<(section|frame)'`
+   to list near-top-level frames with ids, then target those ids.
+4. **Well-built kits embed machine-readable spec tables.** Foundation
+   pages often carry, as literal text per style row: a token name
+   (`font.Body.Body-1.Book`), a token-reference JSON
+   (`{"fontSize":"{global.font.fontSize.24}",...}`), and a **resolved
+   JSON** (`{"fontSize":"24px","lineHeight":"130%",...}`) — the
+   Tokens-Studio format. `get_design_context` on the spec frame
+   returns them in the reference code's text nodes. Extract with:
+   `jq -r '.[].text' <dump> | grep -oE '<prefix>\.[A-Za-z0-9./ -]+|\{"[a-zA-Z]+[^`]*\}'`.
+   This is the primary type-ramp source; prefer it over visual
+   inference every time it exists.
+5. **`get_design_context` doubles as a resolved-value source.** Its
+   generated code references CSS custom properties *with fallback
+   values*: `var(--global\/font\/fontsize\/28,28px)` — token name and
+   resolved value in one string. Use as a cross-check for recipe 4.
+6. **Screenshots follow the canvas.** `get_screenshot` renders the
+   node as seen on canvas; pass `contentsOnly: true` only when page
+   furniture (annotations, connectors) overlaps the frame. Screenshot
+   image data lands in context — capture module screenshots in
+   subagents or one at a time, never as a bulk fan-in to the main
+   context.
+
+## Standard capture sequence
+
+1. No-arg `get_metadata` → page inventory. Classify pages.
+2. Per foundation page: `get_variable_defs(pageId)` → seed token set.
+3. Per foundation page: `get_metadata(pageId)` → grep top-level
+   frames (recipe 3) → `get_design_context` on spec/ramp frames →
+   parse spec tables (recipes 4–5). Union with step 2; record the
+   source node id next to every value.
+4. Per module page: `get_metadata` for the variant structure,
+   `get_screenshot` for the vision reference, `get_design_context`
+   only when building that module (it is the most expensive call).
+5. Write `_crawl-log.json` with `fetchTechnique: "figma-mcp"`, the
+   app/file context, and the quirks encountered — the provenance
+   contract requires saying explicitly that nothing was
+   browser-rendered.
+
+## Export traps (learned gating real modules)
+
+- **Height caps compound**: full-frame exports of tall nodes are
+  height-capped like width; a tall board's export resamples photos
+  badly. Prefer scale-1 exports of the exact instance you gate.
+- **Some exports bake a canvas ground** (e.g. uniform `#f9f9f9`) even
+  when the node has no fill — sample the corners and match the gate
+  page's section option to it; distinguish from the checkerboard case.
+- **Figma strokes don't displace layout** — kit rules/dividers drawn
+  as strokes must be overlays (inset box-shadow / outline), or every
+  element below drifts by the stroke width.
+- **Kit line boxes are floored** (22×1.3 → 28, not 28.6). For dense
+  stacked rows (accordion items, tab rows) pin the line box to the
+  kit's floored value or drift compounds per row.
+- **`.png` asset URLs may serve JPEG bytes** — check magic bytes
+  before trusting the extension.
+- **Instance exports can carry a canvas offset** relative to their own
+  metadata (observed 60.5px) — verify the export against the node's
+  metadata box before gating, crop accordingly.
+
+## Exactness rule
+
+Every captured value is extracted programmatically from a dump
+(jq/grep/script) — never retyped from a screenshot or from memory.
+Exactness must hold by construction, because the downstream token
+probe asserts byte equality.

--- a/plugins/stardust/skills/figma-to-eds/reference/gates.md
+++ b/plugins/stardust/skills/figma-to-eds/reference/gates.md
@@ -1,0 +1,119 @@
+# Gates — design fidelity against Figma
+
+Three gates, run in order, artifacts under `stardust/figma-to-eds/gates/`.
+The design gate target is **Figma**; any pre-existing live site is
+explicitly NOT a gate surface (its role is the divergence register).
+
+## 1. Token probe (`gates/token-probe.json`)
+
+For each token in `donor-tokens.json`: render a probe page (or the
+real blocks) headlessly, read computed styles, assert **byte
+equality** after the declared normalization ledger (e.g. hex→rgb()
+serialization by the browser is a declared normalization with an
+executable converter; `130%` line-height captured → computed unitless
+is declared, not discovered). A failed probe is a defect in the
+stylesheet, never a reason to loosen the ledger mid-run.
+
+Two probe classes:
+
+- **Existence + value**: the custom property is defined on `:root`
+  with the exact value.
+- **Consumption**: sampled block elements resolve to token values —
+  catches the hardcoded-hex-that-happens-to-match defect when the
+  token later changes.
+
+## 2. Component gate matrix (`gates/components/<module-slug>/`)
+
+One gate frame proves one cell. A module passes gate 2 only when its
+**gate matrix** passes: one row per variant × breakpoint the kit
+documents (the variant axes captured during enumeration ARE the matrix
+definition). Two complementary instruments cover the matrix:
+
+- **Geometry gate** (`scripts/geometry-gate.mjs`) — every variant,
+  including transparent frames where pixel diffing is impossible.
+  Figma metadata gives exact x/y/w/h per node; the gate renders each
+  case at its design viewport and asserts rendered boxes against kit
+  geometry. Rules learned in validation:
+  - Kit-absolute coordinates BELOW a text block embed the kit
+    renderer's line count, which the browser may not reproduce
+    (cross-engine metrics drop/add a wrap line at narrow widths).
+    Assert the inter-element **gap** instead (`gapFrom`) — the gap is
+    the kit invariant; the absolute top is not.
+  - Text-block heights get a declared line-box tolerance
+    (browser fractional line boxes vs Figma's floored ones); text-run
+    widths (e.g. a button label) get a declared text-metric tolerance.
+    Pure geometry (paddings, columns, offsets, fixed heights) stays ±1.
+- **Pixel diff** (`scripts/component-diff.mjs`) — the default variant
+  plus every opaque themed usage board (dark/facet/tinted). Frames
+  whose canvas is transparent render as a baked checkerboard through
+  the MCP and can NEVER be pixel-gated — re-pin to an opaque usage
+  instance (record the re-pin) or rely on the geometry gate.
+
+### Reproducibility and sweeps
+
+Every pixel verdict records its full invocation (page, selector,
+design width, crop, thresholds) — a gate that can't be blindly re-run
+is not a gate. `scripts/run-all-gates.mjs` re-runs every module's
+geometry spec and every recorded pixel gate and prints a summary
+table; run it before and after ANY shared-layer change (styles.css,
+token regeneration, atom promotion) and diff the summaries. Gate
+fixtures must hide chrome that races into screenshots (e.g. consent
+banners: `<style>.consent-banner{display:none}</style>`).
+
+### Threshold discipline (validated classes)
+
+Declared per gate, cause named, never loosened to pass:
+- ~3% — light-ground text modules (AA + cross-engine wrap + line-box).
+- ~3.5% — inverted (light-on-dark) text: heavier AA, same profile.
+- ~4% — grounds using baked raster artwork (JPEG noise adds a band).
+- Above that only with quantified evidence (e.g. per-segment
+  diagnostics or ink-adjacency percentages stored next to the verdict)
+  proving zero unattributed regions. Text-dense narrow frames at
+  export scale may be pixel-ungateable — store the diagnostics,
+  exclude, and cover with geometry (never silently).
+
+### Real-content check
+
+Gate fixtures use kit specimen content and can miss authored-content
+shapes. After a block gates green, render real migrated pages through
+it (the divergence-register pass doubles as this) — single-cell rows,
+legacy markup shapes, and bare-`<strong>` patterns have all produced
+real fixes that fixtures never would.
+
+### Pixel diff mechanics
+
+Per mapped module:
+
+1. Export the gate frame from Figma (`get_screenshot` on the frame id
+   pinned in `mapping.md`).
+2. Render the EDS block with equivalent placeholder content at the
+   frame's width; screenshot.
+3. Pixel-diff. Store `figma.png`, `eds.png`, `diff.png`, and a
+   verdict row (pass / fail / pass-with-tolerances).
+
+Tolerances are **declared per gate, in writing**: font rasterization
+and anti-aliasing differ between Figma's renderer and the browser, so
+a small residual is expected — but each tolerance names what it
+excuses (e.g. "text raster noise ≤N% in text bounding boxes").
+Geometry (spacing, sizes, radii, alignment) gets no tolerance: those
+are token-derived and must be exact.
+
+Content in gate renders is placeholder-but-shaped: same element
+kinds, realistic lengths. The gate tests the surface, not the copy —
+copy is the upstream content gate's job.
+
+## 3. Divergence attribution (`gates/divergence-register.md`)
+
+Only when an existing live site predates the reskin. For each visual
+delta between the live site and the new build, one register row:
+
+| field | rule |
+|---|---|
+| where | page/block + viewport |
+| delta | one sentence, observable |
+| mandate | the Figma node id that requires the new appearance |
+| class | `mandated` (node id present) / `unmandated` (defect — fix or escalate) / `out-of-kit` (no Figma counterpart exists; resolution recorded) |
+
+The register's pass condition: zero `unmandated` rows. This is what
+makes "the new site differs from production" auditable — every
+difference has a design-system citation or it's a bug.

--- a/plugins/stardust/skills/figma-to-eds/scripts/component-diff.mjs
+++ b/plugins/stardust/skills/figma-to-eds/scripts/component-diff.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// Component diff — gate 2 of figma-to-eds (reference/gates.md).
+// Renders a block test page at the Figma gate frame's design width,
+// screenshots the target element, downscales it in-browser to the Figma
+// export's exact pixel size (Figma desktop MCP caps exports at 1024px
+// per axis), and pixelmatch-diffs the pair.
+//
+// Usage: node component-diff.mjs --figma <frame.png> --page <file.html|url>
+//        --width <frame design width> --out <dir>
+//        [--selector <css>] [--threshold <pct>] [--pm <0..1>]
+//        [--crop top,right,bottom,left]  crop applied to the FIGMA image,
+//        in DESIGN px (scaled internally) — e.g. cut chrome baked into a
+//        kit component: --crop 118,0,0,0
+// Env: NODE_MODULES_DIR — node_modules containing playwright, pixelmatch, pngjs.
+
+import { createRequire } from 'node:module';
+import { readFileSync, writeFileSync, mkdirSync, copyFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const arg = (n, d = null) => { const i = process.argv.indexOf(n); return i > 0 ? process.argv[i + 1] : d; };
+const figmaPath = arg('--figma'); const pagePath = arg('--page');
+const designWidth = parseInt(arg('--width'), 10); const outDir = arg('--out');
+const selector = arg('--selector', 'main');
+const thresholdPct = parseFloat(arg('--threshold', '5'));
+const pmThreshold = parseFloat(arg('--pm', '0.1'));
+if (!figmaPath || !pagePath || !designWidth || !outDir) {
+  console.error('usage: --figma <png> --page <html> --width <px> --out <dir> [--selector main] [--threshold 5]');
+  process.exit(2);
+}
+
+const req = createRequire(process.env.NODE_MODULES_DIR
+  ? join(resolve(process.env.NODE_MODULES_DIR), 'diff-resolver.cjs') : import.meta.url);
+const { chromium } = req('playwright');
+const pixelmatchMod = req('pixelmatch');
+const pixelmatch = pixelmatchMod.default || pixelmatchMod; // ESM-built package under CJS require
+const { PNG } = req('pngjs');
+
+mkdirSync(outDir, { recursive: true });
+let figma = PNG.sync.read(readFileSync(figmaPath));
+let scale = figma.width / designWidth; // <1 when Figma downscaled the export
+const crop = (arg('--crop', '0,0,0,0')).split(',').map(Number);
+if (crop.some((v) => v > 0)) {
+  const [t, r, b, l] = crop.map((v) => Math.round(v * scale));
+  const cw = figma.width - l - r; const ch = figma.height - t - b;
+  const c = new PNG({ width: cw, height: ch });
+  PNG.bitblt(figma, c, l, t, cw, ch, 0, 0);
+  figma = c;
+  scale = figma.width / (designWidth - crop[1] - crop[3]);
+}
+
+const effectiveWidth = designWidth - (crop[1] || 0) - (crop[3] || 0);
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: effectiveWidth, height: 1200 }, deviceScaleFactor: 1 });
+const url = /^(https?|file):/.test(pagePath) ? pagePath : 'file://' + resolve(pagePath);
+await page.goto(url, { waitUntil: 'networkidle' });
+await page.evaluate(() => document.fonts.ready);
+await page.waitForTimeout(150); // settle animations/layout
+
+const el = page.locator(selector).first();
+const native = await el.screenshot();
+writeFileSync(join(outDir, 'eds.png'), native);
+
+// in-browser downscale to the Figma export's exact width (no extra deps)
+const scaled = await page.evaluate(async ({ b64, w }) => {
+  const img = await createImageBitmap(await (await fetch('data:image/png;base64,' + b64)).blob());
+  const h = Math.round(img.height * (w / img.width));
+  const c = new OffscreenCanvas(w, h);
+  c.getContext('2d').drawImage(img, 0, 0, w, h);
+  const blob = await c.convertToBlob({ type: 'image/png' });
+  const buf = new Uint8Array(await blob.arrayBuffer());
+  let s = '';
+  for (let i = 0; i < buf.length; i += 32768) s += String.fromCharCode.apply(null, buf.subarray(i, i + 32768));
+  return btoa(s);
+}, { b64: native.toString('base64'), w: figma.width });
+await browser.close();
+
+const eds = PNG.sync.read(Buffer.from(scaled, 'base64'));
+writeFileSync(join(outDir, 'eds-scaled.png'), PNG.sync.write(eds));
+copyFileSync(figmaPath, join(outDir, 'figma.png'));
+
+// pad both to common canvas (white) so height drift shows as diff, not crash
+const W = Math.max(eds.width, figma.width);
+const H = Math.max(eds.height, figma.height);
+const pad = (src) => {
+  const p = new PNG({ width: W, height: H, fill: true });
+  p.data.fill(255);
+  PNG.bitblt(src, p, 0, 0, src.width, src.height, 0, 0);
+  return p;
+};
+const a = pad(eds); const b = pad(figma);
+const diff = new PNG({ width: W, height: H });
+const diffPixels = pixelmatch(a.data, b.data, diff.data, W, H, { threshold: pmThreshold });
+writeFileSync(join(outDir, 'diff.png'), PNG.sync.write(diff));
+
+const pct = (100 * diffPixels) / (W * H);
+const heightDrift = eds.height - figma.height;
+const verdict = {
+  figma: figmaPath, page: pagePath, selector, designWidth,
+  crop: crop.join(','), pmThreshold,
+  figmaSize: { w: figma.width, h: figma.height },
+  edsScaledSize: { w: eds.width, h: eds.height },
+  scale: Number(scale.toFixed(4)), heightDriftPx: heightDrift,
+  diffPixels, diffPct: Number(pct.toFixed(2)), thresholdPct,
+  pass: pct <= thresholdPct,
+};
+writeFileSync(join(outDir, 'verdict.json'), JSON.stringify(verdict, null, 1));
+console.log(`${verdict.pass ? 'PASS' : 'FAIL'} ${pct.toFixed(2)}% diff (threshold ${thresholdPct}%), height drift ${heightDrift}px -> ${outDir}`);
+process.exit(verdict.pass ? 0 : 1);

--- a/plugins/stardust/skills/figma-to-eds/scripts/figma-screenshot.mjs
+++ b/plugins/stardust/skills/figma-to-eds/scripts/figma-screenshot.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// Export a Figma node screenshot to a PNG file via the Figma desktop
+// MCP server's streamable-HTTP endpoint (default http://127.0.0.1:3845/mcp),
+// bypassing the agent context entirely — the image never enters the
+// conversation. Requires the Figma desktop app running with the local
+// MCP server enabled and the target file open.
+//
+// Usage: node figma-screenshot.mjs <nodeId> <outfile.png> [--contents-only]
+//        node figma-screenshot.mjs --batch <manifest.json>
+//   manifest.json: [{ "nodeId": "1:23", "out": "path/to/file.png" }, ...]
+// Env: FIGMA_MCP_URL to override the endpoint.
+
+const MCP_URL = process.env.FIGMA_MCP_URL || 'http://127.0.0.1:3845/mcp';
+
+async function rpc(session, body) {
+  const res = await fetch(MCP_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      ...(session ? { 'mcp-session-id': session } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${body.method}`);
+  const newSession = res.headers.get('mcp-session-id') || session;
+  const text = await res.text();
+  // Responses arrive as SSE (`data: {...}` lines) or plain JSON.
+  let msg = null;
+  for (const line of text.split('\n')) {
+    if (line.startsWith('data:')) {
+      const parsed = JSON.parse(line.slice(5).trim());
+      if (parsed.id === body.id) msg = parsed;
+    }
+  }
+  if (!msg && text.trim().startsWith('{')) msg = JSON.parse(text);
+  return { session: newSession, msg };
+}
+
+async function connect() {
+  const { session } = await rpc(null, {
+    jsonrpc: '2.0', id: 1, method: 'initialize',
+    params: {
+      protocolVersion: '2025-03-26', capabilities: {},
+      clientInfo: { name: 'figma-to-eds-screenshot', version: '0.1.0' },
+    },
+  });
+  if (!session) throw new Error('no mcp-session-id returned by initialize');
+  await fetch(MCP_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      'mcp-session-id': session,
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+  });
+  return session;
+}
+
+async function screenshot(session, id, nodeId, contentsOnly) {
+  const { msg } = await rpc(session, {
+    jsonrpc: '2.0', id, method: 'tools/call',
+    params: {
+      name: 'get_screenshot',
+      arguments: { nodeId, ...(contentsOnly ? { contentsOnly: true } : {}) },
+    },
+  });
+  if (!msg) throw new Error(`no response for ${nodeId}`);
+  if (msg.error) throw new Error(`${nodeId}: ${msg.error.message}`);
+  const img = (msg.result?.content || []).find((c) => c.type === 'image');
+  if (!img) {
+    const texts = (msg.result?.content || []).map((c) => c.text).join(' ');
+    throw new Error(`${nodeId}: no image in result (${texts.slice(0, 200)})`);
+  }
+  return { data: Buffer.from(img.data, 'base64'), mime: img.mimeType };
+}
+
+const { writeFileSync, readFileSync, mkdirSync } = await import('node:fs');
+const { dirname } = await import('node:path');
+const args = process.argv.slice(2);
+
+const jobs = [];
+if (args[0] === '--batch') {
+  for (const j of JSON.parse(readFileSync(args[1], 'utf8'))) {
+    jobs.push({ nodeId: j.nodeId, out: j.out, contentsOnly: !!j.contentsOnly });
+  }
+} else {
+  const [nodeId, out] = args;
+  if (!nodeId || !out) {
+    console.error('usage: figma-screenshot.mjs <nodeId> <out.png> [--contents-only] | --batch <manifest.json>');
+    process.exit(2);
+  }
+  jobs.push({ nodeId, out, contentsOnly: args.includes('--contents-only') });
+}
+
+const session = await connect();
+let failed = 0;
+for (let i = 0; i < jobs.length; i++) {
+  const j = jobs[i];
+  try {
+    const { data, mime } = await screenshot(session, i + 10, j.nodeId, j.contentsOnly);
+    mkdirSync(dirname(j.out), { recursive: true });
+    writeFileSync(j.out, data);
+    console.log(`ok ${j.nodeId} -> ${j.out} (${data.length} bytes, ${mime})`);
+  } catch (e) {
+    failed++;
+    console.error(`FAIL ${j.nodeId}: ${e.message}`);
+  }
+}
+process.exit(failed ? 1 : 0);

--- a/plugins/stardust/skills/figma-to-eds/scripts/geometry-gate.mjs
+++ b/plugins/stardust/skills/figma-to-eds/scripts/geometry-gate.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Geometry gate — the variant-coverage half of figma-to-eds gate 2.
+// Pixel diffs need an opaque reference; Figma metadata gives exact
+// x/y/w/h for EVERY variant, including transparent ones. This gate
+// renders each case at its design viewport and asserts rendered
+// bounding boxes (relative to the target element's origin) against the
+// kit's geometry, within per-check tolerances.
+//
+// Spec file:
+// { "page": "<url>", "origin": "main",
+//   "cases": [ { "name": "tablet", "page": "<override url>",
+//     "viewport": { "width": 834, "height": 1400 },
+//     "checks": [ { "name": "h1", "selector": ".hero h1",
+//       "expect": { "top": 100, "left": 72, "width": 690, "height": 55 },
+//       "tol": { "default": 1, "height": 3, "top": 2 },
+//       "source": "1793:54936" } ] } ] }
+// Any expect key may be omitted. tol.default applies unless overridden.
+//
+// Gap checks: after a text block, browser line counts may differ from the
+// kit render (cross-engine metrics) — absolute kit tops embed the kit's
+// line count. The kit INVARIANT is the spacing between elements. Use:
+//   { "name": "button-gap", "selector": ".hero a.button",
+//     "expect": { "gap": 32 }, "gapFrom": "<selector of element above>" }
+// gap = this.top - gapFrom.bottom.
+//
+// Usage: node geometry-gate.mjs --spec <spec.json> --out <report.json>
+// Env: NODE_MODULES_DIR — node_modules containing playwright.
+
+import { createRequire } from 'node:module';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+const arg = (n) => { const i = process.argv.indexOf(n); return i > 0 ? process.argv[i + 1] : null; };
+const specPath = arg('--spec'); const outPath = arg('--out');
+if (!specPath || !outPath) { console.error('usage: --spec <json> --out <report>'); process.exit(2); }
+
+const req = createRequire(process.env.NODE_MODULES_DIR
+  ? join(resolve(process.env.NODE_MODULES_DIR), 'geo-resolver.cjs') : import.meta.url);
+const { chromium } = req('playwright');
+
+const spec = JSON.parse(readFileSync(specPath, 'utf8'));
+const browser = await chromium.launch();
+const failures = []; let checks = 0;
+const results = [];
+
+for (const c of spec.cases) {
+  const page = await browser.newPage({ viewport: c.viewport, deviceScaleFactor: 1 });
+  await page.goto(c.page || spec.page, { waitUntil: 'networkidle' });
+  await page.evaluate(() => document.fonts.ready);
+  await page.waitForTimeout(100);
+  const measured = await page.evaluate(({ origin, items }) => {
+    const o = document.querySelector(origin).getBoundingClientRect();
+    return items.map(({ sel, gapFrom }) => {
+      const el = document.querySelector(sel);
+      if (!el) return null;
+      const b = el.getBoundingClientRect();
+      const m = { top: b.top - o.top, left: b.left - o.left, width: b.width, height: b.height };
+      if (gapFrom) {
+        const ref = document.querySelector(gapFrom);
+        if (ref) m.gap = b.top - ref.getBoundingClientRect().bottom;
+      }
+      return m;
+    });
+  }, { origin: spec.origin || 'main', items: c.checks.map((k) => ({ sel: k.selector, gapFrom: k.gapFrom })) });
+  await page.close();
+
+  for (let i = 0; i < c.checks.length; i += 1) {
+    const k = c.checks[i]; const m = measured[i];
+    if (!m) { failures.push({ case: c.name, check: k.name, error: 'selector not found', selector: k.selector }); continue; }
+    for (const [prop, exp] of Object.entries(k.expect)) {
+      checks += 1;
+      const tol = (k.tol && (k.tol[prop] ?? k.tol.default)) ?? 1;
+      const got = m[prop];
+      if (Math.abs(got - exp) > tol) {
+        failures.push({ case: c.name, check: k.name, prop, expected: exp, actual: Number(got.toFixed(1)), tol, source: k.source });
+      }
+    }
+    results.push({ case: c.name, check: k.name, measured: Object.fromEntries(Object.entries(m).map(([p, v]) => [p, Number(v.toFixed(1))])) });
+  }
+}
+await browser.close();
+
+const report = { spec: specPath, checks, failures: failures.length, pass: failures.length === 0, detail: failures, measured: results };
+mkdirSync(dirname(resolve(outPath)), { recursive: true });
+writeFileSync(outPath, JSON.stringify(report, null, 1));
+console.log(`${report.pass ? 'PASS' : 'FAIL'} — ${checks} geometry checks, ${failures.length} failures -> ${outPath}`);
+if (failures.length) console.log(failures.slice(0, 15).map((f) => `  ${f.case}/${f.check} ${f.prop || f.error}: expected ${f.expected} got ${f.actual} (tol ${f.tol})`).join('\n'));
+process.exit(failures.length ? 1 : 0);

--- a/plugins/stardust/skills/figma-to-eds/scripts/run-all-gates.mjs
+++ b/plugins/stardust/skills/figma-to-eds/scripts/run-all-gates.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Full gate-suite sweep — runs every module's geometry spec and every
+// recorded pixel gate (verdicts carry page/selector/width/crop/threshold),
+// and prints a summary table. The regression instrument for shared-layer
+// changes: run before and after, diff the summaries.
+//
+// Usage: node run-all-gates.mjs --gates <gates/components dir> [--only <slug-substr>] [--out <summary.json>]
+// Env: NODE_MODULES_DIR — node_modules containing playwright, pixelmatch, pngjs.
+
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { join, resolve, dirname, relative } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const arg = (n, d = null) => { const i = process.argv.indexOf(n); return i > 0 ? process.argv[i + 1] : d; };
+const gatesDir = arg('--gates'); const only = arg('--only'); const outPath = arg('--out');
+if (!gatesDir) { console.error('usage: --gates <dir> [--only <substr>] [--out <json>]'); process.exit(2); }
+
+const here = dirname(fileURLToPath(import.meta.url));
+const rows = []; let fails = 0;
+
+const findVerdicts = (dir) => {
+  const out = [];
+  for (const e of readdirSync(dir)) {
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) {
+      if (e === 'diagnostics') continue; // stored evidence, not gates
+      out.push(...findVerdicts(p));
+    } else if (e === 'verdict.json') out.push(p);
+  }
+  return out;
+};
+
+for (const mod of readdirSync(gatesDir).sort()) {
+  const mdir = join(gatesDir, mod);
+  if (!statSync(mdir).isDirectory()) continue;
+  if (only && !mod.includes(only)) continue;
+
+  const spec = join(mdir, 'geometry-spec.json');
+  try { statSync(spec); } catch { continue; }
+  let r = spawnSync('node', [join(here, 'geometry-gate.mjs'), '--spec', spec,
+    '--out', join(mdir, 'geometry-report.json')], { encoding: 'utf8' });
+  const geo = JSON.parse(readFileSync(join(mdir, 'geometry-report.json'), 'utf8'));
+  rows.push({ module: mod, gate: 'geometry', checks: geo.checks, result: geo.pass ? 'PASS' : `FAIL(${geo.failures})` });
+  if (!geo.pass) fails += 1;
+
+  for (const v of findVerdicts(mdir)) {
+    const j = JSON.parse(readFileSync(v, 'utf8'));
+    if (!j.page || !j.figma) continue;
+    if (j.excluded || v.includes('excluded')) {
+      rows.push({ module: mod, gate: `pixel:${relative(mdir, dirname(v))}`, checks: '-', result: 'EXCLUDED (documented)' });
+      continue;
+    }
+    r = spawnSync('node', [join(here, 'component-diff.mjs'),
+      '--figma', j.figma, '--page', j.page, '--width', String(j.designWidth),
+      '--selector', j.selector, '--crop', j.crop || '0,0,0,0',
+      '--out', dirname(v), '--threshold', String(j.thresholdPct)], { encoding: 'utf8' });
+    const nv = JSON.parse(readFileSync(v, 'utf8'));
+    const name = relative(mdir, dirname(v)) || 'default';
+    rows.push({ module: mod, gate: `pixel:${name}`, checks: '-', result: nv.pass ? `PASS ${nv.diffPct}%` : `FAIL ${nv.diffPct}% (@${nv.thresholdPct})` });
+    if (!nv.pass) fails += 1;
+  }
+}
+
+const pad = (s, n) => String(s).padEnd(n);
+console.log(pad('module', 26) + pad('gate', 26) + pad('checks', 8) + 'result');
+for (const r of rows) console.log(pad(r.module, 26) + pad(r.gate, 26) + pad(r.checks, 8) + r.result);
+console.log(`\n${rows.length} gates, ${fails} failing`);
+if (outPath) writeFileSync(outPath, JSON.stringify({ ranAt: new Date().toISOString(), rows, fails }, null, 1));
+process.exit(fails ? 1 : 0);

--- a/plugins/stardust/skills/figma-to-eds/scripts/token-probe.mjs
+++ b/plugins/stardust/skills/figma-to-eds/scripts/token-probe.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// Token probe — gate 1 of figma-to-eds (reference/gates.md).
+// Asserts a rendered stylesheet against donor-tokens.json:
+//   A. every curated custom property is defined on :root with the exact
+//      authored string (custom properties don't get browser-serialized,
+//      so this is byte equality — no color conversion needed);
+//   B. the element type ramp (kit html-mapping) computes to the expected
+//      font-size / font-weight / font-style / line-height per breakpoint.
+// Normalizations applied are ONLY those declared in the token sheet:
+// percent->unitless line-height (already in the sheet), desktop->web
+// font family name, computed line-height px = size * factor (±0.1px).
+//
+// Usage: node token-probe.mjs --tokens <donor-tokens.json> --css <styles.css> --out <report.json>
+// Env: NODE_MODULES_DIR — a node_modules dir that contains playwright.
+
+import { createRequire } from 'node:module';
+import { writeFileSync, mkdirSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const arg = (n) => { const i = process.argv.indexOf(n); return i > 0 ? process.argv[i + 1] : null; };
+const tokensPath = arg('--tokens'); const cssPath = arg('--css'); const outPath = arg('--out');
+if (!tokensPath || !cssPath || !outPath) { console.error('usage: --tokens <json> --css <css> --out <report>'); process.exit(2); }
+
+const req = createRequire(process.env.NODE_MODULES_DIR
+  ? join(resolve(process.env.NODE_MODULES_DIR), 'probe-resolver.cjs') : import.meta.url);
+const { chromium } = req('playwright');
+
+const sheet = JSON.parse(readFileSync(tokensPath, 'utf8'));
+const T = sheet.tokens;
+
+// probe page: bare elements + the stylesheet under test
+const dir = mkdtempSync(join(tmpdir(), 'token-probe-'));
+const html = `<!doctype html><html><head><meta charset="utf-8">
+<link rel="stylesheet" href="file://${resolve(cssPath)}"></head><body>
+<h1>H1</h1><h2>H2</h2><h3>H3</h3><h4>H4</h4><h5>H5</h5><h6>H6</h6>
+<p class="lead">lead</p><p>para</p><ul><li>item</li></ul></body></html>`;
+writeFileSync(join(dir, 'probe.html'), html);
+
+// family equivalences come from the token sheet's declared normalizations —
+// never hardcoded here (desktop font name vs licensed web font name)
+const FAMILY_EQ = new Set((T.typography.familyEquivalences || [[T.typography.families?.primary]])
+  .flat().filter(Boolean).map((f) => f.toLowerCase()));
+
+const styleKey = (figmaName) => figmaName.toLowerCase().replace(/[/. ]+/g, '-');
+const pickStyle = (name) => T.typography.styles[styleKey(name)]
+  || T.typography.styles[styleKey(name) + '-book'];
+
+const failures = []; let checks = 0;
+const browser = await chromium.launch();
+const page = await browser.newPage();
+await page.goto('file://' + join(dir, 'probe.html'));
+
+// --- A. custom properties on :root ---
+const sections = ['colors', 'radii', 'borderWidths', 'shadows', 'spacing', 'sizing',
+  'spaceSemantic', 'sizeSemantic', 'durations', 'easings'];
+const expected = {};
+for (const s of sections) for (const [p, e] of Object.entries(T[s])) expected[p] = { v: e.value, s };
+const actual = await page.evaluate((props) => {
+  const cs = getComputedStyle(document.documentElement); const out = {};
+  for (const p of props) out[p] = cs.getPropertyValue(p).trim();
+  return out;
+}, Object.keys(expected));
+for (const [p, e] of Object.entries(expected)) {
+  checks += 1;
+  if (actual[p] !== e.v) failures.push({ gate: 'custom-property', prop: p, section: e.s, expected: e.v, actual: actual[p] || '(undefined)' });
+}
+
+// --- B. element ramp per breakpoint ---
+const BREAKPOINTS = { mobile: 430, tablet: 1000, desktop: 1440 };
+const ELEMENTS = Object.entries(sheet.tokens.typography.htmlMapping)
+  .map(([el, style]) => ({ el, sel: el === 'p' ? 'p:not(.lead)' : el, style: pickStyle(style), styleName: style }))
+  .filter((e) => e.style);
+for (const [bp, width] of Object.entries(BREAKPOINTS)) {
+  await page.setViewportSize({ width, height: 900 });
+  const got = await page.evaluate((sels) => sels.map((sel) => {
+    const el = document.querySelector(sel); if (!el) return null;
+    const cs = getComputedStyle(el);
+    return { sel, fontSize: cs.fontSize, fontWeight: cs.fontWeight, fontStyle: cs.fontStyle, lineHeight: cs.lineHeight, family: cs.fontFamily.split(',')[0].replace(/["']/g, '').trim().toLowerCase() };
+  }), ELEMENTS.map((e) => e.sel));
+  for (let i = 0; i < ELEMENTS.length; i += 1) {
+    const e = ELEMENTS[i]; const g = got[i]; if (!g) continue;
+    const props = e.style.props[bp] || e.style.props.all;
+    if (!props) continue;
+    checks += 4;
+    if (g.fontSize !== props['font-size']) failures.push({ gate: 'element-ramp', el: e.el, bp, prop: 'font-size', expected: props['font-size'], actual: g.fontSize });
+    if (g.fontWeight !== props['font-weight']) failures.push({ gate: 'element-ramp', el: e.el, bp, prop: 'font-weight', expected: props['font-weight'], actual: g.fontWeight });
+    if (g.fontStyle !== props['font-style']) failures.push({ gate: 'element-ramp', el: e.el, bp, prop: 'font-style', expected: props['font-style'], actual: g.fontStyle });
+    const expLh = parseFloat(props['font-size']) * parseFloat(props['line-height']);
+    if (Math.abs(parseFloat(g.lineHeight) - expLh) > 0.1) failures.push({ gate: 'element-ramp', el: e.el, bp, prop: 'line-height', expected: `${expLh}px (${props['line-height']} x ${props['font-size']})`, actual: g.lineHeight });
+    checks += 1;
+    if (!FAMILY_EQ.has(g.family)) failures.push({ gate: 'element-ramp', el: e.el, bp, prop: 'font-family', expected: `[${[...FAMILY_EQ].join(' | ')}]`, actual: g.family });
+  }
+}
+await browser.close();
+
+const report = {
+  ranAt: new Date().toISOString(), tokens: tokensPath, css: cssPath,
+  checks, failures: failures.length, pass: failures.length === 0, detail: failures,
+};
+mkdirSync(dirname(resolve(outPath)), { recursive: true });
+writeFileSync(outPath, JSON.stringify(report, null, 1));
+console.log(`${report.pass ? 'PASS' : 'FAIL'} — ${checks} checks, ${failures.length} failures -> ${outPath}`);
+if (failures.length) console.log(failures.slice(0, 12).map((f) => `  ${f.gate} ${f.prop} ${f.el || f.section || ''} ${f.bp || ''}: expected ${f.expected} got ${f.actual}`).join('\n'));
+process.exit(failures.length ? 1 : 0);

--- a/plugins/stardust/skills/reskin/reference/donor-sources.md
+++ b/plugins/stardust/skills/reskin/reference/donor-sources.md
@@ -147,7 +147,12 @@ Recipe notes:
 - **Port hygiene**: kill the server when the capture ends; a stale
   server on the port silently serves an old donor to a re-run.
 
-## 3. Figma (`--donor-figma <url>`) — FUTURE, contract defined
+## 3. Figma (`--donor-figma <url>`) — adapter available: skills/figma-to-eds
+
+The contract below is implemented by the `figma-to-eds` skill (capture
++ curate phases produce these canon-source artifacts via the Figma
+desktop MCP; apply + gate phases add an EDS block target). Original
+contract text retained as the normative shape:
 
 **Not implemented.** When a user asks for a Figma donor, say exactly
 what SKILL.md § Inputs prescribes (export as static HTML →


### PR DESCRIPTION
Implements the `--donor-figma` adapter that `skills/reskin/reference/donor-sources.md` § 3 specs as "FUTURE, contract defined", and extends it with an EDS apply/gate layer as a new stardust skill.

## What's in the skill

- **SKILL.md** — two donor modes (`web-kit` hardened, `sample-pages` contract-defined), five phases (Capture → Curate → Map → Apply → Gate), reskin-contract compliance (`figma-mcp` provenance, canon-source artifacts, node-id citations everywhere).
- **5 generic instruments** (`scripts/`): `figma-screenshot.mjs` (PNG export via the Figma desktop MCP's streamable-HTTP endpoint — zero agent-context cost, batchable), `token-probe.mjs` (byte-equality custom-property + element-ramp gate), `geometry-gate.mjs` (variant-matrix gate from Figma metadata x/y/w/h, with gap semantics below text blocks), `component-diff.mjs` (scaled pixel diff, reproducible verdicts recording crop/selector/threshold), `run-all-gates.mjs` (full-suite sweep for shared-layer regression).
- **Method references** (`reference/`): the Figma MCP quirk ledger (usage-scoped variables, oversized dumps, embedded Tokens-Studio spec tables), export traps (baked checkerboards, floored line boxes, non-displacing strokes, height caps, canvas offsets, JPEG-in-PNG assets), threshold discipline with named tolerance classes, the gate-matrix model, EDS mapping rules, and the divergence-attribution register (live-vs-new deltas must cite a Figma mandate).
- **Synthetic eval** (`eval/run-eval.mjs`): 4 checks on an invented design system — token probe positive + negative (single-hex perturbation detected), geometry gate, component-diff round-trip — no Figma connection required, only a node_modules with playwright/pixelmatch/pngjs (`NODE_MODULES_DIR`).

Also adds a cross-reference in reskin's donor-sources.md § 3 pointing at the adapter, and a CHANGELOG entry.

## Validation

Hardened on a full production run against a financial-services client's Figma web kit (not included — the skill tree is grep-gated for client vocabulary): 35 modules gated (~2,700 geometry checks, ~120 pixel gates incl. functional gates for interactive chrome), 13 page archetypes audited through the divergence register with every delta traced to a kit mandate. The eval passes 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)