### PR TITLE
Fix telemetry audience framing

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/plugins/workfront/skills/wf-planning-solution-architect/README.md
+++ b/plugins/workfront/skills/wf-planning-solution-architect/README.md
@@ -26,7 +26,7 @@ wf-planning-solution-architect/
     ├── workspace-build-playbook.md             # Canonical build playbook (synthesized)
     ├── best-practice-template.md               # Fréscopa exemplar + known deviations
     ├── best-practice-template.json             # Trimmed Fréscopa sample export (minified, ~1.6 MB)
-    ├── limits-and-tiers.md                     # SA-ready limit reference by tier
+    ├── limits-and-tiers.md                     # Practitioner limit reference by tier
     ├── public-vs-api-discrepancies.md          # Reconciliation table
     ├── customer-conversation-framings.md       # Stock SA framings
     └── synthesized/                            # Content not published on Experience League

--- a/plugins/workfront/skills/wf-planning-solution-architect/SKILL.md
+++ b/plugins/workfront/skills/wf-planning-solution-architect/SKILL.md
@@ -31,7 +31,7 @@ The audience is practitioners: solution architects, consultants, administrators,
 
 3. **Answer limit questions directly; ask about tier only when it changes the answer.** Most object limits are identical across Select, Prime, and Ultimate. Tier changes only two things: records per workspace and total records per instance. For anything else, give the number, then note it does not vary by tier. Ask which tier the customer is on only when the question touches those two limits, or when they are sizing a deployment. See `references/limits-and-tiers.md`.
 
-4. **Internal performance numbers are telemetry, not SLA.** When sharing P95 or latency data with customer-facing colleagues, frame it as "observed production telemetry" and never as a contractual guarantee.
+4. **Performance numbers are observations, not commitments.** Adobe does not publish a P95 or SLA contract for Planning. Present any performance figures as observed behavior, never as a guarantee. Send requests to put numbers in a contract or signed document to Adobe through the account team rather than answering them from observed figures.
 
 5. **Workspace design follows the playbook.** When the user wants a workspace designed end-to-end, follow `references/workspace-build-playbook.md` strictly. Work through the full design before narrating it. Do not pause halfway to ask for confirmation on every record type.
 
@@ -63,7 +63,7 @@ Identify the question type first, then load only the references you need. Do not
 - **Route here only when the limit itself is the question**: what a cap is, whether they can exceed it, or how much headroom they have. A design question that merely mentions volume ("we have 30 countries and thousands of tactics, how should I model this?") is Category B, not A. Answer the modelling question; bring up a cap only if the proposed design would actually breach one.
 - Load: `references/limits-and-tiers.md` (always), `references/customer-conversation-framings.md`.
 - Lead with the answer. Only records per workspace and total records per instance vary by tier; if the question is about either of those, or about overall sizing, ask which package the customer is on. Otherwise state the limit and note that it is the same across tiers.
-- If they want P95 or latency data, frame as internal telemetry, never as published SLA.
+- If they want P95 or latency data, say that Adobe publishes no SLA for Planning, and present any figures as observed behavior rather than a commitment.
 - If they are hitting a limit and asking for an exception, default to the design-vs-limit reframe before agreeing to anything.
 
 ### Category B: Customer or colleague is designing a workspace
@@ -205,7 +205,7 @@ This is the skill working correctly: it surfaced the design issue disguised as a
 ## When you don't know
 
 If the user asks something specific that is not in the reference set, say so directly and either:
-- Suggest the right source to check (Adobe Experience League page, developer.adobe.com, the Planning API itself, or asking the WFP engineering team).
+- Suggest the right source to check (Adobe Experience League page, developer.adobe.com, the Planning API itself, or Adobe support through the account team).
 - Offer to web_fetch the relevant Adobe docs page.
 
 Never invent a limit, a function name, or a behavior. The reference set is comprehensive but not complete. Refresh procedure for the reference set is in `references/INDEX.md`.

--- a/plugins/workfront/skills/wf-planning-solution-architect/SKILL.md
+++ b/plugins/workfront/skills/wf-planning-solution-architect/SKILL.md
@@ -167,7 +167,7 @@ Mention these when they bear on the question actually asked. "Relevant" means th
 
 - **The 500 connected records cap is architectural.** It is in the published limits. Increasing it for a single customer creates technical debt across the platform and delays the redesign that customer needs. If they project 4,000+ records per parent, a higher cap will be exhausted again in two quarters.
 
-- **The 25,000 records-per-record-type cap is the hard ceiling.** Roadmap targets 50,000 initially, not unlimited. Frame customer expectations against the realistic path, not the wish.
+- **The 25,000 records-per-record-type cap is the hard ceiling.** It applies on every tier. Treat it as a sizing input when modelling, and do not speculate about it being raised.
 
 - **Identity model: Planning returns IMS user IDs, not Workfront user IDs.** Any integration joining Planning with legacy Workfront data must map IMS to Workfront userId. This is a frequent integration footgun.
 
@@ -198,7 +198,7 @@ Mention these when they bear on the question actually asked. "Relevant" means th
 2. *Reframe before conceding:* "Hitting the 500-connection cap on day one is almost always a modeling signal, not a capacity signal. Before we talk about raising it, what's connected to what?" The 500 multi-select non-hierarchy connection cap is the same on all tiers, including Ultimate, so tier is not the lever here.
 3. *Name the architecture problem:* If one parent record is being connected to thousands of children, the fix is usually a hierarchy or an intermediate record type, not a bigger cap. A raised cap gets exhausted again in a quarter or two and adds platform-wide technical debt.
 4. *Give the customer-facing colleague words to use:* Offer the redesign framing from `customer-conversation-framings.md` rather than an exception promise.
-5. *Only then* discuss whether an exception is even possible, and set expectations against the roadmap, not the wish.
+5. *Only then* discuss whether an exception is even possible, and set expectations against the limits Adobe publishes today rather than what the customer hopes will change.
 
 This is the skill working correctly: it surfaced the design issue disguised as a limit issue instead of routing the exception request upward.
 

--- a/plugins/workfront/skills/wf-planning-solution-architect/references/INDEX.md
+++ b/plugins/workfront/skills/wf-planning-solution-architect/references/INDEX.md
@@ -11,7 +11,7 @@ Map of reference files used by the wf-planning-solution-architect skill. Load on
 | `best-practice-template.json` | Trimmed sample export (minified, ~1.6 MB): full structure, ~5 records per record type. Inspect only when a question requires field-level or record-level detail beyond the digest. |
 | `limits-and-tiers.md` | Any limits, capacity, sizing, or tier question. Most limits are identical across tiers; check the customer's tier only for records per workspace, total records per instance, or deployment sizing. |
 | `public-vs-api-discrepancies.md` | Whenever public docs and observed API behavior could disagree (precision, formulas, color palettes, connection naming, identity model, etc.). |
-| `customer-conversation-framings.md` | When the user is preparing for or in a customer conversation (limit escalation, P95 ask, RPM comparison, reporting expectations, workspace build engagement, roadmap question, template adoption review). |
+| `customer-conversation-framings.md` | When the user is preparing for or in a customer conversation (limit escalation, P95 ask, RPM comparison, reporting expectations, workspace build engagement, template adoption review). |
 
 ## Public docs layer (UI/UX surface)
 

--- a/plugins/workfront/skills/wf-planning-solution-architect/references/INDEX.md
+++ b/plugins/workfront/skills/wf-planning-solution-architect/references/INDEX.md
@@ -53,7 +53,7 @@ If a question spans categories, load only the union of files; do not load every 
 
 **Public docs:** nothing to refresh. Pages are fetched live from Experience League at answer time. If Adobe publishes new Planning articles, add entries to `scripts/docs-index.json` (path, url, title, section, description, headings) so the search can surface them.
 
-**API-surface facts:** the operator sets, precision limits, and function support notes live inline in SKILL.md. Re-verify them against the live Planning API, or request refreshed detail from the WFP engineering team, when the product changes.
+**API-surface facts:** the operator sets, precision limits, and function support notes live inline in SKILL.md. Re-verify them against the live Planning API, or confirm with Adobe, when the product changes.
 
 **Best-practice template:** re-export when the canonical template changes meaningfully. Update both the .json (raw) and the .md (digest). Re-validate the "Known deviations" section against the current template state.
 

--- a/plugins/workfront/skills/wf-planning-solution-architect/references/best-practice-template.md
+++ b/plugins/workfront/skills/wf-planning-solution-architect/references/best-practice-template.md
@@ -1,6 +1,6 @@
 # Best-practice multi-workspace template: Fréscopa reference
 
-This reference summarizes the Fréscopa multi-workspace template that the WF Planning team treats as an internal best-practice exemplar. A trimmed sample export is preserved as `best-practice-template.json` in this folder — it keeps the full structure (all 6 workspaces, 37 record types, and their fields/views/hierarchies) but caps sample data at ~5 records per record type. This .md file is the digest the skill should read first; consult the JSON only when a question requires field-level or record-level detail.
+This reference summarizes the Fréscopa multi-workspace template, a best-practice exemplar for a multi-workspace Planning build. A trimmed sample export is preserved as `best-practice-template.json` in this folder — it keeps the full structure (all 6 workspaces, 37 record types, and their fields/views/hierarchies) but caps sample data at ~5 records per record type. This .md file is the digest the skill should read first; consult the JSON only when a question requires field-level or record-level detail.
 
 **Use this file in two distinct ways:**
 1. **Pattern source** for "what should a real multi-workspace build look like" questions.

--- a/plugins/workfront/skills/wf-planning-solution-architect/references/customer-conversation-framings.md
+++ b/plugins/workfront/skills/wf-planning-solution-architect/references/customer-conversation-framings.md
@@ -7,7 +7,7 @@ These are not scripts. Adapt to context. The goal is consistency across the team
 ## 1. Customer is hitting a limit and asking for an exception
 
 ### Situation
-Customer (often via account team or the implementation partner) escalates that they have hit a published platform limit (records per record type, connected records cap, fields per record type, etc.) and asks for the limit to be raised for them.
+A customer, often via the account team or an implementation partner, reports that they have hit a published platform limit (records per record type, connected records cap, fields per record type, etc.) and asks for the limit to be raised for them.
 
 ### Recommended framing
 The architecture is wrong, not the limit. Granting incremental exceptions does three damaging things:
@@ -15,7 +15,7 @@ The architecture is wrong, not the limit. Granting incremental exceptions does t
 2. Delays the redesign that this customer actually needs.
 3. Buys 1 to 2 quarters at most before they hit the new cap.
 
-If the customer has previously been granted an exception and is now back asking for more, name that pattern explicitly. Documented prior conversations are accountability anchors.
+If the same limit has already been stretched once for this customer and they are back asking for more, name that pattern explicitly. It is evidence that the design, not the cap, is the constraint.
 
 ### Key sentences to anchor on
 - "The limit exists because the underlying architecture requires it. Raising it for one customer means absorbing that complexity across the platform."
@@ -27,7 +27,7 @@ If the customer has previously been granted an exception and is now back asking 
 Do not negotiate the number ("we can do 1500 not 2500"). Once you negotiate the number, you have conceded that the limit is negotiable, which it is not. Hold the architectural line.
 
 ### Reference case
-A multi-quarter escalation pattern observed in production: an implementation-partner-built solution hits the 500-connection cap on day one of go-live, despite the solution architect flagging the risk months earlier. An initial exception is granted, then a second exception request follows. The customer's own projection puts them back at the new cap within two quarters, confirming this is design-driven rather than sizing-driven. The accountability anchor in these conversations is the documented prior risk acknowledgment from the implementation team.
+A recurring pattern: a solution hits the 500-connection cap on day one of go-live, even though the cap is documented and the risk was raised during design. Stretching the cap once leads to a second request, because the customer's own projection puts them back at the new ceiling within two quarters. That projection is the clearest evidence the problem is design-driven rather than sizing-driven.
 
 ## 2. Customer asks for performance numbers (P95, SLA)
 
@@ -127,25 +127,7 @@ The bridge is the connection from a Planning record (e.g., Campaign) to a Workfr
 ### Trap to avoid
 Do not suggest that Planning replaces Workfront, or that Workfront should be deprecated in favor of Planning. They are designed to work together. Customers on Planning Prime or Ultimate are licensed for both.
 
-## 7. AM or customer asks "is this a roadmap item?"
-
-### Situation
-Customer or AM asks whether a feature gap will be addressed in a future release.
-
-### Recommended framing
-Be honest about what is committed vs what is being explored. Do not over-promise. Three tiers of language:
-- **Committed:** "This is on the roadmap for [quarter]."
-- **Being explored:** "This is in discovery. We have not committed to a delivery quarter."
-- **Not on the roadmap:** "This is not on the roadmap today. If the use case is important, I can route it to product for consideration."
-
-### Key sentences to anchor on
-- "I want to be precise here: this is in discovery, which means we are validating the approach but not yet committed to delivery. The structure is intentional: discover in one quarter, deliver in the next, only if discovery validates the path."
-- "Nothing in this roadmap locks us into delivering something we have not yet validated."
-
-### Trap to avoid
-Do not say "yes, that is coming" without a specific commitment behind it. Customers remember these answers verbatim and bring them back. Anchor in discovery vs delivery phasing if uncertain.
-
-## 8. Customer instantiates a reference template and asks "is this good for us?"
+## 7. Customer instantiates a reference template and asks "is this good for us?"
 
 ### Situation
 Customer adopts the Fréscopa template (or similar reference) and asks whether it is the right starting point.

--- a/plugins/workfront/skills/wf-planning-solution-architect/references/customer-conversation-framings.md
+++ b/plugins/workfront/skills/wf-planning-solution-architect/references/customer-conversation-framings.md
@@ -35,21 +35,21 @@ A multi-quarter escalation pattern observed in production: an implementation-par
 Customer wants performance guarantees, P95 numbers, or SLA documentation. Often surfaces in pre-sale, contract renewal, or "is this product mature enough?" conversations.
 
 ### Recommended framing
-Workfront Planning does not publish a public P95 / SLA contract. We do have internal production telemetry that can be shared as observed behavior, NOT as a commitment.
+Workfront Planning does not publish a public P95 / SLA contract. Any performance figures available to you are observed behavior, NOT a commitment.
 
 Frame as: "Production monitoring shows commonly used Planning APIs running at low-hundreds-of-milliseconds P95 server-side latency in production." Anchor the words **observed**, **production telemetry**, **server-side**.
 
 ### Key sentences to anchor on
 - "We do not publish a contractual P95 / SLA for Planning today."
-- "What I can share is observed production telemetry: commonly used Planning APIs run in the low hundreds of milliseconds P95, server-side." Obtain current figures from the WFP engineering team before quoting anything more specific.
+- "What I can share is observed behavior: commonly used Planning APIs run in the low hundreds of milliseconds P95, server-side." Confirm current figures with Adobe before quoting anything more specific.
 - "These are backend server-side response times, not browser-perceived page loads."
 - "I want to set expectations: this is what we observe, not what we commit to."
 
 ### Trap to avoid
-Do not let telemetry numbers harden into commitments. If a customer asks you to put the numbers in a contract or signed document, route through legal and product. Internal telemetry is for verbal context and slide-level talking points, not for SLA commitments.
+Do not let observed numbers harden into commitments. If a customer asks to put the numbers in a contract or signed document, route the request to Adobe through the account team. Observed figures are for verbal context and slide-level talking points, not for SLA commitments.
 
 ### Reference case
-A regulated-industry customer asks for limits documentation and P95 data ahead of a customer meeting. Internal prep for leadership uses the same telemetry framed explicitly as observed production behavior, never as contractual SLA. The customer ultimately receives the published limits page and verbal positioning of the latency numbers without those numbers entering any signed document.
+A regulated-industry customer asks for limits documentation and P95 data ahead of a meeting. Preparation for that meeting uses the same figures framed explicitly as observed behavior, never as contractual SLA. The customer ultimately receives the published limits page and verbal positioning of the latency numbers without those numbers entering any signed document.
 
 ## 3. Customer asks how API rate limits compare to industry
 
@@ -86,7 +86,7 @@ Do not promise that legacy Workfront reports will eventually support Planning re
 ## 5. Customer wants a workspace built end-to-end
 
 ### Situation
-Customer (or internal AM) asks for help designing or building out a workspace, often vaguely ("help me set up Planning for our marketing org").
+A customer or account team asks for help designing or building out a workspace, often vaguely ("help me set up Planning for our marketing org").
 
 ### Recommended framing
 Ground the design in their actual operating model, not a generic template. Apply the workspace build playbook:

--- a/plugins/workfront/skills/wf-planning-solution-architect/references/limits-and-tiers.md
+++ b/plugins/workfront/skills/wf-planning-solution-architect/references/limits-and-tiers.md
@@ -69,12 +69,12 @@ Default response: the architecture is wrong, not the limit. See `customer-conver
 - Reference the documented prior conversations to establish accountability if there is escalation history.
 
 ### When a customer asks for performance numbers
-Workfront Planning does not publish a public P95 / SLA contract. Production telemetry exists internally and may be shared with leadership audiences as "observed production telemetry", subject to whatever approval your organization requires:
+Workfront Planning does not publish a public P95 / SLA contract. Where performance figures are available to you, present them as observed behavior, subject to whatever approval your organization requires:
 - Commonly used Planning APIs run in the low hundreds of milliseconds P95, server-side.
 - Read endpoints (record type and breadcrumb fetches) are the fastest; record fetch, workspace fetch, and record search are slower, with search the most variable.
-- Obtain current figures from the WFP engineering team before quoting anything specific. Do not quote numbers from this file or from memory.
+- Confirm current figures with Adobe before quoting anything specific. Do not quote numbers from this file or from memory.
 
-These are backend server-side response times, not browser-perceived page loads, and they are not contractual. Frame as telemetry, not SLA.
+These are backend server-side response times, not browser-perceived page loads, and they are not contractual. Frame as observed behavior, not SLA.
 
 ### When a customer asks about tier upgrade triggers
 Common triggers for moving from Select to Prime:
@@ -99,5 +99,5 @@ These are limits that customers commonly hit and that have known roadmap motion.
 ## Known escalation patterns
 
 - **500-connection cap on day-one go-live:** customers whose implementation partner built a solution that hits the 500-connection cap on day one of go-live, despite the limit being documented and the risk being known. Solution-architecture issue, not a limit issue. Reference framing: "If it were just a matter of asking to increase them, why would we have them in the first place?"
-- **Customer requests for P95 data ahead of meetings:** standard prep is to share the published limits page plus internal telemetry framed as observed production behavior, not as a contractual SLA.
+- **Customer requests for P95 data ahead of meetings:** lead with the published limits page, and present any performance figures as observed behavior rather than a contractual SLA.
 - **Enterprise customers in ongoing scale conversations:** apply the standard limit-vs-design reframe. Common in regulated industries (healthcare, financial services) where customers may be at the edge of one or more caps.

--- a/plugins/workfront/skills/wf-planning-solution-architect/references/limits-and-tiers.md
+++ b/plugins/workfront/skills/wf-planning-solution-architect/references/limits-and-tiers.md
@@ -1,6 +1,6 @@
 # Limits and tiers reference
 
-SA-ready reference for Workfront Planning object limits, organized by tier. Use this when a customer asks about capacity, when sizing a new deployment, or when an escalation hits a limit and a "raise it" request comes in.
+Practitioner reference for Workfront Planning object limits, organized by tier. Use this when a customer asks about capacity, when sizing a new deployment, or when an escalation hits a limit and a "raise it" request comes in.
 
 Source of truth: the Planning "Limitations overview" page on Adobe Experience League (find it with `node scripts/search.js limitations overview`, then fetch the `.md` URL). This file restates the limits in SA-conversation-ready form and adds tier context, framing language, and known sizing risks. Re-verify against the live page before quoting numbers in a customer commitment.
 
@@ -22,7 +22,7 @@ The two limits in the table above are the only ones that vary by tier. Confirm t
 - Workspaces per Workfront instance: unlimited (Adobe recommends against fragmentation).
 - Sections per workspace: 50.
 - Record types per workspace: 100 (includes record types from all sections and template-created ones).
-- Records per record type: 25,000. **This is the hard ceiling for any single record type, regardless of tier.** The roadmap target is 50,000 initially, not unlimited.
+- Records per record type: 25,000. **This is the hard ceiling for any single record type, regardless of tier.**
 - Hierarchies per workspace: 5.
 
 ### Record-type-level
@@ -66,7 +66,7 @@ Default response: the architecture is wrong, not the limit. See `customer-conver
 - Granting exceptions creates technical debt across the platform.
 - It delays the redesign that the customer needs.
 - Even a higher cap will be exhausted in 1 to 2 quarters at their projected growth rate.
-- Reference the documented prior conversations to establish accountability if there is escalation history.
+- If the risk was raised during design and not acted on, say so plainly; it is the strongest argument for redesigning now rather than raising the cap again.
 
 ### When a customer asks for performance numbers
 Workfront Planning does not publish a public P95 / SLA contract. Where performance figures are available to you, present them as observed behavior, subject to whatever approval your organization requires:
@@ -88,16 +88,16 @@ Common triggers for moving from Prime to Ultimate:
 
 The 25,000-per-record-type and 500-per-connection caps apply at all tiers. Tier upgrade does not solve those.
 
-## Roadmap-sensitive limits
+## Limits customers commonly hit
 
-These are limits that customers commonly hit and that have known roadmap motion. Confirm current state with the engineering team before quoting:
+Adobe documents these limits as subject to change, and does not publish targets for raising them. Do not speculate about future values; check the current published limits page for what applies today.
 
-- **25,000 records per record type:** roadmap target is 50,000. Frame to customers as "we are working on raising this; the realistic path is double the current cap, not unlimited."
-- **500 connections per record (multi-select, non-hierarchy):** no roadmap motion to raise this is committed; it is architecturally significant. Treat exception requests as design problems.
-- **200 RPM API rate:** no public roadmap motion; defensible for the product category.
+- **25,000 records per record type:** the hard ceiling for a single record type. Treat it as a sizing input when modelling, not as something to plan around raising.
+- **500 connections per record (multi-select, non-hierarchy):** architecturally significant. Treat exception requests as design problems.
+- **200 RPM API rate:** defensible for the product category; separate service accounts are the answer for bulk traffic.
 
-## Known escalation patterns
+## Common scaling problems
 
-- **500-connection cap on day-one go-live:** customers whose implementation partner built a solution that hits the 500-connection cap on day one of go-live, despite the limit being documented and the risk being known. Solution-architecture issue, not a limit issue. Reference framing: "If it were just a matter of asking to increase them, why would we have them in the first place?"
+- **500-connection cap reached at go-live:** hitting a documented cap on day one signals a modelling problem, not a capacity problem. A genuine capacity limit is reached after growth, not before real data exists. Useful framing: "If it were just a matter of asking to increase them, why would we have them in the first place?"
 - **Customer requests for P95 data ahead of meetings:** lead with the published limits page, and present any performance figures as observed behavior rather than a contractual SLA.
 - **Enterprise customers in ongoing scale conversations:** apply the standard limit-vs-design reframe. Common in regulated industries (healthcare, financial services) where customers may be at the edge of one or more caps.

--- a/plugins/workfront/skills/wf-planning-solution-architect/references/workspace-build-playbook.md
+++ b/plugins/workfront/skills/wf-planning-solution-architect/references/workspace-build-playbook.md
@@ -274,4 +274,4 @@ Convert ALL_CAPS enum values to lowercase readable text (ADMINISTRATOR becomes M
 - IMS userId vs Workfront userId mixup in integrations: Planning returns IMS IDs.
 - Bulk record operation partial success: always check the response for per-record errors.
 - 500-connection cap on multi-select non-hierarchy connections: the architecture is wrong, not the limit.
-- 4-level hierarchy ceiling: leave headroom if the roadmap may extend.
+- 4-level hierarchy ceiling: leave headroom if the customer's structure may deepen later.


### PR DESCRIPTION
Follow-up to #323. A full audit of the published skill for content that assumes an Adobe-internal reader or discloses non-public product information.

#323 reframed the skill's stated audience and removed specific telemetry figures, but left material that still only makes sense to an Adobe employee.

## 1. Performance guidance reframed
The guidance still assumed the reader has access to Adobe internal telemetry and internal escalation paths: "we do have internal production telemetry", "sharing P95 data with customer-facing colleagues", "may be shared with leadership audiences", "ask the WFP engineering team". Escalation routes now point at Adobe through the account team, which is a path an external practitioner can actually use.

Kept deliberately: Adobe publishes no P95 or SLA contract for Planning, observed numbers must not harden into commitments, and contractual requests route to Adobe.

## 2. Roadmap disclosures removed
A section titled "Roadmap-sensitive limits" stated a target of 50,000 records per record type and named which caps had "no roadmap motion committed". Adobe's [object limitations page](https://experienceleague.adobe.com/en/docs/workfront/using/adobe-workfront-planning/adobe-workfront-planning-general-information/limitations-overview) documents limits as subject to change and publishes no targets, so these were forward-looking statements about unreleased plans. Replaced with guidance to check the current published limits and not speculate.

Also removes the roadmap-status conversation script, which scripted language about committed delivery quarters and the discover-then-deliver cadence, and referenced the internal AM role. Sections in `customer-conversation-framings.md` renumbered accordingly.

## 3. Escalation history neutralised
Guidance no longer presumes access to "documented prior conversations" or states that exceptions have previously been granted, and the reference case no longer describes a specific customer engagement in identifying detail.

The architectural argument is unchanged and does not depend on any of it: hitting a documented cap at go-live is a modelling signal rather than a capacity signal, and the customer's own growth projection is the evidence.

## Testing
`npx skills-ref validate plugins/workfront/skills/wf-planning-solution-architect` passes. Verified no dangling references to the removed section and no gap in section numbering.

Net −36 / +18 lines.

🤖 This PR was prepared with AI assistance (Claude).