### PR TITLE
feat(stardust): 0.19.0 — Experience Workspace editability contract (EW1–EW10) + gate

### DIFF
--- a/plugins/stardust/.claude-plugin/plugin.json
+++ b/plugins/stardust/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stardust",
   "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-  "version": "0.18.5",
+  "version": "0.19.0",
   "author": {
     "name": "Adobe"
   },

--- a/plugins/stardust/CHANGELOG.md
+++ b/plugins/stardust/CHANGELOG.md
@@ -4,6 +4,54 @@ This file starts at 0.14.0. Prior versions (0.3.0 – 0.13.1) are documented in
 git history only (plus the branch-scoped notes in
 `CHANGELOG-redesign-adobecom.md` and `CHANGELOG-delivery-media-fidelity.md`).
 
+## 0.19.0 — Experience Workspace editability contract (EW1–EW10) + gate
+
+Every text an author wrote in a DA document must be inline-editable in
+Experience Workspace (da.live canvas, "quick-edit") once generated block JS
+has decorated the page — and the block must look the same while it is being
+edited. Field finding (rwe.com, 2026-09-03, two rounds: 3 blocks, then 17):
+over a 29-page covering sample only 841 of 1452 authored texts were
+editable; every template-slotted block was 0 %. The generated blocks were
+correct implementations of the skill's own guidance (value-slotting,
+`text(cell)`, clone-the-anchor) — the guidance was the bug. Mechanism
+verified against da.live `editor-utils.js`/`prose2aem.js` and da-nx
+`quick-edit.js`/`prose.js`; deploy improvement #123. Minor bump: new gate +
+new qa check.
+
+- **Deploy:** § Target runtime documents the workspace instrumentation
+  (`data-prose-index` on outermost editables, `decorate()` re-runs over it,
+  only surviving indices become editors). § 2b redefines template-slotted as
+  **node-slotting** and bans value-slotting. § 3 ships three edit-mode
+  foundation snippets (CTA repaint from `<strong>/<em>` marks under
+  `.prosemirror-editor`, card-as-link inner anchor, `:where()` wrapper
+  variants at equal specificity) + EW10 for section prose. § 5 Buttons,
+  #55, #62/#71, #70 and § Section heads rewritten to MOVE authored elements.
+  § 8 gets a move-based scaffold (`wrapNode`, `labelWrap`,
+  `stripInstrumentation`) and the named **Experience Workspace editability
+  contract (EW1–EW10)** with the gate command; Step-7 brief carries the
+  contract; Local QA + Checklist gain the EW gate, edit-mode simulation,
+  static review and pixel-parity lines; anti-patterns 18 (value-slotting)
+  and 19 (class on the authored element); References cite the da.live/da-nx
+  sources.
+- **Scripts:** new `deploy/scripts/ew-editability-probe.mjs` (URL and
+  `--content` harness modes, `--simulate-editor` drift report, `@ew-exempt`
+  JSDoc tags); `block-roundtrip.mjs --ew` (default on) fails dead
+  non-exempt texts and duplicated indices 🔴; `render-harness.mjs --ew
+  --simulate-editor` + hides `body > header`; `section-schema.mjs` emits
+  `editableTexts` per section; `content-inventory.mjs` exports the
+  outermost-editable classifier and `content-diff` reports an
+  `EDITABLE COUNT` advisory.
+- **qa:** new `editability` check (`editability/dead-text` error,
+  `editability/duplicated-index` warn, per-page summary; `--blocks-dir` /
+  `--ew-exempt` for exemptions).
+- **replica / rollout / reskin / migrate fidelity-tiers:** every block-authoring
+  handoff cites the contract and the EW gate (the brief skipped it on 27/27
+  blocks because it did not carry it).
+- **Evals:** new `ew-editability` (node-slotting, move-not-rebuild,
+  wrapper-descendant selectors, gate evidence, fidelity not traded).
+- **Ledger:** deploy `IMPROVEMENTS.md` #123; master `reference/learnings.md`
+  example entry.
+
 ## 0.18.5 — migration-flow routing: replica subsumes prepare-migration
 
 Routing-surface fix, no pipeline behaviour change. Field finding

--- a/plugins/stardust/evals/README.md
+++ b/plugins/stardust/evals/README.md
@@ -89,6 +89,7 @@ v2 evals without modification.
 | `intent-reasoning-style/`    | Master skill principle    | "Open and reasoned" — vague phrases get clarified, never silently mapped to commands. Pending direction persisted.          |
 | `replica-source-fidelity/`   | Entry point (`replica`)   | Mechanical preserve direction (no `direct`) + inconsistency register + clean re-authoring + the measured source-fidelity gate at both breakpoints + standard handoff. |
 | `reskin-content-fidelity/`   | Entry point (`reskin`)    | Donor via `--design-source` + content-model capture with scope guard + mapping-brief contract (≥80% mapped) + programmatic render + dual content/design-adoption gates. |
+| `ew-editability/`            | Entry point (`deploy`)    | Experience Workspace editability contract (EW1–EW10): node-slotting not value-slotting, authored elements moved into wrappers, wrapper-descendant selectors, `block-roundtrip --ew` + probe evidence, exemptions declared, fidelity not traded. |
 
 ## Coverage map
 

--- a/plugins/stardust/evals/ew-editability/criteria.json
+++ b/plugins/stardust/evals/ew-editability/criteria.json
@@ -1,0 +1,55 @@
+{
+  "criteria": [
+    {
+      "id": "node_slotting_no_value_slotting",
+      "weight": 20,
+      "description": "No block copies authored text into generated markup: no `textContent =`/`innerHTML =` assignments or template-literal interpolation whose source is an authored element; template-slotted blocks hold empty slot containers and MOVE the authored elements into them (Step 2b node-slotting)."
+    },
+    {
+      "id": "move_not_rebuild",
+      "weight": 15,
+      "description": "Every authored h1–h6/p/ul/ol/picture is placed with append()/prepend()/before(); no cloneNode+discard, no retagging, no .trim()/normalisation of displayed text; sibling walks capture nextElementSibling before append() (EW1)."
+    },
+    {
+      "id": "wrapper_descendant_selectors",
+      "weight": 15,
+      "description": "Layout classes live on generated wrappers; block CSS styles authored elements as wrapper descendants (`.headline :is(h2, h3)`), with no class on the authored element and no child combinator or positional pseudo-class between a wrapper class and an authored element (EW2/EW10)."
+    },
+    {
+      "id": "cta_paragraph_moves",
+      "weight": 10,
+      "description": "CTAs move as their paragraph (`a.closest('p') || a`); card-as-link blocks unwrap the inner anchor in the live DOM after reading its href; no manufactured button anchors (EW3/EW6)."
+    },
+    {
+      "id": "clones_stripped_interactive_hosts",
+      "weight": 10,
+      "description": "Presentational clones (loop slides, marquee copies) pass through stripInstrumentation(); no authored text is hosted inside a <button>/<summary> (EW4/EW7)."
+    },
+    {
+      "id": "foundation_edit_mode_snippets",
+      "weight": 5,
+      "description": "styles/styles.css ships the `.prosemirror-editor` CTA repaint from <strong>/<em> marks (on-media variants last), `a .prosemirror-editor a:any-link { color: inherit; text-decoration: none }`, and `:where()` wrapper variants at equal specificity for every styled-text-link utility introduced (Step 3)."
+    },
+    {
+      "id": "ew_gate_run_and_green",
+      "weight": 15,
+      "description": "block-roundtrip runs with --ew on (per block and whole page) and ew-editability-probe.mjs --content runs before done: evidence on disk/in the log shows dead = 0 outside declared @ew-exempt and duplicated = 0; --no-ew is not used to pass."
+    },
+    {
+      "id": "edit_mode_simulation_clean",
+      "weight": 5,
+      "description": "ew-editability-probe.mjs --simulate-editor reports no font/colour/line-height drift per text and block height Δ ≤ 2 px."
+    },
+    {
+      "id": "exemptions_declared",
+      "weight": 5,
+      "description": "Any dead text is declared with an @ew-exempt JSDoc tag in one of the three categories (metadata / derived / index-driven) and recorded in the conversion log; nothing is dropped silently."
+    },
+    {
+      "id": "fidelity_not_traded",
+      "weight": 5,
+      "description": "The role round-trip still closes (0 structural 🔴) and the published render is unchanged — editability was not achieved by rendering less."
+    }
+  ],
+  "total": 100
+}

--- a/plugins/stardust/evals/ew-editability/task.md
+++ b/plugins/stardust/evals/ew-editability/task.md
@@ -1,0 +1,65 @@
+# Eval: deploy — every generated text is editable in Experience Workspace
+
+## Setup
+
+A project with a renderable static prototype fixture (one page: hero with
+eyebrow + `<h1>` + lede + two CTAs; a 3-up card grid whose cards are links;
+a carousel/marquee band with looped slides; an accordion; a section head
+authored as default content above a repeating block) and a vanilla
+aem-boilerplate checkout (`styles/`, `blocks/`, `scripts/`). Impeccable
+installed. Node + Playwright available. No DA token is required — the gates
+run in harness mode.
+
+## User prompt
+
+"$stardust deploy <prototype>.html — convert this page to EDS blocks and
+content, ready to push to DA"
+
+## Expected behavior
+
+The `stardust:deploy` skill is invoked. It:
+
+1. Chooses a decode tier per section (Step 2b) and, for the template-slotted
+   ones, writes **node-slotting** decode: the template holds empty slot
+   containers and the authored elements are MOVED into them. No block copies
+   authored text into a template (`textContent =`, `innerHTML =`, template
+   literal interpolation of authored text).
+2. Writes every block against the **Experience Workspace editability
+   contract (EW1–EW10)**: authored `h*/p/ul/ol/picture` are moved with
+   `append()`; wrappers carry the layout classes; block CSS styles authored
+   elements as wrapper descendants (`.headline :is(h1, h2, h3)`), never via a
+   class on the authored element and never through `>`/`:first-child`; CTA
+   paragraphs move whole (`a.closest('p')`); carousel/marquee clones are
+   passed through `stripInstrumentation()`; the accordion title lives in a
+   `div`, not inside the `<button>`; the reabsorbed section head MOVES the
+   default-content wrapper's children.
+3. Ships the three edit-mode foundation snippets in `styles/styles.css`
+   (CTA repaint from `<strong>/<em>` marks under `.prosemirror-editor`,
+   `a .prosemirror-editor a:any-link` inheritance, `:where()` wrapper
+   variants for every styled-text-link utility it introduces).
+4. Runs `block-roundtrip.mjs` per block with `--ew` on (default) and the
+   whole-page run before declaring done: **0 dead texts outside declared
+   `@ew-exempt` tags, 0 duplicated indices**, alongside 0 structural 🔴.
+5. Runs `ew-editability-probe.mjs --content … --simulate-editor`: 0
+   font/colour/line-height drift per text, block height Δ ≤ 2 px.
+6. Any text it cannot make editable is declared in the block JSDoc with an
+   `@ew-exempt` tag in one of the three categories (metadata / derived /
+   index-driven) and listed in the conversion log — never dropped silently.
+7. Fidelity is not traded for editability: the role round-trip still closes
+   (0 structural 🔴) and, where a previous version of a block exists, the
+   published render is pixel-identical at 1440 (`body > header` hidden).
+
+## Failure modes this eval pins against
+
+- Value-slotting (copying authored text into template nodes) in any block —
+  pixel-perfect and 100 % uneditable.
+- Cloning the CTA anchor or `childNodes` instead of moving the paragraph.
+- A layout class on the authored element (`h3.headline`, `ul.items`,
+  `a.link-download`) or a `>`/`:nth-child` path to it.
+- Carousel/marquee clones keeping `data-prose-index` (editor attaches to a
+  hidden copy).
+- Authored text inside a `<button>`/`<summary>`.
+- Declaring the page done with `--no-ew`, without the probe, or with dead
+  texts that are not declared `@ew-exempt`.
+- Passing the EW gate by rendering less (a dropped CTA/heading also removes
+  its dead text — the role round-trip must still be 0 🔴).

--- a/plugins/stardust/skills/deploy/IMPROVEMENTS.md
+++ b/plugins/stardust/skills/deploy/IMPROVEMENTS.md
@@ -1086,3 +1086,61 @@ broken-image probe both passed.
 `clientWidth > 0` per visible loaded image; qa gains the `zero-size-image`
 check (in-layout via `getClientRects()` so display:none images don't
 false-flag); reskin's Image-paint gate documents the same blind spot.
+
+### #123 🔴 Every generated block was uneditable in Experience Workspace — value-slotting, `text(cell)`, clone-the-anchor were the skill's own guidance ✅
+**Where:** rwe.com migration (2026-09-03), `da.live/canvas#/…/index`. Clicking
+hero or spotlight text did nothing; `columns` body paragraphs edited fine but
+its CTA did not. Probe over a 29-page covering sample: **841 / 1452** authored
+texts editable — default content 446/446, the 20 stardust blocks 395/970.
+Census over 27 blocks: 25 call `textContent`, 13 assign `innerHTML`, 16 clone,
+23 `replaceChildren`. Two external analyses had the symptom right and the
+mechanism wrong.
+**Mechanism (verified in da.live `editor-utils.js`/`prose2aem.js` and da-nx
+`quick-edit.js`/`prose.js`):** the canvas stamps `data-prose-index` on every
+OUTERMOST `h1–h6/p/ol/ul/pre/blockquote`, swaps the instrumented HTML into
+`document.body`, re-runs the page's own `loadPage()` (so `decorate()` runs over
+it), then `querySelector('[data-prose-index="N"]').replaceWith(editor)` per
+index. Only `data-block-index` is repaired afterwards. A text is editable iff
+exactly ONE element still carries its index; zero = dead (rebuilt from
+`textContent`/`innerHTML`, synthesized `<p>`, retagged); several = editor on the
+FIRST in DOM order (hidden carousel clone). The editor renders the DOC node —
+same tag, no classes, no spans, inline marks only — inside TWO wrapper divs
+(`div.prosemirror-editor > div.ProseMirror > <tag>`), and cursor math uses
+`textContent` length. In the workspace every block cell contains a `<p>`
+(published pipeline unwraps it; runtime `wrapTextNodes` re-wraps).
+**The clone corollary:** `cloneNode(true)` is NOT what kills editing — the
+clone keeps the attribute (that is exactly why clone-based `columns` worked
+while `textContent`-based `hero` did not). Cloning is still wrong (duplicate
+indices, stale identity); the fix is MOVE, not "avoid clone".
+**The specificity trap:** a wrapper variant written as `.affordance-wrap a`
+out-ranks `a:any-link` and silently flipped link colour navy → teal;
+`.affordance-wrap :where(a)` keeps `.affordance`'s specificity.
+**The two-wrapper selector rule:** `h3.headline {…}` → `.headline :is(h2, h3, h4)
+{…}` (same specificity, still matches the editor's re-rendered `<h3>`); no
+child combinators or positional pseudo-classes on the path to an authored
+element; exclude a moved CTA `<p>` from a lede rule with
+`p:where(:not(.affordance p))`.
+**Root cause in the skill:** § 2b template-slotted tier slotted authored
+VALUES by role; § 8 scaffold taught `text(cell)` + "build the prototype's DOM";
+§ 5 said "block JS just clones them as-is"; #55 cloned `childNodes` into a new
+heading; #62/#71 synthesized `<p>`s; #70 edited the authored text node;
+§ Section heads rebuilt the `.section-head`; no gate measured editability.
+**Fix applied:** § Target runtime documents the instrumentation; § 2b redefines
+template-slotted as NODE-slotting and bans value-slotting; § 3 ships three
+edit-mode foundation snippets (CTA repaint from `<strong>/<em>` marks under
+`.prosemirror-editor`, card-as-link inner anchor, `:where()` wrapper variants)
++ EW10; § 5/#55/#62/#70/§ Section heads rewritten to MOVE; § 8 gets a
+move-based scaffold (`wrapNode`, `labelWrap`, `stripInstrumentation`) and the
+named **Experience Workspace editability contract (EW1–EW10)**; new
+`scripts/ew-editability-probe.mjs` (URL + `--content` harness modes,
+`--simulate-editor` drift, `@ew-exempt` JSDoc tags); `block-roundtrip --ew`
+(default on) fails dead/duplicated texts 🔴; `render-harness --ew
+--simulate-editor`; `section-schema` emits `editableTexts`;
+`content-inventory` exports the outermost-editable classifier for
+`content-diff`'s advisory; qa gains the `editability` check; the Step-7 brief
+carries the contract (it skipped 27/27 blocks because the brief did not);
+replica/rollout/reskin/fidelity-tiers cite it; eval `ew-editability`.
+**Result on rwe (2 rounds, 3 + 17 blocks):** 841 → **1416 / 1452** editable;
+the 36 left are declared exemptions (index-driven listings, derived dates, a
+breadcrumb needing an ENCODE `<ul>`); 27 block instances pixel-identical at
+1440; 0 edit-mode drift except the hero's per-line span gap.

--- a/plugins/stardust/skills/deploy/SKILL.md
+++ b/plugins/stardust/skills/deploy/SKILL.md
@@ -32,6 +32,7 @@ The stock boilerplate provides everything the conversion needs; the runtime is n
 - **Fonts:** `@font-face` lives in `styles/fonts.css`, loaded by `loadFonts()` (eagerly on desktop / repeat views via a `fonts-loaded` session flag, always in `loadLazy`); `styles.css` carries the metric-matched fallback faces. See Step 4.
 - **Auto-blocking hook:** `buildAutoBlocks()` in `scripts.js` is project-owned — the home for D1 auto-blocks (video/embed URLs, fragment links).
 - **Lint:** generated blocks and styles lint under the project's own config; there is no vendored runtime to exempt. Do not create an `.eslintignore` for runtime files.
+- **Experience Workspace instrumentation (da.live canvas "quick-edit" — the inline editor your blocks must survive).** The workspace stamps `data-prose-index` on every OUTERMOST `h1–h6 / p / ol / ul / pre / blockquote` of the authored document, `data-image-index` on every `img` and `data-block-index` on every block div, swaps that instrumented HTML into `document.body`, and re-runs the page's own `loadPage()` — so every block's `decorate()` runs over the instrumented markup. In the workspace **every block cell contains a `<p>`** (prose2aem copies cell innerHTML; the published pipeline unwraps single-paragraph cells to bare text and the runtime's `wrapTextNodes` re-wraps them, so `decorate()` sees a `<p>` in both worlds). Afterwards ONLY elements that still carry their `data-prose-index` become editors (`querySelector('[data-prose-index="N"]').replaceWith(editor)`); nothing repairs a lost index. A text your block rebuilt from `textContent`/`innerHTML`, synthesized, or retagged is silently uneditable. Contract + gate: Step 8 § Experience Workspace editability contract (EW1–EW10).
 
 **The boilerplate itself drifts** (e.g. current `main` emits `p.button-wrapper`; older clones emit `p.button-container` and buttonize bare links). Never assume — the Runtime-detection probe below records what THIS target actually does, from its own `scripts.js`/`aem.js`.
 
@@ -145,7 +146,7 @@ Structural rules (the lint's 🔴 tier):
 A head-bearing block (one with a section eyebrow/heading/lede above repeating units) should NOT carry that head as block rows. Author the head as **default content** in the section, before the block; the block table holds only the repeating units. Then the block **reabsorbs** the head so the decorated DOM — and every pixel — is identical to the old in-table form:
 
 - **First choice — style the head IN PLACE, no JS at all.** The runtime gives the section a `.<name>-container` class, so the head is directly addressable: `.cards-container .default-content-wrapper { … }`. When the prototype's head sits visually OUTSIDE the block's grid (the common case), this is the whole implementation — no reabsorption needed.
-- **Reabsorb only when the head must live INSIDE the block's layout container** (e.g. the head is a grid cell of the same grid as the units). On `decorate(block)`, read the section's leading default-content wrapper, build the SAME `.section-head` the block used to build from its first rows, and **remove the wrapper**. The head wrapper is a sibling of the block's `.<name>-wrapper`, not of the block itself: use `block.parentElement.previousElementSibling`, match `.default-content-wrapper` (`block.previousElementSibling` alone is `null` — the block is nested in its wrapper).
+- **Reabsorb only when the head must live INSIDE the block's layout container** (e.g. the head is a grid cell of the same grid as the units). On `decorate(block)`, read the section's leading default-content wrapper, build the SAME `.section-head` layout the block used to build from its first rows — **MOVING the wrapper's children into it** (`head.append(...wrapper.childNodes)`; they are already inline-editable as default content and a rebuild from `textContent` kills that — EW8) — and **remove the emptied wrapper**. The head wrapper is a sibling of the block's `.<name>-wrapper`, not of the block itself: use `block.parentElement.previousElementSibling`, match `.default-content-wrapper` (`block.previousElementSibling` alone is `null` — the block is nested in its wrapper).
 - Keep the old in-table head (leading non-unit rows) as a **defensive decode fallback**.
 - **Verify zero change:** diff the *decorated* block `outerHTML` (ids/`media_<hash>` normalised) old-vs-new — it must be byte-identical, with 0 default-content wrappers left after decorate.
 
@@ -268,10 +269,10 @@ Cross-check `repeats[].uniform` against the #90 fingerprint: `uniform: false` me
 
 **Pick the decode tier per section — template-slotted vs reconstructive (#95).** Reconstruction is where decode bugs live, so only reconstruct where authors need the structural freedom:
 
-- **Template-slotted (fidelity by construction).** For fixed-composition sections whose structure never changes at authoring time (a bespoke hero, a cinematic band, a stat/countdown composition): `decorate()` holds the prototype section's inner DOM verbatim as a template literal and SLOTS the authored values into it by role — eyebrow text into the template's eyebrow node, heading into the `<h1>`, each CTA's text+href, the authored `<picture>` into the media slot. The decorated DOM ships byte-equal to the prototype, so the segmentation-bug class (#48/#52/#56/#76) cannot occur. Editors still own every line of copy — the content page is unchanged and server-rendered (this is NOT client-injected chrome; #86 doesn't bite). Structure edits need a developer: the right trade for sections whose structure nobody edits.
+- **Template-slotted = NODE-slotting (fidelity by construction, editability by construction).** For fixed-composition sections whose structure never changes at authoring time (a bespoke hero, a cinematic band, a stat/countdown composition): `decorate()` holds the prototype section's inner DOM as a template literal whose text positions are **empty slot containers** (`<div class="headline"></div>`, `<div class="eyebrow"></div>`, `<div class="actions"></div>`, `<div class="media"></div>`), and MOVES the authored elements into them by role — the authored `<h1>` into `.headline`, the eyebrow `<p>` into `.eyebrow`, each CTA's `<p>` into `.actions`, the authored `<picture>` into `.media`. The wrapper carries the layout class; the authored element keeps its tag, its attributes and its identity. The decorated DOM ships structurally equal to the prototype, so the segmentation-bug class (#48/#52/#56/#76) cannot occur, AND every authored text stays inline-editable in Experience Workspace (EW1/EW2). **Value-slotting — copying authored TEXT into template nodes (`slot.textContent = cell.textContent`, `innerHTML` templates with `${text}` interpolation) — is banned:** it renders pixel-perfect and is 100 % uneditable in the workspace (every template-slotted block on a real site failed this way; anti-pattern 18). Editors still own every line of copy — the content page is unchanged and server-rendered (this is NOT client-injected chrome; #86 doesn't bite). Structure edits need a developer: the right trade for sections whose structure nobody edits.
 - **Reconstructive (authorable structure).** For repeating/data sections where authors add/remove units (cards, FAQs, listings, menus): classify + segment defensively per #48/#50/#52 — and let the schema + round-trip gate carry the burden of proof.
 
-Record the tier per block in the conversion log. Default: template-slotted for bespoke one-offs, reconstructive for repeat groups.
+Record the tier per block in the conversion log. Default: template-slotted for bespoke one-offs, reconstructive for repeat groups. **Both tiers are subject to the Experience Workspace editability contract (Step 8, EW1–EW10); the gate is `block-roundtrip --ew` (default on) / `ew-editability-probe.mjs`** — a block that passes the role round-trip but leaves a dead text is not done.
 
 **Record two more things per section in the schema (D1/D11 + forward-compat):** sections triaged to default content in Step 2 carry `"defaultContent": true` (the encode side emits prose, not a table — the lint flags a block wrapping bare default content); and every block's authored shape must be expressible as one of the three component-model shapes — **simple** (one property per row), **key-value** (config), or **container** (own rows + one row per child) — so a later Universal Editor adoption needs no content migration (see aem.live "component model definitions"). A shape that fits none of the three is a signal the model is wrong, not that a fourth shape is needed.
 
@@ -286,6 +287,22 @@ Rebrand `styles/styles.css` — replace the boilerplate's DEMO layer (roboto tok
 - **One `style` value per section — multi-value `style` is unreliable (#120).** `style: a, b` (comma- or space-separated) delivered only the FIRST class on a real stack. When a section needs a second styling axis, anchor it to content instead: `main .section.a:has(img[alt^="…"])` — content-anchored `:has()` selectors survive the metadata pipeline; second style tokens may not.
 - **Empty styled sections must respect the section-status hiding (#121).** A `style`-carrying section that is otherwise empty needs `display: block !important` to defeat the boilerplate's `:empty { display: none }` — but an unscoped override ALSO defeats the runtime's PRE-LOAD hiding (`data-section-status` + inline `display:none`, see the scaffold rule above), so the section paints before the rest of the page and produces a massive layout shift (measured 0.75 CLS). Always scope the override: `main .section.x[data-section-status='loaded'] { display: block !important }`.
 - A global button system (see next section). This is the one place per-block CSS does NOT own its paint — buttons are site-wide and convention-driven.
+- **Experience Workspace edit-mode foundation (EW3/EW6/EW10 — Step 8 § contract).** Three snippets ship in `styles.css`; all are scoped on `.prosemirror-editor`, which exists ONLY inside the da.live inline editor, so they cost nothing on published pages:
+  - **(a) Edit-mode CTA repaint.** `decorateButtons()` put `.button.primary/.secondary` on authored anchors BEFORE `decorate()`; the editor re-renders the CTA paragraph from its authored `<strong>`/`<em>` marks with NO classes, so the button look collapses the moment an author clicks. Repaint it from the marks with the project's own button declarations (`strong` = primary paint, `em` = secondary paint):
+    ```css
+    /* Experience Workspace edit mode: repaint CTAs from their authored marks */
+    .prosemirror-editor p > :is(strong, em) > a:any-link,
+    .prosemirror-editor p > a:any-link:has(> :is(strong, em):only-child) { /* the project's a.button declarations */ }
+    .prosemirror-editor p > a:any-link > :is(strong, em) { font-weight: inherit; font-style: inherit; }
+    .prosemirror-editor p > strong > a:any-link,
+    .prosemirror-editor p > a:any-link:has(> strong:only-child) { /* a.button.primary paint */ }
+    .prosemirror-editor p > em > a:any-link,
+    .prosemirror-editor p > a:any-link:has(> em:only-child) { /* a.button.secondary paint */ }
+    ```
+    On-media/on-dark variants of this repaint go **LAST in the file** (`main :is(.on-media, .banner, .hero .gradient) .prosemirror-editor p > em > a:any-link { color: #fff }`) — nothing may follow them.
+  - **(b) Card-as-link inner anchor.** A CTA paragraph moved into a card `<a>` (EW6) re-renders its inner link while editing; it must read like the card text: `a .prosemirror-editor a:any-link { color: inherit; text-decoration: none; }`.
+  - **(c) Styled-text-link utilities exist as WRAPPER variants at EQUAL specificity.** Any utility a block applies to an authored link or list (`.affordance`, `.eyebrow`, `.meta`, `.link-download`) dies in edit mode (the editor drops classes on authored elements), so each also exists as a wrapper-descendant variant written with `:where()` so the cascade does not move: `.affordance, .affordance-wrap :where(a) { … }`, `.affordance::after, .affordance-wrap :where(a)::after { … }`. A plain `.affordance-wrap a` out-ranks `a:any-link` and silently flips the link colour (navy → teal on a real site); `:where()` keeps it at `.affordance`'s specificity.
+  - **(EW10) Section prose rules follow the same selector rules.** The editor inserts TWO wrapper divs above an authored element (`div.prosemirror-editor > div.ProseMirror > <tag>`), so section styles on default content written as `main .section.x .default-content-wrapper > p:first-child` or `p:has(picture) + p` stop matching while editing. Use descendant selectors and no positional pseudo-classes on prose elements (`main .section.x .default-content-wrapper p`).
 - **Reserve the header's real height — or the late chrome load shifts the first section → CLS (#81).** The `header` block loads in `loadLazy`, AFTER first paint. In the common layout where the header sits in flow ABOVE the first section (full-bleed hero *below* the nav), the hero would render at `y=0`, then jump DOWN by the header's height when the nav lands — a large layout shift the browser attributes to the hero block (a real page measured **CLS 0.143, ~0.13 of it the hero**; metric-matched fonts do NOT fix it because the cause is the header box appearing, not a font swap). The boilerplate reserves this natively — `header { height: var(--nav-height) }` plus `header .header { visibility: hidden }` until `[data-block-status="loaded"]` — so the job is to make the reservation MATCH your chrome: set `--nav-height` (responsive, per breakpoint) to the prototype header's real rendered height, and give the bare `<header>` the chrome's own `background` so any reserve-vs-actual delta is invisible:
   ```css
   :root { --nav-height: 98px; }                                       /* desktop nav+banner height */
@@ -464,7 +481,7 @@ Never substitute classifications (don't match a serif brand to Arial; don't matc
 
 ### 5. Lean on EDS button conventions — DO NOT manufacture button anchors in block JS
 
-The boilerplate's `decorateButtons()` (in `scripts/scripts.js`) applies button classes when authors wrap a link in inline emphasis (D6). It runs in `decorateMain()`, BEFORE any block's `decorate()` — so by the time block JS sees a cell, its anchors already carry the button classes; block JS just clones them as-is.
+The boilerplate's `decorateButtons()` (in `scripts/scripts.js`) applies button classes when authors wrap a link in inline emphasis (D6). It runs in `decorateMain()`, BEFORE any block's `decorate()` — so by the time block JS sees a cell, its anchors already carry the button classes. Block JS **MOVES the CTA's paragraph** — `actions.append(a.closest('p') || a)` — never clones it: the index the workspace's inline editor keys on sits on the `<p>`, not the `<a>` (EW3), and a `cloneNode`/childNodes copy leaves the authored paragraph behind, dead. The `.button.*` classes die while editing; the foundation's edit-mode repaint (Step 3 (a)) covers that.
 
 **Author markup → auto-applied class (current `adobe/aem-boilerplate` main — confirm per target in `runtime-contract.json`, older clones differ):**
 
@@ -514,7 +531,7 @@ p.button-wrapper { display: inline-flex; flex-wrap: wrap; gap: 16px; align-items
 
 **Surface-aware variants: scope to the BLOCK class, not just the section (#41).** When a button/link/text treatment differs on dark vs light surfaces, the prototype's dark-surface cue (e.g. `.hero`, `.cta-dark`) becomes a **block class** after conversion — a `<div class="hero block">` nested inside the `<div class="section">`. So an override written as `main .section.hero a.button.secondary` never matches (the `.hero` is one level below `.section`), and the on-dark CTA silently renders dark-on-dark. Scope on-dark overrides to BOTH: `main .section.dark a.button.secondary, main .hero a.button.secondary { … }`. QA any block on a dark background for secondary/ghost-CTA contrast (light outline + light text) — the button "exists" in metrics, so only contrast/eyeball catches this.
 
-**Block JS pattern — just clone the cell:**
+**Block JS pattern — MOVE the CTA paragraphs (EW3):**
 
 ```js
 // Get the cell that holds the CTAs
@@ -522,10 +539,14 @@ const ctaCell = rows[N]?.firstElementChild;
 if (ctaCell && ctaCell.querySelector('a')) {
   const actions = document.createElement('div');
   actions.className = 'actions';
-  [...ctaCell.childNodes].forEach((n) => actions.append(n.cloneNode(true)));
+  // the workspace's editor index is on the <p>, so move the paragraph, not the anchor;
+  // capture the list BEFORE moving (append() ends a live sibling walk — EW1)
+  [...ctaCell.querySelectorAll('a')].forEach((a) => actions.append(a.closest('p') || a));
   container.append(actions);
 }
 ```
+
+Never `cloneNode(true)` the anchor or copy `childNodes` — the clone renders identically and is dead in Experience Workspace (the authored `<p>` carrying `data-prose-index` was discarded). When the block itself needs a variant class on the CTA (#25 multi-variant systems), put it on the `.actions` wrapper and style `.actions.ghost a`, not on the authored anchor.
 
 DO NOT manufacture anchors with `cta.className = 'btn-loud'` or inject custom SVG arrows. The global `::after` arrow + the convention's class system handle 95% of cases.
 
@@ -598,7 +619,9 @@ The brief template:
 >
 > **David's Model (the authored-structure contract — `davids-model.md`)**: a prose section with no repeating units and no bespoke structure is DEFAULT CONTENT, not a block (D1 — the Step-2 triage in the conversion log says which of your sections these are); no nested block tables (D2); blocks stay ≤4 columns (D10); if your section matches a Block Collection pattern the conversion log names, follow that block's authoring shape (D11); no code visible as text in cells (D15). Your pages must pass `node skills/deploy/scripts/davids-model-lint.mjs content/<page>.html` with 0 🔴.
 >
-> **Buttons**: do NOT manufacture button anchors. Author CTAs paragraph-wrapped as `<strong><a>` (primary) or `<em><a>` (secondary) in the content page — `decorateButtons()` classes them (`a.button.primary`/`.secondary`) BEFORE your `decorate()` runs; in block JS, clone the cell's child nodes into a `.actions` wrapper. Block CSS only overrides global button styles when something is genuinely different (e.g. larger size). Text links with flourish (wavelength underline) are NOT buttons — leave as plain `<a>` and style per-block.
+> **Buttons**: do NOT manufacture button anchors. Author CTAs paragraph-wrapped as `<strong><a>` (primary) or `<em><a>` (secondary) in the content page — `decorateButtons()` classes them (`a.button.primary`/`.secondary`) BEFORE your `decorate()` runs; in block JS, MOVE the CTA paragraph into a `.actions` wrapper (`actions.append(a.closest('p') || a)`) — never clone it (EW3). Block CSS only overrides global button styles when something is genuinely different (e.g. larger size). Text links with flourish (wavelength underline) are NOT buttons — leave as plain `<a>` and style per-block.
+>
+> **Experience Workspace editability contract (Step 8, EW1–EW10) — every block you write obeys it and passes the EW gate before it is done.** MOVE authored `h1–h6/p/ul/ol/picture` into generated wrappers (`wrap.append(heading)`); never rebuild from `textContent`/`innerHTML`, never `cloneNode` + discard, never retag, never `.trim()` displayed text (EW1). Wrappers carry the layout classes; style the authored element through the wrapper with DESCENDANT selectors (`.headline :is(h2, h3)`), never a class on the authored element and never `>`/`:first-child`/`:nth-child` on the path to it (EW2). CTAs move as their `<p>` (EW3). Presentational clones (loop slides, marquee copies) get `stripInstrumentation()` (EW4). Text you cannot make editable is declared with an `@ew-exempt` JSDoc tag, never dropped silently (EW5). A `<button>`/`<summary>` cannot host the editor (EW7). `block-roundtrip` runs with `--ew` by default: a dead non-exempt text or a duplicated index is a 🔴.
 >
 > **EDS block convention**: each block at `blocks/<name>/<name>.{js,css}`. JS exports `default async function decorate(block)`. Block input is `<div class="block-name"><div>row<div>cell</div></div>…</div>` (the runtime adds `.block` + `data-block-name` and nests it in `.<name>-wrapper` before your JS runs). CSS scoped under `.block-name`. Inline SVG markup per-block (no shared utility). Honor `prefers-reduced-motion`.
 >
@@ -626,25 +649,102 @@ Agents do not need to coordinate on shared blocks — the brief tells them which
  *   6..N: card rows — cells: num | label | description
  */
 
-function text(cell) { return cell ? cell.textContent.trim() : ''; }
-function pic(cell)  { return cell ? cell.querySelector('picture, img') : null; }
+// ── Experience Workspace helpers (EW1–EW4) — copy into every block, no shared import ──
+// Wrap an AUTHORED element in a generated wrapper that carries the layout class.
+// The element moves (keeps its tag, attributes and data-prose-index); never copy it.
+function wrapNode(node, className) {
+  const w = document.createElement('div');
+  w.className = className;
+  w.append(node);
+  return w;
+}
+// CTA label: MOVE the authored <p> (the editor index is on the paragraph) and,
+// for card-as-link layouts (EW6), unwrap the inner anchor after reading its href.
+function labelWrap(link, className, { unwrap = false } = {}) {
+  const w = document.createElement('div');
+  w.className = className;
+  const par = link.closest('p');
+  w.append(par || link);
+  if (unwrap && par) link.replaceWith(...link.childNodes);
+  return w;
+}
+// Presentational clones (loop slides, marquee duplicates) must not keep the
+// editor's indices — one element per index, and it must be the visible one (EW4).
+function stripInstrumentation(el) {
+  el.querySelectorAll('[data-prose-index], [data-image-index]').forEach((n) => {
+    n.removeAttribute('data-prose-index');
+    n.removeAttribute('data-image-index');
+  });
+  el.removeAttribute('data-prose-index');
+  return el;
+}
+// Read-only classification helper — use for DECISIONS (is this the eyebrow?),
+// never to produce displayed text (EW1).
+const text = (el) => (el ? el.textContent.trim() : '');
+const pic = (cell) => (cell ? cell.querySelector('picture, img') : null);
 
 export default async function decorate(block) {
   const rows = [...block.children];
   if (!rows.length) return;
 
-  // 1. Read content by QUERYING, not by hard row index, for lead/hero blocks (#42):
-  //    const h = block.querySelector('h1, h2');           // the heading
+  // 1. QUERY content and CAPTURE traversal starts before moving anything (#42, EW1):
+  //    const heading = block.querySelector('h1, h2, h3');
   //    const ps = [...block.querySelectorAll('p')];
-  //    const lede = ps.find((p) => !p.querySelector('a')); // first link-free <p>
-  //    const ctaP = ps.find((p) => p.querySelector('a'));  // link-bearing <p>
-  //    const pic = block.querySelector('picture, img');
-  // 2. Build the prototype's DOM (with prototype-style class names)
-  // 3. For CTA rows, clone the cell's child nodes into a .actions wrapper —
-  //    do NOT manufacture button anchors with custom classes.
-  // 4. block.replaceChildren(...newMarkup);
+  //    const lede = ps.find((p) => !p.querySelector('a, picture, img'));
+  //    const ctas = ps.filter((p) => p.querySelector('a'));
+  //    const media = block.querySelector('picture, img');
+  //    const start = heading ? heading.nextElementSibling : null; // capture BEFORE append()
+  // 2. CREATE wrappers that carry the prototype's layout classes:
+  //    const box = document.createElement('div'); box.className = 'stage-box';
+  // 3. MOVE the authored nodes into them — never textContent/innerHTML/cloneNode/retag:
+  //    if (media) box.append(wrapNode(media, 'media'));
+  //    if (heading) box.append(wrapNode(heading, 'headline'));   // CSS: .headline :is(h1, h2, h3)
+  //    if (lede) box.append(wrapNode(lede, 'lede'));
+  //    if (ctas.length) { const a = document.createElement('div'); a.className = 'actions'; a.append(...ctas); box.append(a); }
+  //    Sibling walks: `const next = node.nextElementSibling; wrapper.append(node); node = next;`
+  // 4. block.replaceChildren(box); — the emptied rows go; the authored nodes already moved.
 }
 ```
+
+#### Experience Workspace editability contract (EW1–EW10)
+
+The hard property of stardust output: **any text an author wrote in a DA document is inline-editable in Experience Workspace (da.live canvas, "quick-edit") once the page is decorated by generated block JS — and the block looks the same while it is being edited.** Mechanism: § Target runtime → *Experience Workspace instrumentation*. The generated blocks were correct implementations of the old guidance (value-slotting, `text(cell)`, clone-the-anchor); the guidance was the bug — a 29-page sample measured 841 of 1452 authored texts editable before, 1416 after, with 0 px visual change and every remaining one a declared exemption.
+
+**EW1 — Move authored elements; never rebuild them.** Every authored `h1–h6 / p / ul / ol / pre / blockquote / picture / img` is slotted into the generated layout with `append()`/`prepend()`/`before()`. Never re-create it from `textContent`/`innerHTML`, never `cloneNode` + discard, never retag (an authored `<h2>` stays an `<h2>`; the ENCODE side authors the tag the design needs), never `.trim()`/normalise displayed text (the editor's cursor math uses `textContent` length). Discarding the emptied rows afterwards (`block.replaceChildren(...)`) is fine — the nodes have already moved. When you walk siblings while moving them, capture `nextElementSibling` **before** `append()` — moving a node ends the walk otherwise (a real block dropped every subsidiary link silently).
+
+**EW2 — Wrappers carry layout classes; style the authored element through the wrapper with descendant selectors.** The editor swap re-renders the same tag *without classes or spans* and inserts **two wrapper divs** (`div.prosemirror-editor > div.ProseMirror > <tag>`), so:
+- rewrite `h3.headline { … }` as `.headline :is(h2, h3, h4) { … }` — same specificity, same cascade (the element keeps its global heading type and margins), and it still matches the editor's `<h3>`;
+- never use child combinators or positional pseudo-classes on the path to an authored element (`.affordance > p`, `header > p`, `:first-child`, `:nth-child`); to exclude a moved CTA paragraph from a lede rule use `header p:where(:not(.affordance p))` (zero-specificity exclusion);
+- only when the old rule itself set the type (a bespoke hero headline) does the wrapper carry `font-*` and the inner element gets `font: inherit; color: inherit; margin: 0`;
+- `color` on the wrapper must be explicit when spans used to carry it (global `h1–h6 { color }` beats inheritance);
+- inner restructuring of the authored element (per-line `<span>`s) is allowed only as a presentation refinement the wrapper does not depend on.
+
+**EW3 — CTAs move as their paragraph.** The index is on the `<p>`, not the `<a>`: `actions.append(a.closest('p') || a)`. `decorateButtons()` already put `.button.primary/.secondary` on the anchor before `decorate()` ran; those classes die while editing, so the foundation ships an **edit-mode repaint** derived from the authored marks (Step 3 (a)) — zero effect on published pages. Classes a block itself adds to an authored anchor or list (`a.link-download`, `ul.icon-list-items`) die the same way: style by element or attribute instead (`.icon-list ul`, `a[href*=".pdf"]`).
+
+**EW4 — Presentational clones strip instrumentation.** Carousel loop slides, marquee duplicates, sticky copies: `stripInstrumentation(clone)` (scaffold helper). One element per index, and it must be the visible one — a duplicated index attaches the editor to the FIRST copy in DOM order, often a hidden clone.
+
+**EW5 — Exempt text is declared, not silently dropped.** Three categories: (a) *text-as-metadata* never displayed (glyph keys, `label | value` keys, variant selectors, video/embed source links, hidden config rows); (b) *derived text* (an ISO date re-rendered as day/month spans) — prefer authoring the displayed form; (c) *index/API-driven blocks* whose authored rows are only the no-JS fallback (press listings, job lists, forms, maps). Declare each in the block JSDoc with a machine-readable tag — `@ew-exempt <p> ISO date (cell 1) — derived`, or `@ew-exempt all — index-driven listing, authored rows are the no-JS fallback` — so the gate whitelists it. A fourth shape — one authored paragraph rendered as N elements (a breadcrumb trail) — cannot be made editable by the block: the ENCODE side must author a `<ul>` (a list is one editable unit).
+
+**EW6 — Card-as-link: unwrap the authored inner anchor in the live DOM** (`link.replaceWith(...link.childNodes)`) after reading its `href`; the indexed paragraph survives inside the card `<a>`, no nested anchors on the published page (`labelWrap(link, 'affordance-wrap', { unwrap: true })`). The editor re-renders the inner link while editing, so the foundation ships `a .prosemirror-editor a:any-link { color: inherit; text-decoration: none }` (Step 3 (b)).
+
+**EW7 — Interactive containers cannot host the editor.** A `<button>` (or `<summary>`) swallows focus and clicks: an accordion title moves into a sibling `div.accordion-title`, the whole headline row takes the click handler, and the button becomes a chevron-only toggle with an `aria-label`. Content hidden at rest (collapsed panels, inactive tabs, non-active slides) is editable but only reachable after the author opens it — keep those controls working inside the workspace (link navigation is blocked there, buttons are not).
+
+**EW8 — Section heads reabsorbed from default content MOVE the wrapper's children** (they are already editable as default content) and remove the empty wrapper (§ Section heads).
+
+**EW9 — Re-entrancy.** `setBody()` re-runs `loadPage()` on a fresh body every time; blocks that adopt sibling sections (tabs, accordions) must move those decorated blocks whole and must not depend on module-level state from the previous run.
+
+**EW10 — Default content styling follows the same selector rules.** Section styles on prose (`main .section.x .default-content-wrapper > p:first-child`, `p:has(picture) + p`) drift in edit mode for the same two-wrapper reason; use descendant selectors and avoid positional pseudo-classes on prose elements (Step 3).
+
+**The EW gate — run it per block, in the loop.** `block-roundtrip.mjs` runs with `--ew` on by default (below) and fails on a dead non-exempt text or a duplicated index. The standalone probe measures the same thing on a whole page, and `--simulate-editor` performs the editor swap to report font/colour/height drift per text and block height Δ:
+
+```bash
+# harness mode — no server, same technique as block-roundtrip
+node skills/deploy/scripts/ew-editability-probe.mjs --content content/<page>.html --verbose --simulate-editor
+# URL mode — a served page (dev server, preview origin); --blocks-dir lets it read @ew-exempt tags
+node skills/deploy/scripts/ew-editability-probe.mjs http://localhost:3000/qa/page.html --blocks-dir blocks --verbose --simulate-editor
+```
+
+Exit 0 = every non-exempt authored text editable, no duplicates; 1 = dead/duplicated; 2 = probe error. Fix by moving the offending element (EW1) or the offending selector to wrapper-descendant form (EW2) — never by weakening the gate. Corollary the two external write-ups missed: `cloneNode(true)` is *not* what kills editing (the clone carries the attribute — that is why clone-based blocks worked while `textContent`-based ones did not); cloning is still wrong (duplicates, stale identity), but the fix is "move", not "avoid clone".
 
 **Prove each block's round-trip IN THE LOOP — per block, before deploy (#94).** Step 10's `content-diff` is the post-deploy proof; it must not be where defects are FOUND. After writing a block (and its authored rows), run the harness round-trip:
 
@@ -653,15 +753,15 @@ node skills/deploy/scripts/block-roundtrip.mjs \
   "http://localhost:8791/<prototype>.html" content/<page>.html --blocks <name>   # omit --blocks for all
 ```
 
-It decorates the authored content locally with the block's own JS+CSS (the render-harness technique — no DA, no dev server), extracts the role inventory from the decorated section AND the matching prototype section with the SAME classifier as `content-diff` (`skills/deploy/scripts/content-inventory.mjs`), and diffs them. Pass `--map <name>=<selector>` when the prototype section class differs from the block name; `--styles`/`--blocks-dir` when the repo layout isn't `eds/`- or root-level. Exit 2 on any structural 🔴 (MISSING CTA/HEADING/EYEBROW, ROLE SWAP) **or any decorate error** — fix the decode (or the authored rows) and re-run; the block is done when it exits 0. Font forks are deliberately NOT checked here (the harness renders local fonts; faces are Step 4 + Step 10's business). A `decorate errors` line means the block threw mid-run or its JS never installed (the harness INLINES block JS, so a module-scope `import` cannot resolve — inline the helper, or verify that one block via the dev-server harness + Step 10); either way the raw rows can false-match the prototype, so these fail the gate on their own. Template-slotted blocks (#95) still run the gate: it catches slot-fill mistakes and authored-row drift.
+It decorates the authored content locally with the block's own JS+CSS (the render-harness technique — no DA, no dev server), extracts the role inventory from the decorated section AND the matching prototype section with the SAME classifier as `content-diff` (`skills/deploy/scripts/content-inventory.mjs`), and diffs them. Pass `--map <name>=<selector>` when the prototype section class differs from the block name; `--styles`/`--blocks-dir` when the repo layout isn't `eds/`- or root-level. Exit 2 on any structural 🔴 (MISSING CTA/HEADING/EYEBROW, ROLE SWAP) **or any decorate error** — fix the decode (or the authored rows) and re-run; the block is done when it exits 0. Font forks are deliberately NOT checked here (the harness renders local fonts; faces are Step 4 + Step 10's business). A `decorate errors` line means the block threw mid-run or its JS never installed (the harness INLINES block JS, so a module-scope `import` cannot resolve — inline the helper, or verify that one block via the dev-server harness + Step 10); either way the raw rows can false-match the prototype, so these fail the gate on their own. Template-slotted blocks (#95) still run the gate: it catches slot-fill mistakes and authored-row drift. **With `--ew` (default on) the same run stamps the workspace's `data-prose-index` on the authored editables BEFORE `decorate()` and reports, per block, `editable N/M, dead K, duplicated D, exempt E` — a dead non-exempt text (`DEAD TEXT`) or a duplicated index (`DUPLICATED INDEX`) is a 🔴 alongside MISSING CTA/HEADING (§ contract above); `--no-ew` exists only for diagnosing the role diff in isolation.**
 
 **Copy set for the playwright ESM rule:** when copying these gates into the project (extract SKILL.md § Setup — bundled scripts must run from the project so `import 'playwright'` resolves), copy `skills/deploy/scripts/` — it is now self-contained (the shared role classifier `content-inventory.mjs` + `diff-profiles.mjs` live there; `block-roundtrip.mjs`/`section-schema.mjs` import them locally). Only if you also run the Step-10 advisory `content-diff` do you additionally need `skills/diff/scripts/` (`content-diff.mjs` + `live-session.mjs`, which import back into `../../deploy/scripts/`).
 
 **Lead/hero blocks: query content, don't hard-index rows (#42).** A hero that reads `rows[3]=headline, rows[4]=lede, rows[5]=CTA` breaks the moment the content shape differs — and the mandatory-metadata / single-`<h1>` SEO rework (#34/#35) actively **consolidates** the headline + lede + CTAs into ONE cell, so the fixed indices come back `undefined` and the hero `.wrap` (the LCP element and the only `<h1>`) renders EMPTY with no error. Decorate lead blocks by querying (`block.querySelector('h1,h2')`; link-bearing `<p>` = CTAs; `picture` from anywhere) so they tolerate BOTH the rich multi-row shape and the consolidated single-cell shape. **Disambiguate eyebrow vs lede by ORDER/length, not "first `<p>`" (#51):** both are link-free `<p>`s, so "first link-free paragraph = lede" swaps them (the short eyebrow comes first). The canonical lead order is **eyebrow → heading → lede**: the eyebrow is the short/uppercase line *before* the heading; the lede is the sentence-length `<p>` *after* it. Local-QA check: after decoration, assert the hero's inner wrap is non-empty and contains the `<h1>`.
 
-**When cloning a cell into your OWN heading element, UNWRAP the cell's heading first (#55).** If you build a live `<h1>` and clone a source cell's *childNodes* into it, and that cell wraps its text in its own `<h1>` (which #35/#42 actively encourage), you get `<h1><h1>…</h1></h1>` — a duplicate heading and a doubled font cascade. Always `const inner = cell.querySelector('h1,h2,h3,h4,h5,h6') || cell;` then clone `inner.childNodes`. Local-QA: exactly one `<h1>`, and 0 descendant headings inside the live headline.
+**Never build your OWN heading element — MOVE the authored one (#55, EW1).** The old recipe (build a live `<h1>`, clone the cell's `childNodes` into it) produced `<h1><h1>…</h1></h1>` when the cell already carried a heading (#35/#42 encourage that), and even the "unwrap first, clone `inner.childNodes`" fix leaves a dead headline in Experience Workspace — childNodes carry no `data-prose-index`. The rule now: `const heading = cell.querySelector('h1,h2,h3,h4,h5,h6'); box.append(wrapNode(heading, 'headline'))` — the authored tag is the tag (the ENCODE side authors `<h1>` for the lead, `<h2>` elsewhere, #35/#57); the wrapper carries the class; CSS is `.headline :is(h1, h2, h3)`. Only a cell with NO heading element (off-pipeline harness content) falls back to wrapping the bare text — flag that branch in the JSDoc, it never fires on DA content. Local-QA: exactly one `<h1>`, 0 descendant headings inside `.headline`, and the EW gate shows the headline editable.
 
-**Marker injection must be IDEMPOTENT (#70).** When `decorate()` PREPENDS a fixed decorative marker to authored heading/link text (a glyph `▶`, a badge, a `CH NN` number), first STRIP a matching leading occurrence from the cloned text node — `firstText.textContent = firstText.textContent.replace(/^\s*▶\s*/, '')` — because the author (or the #34/#35 SEO content rebuild) may already type it, so the marker doubles (`▶ ▶ Latest signal`). Apply the SAME strip at EVERY place the block injects that marker (section titles AND card links), not just some. (The deployed eyeball catches a doubled glyph `X X …`.)
+**Marker injection must be IDEMPOTENT — and must never edit the authored text node (#70, EW1).** When `decorate()` PREPENDS a fixed decorative marker to authored heading/link text (a glyph `▶`, a badge, a `CH NN` number), the author (or the #34/#35 SEO content rebuild) may already type it, so the marker doubles (`▶ ▶ Latest signal`). Resolve it on the GENERATED side: emit the marker as a separate element (`<span class="marker" aria-hidden="true">▶</span>` before the moved heading, or a CSS `::before` on the wrapper) and SKIP emitting it when the authored text already starts with the glyph (`/^\s*▶/.test(heading.textContent)`). Never `replace()` the authored text node — that changes its `textContent` length and breaks the editor's cursor offsets (EW1). Apply the SAME check at EVERY place the block injects that marker (section titles AND card links), not just some. (The deployed eyeball catches a doubled glyph `X X …`.)
 
 **Carousel slide segmentation is HEADING-boundary driven and ORDER-AGNOSTIC (#69).** Segment slides ONLY on the heading boundary — one heading opens one slide (a leading `<picture>` before the first heading may open slide 0). Fold EVERYTHING between two headings into the open slide regardless of authored order (eyebrow/label may come AFTER the heading, not before): first non-link text run = eyebrow, links = CTAs, extra text = description. Never let a post-heading text node open a NEW slide (that steals the heading slot and the CTAs never attach — symptom: N+2 jumbled slides with 0 CTAs). Local-QA: rendered slide count == authored heading count AND each slide's CTA count == authored.
 
@@ -687,17 +787,25 @@ function collectNodes(block) {
         && kids[0].querySelector('picture, img')) {
       const inner = [...kids[0].childNodes].map((n) => {
         if (n.nodeType === 1) return n;
-        if (n.textContent.trim()) { const p = document.createElement('p'); p.textContent = n.textContent.trim(); return p; }
+        // HARNESS-ONLY fallback (EW5): a bare text node inside the wrapper <p>. In DA
+        // content every text is already a <p>/<h*> (prose2aem keeps the <p> in every
+        // cell), so this branch never fires there; a synthesized <p> is dead in the
+        // workspace. Move the TEXT NODE into a fresh <p> (p.append(n)) — never copy
+        // its textContent — so the harness and the gate see the same node.
+        if (n.textContent.trim()) { const p = document.createElement('p'); p.append(n); return p; }
         return null;
       }).filter(Boolean);
       kids = inner;
     }
     if (kids.length) out.push(...kids);
-    else if (cell.textContent.trim()) { const p = document.createElement('p'); p.textContent = cell.textContent.trim(); out.push(p); }
+    // HARNESS-ONLY fallback (EW5) — same rule: wrap the existing text nodes, never
+    // synthesize from textContent. Flag the branch in the block JSDoc.
+    else if (cell.textContent.trim()) { const p = document.createElement('p'); p.append(...cell.childNodes); out.push(p); }
   });
   return out.length ? out : [...block.children]; // last-ditch: direct children
 }
 ```
+`collectNodes()` returns EXISTING authored elements — that is the point: everything it returns is then MOVED into the layout (EW1). The two synthesized-`<p>` branches are harness-only fallbacks for off-pipeline content and must be commented as such; if the EW gate reports a dead text on DA-shaped content, the block is copying text somewhere downstream of the collector.
 Then segment/classify the returned nodes by content; one-cell-per-row is a fallback. **Local-QA: assert every block's primary content container is non-empty post-decorate (childCount>0 / height>0)** — a 0-node selector mismatch otherwise renders a silent blank box (a blank hero only surfaces via a per-block height probe; testimonials surfaced as a CONTENT GAP). **Local-QA / Checklist assertion:** after `decorate()`, the rendered count must equal the authored count — the hero wrap is non-empty and has the `<h1>`; a card grid holds N cards (= N repeat-headings in source), never 1. Index-based contracts pass lint but silently render 1/N.
 
 **Card grids that alternate ground: reconstruct the rhythm by INDEX when no marker survives (#61).** A prototype encodes a grid's light/dark alternation structurally (the 2nd card has `--dark`), but that marker does NOT survive into DA content. A block that flips dark only on an explicit authored "dark" cell renders every card light — the dark card's white heading/CTA go invisible (caught by the #59 `SURFACE/GROUND MISMATCH` flag). Fallback to the positional pattern: `const dark = explicitMarker ?? (i % 2 === 1)`. Then scope on-dark button/text overrides to the resulting `.card.dark` block class (#41).
@@ -784,7 +892,11 @@ node skills/deploy/scripts/build-harness.mjs content/<path>.html qa/page.html   
 
 Open `http://localhost:3000/qa/page.html` — `scripts.js` runs `loadPage()` (which adds `body.appear`, decorates, and loads sections), blocks load from the code origin, chrome loads via the `header`/`footer` blocks fetching `/nav` and `/footer`. Screenshot / inspect with headless Chrome (`--virtual-time-budget=9000 --screenshot` / `--dump-dom`) or Playwright.
 
-**Before any DA push, run the whole-page round-trip gate (#94)** — `block-roundtrip.mjs` with no `--blocks` (all blocks, DA-free): it catches cross-block drops a per-block run can miss (a section head absorbed by the wrong block, an instance-count mismatch between authored blocks and prototype sections).
+**Before any DA push, run the whole-page round-trip gate (#94)** — `block-roundtrip.mjs` with no `--blocks` (all blocks, DA-free): it catches cross-block drops a per-block run can miss (a section head absorbed by the wrong block, an instance-count mismatch between authored blocks and prototype sections). Its `--ew` pass (default on) is the whole-page **Experience Workspace editability gate**: 0 dead texts outside declared `@ew-exempt`, 0 duplicated indices.
+
+**Then the edit-mode simulation (Step 8 § contract)** — `node skills/deploy/scripts/ew-editability-probe.mjs --content content/<page>.html --simulate-editor --verbose`: it performs the workspace's editor swap on every surviving text and reports font-family/size/weight, line-height and colour drift per text plus the per-block height delta. Target: no drift, block height Δ ≤ 2 px. Drift means a class sits on the authored element or its spans, or a `>`/`:first-child` path — move the selector to wrapper-descendant form (EW2). `render-harness.mjs --ew --simulate-editor` screenshots the same state for eyeballing (it hides `body > header`, so tall-block element shots are not polluted by a sticky header).
+
+**Pixel parity of the published render before/after an editability conversion** — when converting an already-shipped block to the move-based pattern, capture element screenshots of every block instance at 1440 with `body > header` hidden and live-widget iframes excluded, convert, re-shoot, `pixelmatch` = 0 per instance. The gate must never trade fidelity for editability (a 27-instance conversion shipped 0 px difference).
 
 **Then run the stock QA gate — do NOT hand-roll a probe script (#101):**
 
@@ -886,7 +998,7 @@ Defining `.section.dark`, `.section.prose-2col`, `.section.eyebrow`, etc. as a s
 A wave SVG that all blocks import seems reusable. But each prototype section uses its wave differently (different dimensions, colors, animation). Inlining the SVG inside the owning block is more code on paper but eliminates a coupling and makes each block self-contained.
 
 **4. Manually creating button anchors in block JS.**
-Code like `cta.className = 'btn-loud'; cta.innerHTML = '<span>…</span>' + ARROW_SVG;` duplicates the EDS button decorator's job, fights its class-application order, and ties block JS to specific button classes. **Clone the cell anchor — `decorateButtons()` already classed it before your block ran.** Block CSS overrides the global button style only when something is actually different (size, hover variant).
+Code like `cta.className = 'btn-loud'; cta.innerHTML = '<span>…</span>' + ARROW_SVG;` duplicates the EDS button decorator's job, fights its class-application order, and ties block JS to specific button classes. **Move the CTA's paragraph (`a.closest('p')`) — `decorateButtons()` already classed the anchor before your block ran, and the paragraph carries the workspace's editor index (EW3).** Block CSS overrides the global button style only when something is actually different (size, hover variant).
 
 **5. Reconstructive parsing of chrome content.**
 Chrome blocks that heuristically re-classify arbitrary authored content ("first list = nav, second link = CTA, guess the rest") are fragile and lossy — one authored change scrambles the header. Chrome is **template-slotted** (Step 6): the block holds the prototype's chrome DOM and fills fixed role slots from the `/nav`/`/footer` documents' fixed section contract (brand / links / tools). If you find yourself writing open-ended parsing heuristics for header/footer, stop and pin the document contract instead.
@@ -929,6 +1041,12 @@ Prototypes often hide sections with `.reveal { opacity:0 }` and reveal them via 
 **17. Injecting a `<main>` element from block JS.**
 A block that builds its own layout/view wrapper (common for interactive blocks that swap views, #33) must NOT use `<main>`. The page already has one `<main>` — a second is invalid HTML and a duplicated landmark, and any runtime or probe code that does `document.querySelector('main')` (the runtime's own `loadSections`, the diff probes' inventory extraction) can bind to the WRONG one, silently skipping or double-processing sections. Structural CSS scoped to `main .section`/`main > .section` can also start matching injected DOM it was never meant for. Use a `<section>` (or keep injected nodes scoped under the block element). Don't port a prototype's `<main>` wrapper literally into block-injected DOM.
 
+**18. Value-slotting: copying authored text into template nodes.**
+`slot.textContent = cell.textContent`, `h.innerHTML = heading.innerHTML`, `` `<h2 class="t">${text(cell)}</h2>` `` — every template-slotted and reconstructive block on a real site did this because the old scaffold taught it. It looks perfect on the published page, is **100 % uneditable in Experience Workspace** (the authored element carrying `data-prose-index` was discarded), and no fidelity gate catches it — role round-trip, content-diff and pixel diff all pass. Found by the customer clicking text in the canvas. Node-slot instead: empty slot containers in the template, authored elements MOVED into them (Step 2b, EW1). The `--ew` gate now fails it in the loop.
+
+**19. A class on the authored element (`h3.headline`, `ul.items`, `a.link-download`, `a.button`).**
+Editable, but the look collapses the moment the author clicks: the editor re-renders the same tag with no classes and two wrapper divs above it. Wrappers carry the classes; style the authored element as a descendant of the wrapper (`.headline :is(h2, h3)`), by element (`.icon-list ul`) or by attribute (`a[href*=".pdf"]`); repaint buttons from their `<strong>`/`<em>` marks under `.prosemirror-editor` (Step 3, EW2/EW3). The `--simulate-editor` probe measures the drift.
+
 ## Checklist (per page)
 
 - [ ] Each section in the prototype `<main>` has a corresponding section in the content page — a block for pattern sections, default content for prose sections (D1, Step 2 triage recorded in the conversion log).
@@ -940,6 +1058,10 @@ A block that builds its own layout/view wrapper (common for interactive blocks t
 - [ ] **`content-diff` summary reviewed (advisory)** for the first page of each template — per-role/img count deltas checked; any per-node 🔴 confirmed by the deployed eyeball as a real DA-transport reshape vs a known false-positive (in-block fidelity is already gated pre-deploy by `block-roundtrip`).
 - [ ] **Section schema emitted + used (#93)** — `stardust/eds-schema/<page>.json` exists; authored rows follow its order/units; each block's JSDoc cites its section's schema; deliberate drops recorded in the conversion log.
 - [ ] **Every block passed `block-roundtrip` BEFORE deploy (#94)** — exit 0 (0 structural 🔴) per block against its prototype section, plus one whole-page run (no `--blocks`) clean before the DA push.
+- [ ] **EW gate exits 0 for every block (EW1–EW10)** — `block-roundtrip --ew` (default) / `ew-editability-probe.mjs`: dead = 0 outside declared `@ew-exempt` tags, duplicated = 0; every exemption is one of the three declared categories (metadata / derived / index-driven) and is written in the block JSDoc, never implied.
+- [ ] **Edit-mode simulation clean** — `ew-editability-probe.mjs --simulate-editor`: no font/colour/line-height drift on any text, block height Δ ≤ 2 px; the foundation ships the edit-mode CTA repaint, the card-as-link inner-anchor rule and `:where()` wrapper variants for every styled-text-link utility (Step 3).
+- [ ] **Block JS/CSS static review (EW1/EW2/EW4)** — no `textContent =`/`innerHTML =`/`${…}` interpolation producing displayed text from an authored element; no `cloneNode` of an indexed element without `stripInstrumentation()`; no `>`/`:first-child`/`:nth-child` between a wrapper class and an authored element; no class added to an authored `h*/p/ul/a` (wrappers carry classes); no `<button>`/`<summary>` hosting authored text (EW7).
+- [ ] **Pixel parity before/after an editability conversion** — element screenshots of every block instance at 1440 with `body > header` hidden and live-widget iframes excluded: `pixelmatch` = 0 per instance (fidelity is never traded for editability).
 - [ ] **Decode tier chosen per section (#95)** — bespoke fixed-composition sections are template-slotted (verbatim prototype DOM + role slots); only repeat/authorable sections are reconstructive; tiers recorded in the conversion log.
 - [ ] `<header></header>` and `<footer></footer>` are EMPTY (the `header`/`footer` blocks load `/nav` and `/footer` automatically); `content/nav.html` + `content/footer.html` exist, follow the section contract (brand / links / tools), and are on the publish roster.
 - [ ] **Page begins with a `metadata` block** (#34): real Title (≤60 chars, from the `<h1>`, never a block name) + Description (~155 chars). `nav` / `footer` path overrides / `Robots` rows go in the same block when needed.
@@ -956,7 +1078,7 @@ A block that builds its own layout/view wrapper (common for interactive blocks t
 - [ ] Hero LCP image is `loading="eager"` + `fetchpriority="high"` (set in `decorate()` — the empty metadata-first section defeats the runtime's `waitForFirstImage`, #100) and its media slot is CSS-reserved (`min-height`/`aspect-ratio`); the CLS probe ran ONLY against the DEPLOYED preview (#101 — a harness CLS number is meaningless).
 - [ ] **`qa-gate.mjs` run against the harness (advisory smoke test)** — stock script + the page's eds-schema, no hand-rolled probe (#101). Its unique pre-deploy value is the schema unit-counts + one-`<h1>`; decoration/broken-img/grid checks are superseded by the DEPLOYED computed-style guard (a harness qa-gate failure on chrome-empty or auth-gated DA images is a known harness limitation, not a defect). The advisory `content-diff` was run against the DEPLOYED URL only.
 - [ ] Any styling that depends on a `<span>`/class INSIDE a block cell is re-created in `decorate()` (#39) — EDS strips `<span>` in block cells (e.g. wrap a `.stars` run in JS, don't author it).
-- [ ] Every block reads plain-text fields by CELL/`textContent`, NOT `querySelectorAll('p')` (#79) — the pipeline unwraps the `<p>` in single-text cells, so a `p`-based read drops eyebrow/subhead/lede/tag/body on live while the raw-`<p>` harness still shows them. Verify against the decorated live/preview render or a `<p>`-stripping harness, and assert each text field is present (counts alone don't catch it).
+- [ ] Every block CLASSIFIES plain-text fields by CELL (`cell.textContent` for the decision, #79) but DISPLAYS them by MOVING the cell's element (EW1) — the runtime's `wrapTextNodes` (#104) re-wraps a bare-text cell in a `<p>` before `decorate()`, and the workspace always delivers a `<p>`, so the element to move exists in both worlds; a `p`-only *read* that skips a cell still drops content on older runtimes. Verify against the decorated live/preview render, and assert each text field is present AND editable (counts alone don't catch it).
 - [ ] No `<style>` or `<script>` tags in the content page, and no code visible as text in any cell (D15).
 - [ ] Section-metadata blocks appear ONLY on default-content sections, `style` values from the Step-3 closed set (never on block sections — anti-pattern 2).
 - [ ] Closing CTA reuses the shared `closing` block.
@@ -988,3 +1110,5 @@ Update `stardust/eds-conversion-log.md` (or create one) with: final block invent
 - `davids-model.md` — David's Model (aem.live) distilled: the 15 rules (`D#N`), each mapped to the contract or gate in this skill that enforces it, plus the component-model shape compatibility notes.
 - `da-deploy-protocol.md` — the curl-based DA Source API deploy contract (auth, source PUT, preview/publish, asset-before-preview ordering).
 - `IMPROVEMENTS.md` — running log of friction/gaps and the numbered findings (#NN) that the `stardust:diff` `eds` profile cites.
+- `scripts/ew-editability-probe.mjs` — the Experience Workspace editability gate (Step 8 § contract): instrument → decorate → count survivors; `--simulate-editor` edit-mode drift; URL and `--content` harness modes; reads `@ew-exempt` JSDoc tags.
+- Experience Workspace sources the contract was verified against (read them when the mechanism seems to have changed): da.live `blocks/canvas/editor-utils/editor-utils.js` (`getInstrumentedHTML` — what is stamped), `blocks/canvas/ew-editor-wysiwyg/ew-editor-wysiwyg.js`, `blocks/shared/prose2aem.js` (cells keep their `<p>`); da-nx `nx/public/plugins/quick-edit/quick-edit.js` (`setBody` → `loadPage` → `restoreBlockIndices`), `src/prose.js` (`createEditor` swap shape), `src/images.js`, `src/dom-index.js`, `src/selection.js` (cursor math on `textContent` length).

--- a/plugins/stardust/skills/deploy/scripts/block-roundtrip.mjs
+++ b/plugins/stardust/skills/deploy/scripts/block-roundtrip.mjs
@@ -25,12 +25,31 @@
  *     --blocks-dir <dir> blocks root (default eds/blocks, then blocks)
  *     --width <px>       viewport width (default 1280)
  *     --profile <p>      eds | generic (default eds)
- *     --json             dump per-block inventories
+ *     --ew | --no-ew     Experience Workspace editability gate (default ON): before
+ *                        decorate() the authored content is instrumented like the
+ *                        da.live canvas (`data-prose-index` on every outermost
+ *                        h1-h6/p/ul/ol/pre/blockquote, bare-text cells re-wrapped
+ *                        as <p>); afterwards each text must survive on EXACTLY one
+ *                        element. Dead (rebuilt from textContent/innerHTML,
+ *                        synthesized, retagged) or duplicated (clone slides) texts
+ *                        are 🔴 alongside MISSING CTA/HEADING; `@ew-exempt <reason>`
+ *                        in the block's leading JSDoc declares config/derived/index
+ *                        texts (⚪ advisory). Shared instrument: ew-editability-probe.mjs.
+ *     --json             dump per-block inventories (+ the editability survey)
  *
- * Exit codes: 0 = round-trip closed (no structural 🔴, no decorate errors),
- * 2 = structural 🔴 found OR a block's decorate() failed to install/run (a block
- * that cannot be decorated must never pass — its raw rows would match the
- * prototype and green-light a decode that was never exercised), 1 = tool error.
+ * EW contract in two sentences (deploy SKILL.md § Experience Workspace editability
+ * contract, EW1–EW10): the workspace stamps an index on every authored text element,
+ * runs the page's own decorate() over it, and can only attach an editor to an element
+ * that still carries its index — so block JS must MOVE authored h1-h6/p/ul/ol/picture
+ * nodes into generated wrappers (append/prepend), never rebuild them from text or
+ * clone-and-discard. Wrappers carry the layout classes; presentational clones strip
+ * instrumentation; exempt text is declared with `@ew-exempt`, never silently dropped.
+ *
+ * Exit codes: 0 = round-trip closed (no structural 🔴, no dead/duplicated text, no
+ * decorate errors), 2 = structural 🔴 found (incl. DEAD TEXT / DUPLICATED INDEX under
+ * --ew) OR a block's decorate() failed to install/run (a block that cannot be
+ * decorated must never pass — its raw rows would match the prototype and
+ * green-light a decode that was never exercised), 1 = tool error.
  *
  * Limitation: block JS is INLINED into the harness page, so module-scope
  * `import` statements cannot be resolved — such a block FAILS the gate loudly
@@ -42,10 +61,11 @@ import { chromium } from 'playwright';
 import fs from 'fs';
 import { resolveProfile } from './diff-profiles.mjs';
 import { inventory, diffInventories, summarise } from './content-inventory.mjs';
+import { EDITABLE, runtimeMimic, instrument, survey, installBlockJs, runDecorate, readBlockExemptions, aggregate } from './ew-editability-probe.mjs';
 
 function parseArgs(argv) {
   const [, , proto, content, ...rest] = argv;
-  const opts = { blocks: null, map: {}, styles: null, blocksDir: null, width: 1280, profile: 'eds', json: false };
+  const opts = { blocks: null, map: {}, styles: null, blocksDir: null, width: 1280, profile: 'eds', json: false, ew: true };
   for (let i = 0; i < rest.length; i += 1) {
     const a = rest[i];
     if (a === '--blocks') { opts.blocks = rest[i += 1].split(',').map((s) => s.trim()).filter(Boolean); }
@@ -55,6 +75,8 @@ function parseArgs(argv) {
     else if (a === '--width') { opts.width = Number(rest[i += 1]); }
     else if (a === '--profile') { opts.profile = rest[i += 1]; }
     else if (a === '--json') { opts.json = true; }
+    else if (a === '--ew') { opts.ew = true; }
+    else if (a === '--no-ew') { opts.ew = false; }
   }
   return { proto, content, opts };
 }
@@ -129,7 +151,7 @@ async function settle(page) {
 async function main() {
   const { proto, content, opts } = parseArgs(process.argv);
   if (!proto || !content) {
-    process.stderr.write('usage: node skills/deploy/scripts/block-roundtrip.mjs <prototypeURL> <content/page.html> [--blocks a,b] [--map name=sel] [--styles css] [--blocks-dir dir] [--width px] [--profile p] [--json]\n');
+    process.stderr.write('usage: node skills/deploy/scripts/block-roundtrip.mjs <prototypeURL> <content/page.html> [--blocks a,b] [--map name=sel] [--styles css] [--blocks-dir dir] [--width px] [--profile p] [--ew|--no-ew] [--json]\n');
     process.exit(1);
   }
   const prof = resolveProfile(opts.profile);
@@ -171,77 +193,30 @@ async function main() {
     await harness.evaluate(dropMetadata);
     const harnessCounts = await harness.evaluate(tagHarnessSections, names);
     // AFTER tagging (which reads the raw authored shape), mimic the vanilla
-    // runtime's decorateSections/decorateBlock DOM — .section wrappers,
-    // .default-content-wrapper, .<name>-wrapper/.block/.<name>-container, AND
-    // wrapTextNodes cell normalization (#104: a media-led / unlisted-first-child
+    // runtime's decorateButtons/decorateSections/decorateBlock DOM — .section
+    // wrappers, .default-content-wrapper, .<name>-wrapper/.block/.<name>-container,
+    // AND wrapTextNodes cell normalization (#104: a media-led / unlisted-first-child
     // cell's whole content folds into ONE <p> on live; without mimicking it here
     // a collector that reads cell.children false-passes the gate and drops every
     // sibling after the image in production) — so block/foundation CSS and
     // decode both face the live shape. data-rt tags survive: the tagged
-    // elements are moved, not recreated.
-    await harness.evaluate(() => {
-      const VALID_WRAPPERS = ['P', 'PRE', 'UL', 'OL', 'PICTURE', 'TABLE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6'];
-      const wrapTextNodes = (block) => {
-        const wrap = (el) => { const w = document.createElement('p'); w.append(...el.childNodes); el.append(w); };
-        block.querySelectorAll(':scope > div > div').forEach((cell) => {
-          if (!cell.hasChildNodes()) return;
-          const first = cell.firstElementChild;
-          const hasWrapper = !!first && VALID_WRAPPERS.includes(first.tagName);
-          if (!hasWrapper) wrap(cell);
-          else if (first.tagName === 'PICTURE' && (cell.children.length > 1 || !!cell.textContent.trim())) wrap(cell);
-        });
-      };
-      document.querySelectorAll('main > div').forEach((section) => {
-        const wrappers = [];
-        let defaultContent = false;
-        [...section.children].forEach((e) => {
-          if (e.tagName === 'DIV' || !defaultContent) {
-            const wrapper = document.createElement('div');
-            wrappers.push(wrapper);
-            defaultContent = e.tagName !== 'DIV';
-            if (defaultContent) wrapper.classList.add('default-content-wrapper');
-          }
-          wrappers[wrappers.length - 1].append(e);
-        });
-        wrappers.forEach((w) => section.append(w));
-        section.classList.add('section');
-        section.querySelectorAll(':scope > div > div[class]').forEach((block) => {
-          const name = block.classList[0];
-          if (!name) return;
-          block.classList.add('block');
-          block.dataset.blockName = name;
-          wrapTextNodes(block);
-          block.parentElement.classList.add(`${name}-wrapper`);
-          section.classList.add(`${name}-container`);
-        });
-      });
-    });
+    // elements are moved, not recreated. Shared with the EW probe / render-harness.
+    await harness.evaluate(runtimeMimic);
+    // --ew: stamp the workspace's instrumentation on the authored (pre-decorate)
+    // shape; each text remembers its data-rt unit so survivors are counted per block.
+    const ewTexts = opts.ew ? (await harness.evaluate(instrument, EDITABLE)).texts : [];
     const decorateErrs = [];
-    const withJs = [];
-    for (const name of names) {
-      let js;
-      try { js = fs.readFileSync(`${blocksDir}/${name}/${name}.js`, 'utf8'); } catch { continue; } // CSS-only block: nothing to decode
-      withJs.push(name);
-      await harness.addScriptTag({ content: `window.__b=window.__b||{};window.__b[${JSON.stringify(name)}]=(function(){${js.replace(/export default\s+/, '')}\nreturn decorate;})();` });
-    }
     // A block whose inlined JS failed to evaluate (module-scope import/export, a
     // syntax error) leaves window.__b[name] undefined — that MUST fail the gate:
     // the undecorated raw rows would match the prototype and exit 0 while the
     // decode was never exercised.
-    const notInstalled = await harness.evaluate((ns) => ns.filter((n) => !(window.__b && window.__b[n])), withJs);
+    const notInstalled = await installBlockJs(harness, names, blocksDir);
     notInstalled.forEach((n) => decorateErrs.push(`${n}: block JS failed to install — module-scope import/export or a syntax error (the harness inlines block JS and cannot resolve imports; inline the helper or verify this block via the dev-server harness)`));
-    const errs = await harness.evaluate(async (ns) => {
-      const out = [];
-      for (const n of ns) {
-        if (!window.__b || !window.__b[n]) continue;
-        for (const el of document.querySelectorAll(`.${n}`)) {
-          try { await window.__b[n](el); } catch (e) { out.push(`${n}: ${e.message}`); }
-        }
-      }
-      return out;
-    }, names);
-    decorateErrs.push(...errs);
+    decorateErrs.push(...await runDecorate(harness, names));
     await harness.waitForTimeout(800);
+    const ewRows = opts.ew ? await harness.evaluate(survey, ewTexts) : [];
+    const exemptions = opts.ew ? readBlockExemptions(blocksDir, names) : {};
+    const ewTotals = { authored: 0, editable: 0, dead: 0, duplicated: 0, exempt: 0 };
 
     // ── prototype ──
     const protoPage = await browser.newPage({ viewport: { width: opts.width, height: 1000 }, reducedMotion: 'reduce' });
@@ -268,16 +243,30 @@ async function main() {
         const tgtInv = await harness.evaluate(inventory, [`[data-rt="${name}-${i}"]`, prof.eyebrow]);
         const { flags } = diffInventories(srcInv.items, tgtInv.items, rtProf);
         if (srcInv.imgCount !== tgtInv.imgCount) flags.push({ sev: '🟡', kind: 'IMG COUNT', msg: `${prof.source} renders ${srcInv.imgCount} img, ${prof.target} ${tgtInv.imgCount} — a dropped/duplicated <picture>, or an intentional CSS-background/image-slot difference.` });
+        // ── Experience Workspace editability (per data-rt unit) ──
+        let ew = null;
+        if (opts.ew) {
+          const unit = `${name}-${i}`;
+          ew = aggregate(ewRows.filter((r) => r.unit === unit), { exemptions, keyOf: () => unit }).blocks[0]
+            || { authored: 0, editable: 0, dead: 0, duplicated: 0, exempt: 0, deadItems: [], dupItems: [], exemptItems: [], exemptReasons: [] };
+          Object.keys(ewTotals).forEach((k) => { ewTotals[k] += ew[k]; });
+          const quote = (d) => `<${d.tag}> "${d.text.slice(0, 48)}${d.text.length > 48 ? '…' : ''}"`;
+          ew.deadItems.slice(0, 8).forEach((d) => flags.push({ sev: '🔴', kind: 'DEAD TEXT', msg: `${quote(d)} — rebuilt from textContent/innerHTML, synthesized, or retagged; MOVE the authored element (EW1)` }));
+          if (ew.deadItems.length > 8) flags.push({ sev: '🔴', kind: 'DEAD TEXT', msg: `… and ${ew.deadItems.length - 8} more dead text(s) in this block (${ew.dead} of ${ew.authored} authored) — same cause, same fix (EW1)` });
+          ew.dupItems.forEach((d) => flags.push({ sev: '🔴', kind: 'DUPLICATED INDEX', msg: `${quote(d)} on ${d.hits} elements — strip instrumentation from presentational clones (EW4)` }));
+          if (ew.exemptItems.length) flags.push({ sev: '⚪', kind: 'EXEMPT', msg: `${ew.exemptItems.length} declared non-editable text(s) (${ew.exemptReasons.join('; ')}): ${ew.exemptItems.slice(0, 4).map(quote).join(', ')}${ew.exemptItems.length > 4 ? ', …' : ''} (EW5)` });
+        }
         const red = flags.filter((f) => f.sev === '🔴').length;
         totalRed += red;
         const label = pairs > 1 ? `${name}[${i}]` : name;
-        process.stdout.write(`\n■ ${label}: ${flags.length ? `${flags.length} finding(s), ${red} structural 🔴` : '✓ round-trip closed'}\n`);
+        process.stdout.write(`\n■ ${label}: ${flags.length ? `${flags.length} finding(s), ${red} structural 🔴` : '✓ round-trip closed'}${ew ? ` — EW editable ${ew.editable}/${ew.authored}, dead ${ew.dead}, duplicated ${ew.duplicated}, exempt ${ew.exempt}` : ''}\n`);
         process.stdout.write(`    ${prof.source}: ${summarise(srcInv)}\n    ${prof.target}: ${summarise(tgtInv)}\n`);
         flags.forEach((f) => process.stdout.write(`  ${f.sev} ${f.kind}: ${f.msg}\n`));
-        if (opts.json) dump[label] = { [prof.source]: srcInv, [prof.target]: tgtInv };
+        if (opts.json) dump[label] = { [prof.source]: srcInv, [prof.target]: tgtInv, ...(ew ? { editability: ew } : {}) };
       }
     }
     if (opts.json) process.stdout.write(`\nInventories JSON:\n${JSON.stringify(dump, null, 1)}\n`);
+    if (opts.ew) process.stdout.write(`\nEW gate: editable ${ewTotals.editable}/${ewTotals.authored}, dead ${ewTotals.dead}, duplicated ${ewTotals.duplicated}, exempt ${ewTotals.exempt}${ewTotals.dead || ewTotals.duplicated ? ' — dead/duplicated texts are 🔴 above' : ''}\n`);
     const bad = [];
     if (totalRed) bad.push(`${totalRed} structural 🔴`);
     if (decorateErrs.length) bad.push(`${decorateErrs.length} decorate error(s)`);

--- a/plugins/stardust/skills/deploy/scripts/content-inventory.mjs
+++ b/plugins/stardust/skills/deploy/scripts/content-inventory.mjs
@@ -25,6 +25,17 @@
  * from a diff-profiles.mjs profile. Pass fontDelta: Infinity to suppress the
  * FONT FORK pass (the in-loop harness renders with local fonts, so face
  * fidelity is Step 4/10's business there, not the round-trip's).
+ *
+ * `editableInventory` runs IN the page (ONE arg): page.evaluate(editableInventory, [rootSel])
+ * returns { count, items: [{tag, text}] } — the OUTERMOST h1-h6/p/ul/ol/pre/
+ * blockquote elements under the root that carry visible text (outermost = no
+ * ancestor matching the same list inside the root; empty and image-only elements
+ * skipped). That is exactly the set Experience Workspace stamps `data-prose-index`
+ * on (deploy SKILL.md § Experience Workspace editability contract): the ENCODE side
+ * counts it on the prototype (section-schema `editableTexts`), the DECODE side on
+ * the decorated page (content-diff's "editable texts" advisory, the --ew gate) —
+ * fewer surviving outermost editables after decoration means authored elements
+ * were rebuilt or merged.
  */
 
 /* eslint-disable no-plusplus, no-continue, max-len */
@@ -114,6 +125,23 @@ export function inventory(args) {
   });
   probe.remove();
   return { items: out, imgCount };
+}
+
+// Runs IN the page (ONE arg). args = [rootSel]. Outermost editable elements with
+// visible text — the Experience Workspace instrumentation set (see header).
+export function editableInventory(args) {
+  const [rootSel] = args;
+  const root = document.querySelector(rootSel) || document.querySelector('main') || document.body;
+  const SEL = 'h1, h2, h3, h4, h5, h6, p, ul, ol, pre, blockquote';
+  const items = [];
+  root.querySelectorAll(SEL).forEach((el) => {
+    const anc = el.parentElement && el.parentElement.closest(SEL);
+    if (anc && anc !== root && root.contains(anc)) return; // nested inside another editable
+    const text = (el.textContent || '').replace(/\s+/g, ' ').trim();
+    if (!text) return; // empty or image-only (edited via data-image-index, not a text editor)
+    items.push({ tag: el.tagName.toLowerCase(), text: text.slice(0, 70) });
+  });
+  return { count: items.length, items };
 }
 /* eslint-enable no-undef */
 

--- a/plugins/stardust/skills/deploy/scripts/ew-editability-probe.mjs
+++ b/plugins/stardust/skills/deploy/scripts/ew-editability-probe.mjs
@@ -1,0 +1,567 @@
+#!/usr/bin/env node
+/**
+ * ew-editability-probe.mjs — the Experience Workspace (da.live) editability gate.
+ *
+ * Reproduces the workspace's inline-edit instrumentation over a page and reports,
+ * per block, which authored text elements survive decorate() and would therefore
+ * be editable in the canvas. Mirrors da-nx nx/public/plugins/quick-edit
+ * (setBody → loadPage → editors):
+ *   1. stamp `data-prose-index` on every OUTERMOST h1-h6/p/ol/ul/pre/blockquote
+ *      inside <main>, `data-image-index` on every <img>, `data-block-index` on
+ *      every block div (as editor-utils.getInstrumentedHTML does). prose2aem keeps
+ *      a <p> inside every block cell while the published pipeline unwraps
+ *      single-paragraph cells to bare text — so bare-text cells are re-wrapped as
+ *      <p> first (the runtime's wrapTextNodes does the same before decorate()).
+ *   2. let the block JS decorate the instrumented body;
+ *   3. an authored text is EDITABLE iff exactly one element still carries its
+ *      `data-prose-index` (createEditor → querySelector + replaceWith). Zero =
+ *      DEAD (rebuilt from textContent/innerHTML, synthesized, retagged); >1 =
+ *      DUPLICATED (clone slides — the editor attaches to the first in DOM order).
+ *      cloneNode(true) keeps the attribute; the fix is "move", not "avoid clone".
+ *   4. --simulate-editor additionally performs the editor swap the way
+ *      prose.js createEditor does (element → div.prosemirror-editor > div.ProseMirror
+ *      > <same tag, no classes/spans>) and reports per text any computed-style or
+ *      height drift between published and edit mode — a class on the authored
+ *      element (or on an inner <span>) dies in that swap; wrapper-descendant
+ *      selectors survive it (deploy SKILL.md § Experience Workspace editability
+ *      contract, EW2).
+ *
+ * Two modes:
+ *   URL mode (served page, the page's own scripts.js decorates):
+ *     node ew-editability-probe.mjs <url> [<url> ...] [--json] [--verbose] [--simulate-editor]
+ *         [--exempt a,b] [--blocks-dir <dir>]
+ *   Harness mode (no server — the render-harness/block-roundtrip inline-decorate
+ *   technique: <main> from the content file, styles.css + block CSS inlined, the
+ *   runtime's decorateButtons/decorateSections/decorateBlock/wrapTextNodes DOM
+ *   mimicked, block JS inlined and decorate() run per block):
+ *     node ew-editability-probe.mjs --content <content/page.html> [--blocks-dir <dir>]
+ *         [--styles <css>] [--width <px>] [--json] [--verbose] [--simulate-editor] [--exempt a,b]
+ *     defaults: --blocks-dir eds/blocks then blocks; --styles eds/styles/styles.css then styles/styles.css
+ *
+ * Exemptions (EW5 — exempt text is declared, not silently dropped):
+ *   --exempt a,b            CLI fallback: blocks whose authored rows are config /
+ *                           derived / index fallback (still reported, excluded from
+ *                           the exit code)
+ *   @ew-exempt <reason>     JSDoc tag in <blocksDir>/<name>/<name>.js (leading
+ *                           comment). Any tag exempts the block's dead texts (they
+ *                           are reported as `exempt`, with the declared reasons);
+ *                           `@ew-exempt all` = the whole block is index/API-driven.
+ *                           Read whenever a blocks dir is known (harness mode
+ *                           always; URL mode with --blocks-dir). Union with --exempt.
+ *   metadata / section-metadata cells are pipeline config (never displayed) and
+ *   are not counted at all.
+ *
+ * Exit code 0 = every non-exempt authored text editable and no duplicated index,
+ * 1 = dead non-exempt text OR duplicated index, 2 = probe error (including a
+ * block whose JS failed to install/decorate in harness mode — an undecorated
+ * block's raw rows would false-pass).
+ *
+ * The in-page functions (runtimeMimic, instrument, survey, simulateEditor) and
+ * the exemption/aggregation helpers are EXPORTED so block-roundtrip.mjs,
+ * render-harness.mjs and the qa `editability` check measure with the same
+ * instrument. Importing this module does not run the CLI and does not load
+ * playwright (the CLI resolves it lazily from the cwd project, then bare).
+ */
+
+/* eslint-disable import/no-extraneous-dependencies, import/extensions, no-await-in-loop, no-restricted-syntax, brace-style, object-curly-newline, max-len, no-plusplus, no-continue, no-param-reassign */
+import fs from 'fs';
+import path from 'path';
+import { createRequire } from 'module';
+import { pathToFileURL } from 'url';
+
+export const EDITABLE = 'h1, h2, h3, h4, h5, h6, p, ol, ul, pre, blockquote';
+export const QE_CSS = 'https://raw.githubusercontent.com/adobe/da-nx/main/nx/public/plugins/quick-edit/quick-edit.css';
+// EW5 categories a declared exemption is expected to name (informational — any
+// @ew-exempt tag exempts; the category is recorded so reports can group reasons).
+export const EW_EXEMPT_CATEGORIES = ['derived', 'metadata', 'index', 'integration', 'fallback', 'config', 'structure', 'all'];
+
+// ────────────────────────────────────────────────────────────── in-page ──
+// Every function below runs IN the page (Playwright-serialized: self-contained,
+// ONE argument, no closure over module scope).
+/* eslint-disable no-undef */
+
+// Remove pipeline config blocks from an authored <main> — in the DOM, never by
+// regexing the HTML (a lazy regex over-swallows past a shallow metadata block).
+export function dropMetadata() {
+  document.querySelectorAll('main div.metadata, main div.section-metadata').forEach((el) => el.remove());
+}
+
+// Block names present in an authored <main> (raw shape), pipeline config excluded.
+export function discoverBlocks() {
+  const names = [];
+  document.querySelectorAll('main > div > div[class]').forEach((b) => {
+    const n = (b.className || '').trim().split(' ')[0];
+    if (n && n !== 'metadata' && n !== 'section-metadata' && !names.includes(n)) names.push(n);
+  });
+  return names;
+}
+
+// Mimic the vanilla runtime's decorateMain over a raw authored <main> (aem.js):
+// decorateButtons (a.button.primary/.secondary from <strong>/<em> wrapping),
+// decorateSections (.section + .default-content-wrapper), decorateBlock
+// (.block, data-block-name, .<name>-wrapper, .<name>-container) and wrapTextNodes
+// (#104: a bare-text / media-led cell folds into ONE <p> on live). Tagged
+// elements (data-rt etc.) survive: they are moved, not recreated. Idempotent on
+// an already-decorated main (skips sections that carry .section).
+export function runtimeMimic() {
+  const VALID_WRAPPERS = ['P', 'PRE', 'UL', 'OL', 'PICTURE', 'TABLE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6'];
+  const main = document.querySelector('main');
+  if (!main) return;
+  const wrapTextNodes = (block) => {
+    const wrap = (el) => { const w = document.createElement('p'); w.append(...el.childNodes); el.append(w); };
+    block.querySelectorAll(':scope > div > div').forEach((cell) => {
+      if (!cell.hasChildNodes()) return;
+      const first = cell.firstElementChild;
+      const hasWrapper = !!first && VALID_WRAPPERS.includes(first.tagName);
+      if (!hasWrapper) wrap(cell);
+      else if (first.tagName === 'PICTURE' && (cell.children.length > 1 || !!cell.textContent.trim())) wrap(cell);
+    });
+  };
+  // decorateButtons — runs on main BEFORE sections/blocks, as in loadEager.
+  main.querySelectorAll('a').forEach((a) => {
+    if (a.classList.contains('button') || a.href === a.textContent || a.querySelector('img, picture')) return;
+    const up = a.parentElement; const twoup = up && up.parentElement;
+    if (!up) return;
+    if (up.childNodes.length === 1 && (up.tagName === 'P' || up.tagName === 'DIV')) { a.className = 'button'; up.classList.add('button-container'); }
+    if (twoup && up.childNodes.length === 1 && up.tagName === 'STRONG' && twoup.childNodes.length === 1 && twoup.tagName === 'P') { a.className = 'button primary'; twoup.classList.add('button-container'); }
+    if (twoup && up.childNodes.length === 1 && up.tagName === 'EM' && twoup.childNodes.length === 1 && twoup.tagName === 'P') { a.className = 'button secondary'; twoup.classList.add('button-container'); }
+  });
+  main.querySelectorAll(':scope > div').forEach((section) => {
+    if (section.classList.contains('section')) return;
+    const wrappers = [];
+    let defaultContent = false;
+    [...section.children].forEach((e) => {
+      if (e.tagName === 'DIV' || !defaultContent) {
+        const wrapper = document.createElement('div');
+        wrappers.push(wrapper);
+        defaultContent = e.tagName !== 'DIV';
+        if (defaultContent) wrapper.classList.add('default-content-wrapper');
+      }
+      wrappers[wrappers.length - 1].append(e);
+    });
+    wrappers.forEach((w) => section.append(w));
+    section.classList.add('section');
+    section.querySelectorAll(':scope > div > div[class]').forEach((block) => {
+      const name = block.classList[0];
+      if (!name) return;
+      block.classList.add('block');
+      block.dataset.blockName = name;
+      wrapTextNodes(block);
+      block.parentElement.classList.add(`${name}-wrapper`);
+      section.classList.add(`${name}-container`);
+    });
+  });
+}
+
+// Instrument like editor-utils.getInstrumentedHTML. Works over BOTH shapes: the
+// raw authored/published <main> (URL mode) and a runtime-mimicked one (harness
+// mode). Returns the instrumented document HTML plus one record per authored
+// text: { index, tag, block, unit, text }. `unit` is the closest [data-rt]
+// ancestor (block-roundtrip's round-trip unit), null elsewhere.
+export function instrument(EDITABLE_SEL) {
+  const main = document.querySelector('main');
+  if (!main) return { html: document.documentElement.outerHTML, texts: [] };
+  const VALID_WRAPPERS = ['P', 'PRE', 'UL', 'OL', 'PICTURE', 'TABLE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6'];
+  const isConfig = (b) => b.classList.contains('metadata') || b.classList.contains('section-metadata');
+  const texts = [];
+  let n = 1;
+  // prose2aem keeps the <p> inside every block cell; the published pipeline unwraps
+  // a single-paragraph cell to bare text (or a bare <a>/<strong>). Restore the <p>
+  // exactly as the runtime's wrapTextNodes will, so the cell looks like the
+  // workspace's instrumented HTML. Idempotent on an already-wrapped cell.
+  const wrapCell = (cell) => {
+    if (!cell.hasChildNodes()) return;
+    const first = cell.firstElementChild;
+    const hasWrapper = !!first && VALID_WRAPPERS.includes(first.tagName);
+    const needs = !hasWrapper || (first.tagName === 'PICTURE' && (cell.children.length > 1 || !!cell.textContent.trim()));
+    if (!needs) return;
+    const p = document.createElement('p');
+    p.append(...cell.childNodes);
+    cell.append(p);
+  };
+  main.querySelectorAll(':scope > div > div[class], main .block').forEach((block) => {
+    if (isConfig(block) || block.classList.contains('default-content-wrapper') || /-wrapper$/.test(block.classList[0] || '')) return;
+    block.querySelectorAll(':scope > div > div').forEach(wrapCell);
+  });
+  const blockOf = (el) => {
+    const decorated = el.closest('main .block[data-block-name]');
+    if (decorated) return decorated.dataset.blockName;
+    const section = el.closest('main > div');
+    const top = [...(section?.children ?? [])].find((c) => c.contains(el));
+    if (!top || top.tagName !== 'DIV' || !top.classList.length || top.classList.contains('default-content-wrapper')) return 'default';
+    return top.classList[0];
+  };
+  main.querySelectorAll(EDITABLE_SEL).forEach((el) => {
+    if (el.parentElement?.closest(EDITABLE_SEL)) return; // outermost only
+    const block = blockOf(el);
+    if (block === 'metadata' || block === 'section-metadata') return; // pipeline config, never displayed
+    n += 1;
+    el.setAttribute('data-prose-index', String(n));
+    // Text-less elements (an image-only <p>, an empty paragraph) are stamped like
+    // the workspace does but not surveyed: images are edited via data-image-index,
+    // and there is no text for an editor to attach to (same rule as
+    // section-schema editableTexts / content-inventory editableInventory).
+    if (el.textContent.trim()) {
+      const unitEl = el.closest('[data-rt]');
+      texts.push({ index: n, tag: el.tagName.toLowerCase(), block, unit: unitEl ? unitEl.getAttribute('data-rt') : null, text: el.textContent.trim().slice(0, 70) });
+    }
+    n += el.textContent.length + 1;
+  });
+  main.querySelectorAll('img').forEach((img) => { n += 1; img.setAttribute('data-image-index', String(n)); });
+  main.querySelectorAll(':scope > div > div[class], main .block').forEach((b) => { if (!isConfig(b) && !b.classList.contains('default-content-wrapper')) { n += 1; b.setAttribute('data-block-index', String(n)); } });
+  return { html: document.documentElement.outerHTML, texts };
+}
+
+// In the decorated page: which indices survived, how many times, and where.
+export function survey(texts) {
+  return texts.map((t) => {
+    const hits = [...document.querySelectorAll(`[data-prose-index="${t.index}"]`)];
+    const first = hits[0];
+    const visible = first ? first.getClientRects().length > 0 : false;
+    const liveText = first ? first.textContent.trim().slice(0, 70) : null;
+    return { ...t, hits: hits.length, visible, liveText, sameText: first ? liveText === t.text : false };
+  });
+}
+
+// In the decorated page: swap every surviving element for a ProseMirror-shaped
+// editor (prose.js createEditor) and measure style/height drift.
+export function simulateEditor(texts) {
+  const rec = (el) => {
+    const cs = getComputedStyle(el);
+    const r = el.getBoundingClientRect();
+    return { h: Math.round(r.height), fontSize: cs.fontSize, fontWeight: cs.fontWeight, fontFamily: cs.fontFamily.split(',')[0], lineHeight: cs.lineHeight, color: cs.color };
+  };
+  const blockRect = {};
+  document.querySelectorAll('main .block').forEach((b) => { blockRect[b.dataset.blockName] = Math.round(b.getBoundingClientRect().height); });
+  const before = {};
+  texts.forEach((t) => { const el = document.querySelector(`[data-prose-index="${t.index}"]`); if (el) before[t.index] = rec(el); });
+  texts.forEach((t) => {
+    const el = document.querySelector(`[data-prose-index="${t.index}"]`);
+    if (!el || el.querySelector('img, picture')) return; // images are edited via data-image-index, not a text editor
+    const parent = document.createElement('div');
+    parent.className = 'prosemirror-editor';
+    parent.setAttribute('data-prose-index', t.index);
+    const pm = document.createElement('div');
+    pm.className = 'ProseMirror';
+    pm.setAttribute('contenteditable', 'true');
+    // ProseMirror renders the DOC node, not the DOM: same tag, no classes, inline marks only.
+    const node = document.createElement(el.tagName);
+    node.innerHTML = el.innerHTML;
+    // decorateButtons() replaced the authored <strong>/<em> with button classes; the
+    // editor renders the DOC, which still has the marks — restore them for the swap
+    // (decorateButtons leaves the authored <strong>/<em> in place; reuse it, never
+    // double-wrap).
+    node.querySelectorAll('a.button').forEach((a) => {
+      const mark = a.classList.contains('accent') ? ['em', 'strong'] : a.classList.contains('primary') ? ['strong'] : a.classList.contains('secondary') ? ['em'] : [];
+      let outer = a;
+      mark.forEach((m) => {
+        const p = outer.parentElement;
+        if (p && p.tagName === m.toUpperCase() && p.childNodes.length === 1) { outer = p; return; }
+        const w = document.createElement(m); outer.replaceWith(w); w.append(outer); outer = w;
+      });
+    });
+    // presentational block spans stand for authored hard breaks: restore the <br>
+    node.querySelectorAll('span').forEach((sp) => {
+      const src = el.querySelectorAll('span')[[...node.querySelectorAll('span')].indexOf(sp)];
+      const block = src && getComputedStyle(src).display === 'block' && sp.nextElementSibling?.tagName === 'SPAN';
+      sp.replaceWith(...sp.childNodes, ...(block ? [document.createElement('br')] : []));
+    });
+    node.querySelectorAll('*').forEach((c) => { [...c.attributes].forEach((a) => { if (!(c.tagName === 'A' && a.name === 'href')) c.removeAttribute(a.name); }); });
+    pm.append(node);
+    parent.append(pm);
+    el.replaceWith(parent);
+  });
+  const after = {};
+  texts.forEach((t) => { const node = document.querySelector(`.prosemirror-editor[data-prose-index="${t.index}"] > .ProseMirror > *`); if (node) after[t.index] = rec(node); });
+  const blockDelta = {};
+  document.querySelectorAll('main .block').forEach((b) => { const h = Math.round(b.getBoundingClientRect().height); blockDelta[b.dataset.blockName] = h - (blockRect[b.dataset.blockName] ?? h); });
+  const drift = texts.filter((t) => before[t.index] && after[t.index]).map((t) => {
+    const b = before[t.index]; const a = after[t.index]; const d = [];
+    ['fontFamily', 'fontSize', 'fontWeight', 'lineHeight', 'color'].forEach((k) => { if (b[k] !== a[k]) d.push(`${k} ${b[k]} → ${a[k]}`); });
+    if (Math.abs(b.h - a.h) > 2) d.push(`height ${b.h} → ${a.h}`);
+    return { index: t.index, block: t.block, tag: t.tag, text: t.text, drift: d };
+  });
+  return { drift, blockDelta };
+}
+/* eslint-enable no-undef */
+
+// ──────────────────────────────────────────────────────── node-side helpers ──
+
+export const firstExisting = (cands, kind) => {
+  const hit = cands.find((p) => fs.existsSync(p));
+  if (!hit) throw new Error(`no ${kind} found (tried ${cands.join(', ')}) — pass it explicitly`);
+  return hit;
+};
+
+// <main> of an authored content file. Only the element bounds are matched here;
+// metadata blocks are removed in the DOM afterwards (dropMetadata), never by regex.
+export function readMainHtml(contentPath) {
+  const raw = fs.readFileSync(contentPath, 'utf8');
+  const m = raw.match(/<main>([\s\S]*?)<\/main>/);
+  if (!m) throw new Error(`${contentPath} has no <main> element`);
+  return m[1];
+}
+
+// `--exempt a,b` → Set of block names.
+export function parseExemptList(str) {
+  return new Set((str || '').split(',').map((s) => s.trim()).filter(Boolean));
+}
+
+// @ew-exempt tags in the LEADING JSDoc of a block's JS. Returns null when the
+// block declares nothing, else { all, reasons: [...], categories: [...] }.
+export function parseExemptTags(js) {
+  const lead = (js.match(/^\s*\/\*\*([\s\S]*?)\*\//) || [])[1];
+  if (!lead) return null;
+  const reasons = [...lead.matchAll(/@ew-exempt\s+([^\n]*)/g)].map((m) => m[1].replace(/^\*\s*/, '').trim()).filter(Boolean);
+  if (!reasons.length) return null;
+  const all = reasons.some((r) => /^all\b/i.test(r));
+  const categories = EW_EXEMPT_CATEGORIES.filter((c) => reasons.some((r) => new RegExp(`\\b${c}\\b`, 'i').test(r)));
+  return { all, reasons, categories };
+}
+
+// Exemptions for a set of blocks: JSDoc tags from <blocksDir>/<name>/<name>.js
+// (when a blocks dir is known) ∪ the CLI list. Returns { name: {all, reasons, categories, source} }.
+export function readBlockExemptions(blocksDir, names, cliExempt = new Set()) {
+  const out = {};
+  (names || []).forEach((name) => {
+    if (!blocksDir) return;
+    let js;
+    try { js = fs.readFileSync(path.join(blocksDir, name, `${name}.js`), 'utf8'); } catch { return; }
+    const tags = parseExemptTags(js);
+    if (tags) out[name] = { ...tags, source: '@ew-exempt' };
+  });
+  cliExempt.forEach((name) => {
+    if (out[name]) out[name].reasons = [...out[name].reasons, '--exempt (CLI)'];
+    else out[name] = { all: false, reasons: ['--exempt (CLI)'], categories: [], source: '--exempt' };
+  });
+  return out;
+}
+
+// Group survey rows per block (or per any key) into the gate's counters.
+//   rows: survey() output; sim: simulateEditor() output or null;
+//   exemptions: readBlockExemptions() output; keyOf: row → group key (default block).
+export function aggregate(rows, { sim = null, exemptions = {}, keyOf = (r) => r.block, blockOf = (r) => r.block } = {}) {
+  const byKey = {};
+  rows.forEach((r) => {
+    const key = keyOf(r);
+    const block = blockOf(r);
+    const ex = exemptions[block];
+    const b = byKey[key] ??= { block: key, authored: 0, editable: 0, dead: 0, duplicated: 0, exempt: 0, textDrift: 0, deadItems: [], dupItems: [], exemptItems: [], exemptReasons: ex ? ex.reasons : [] };
+    b.authored += 1;
+    const label = `<${r.tag}> ${r.text}`;
+    if (r.hits === 1) { b.editable += 1; if (!r.sameText) b.textDrift += 1; }
+    else if (r.hits > 1) { b.duplicated += 1; b.editable += 1; b.dupItems.push({ tag: r.tag, text: r.text, hits: r.hits, label: `${label} (×${r.hits})` }); }
+    else if (ex) { b.exempt += 1; b.exemptItems.push({ tag: r.tag, text: r.text, label }); }
+    else { b.dead += 1; b.deadItems.push({ tag: r.tag, text: r.text, label }); }
+  });
+  if (sim) {
+    sim.drift.forEach((d) => {
+      const b = byKey[keyOf(d)] || byKey[d.block];
+      if (!b) return;
+      b.editDrift = (b.editDrift ?? 0) + (d.drift.length ? 1 : 0);
+      if (d.drift.length) (b.driftItems ??= []).push(`<${d.tag}> ${d.text.slice(0, 40)} :: ${d.drift.join('; ')}`);
+    });
+    Object.entries(sim.blockDelta).forEach(([name, delta]) => { if (byKey[name]) byKey[name].blockHeightDelta = delta; });
+  }
+  const blocks = Object.values(byKey);
+  const totals = blocks.reduce((a, b) => ({ authored: a.authored + b.authored, editable: a.editable + b.editable, dead: a.dead + b.dead, duplicated: a.duplicated + b.duplicated, exempt: a.exempt + b.exempt }), { authored: 0, editable: 0, dead: 0, duplicated: 0, exempt: 0 });
+  return { blocks, totals };
+}
+
+export function formatTable(label, { blocks, totals }, { sim = null, verbose = false, errors = [] } = {}) {
+  const out = [];
+  out.push(`\n${label}  authored=${totals.authored} editable=${totals.editable} dead=${totals.dead} duplicated=${totals.duplicated} exempt=${totals.exempt}`);
+  out.push(`block            authored editable dead dup exempt drift${sim ? '  editDrift blockΔh' : ''}`);
+  blocks.forEach((b) => out.push(`${b.block.padEnd(16)} ${String(b.authored).padStart(8)} ${String(b.editable).padStart(8)} ${String(b.dead).padStart(4)} ${String(b.duplicated).padStart(3)} ${String(b.exempt).padStart(6)} ${String(b.textDrift).padStart(5)}${sim ? `  ${String(b.editDrift ?? 0).padStart(9)} ${String(b.blockHeightDelta ?? 0).padStart(7)}` : ''}`));
+  if (errors.length) { out.push('\n  ⚠ decorate errors (survey not trustworthy for these blocks):'); errors.forEach((e) => out.push(`    ${e}`)); }
+  if (verbose) {
+    blocks.filter((b) => b.deadItems.length).forEach((b) => { out.push(`\n  DEAD in ${b.block}:`); b.deadItems.forEach((d) => out.push(`    ${d.label}`)); });
+    blocks.filter((b) => b.dupItems.length).forEach((b) => { out.push(`\n  DUPLICATED in ${b.block}:`); b.dupItems.forEach((d) => out.push(`    ${d.label}`)); });
+    blocks.filter((b) => b.exemptItems.length).forEach((b) => { out.push(`\n  EXEMPT in ${b.block} (${b.exemptReasons.join('; ')}):`); b.exemptItems.forEach((d) => out.push(`    ${d.label}`)); });
+    if (sim) blocks.filter((b) => b.driftItems?.length).forEach((b) => { out.push(`\n  EDIT-MODE DRIFT in ${b.block}:`); b.driftItems.forEach((d) => out.push(`    ${d}`)); });
+  }
+  return out.join('\n');
+}
+
+// Gate verdict over aggregated blocks: dead non-exempt text or duplicated index → fail.
+export function verdict({ blocks }) {
+  return { dead: blocks.some((b) => b.dead > 0), duplicated: blocks.some((b) => b.duplicated > 0) };
+}
+
+// Quick-edit CSS for --simulate-editor; degrades to '' offline.
+export async function fetchQuickEditCss() {
+  return fetch(QE_CSS).then((r) => (r.ok ? r.text() : '')).catch(() => '');
+}
+
+// Inline each block's JS into the harness page as window.__b[name] (export
+// default stripped; the default export must be `decorate`). Returns the names
+// whose JS failed to install (module-scope import/export, syntax error).
+export async function installBlockJs(page, names, blocksDir) {
+  const withJs = [];
+  for (const name of names) {
+    let js;
+    try { js = fs.readFileSync(path.join(blocksDir, name, `${name}.js`), 'utf8'); } catch { continue; } // CSS-only block
+    withJs.push(name);
+    await page.addScriptTag({ content: `window.__b=window.__b||{};window.__b[${JSON.stringify(name)}]=(function(){${js.replace(/export default\s+/, '')}\nreturn decorate;})();` });
+  }
+  return page.evaluate((ns) => ns.filter((n) => !(window.__b && window.__b[n])), withJs);
+}
+
+// Run decorate() over every .<name> element; returns "<name>: <error>" strings.
+export async function runDecorate(page, names) {
+  return page.evaluate(async (ns) => {
+    const out = [];
+    for (const n of ns) {
+      if (!window.__b || !window.__b[n]) continue;
+      for (const el of document.querySelectorAll(`.${n}`)) {
+        try { await window.__b[n](el); } catch (e) { out.push(`${n}: ${e.message}`); }
+      }
+    }
+    return out;
+  }, names);
+}
+
+// Harness mode: decorate an authored content file locally and survey it.
+// Returns { texts, rows, sim, names, errors, page } — the page is left open
+// (screenshots / further evaluation) for the caller to close.
+export async function probeContent(browser, { content, blocksDir, stylesPath, width = 1440, simulate = false, extraCss = '', instrumentFirst = true }) {
+  const mainHtml = readMainHtml(content);
+  const styles = fs.readFileSync(stylesPath, 'utf8');
+  const page = await browser.newPage({ viewport: { width, height: 1000 }, reducedMotion: 'reduce' });
+  // body.appear satisfies the vanilla foundation's body{display:none} gate the
+  // way loadEager() does; body > header is hidden so sticky headers do not land
+  // in tall element screenshots.
+  await page.setContent(`<!doctype html><html><head><meta charset="utf-8"><style>body{margin:0}body > header{display:none}${styles}\n${extraCss}</style></head><body class="appear"><main>${mainHtml}</main></body></html>`, { waitUntil: 'networkidle' });
+  await page.evaluate(dropMetadata);
+  const names = await page.evaluate(discoverBlocks);
+  const blockCss = names.map((n) => { try { return fs.readFileSync(path.join(blocksDir, n, `${n}.css`), 'utf8'); } catch { return ''; } }).join('\n');
+  if (blockCss) await page.addStyleTag({ content: blockCss });
+  await page.evaluate(runtimeMimic);
+  const texts = instrumentFirst ? (await page.evaluate(instrument, EDITABLE)).texts : [];
+  const errors = [];
+  const notInstalled = await installBlockJs(page, names, blocksDir);
+  notInstalled.forEach((n) => errors.push(`${n}: block JS failed to install — module-scope import/export or a syntax error (the harness inlines block JS and cannot resolve imports)`));
+  errors.push(...await runDecorate(page, names));
+  await page.waitForTimeout(800);
+  const rows = await page.evaluate(survey, texts);
+  let sim = null;
+  if (simulate) {
+    const css = await fetchQuickEditCss();
+    if (css) await page.addStyleTag({ content: css });
+    sim = await page.evaluate(simulateEditor, texts);
+  }
+  return { texts, rows, sim, names, errors, page };
+}
+
+// URL mode: intercept the document response, instrument it in a scratch page,
+// let the served page's own scripts decorate, survey. Returns { texts, rows, sim, page, ctx }.
+export async function probeUrl(browser, url, { width = 1440, simulate = false, settleMs = 500, timeoutMs = 30000, waitUntil = 'networkidle', gotoTimeoutMs = 45000 } = {}) {
+  const ctx = await browser.newContext({ viewport: { width, height: 900 } });
+  const scratch = await ctx.newPage();
+  const page = await ctx.newPage();
+  let texts = [];
+  let instrumented = false;
+  await page.route('**/*', async (route) => {
+    const req = route.request();
+    // The main-frame document only (the first navigation, or its redirect target).
+    if (req.resourceType() !== 'document' || req.frame() !== page.mainFrame() || instrumented) return route.continue();
+    instrumented = true;
+    const resp = await route.fetch();
+    const html = await resp.text();
+    await scratch.setContent(html);
+    const out = await scratch.evaluate(instrument, EDITABLE);
+    texts = out.texts;
+    return route.fulfill({ response: resp, body: out.html, headers: { ...resp.headers(), 'content-type': 'text/html; charset=utf-8' } });
+  });
+  await page.goto(url, { waitUntil, timeout: gotoTimeoutMs });
+  await page.waitForFunction(() => [...document.querySelectorAll('main .section')].every((s) => s.dataset.sectionStatus === 'loaded'), null, { timeout: timeoutMs }).catch(() => {});
+  await page.waitForTimeout(settleMs);
+  const rows = await page.evaluate(survey, texts);
+  let sim = null;
+  if (simulate) {
+    const css = await fetchQuickEditCss();
+    if (css) await page.addStyleTag({ content: css });
+    sim = await page.evaluate(simulateEditor, texts);
+  }
+  return { texts, rows, sim, page, ctx };
+}
+
+// Resolve playwright from the cwd project first (plugin scripts live outside any
+// node_modules tree), then bare.
+export async function loadChromium() {
+  const normalize = (mod) => (mod.chromium ? mod : (mod.default?.chromium ? mod.default : null));
+  try {
+    const req = createRequire(path.join(process.cwd(), 'package.json'));
+    const mod = normalize(await import(pathToFileURL(req.resolve('playwright')).href));
+    if (mod) return mod.chromium;
+  } catch { /* fall through */ }
+  const mod = normalize(await import('playwright'));
+  if (!mod) throw new Error('playwright not found: run from a project that has it installed (npm i -D playwright)');
+  return mod.chromium;
+}
+
+// ──────────────────────────────────────────────────────────────── CLI ──
+
+function parseArgs(argv) {
+  const rest = argv.slice(2);
+  const opts = { json: false, verbose: false, simulate: false, exempt: new Set(), content: null, blocksDir: null, styles: null, width: 1440, urls: [] };
+  for (let i = 0; i < rest.length; i += 1) {
+    const a = rest[i];
+    if (a === '--json') opts.json = true;
+    else if (a === '--verbose') opts.verbose = true;
+    else if (a === '--simulate-editor') opts.simulate = true;
+    else if (a === '--exempt') opts.exempt = parseExemptList(rest[i += 1]);
+    else if (a === '--content') opts.content = rest[i += 1];
+    else if (a === '--blocks-dir') opts.blocksDir = rest[i += 1];
+    else if (a === '--styles') opts.styles = rest[i += 1];
+    else if (a === '--width') opts.width = Number(rest[i += 1]);
+    else if (a.startsWith('--')) throw new Error(`unknown option ${a}`);
+    else opts.urls.push(a);
+  }
+  return opts;
+}
+
+const USAGE = 'usage: ew-editability-probe.mjs <url> [<url> ...] [--json] [--verbose] [--simulate-editor] [--exempt a,b] [--blocks-dir dir]\n'
+  + '       ew-editability-probe.mjs --content <content/page.html> [--blocks-dir dir] [--styles css] [--width px] [--json] [--verbose] [--simulate-editor] [--exempt a,b]\n';
+
+async function main() {
+  const opts = parseArgs(process.argv);
+  if (!opts.urls.length && !opts.content) { process.stderr.write(USAGE); process.exit(2); }
+  const chromium = await loadChromium();
+  const browser = await chromium.launch();
+  const results = [];
+  let fail = false;
+  let probeError = false;
+  try {
+    if (opts.content) {
+      const blocksDir = opts.blocksDir || firstExisting(['eds/blocks', 'blocks'], 'blocks dir');
+      const stylesPath = opts.styles || firstExisting(['eds/styles/styles.css', 'styles/styles.css'], 'styles.css');
+      const { rows, sim, names, errors, page } = await probeContent(browser, { content: opts.content, blocksDir, stylesPath, width: opts.width, simulate: opts.simulate });
+      await page.close();
+      const exemptions = readBlockExemptions(blocksDir, names, opts.exempt);
+      const agg = aggregate(rows, { sim, exemptions });
+      const v = verdict(agg);
+      if (v.dead || v.duplicated) fail = true;
+      if (errors.length) probeError = true;
+      results.push({ content: opts.content, blocksDir, stylesPath, totals: agg.totals, blocks: agg.blocks, rows, sim, exemptions, errors });
+      if (!opts.json) console.log(formatTable(`${opts.content} (harness, ${blocksDir}, ${stylesPath})`, agg, { sim, verbose: opts.verbose, errors }));
+    }
+    for (const url of opts.urls) {
+      const { rows, sim, ctx } = await probeUrl(browser, url, { width: opts.width, simulate: opts.simulate });
+      await ctx.close();
+      const names = [...new Set(rows.map((r) => r.block))];
+      const exemptions = readBlockExemptions(opts.blocksDir, names, opts.exempt);
+      const agg = aggregate(rows, { sim, exemptions });
+      const v = verdict(agg);
+      if (v.dead || v.duplicated) fail = true;
+      results.push({ url, totals: agg.totals, blocks: agg.blocks, rows, sim, exemptions });
+      if (!opts.json) console.log(formatTable(url, agg, { sim, verbose: opts.verbose }));
+    }
+  } catch (e) { console.error(e); process.exit(2); } finally { await browser.close(); }
+  if (opts.json) console.log(JSON.stringify(results, null, 2));
+  if (probeError) { console.error('probe error: some blocks failed to install/decorate — their survey is not trustworthy'); process.exit(2); }
+  process.exit(fail ? 1 : 0);
+}
+
+const isCli = process.argv[1] && path.basename(process.argv[1]) === 'ew-editability-probe.mjs';
+if (isCli) main().catch((e) => { console.error(e); process.exit(2); });

--- a/plugins/stardust/skills/deploy/scripts/render-harness.mjs
+++ b/plugins/stardust/skills/deploy/scripts/render-harness.mjs
@@ -1,78 +1,115 @@
+#!/usr/bin/env node
 /**
  * render-harness.mjs — reproduce EDS block decoration locally (no DA / dev-server).
  *
- * Injects styles.css + each block's CSS, runs every block's decorate() over the authored
- * content, and screenshots — so first-pass conversion fidelity is verifiable even when
- * DA_TOKEN is expired (fidelity is decided at conversion time, not deploy time).
+ * Injects styles.css + each block's CSS, mimics the vanilla runtime's
+ * decorateButtons/decorateSections/decorateBlock/wrapTextNodes DOM, runs every
+ * block's decorate() over the authored content, and screenshots — so first-pass
+ * conversion fidelity is verifiable even when DA_TOKEN is expired (fidelity is
+ * decided at conversion time, not deploy time). `body > header` is hidden in the
+ * harness CSS: sticky headers land in tall element screenshots.
  *
  * Usage:
- *   node render-harness.mjs <content/path.html> <out.png> <block-name> [block-name ...]
+ *   node render-harness.mjs <content/path.html> <out.png> [block-name ...] [options]
+ *     block-name ...      blocks to decorate (default: every block div found in the page)
+ *     --styles <path>     foundation CSS (default eds/styles/styles.css, then styles/styles.css)
+ *     --blocks-dir <dir>  blocks root (default eds/blocks, then blocks)
+ *     --width <px>        viewport width (default 1280)
+ *     --ew                Experience Workspace editability: stamp `data-prose-index`
+ *                         on the authored texts before decorate() and print the
+ *                         survivor table (dead / duplicated / exempt per block —
+ *                         see ew-editability-probe.mjs; `@ew-exempt` JSDoc tags read
+ *                         from the blocks dir). Exit 1 when a non-exempt text is dead
+ *                         or an index is duplicated.
+ *     --simulate-editor   after decorate(), swap every surviving text for the
+ *                         ProseMirror-shaped editor the canvas inserts, so the
+ *                         screenshot shows EDIT MODE (implies --ew instrumentation;
+ *                         the quick-edit CSS fetch degrades gracefully offline)
+ *
+ * Exit codes: 0 rendered (and, with --ew, no dead/duplicated text), 1 = --ew found
+ * dead non-exempt text or a duplicated index, 2 = harness error.
  */
+
+/* eslint-disable import/no-extraneous-dependencies, import/extensions, no-await-in-loop, no-restricted-syntax, brace-style, object-curly-newline, max-len, no-plusplus, no-continue */
 import { chromium } from 'playwright';
 import fs from 'fs';
-const contentPath = process.argv[2], out = process.argv[3];
-const blocks = process.argv.slice(4);
-const raw = fs.readFileSync(contentPath, 'utf8');
-const main = raw.match(/<main>([\s\S]*?)<\/main>/)[1]
-  .replace(/<div class="metadata">[\s\S]*?<\/div>\s*<\/div>\s*<\/div>/, ''); // drop metadata block
-const styles = fs.readFileSync('eds/styles/styles.css', 'utf8');
-const blockCss = blocks.map((n) => { try { return fs.readFileSync(`eds/blocks/${n}/${n}.css`, 'utf8'); } catch { return ''; } }).join('\n');
-const b = await chromium.launch();
-const p = await b.newPage({ viewport: { width: 1280, height: 900 } });
-await p.setContent(`<!doctype html><html><head><meta charset="utf-8"><style>body{margin:0}main .section{padding:0}${styles}\n${blockCss}</style></head><body class="appear"><main>${main}</main></body></html>`, { waitUntil: 'networkidle' });
-// Mimic the vanilla runtime's decorateSections/decorateBlock DOM (aem.js):
-// .section + .default-content-wrapper + .<name>-wrapper/.block/.<name>-container
-// + wrapTextNodes cell normalization (#104 — media-led cells fold into one <p>
-// on live; the harness must present the same shape to decode). body.appear
-// above satisfies the stock body{display:none} gate the same way loadEager()
-// does. Without this, block CSS scoped to the decorated shape silently never
-// matches in the harness.
-await p.evaluate(() => {
-  const VALID_WRAPPERS = ['P', 'PRE', 'UL', 'OL', 'PICTURE', 'TABLE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6'];
-  const wrapTextNodes = (block) => {
-    const wrap = (el) => { const w = document.createElement('p'); w.append(...el.childNodes); el.append(w); };
-    block.querySelectorAll(':scope > div > div').forEach((cell) => {
-      if (!cell.hasChildNodes()) return;
-      const first = cell.firstElementChild;
-      const hasWrapper = !!first && VALID_WRAPPERS.includes(first.tagName);
-      if (!hasWrapper) wrap(cell);
-      else if (first.tagName === 'PICTURE' && (cell.children.length > 1 || !!cell.textContent.trim())) wrap(cell);
-    });
-  };
-  document.querySelectorAll('main > div').forEach((section) => {
-    const wrappers = [];
-    let defaultContent = false;
-    [...section.children].forEach((e) => {
-      if (e.tagName === 'DIV' || !defaultContent) {
-        const wrapper = document.createElement('div');
-        wrappers.push(wrapper);
-        defaultContent = e.tagName !== 'DIV';
-        if (defaultContent) wrapper.classList.add('default-content-wrapper');
-      }
-      wrappers[wrappers.length - 1].append(e);
-    });
-    wrappers.forEach((w) => section.append(w));
-    section.classList.add('section');
-    section.querySelectorAll(':scope > div > div[class]').forEach((block) => {
-      const name = block.classList[0];
-      if (!name) return;
-      block.classList.add('block');
-      block.dataset.blockName = name;
-      wrapTextNodes(block);
-      block.parentElement.classList.add(`${name}-wrapper`);
-      section.classList.add(`${name}-container`);
-    });
-  });
-});
-for (const name of blocks) {
-  const js = fs.readFileSync(`eds/blocks/${name}/${name}.js`, 'utf8').replace(/export default\s+/, '');
-  await p.addScriptTag({ content: `window.__b=window.__b||{};window.__b[${JSON.stringify(name)}]=(function(){${js}\nreturn decorate;})();` });
+import path from 'path';
+import {
+  EDITABLE, firstExisting, readMainHtml, dropMetadata, discoverBlocks, runtimeMimic, instrument, survey, simulateEditor,
+  installBlockJs, runDecorate, readBlockExemptions, aggregate, formatTable, verdict, fetchQuickEditCss,
+} from './ew-editability-probe.mjs';
+
+function parseArgs(argv) {
+  const rest = argv.slice(2);
+  const opts = { positional: [], styles: null, blocksDir: null, width: 1280, ew: false, simulate: false };
+  for (let i = 0; i < rest.length; i += 1) {
+    const a = rest[i];
+    if (a === '--styles') { opts.styles = rest[i += 1]; }
+    else if (a === '--blocks-dir') { opts.blocksDir = rest[i += 1]; }
+    else if (a === '--width') { opts.width = Number(rest[i += 1]); }
+    else if (a === '--ew') { opts.ew = true; }
+    else if (a === '--simulate-editor') { opts.simulate = true; opts.ew = true; }
+    else if (a.startsWith('--')) { throw new Error(`unknown option ${a}`); }
+    else opts.positional.push(a);
+  }
+  const [contentPath, out, ...blocks] = opts.positional;
+  return { contentPath, out, blocks, opts };
 }
-await p.evaluate((names) => {
-  names.forEach((n) => document.querySelectorAll('.' + n).forEach((el) => { try { window.__b[n](el); } catch (e) { el.setAttribute('data-err', e.message); } }));
-}, blocks);
-await p.waitForTimeout(1200);
-await p.screenshot({ path: out, fullPage: true });
-const errs = await p.evaluate(() => [...document.querySelectorAll('[data-err]')].map((e) => e.className + ': ' + e.getAttribute('data-err')));
-console.log('rendered', out, '| block errors:', JSON.stringify(errs));
-await b.close();
+
+async function main() {
+  const { contentPath, out, blocks, opts } = parseArgs(process.argv);
+  if (!contentPath || !out) {
+    process.stderr.write('usage: node render-harness.mjs <content/path.html> <out.png> [block-name ...] [--styles css] [--blocks-dir dir] [--width px] [--ew] [--simulate-editor]\n');
+    process.exit(2);
+  }
+  const stylesPath = opts.styles || firstExisting(['eds/styles/styles.css', 'styles/styles.css'], 'styles.css');
+  const blocksDir = opts.blocksDir || firstExisting(['eds/blocks', 'blocks'], 'blocks dir');
+  const mainHtml = readMainHtml(contentPath);
+  const styles = fs.readFileSync(stylesPath, 'utf8');
+
+  const b = await chromium.launch();
+  let fail = false;
+  try {
+    const p = await b.newPage({ viewport: { width: opts.width, height: 900 }, reducedMotion: 'reduce' });
+    // body.appear satisfies the stock body{display:none} gate the same way
+    // loadEager() does; body > header hidden (sticky headers in tall screenshots).
+    await p.setContent(`<!doctype html><html><head><meta charset="utf-8"><style>body{margin:0}body > header{display:none}main .section{padding:0}${styles}</style></head><body class="appear"><main>${mainHtml}</main></body></html>`, { waitUntil: 'networkidle' });
+    await p.evaluate(dropMetadata);
+    const names = blocks.length ? blocks : await p.evaluate(discoverBlocks);
+    const blockCss = names.map((n) => { try { return fs.readFileSync(path.join(blocksDir, n, `${n}.css`), 'utf8'); } catch { return ''; } }).join('\n');
+    if (blockCss) await p.addStyleTag({ content: blockCss });
+    // Mimic the vanilla runtime's decorateMain DOM (aem.js): .section +
+    // .default-content-wrapper + .<name>-wrapper/.block/.<name>-container +
+    // wrapTextNodes cell normalization (#104 — media-led cells fold into one <p>
+    // on live; the harness must present the same shape to decode). Without this,
+    // block CSS scoped to the decorated shape silently never matches in the harness.
+    await p.evaluate(runtimeMimic);
+    const texts = opts.ew ? (await p.evaluate(instrument, EDITABLE)).texts : [];
+    const errs = [];
+    const notInstalled = await installBlockJs(p, names, blocksDir);
+    notInstalled.forEach((n) => errs.push(`${n}: block JS failed to install (module-scope import/export or syntax error)`));
+    errs.push(...await runDecorate(p, names));
+    await p.waitForTimeout(1200);
+    let agg = null; let sim = null;
+    if (opts.ew) {
+      const rows = await p.evaluate(survey, texts);
+      if (opts.simulate) {
+        const css = await fetchQuickEditCss();
+        if (css) await p.addStyleTag({ content: css });
+        sim = await p.evaluate(simulateEditor, texts);
+        await p.waitForTimeout(300);
+      }
+      agg = aggregate(rows, { sim, exemptions: readBlockExemptions(blocksDir, names) });
+      const v = verdict(agg);
+      fail = v.dead || v.duplicated;
+    }
+    await p.screenshot({ path: out, fullPage: true });
+    console.log('rendered', out, opts.simulate ? '(simulated edit mode)' : '', '| block errors:', JSON.stringify(errs));
+    if (agg) console.log(formatTable(`EW editability — ${contentPath}`, agg, { sim, verbose: true, errors: [] }));
+  } finally {
+    await b.close();
+  }
+  process.exit(fail ? 1 : 0);
+}
+
+main().catch((e) => { process.stderr.write(`render-harness error: ${e.message}\n`); process.exit(2); });

--- a/plugins/stardust/skills/deploy/scripts/section-schema.mjs
+++ b/plugins/stardust/skills/deploy/scripts/section-schema.mjs
@@ -16,6 +16,16 @@
  *     schema's unit composition is the post-decorate count assertion.
  * block-roundtrip.mjs (#94) then verifies the round-trip actually closed.
  *
+ * `editableTexts` (per section) is the ENCODE-side expected editable count for
+ * the Experience Workspace gate: the number of OUTERMOST h1-h6/p/ul/ol/pre/
+ * blockquote elements in the prototype section that carry visible text — the set
+ * the da.live canvas stamps `data-prose-index` on and can attach an inline editor
+ * to (deploy SKILL.md § Experience Workspace editability contract). ENCODE authors
+ * one such element per item (a list is ONE editable unit); after decorate() the
+ * `--ew` gate (block-roundtrip / ew-editability-probe) must find the same number
+ * of surviving instrumented elements — fewer means authored elements were rebuilt,
+ * merged or synthesized (EW1), and the block is not editable in the workspace.
+ *
  * Usage:
  *   node skills/deploy/scripts/section-schema.mjs <prototypeURL> [options]
  *     --out <file>     write JSON here (default stdout)
@@ -32,7 +42,7 @@ import { chromium } from 'playwright';
 import fs from 'fs';
 import path from 'path';
 import { resolveProfile } from './diff-profiles.mjs';
-import { inventory } from './content-inventory.mjs';
+import { inventory, editableInventory } from './content-inventory.mjs';
 
 function parseArgs(argv) {
   const [, , url, ...rest] = argv;
@@ -125,10 +135,12 @@ async function main() {
     sections = [];
     for (const m of mapped) {
       const inv = await page.evaluate(inventory, [`[data-ss-idx="${m.idx}"]`, prof.eyebrow]);
+      const editable = await page.evaluate(editableInventory, [`[data-ss-idx="${m.idx}"]`]);
       sections.push({
         section: m.section,
         items: inv.items.map(({ role, order, text, href }) => (href !== undefined ? { role, order, text, href } : { role, order, text })),
         imgCount: inv.imgCount,
+        editableTexts: editable.count,
         repeats: m.repeats,
       });
     }
@@ -141,7 +153,7 @@ async function main() {
   if (opts.out) {
     fs.mkdirSync(path.dirname(opts.out), { recursive: true });
     fs.writeFileSync(opts.out, `${json}\n`);
-    const totals = sections.map((s) => `${s.section}(${s.items.length} items${s.repeats.length ? `, ${s.repeats.map((r) => `${r.count}×${r.unitSelector}`).join('+')}` : ''})`).join(', ');
+    const totals = sections.map((s) => `${s.section}(${s.items.length} items${s.repeats.length ? `, ${s.repeats.map((r) => `${r.count}×${r.unitSelector}`).join('+')}` : ''}, ${s.editableTexts} editable)`).join(', ');
     process.stdout.write(`schema → ${opts.out}\n${sections.length} sections: ${totals}\n`);
   } else {
     process.stdout.write(`${json}\n`);

--- a/plugins/stardust/skills/diff/scripts/content-diff.mjs
+++ b/plugins/stardust/skills/diff/scripts/content-diff.mjs
@@ -69,7 +69,9 @@ import { chromium } from 'playwright';
 // copies of content-inventory.mjs/diff-profiles.mjs must stay in sync until the diff-skill
 // abrasion PR consolidates them. Keep edits (e.g. the classifier's norm()) applied to both.
 import { resolveProfile } from './diff-profiles.mjs';
-import { inventory, diffInventories, summarise } from './content-inventory.mjs';
+// editableInventory = the Experience Workspace outermost-editable classifier, shared
+// with the deploy gates (section-schema editableTexts, block-roundtrip --ew).
+import { inventory, diffInventories, summarise, editableInventory } from './content-inventory.mjs';
 import { REAL_CHROME_UA, isLiveHttpUrl, defaultWaitUntil, launchStealthHeaded, newLiveContext, gotoLive, dismissOverlays } from './live-session.mjs';
 
 const USAGE = `usage: node skills/diff/scripts/content-diff.mjs <sourceURL> <buildURL> [options]
@@ -142,6 +144,7 @@ async function grab(browser, url, opts, prof) {
   });
   await page.waitForTimeout(400);
   const inv = await page.evaluate(inventory, [opts.main || prof.mainDefault, prof.eyebrow]);
+  inv.editable = await page.evaluate(editableInventory, [opts.main || prof.mainDefault]);
   await ctx.close();
   return inv;
 }
@@ -166,6 +169,14 @@ async function main() {
   process.stdout.write(`\nContent diff @ ${opts.width}px (profile "${prof.name}", root "${opts.main || prof.mainDefault}")\n`);
   process.stdout.write(`  ${prof.source}: ${summarise(srcInv)}\n`);
   process.stdout.write(`  ${prof.target}: ${summarise(tgtInv)}\n`);
+  // Experience Workspace editability advisory (deploy SKILL.md § Experience Workspace
+  // editability contract): the canvas can only attach an editor to an OUTERMOST
+  // h1-h6/p/ul/ol element that survives decorate(); fewer on the build than on the
+  // source means authored elements were rebuilt/merged into wrappers or text.
+  const srcEd = srcInv.editable ? srcInv.editable.count : 0;
+  const tgtEd = tgtInv.editable ? tgtInv.editable.count : 0;
+  process.stdout.write(`  editable texts (outermost h*/p/ul/ol): ${prof.source} ${srcEd} / ${prof.target} ${tgtEd}\n`);
+  if (tgtEd < srcEd) flags.push({ sev: '🟡', kind: 'EDITABLE COUNT', msg: `${prof.target} has ${tgtEd} outermost editable element(s) vs ${srcEd} in the ${prof.source} — fewer outermost editable elements after decoration usually means authored elements were rebuilt/merged — see deploy SKILL.md § Experience Workspace editability contract (run ew-editability-probe.mjs on the build URL for the per-block verdict).` });
 
   if ((srcInv.items.length < 3 || tgtInv.items.length < 3)) {
     process.stdout.write('\n⚠ one side has almost no content — a blank/failed render; fix that before trusting the diff.\n');

--- a/plugins/stardust/skills/diff/scripts/content-inventory.mjs
+++ b/plugins/stardust/skills/diff/scripts/content-inventory.mjs
@@ -25,6 +25,17 @@
  * from a diff-profiles.mjs profile. Pass fontDelta: Infinity to suppress the
  * FONT FORK pass (the in-loop harness renders with local fonts, so face
  * fidelity is Step 4/10's business there, not the round-trip's).
+
+ * `editableInventory` runs IN the page (ONE arg): page.evaluate(editableInventory, [rootSel])
+ * returns { count, items: [{tag, text}] } — the OUTERMOST h1-h6/p/ul/ol/pre/
+ * blockquote elements under the root that carry visible text (outermost = no
+ * ancestor matching the same list inside the root; empty and image-only elements
+ * skipped). That is exactly the set Experience Workspace stamps `data-prose-index`
+ * on (deploy SKILL.md § Experience Workspace editability contract): the ENCODE side
+ * counts it on the prototype (section-schema `editableTexts`), the DECODE side on
+ * the decorated page (content-diff's "editable texts" advisory, the --ew gate) —
+ * fewer surviving outermost editables after decoration means authored elements
+ * were rebuilt or merged.
  */
 
 /* eslint-disable no-plusplus, no-continue, max-len */
@@ -110,6 +121,22 @@ export function inventory(args) {
   });
   probe.remove();
   return { items: out, imgCount };
+}
+// Runs IN the page (ONE arg). args = [rootSel]. Outermost editable elements with
+// visible text — the Experience Workspace instrumentation set (see header).
+export function editableInventory(args) {
+  const [rootSel] = args;
+  const root = document.querySelector(rootSel) || document.querySelector('main') || document.body;
+  const SEL = 'h1, h2, h3, h4, h5, h6, p, ul, ol, pre, blockquote';
+  const items = [];
+  root.querySelectorAll(SEL).forEach((el) => {
+    const anc = el.parentElement && el.parentElement.closest(SEL);
+    if (anc && anc !== root && root.contains(anc)) return; // nested inside another editable
+    const text = (el.textContent || '').replace(/\s+/g, ' ').trim();
+    if (!text) return; // empty or image-only (edited via data-image-index, not a text editor)
+    items.push({ tag: el.tagName.toLowerCase(), text: text.slice(0, 70) });
+  });
+  return { count: items.length, items };
 }
 /* eslint-enable no-undef */
 

--- a/plugins/stardust/skills/migrate/reference/fidelity-tiers.md
+++ b/plugins/stardust/skills/migrate/reference/fidelity-tiers.md
@@ -54,7 +54,9 @@ This is a counts-level gate by design — cheap enough to run on every
 sibling. Per-node structural diffing stays where it lives today (the
 archetype's gates, deploy's `block-roundtrip`, replica's source-fidelity
 gate); the counts catch the dropped-content class those would only see
-later.
+later. Any block JS written for a sibling or archetype obeys the
+Experience Workspace editability contract (deploy SKILL.md § 8, EW1–EW10)
+and passes the EW gate (`block-roundtrip --ew`) before the page is done.
 
 ## Declaration (per page)
 

--- a/plugins/stardust/skills/qa/SKILL.md
+++ b/plugins/stardust/skills/qa/SKILL.md
@@ -39,6 +39,9 @@ delivered HTML ≠ rendered correctly.
    - `--scrape stardust/scrape` — verbatim fidelity vs the extraction capture
    - `--expected-blocks <json>` — explicit per-template block expectations
      (otherwise derived by fleet consensus)
+   - `--blocks-dir <dir>` — the site's `blocks/` checkout, so the
+     `editability` check can honour `@ew-exempt` JSDoc tags (otherwise
+     pass `--ew-exempt a,b` for index-driven blocks)
 5. Browser checks need **playwright resolvable from the project** (`node_modules/playwright`).
    If missing, run the delivery-layer checks only (`--checks routing,content,templates,metadata,links`)
    and tell the user what was skipped.
@@ -62,6 +65,15 @@ under `stardust/qa/shots/`, and (first run) visual baselines under
 2 = infra failure. `reference/checks.md` documents every check, its finding
 ids, and severity rationale. Useful variants: `--checks <subset>`,
 `--max-pages <n>` (smoke run), `--fail-on warn` (strict gate).
+
+The `editability` check is the post-deploy **Experience Workspace
+editability gate** (deploy SKILL.md § 8, EW1–EW10): per page it re-creates
+the da.live canvas's instrumentation on the served document, lets the live
+page decorate, and counts which authored texts still carry their editor
+index. `editability/dead-text` (error) = a block rebuilt authored text and
+the author cannot click it in the canvas; `editability/duplicated-index`
+(warn) = a presentational clone kept the index. Dead texts inside blocks
+declared `@ew-exempt` (or listed in `--ew-exempt`) are info, not errors.
 
 First run on a site: expect a wave of `visual/baseline-created` info findings —
 that is the baseline being established, not a defect. Baselines should be

--- a/plugins/stardust/skills/qa/reference/checks.md
+++ b/plugins/stardust/skills/qa/reference/checks.md
@@ -121,6 +121,38 @@ for a judgment pass without re-crawling.
 | `measurement` | info | per-page numbers, always recorded |
 | `load-timeout` | warn | no load event in 60s |
 
+## editability (J, browser, desktop 1440 — Experience Workspace inline-edit gate)
+
+Reproduces what the da.live canvas does when an author opens a migrated page:
+the document response is intercepted and instrumented like
+`editor-utils.getInstrumentedHTML` (`data-prose-index` on every OUTERMOST
+`h1-h6/p/ul/ol/pre/blockquote` inside `<main>`, bare-text block cells re-wrapped
+as `<p>` first), the live page's own `scripts.js` decorates it, and each authored
+text is then looked up by its index. Exactly one surviving element = editable;
+zero = **dead** (the block rebuilt it from `textContent`/`innerHTML`, synthesized
+or retagged it); several = **duplicated** (clone slides — the editor attaches to
+the first in DOM order). Shared instrument:
+`skills/deploy/scripts/ew-editability-probe.mjs`; contract: deploy SKILL.md
+§ Experience Workspace editability contract (EW1–EW10).
+
+| id | sev | what |
+|---|---|---|
+| `dead-text` | error | a block has ≥1 non-exempt authored text that no longer carries its index after decoration — the author clicks it in the workspace and nothing happens. Message: block name, dead/authored count, first 3 texts; evidence lists up to 8. Fix in the block JS: MOVE the authored element into the wrapper (EW1) |
+| `duplicated-index` | warn | a text's index survives on several elements (presentational clones) — editable, but the editor may attach to a hidden copy; strip instrumentation from clones (EW4) |
+| `summary` | info | per page: authored / editable / dead / duplicated / exempt totals and the per-block breakdown — evidence for the migration ledger |
+| `probe-failed` | warn | navigation or instrumentation failed for the page (timeout, blocked response); nothing measured |
+
+Severity rationale: dead text is an **error** because an author is harmed right
+now (silently uneditable content, found by the customer in the canvas — no other
+gate sees it); duplicates are **warn** because editing still works, on the wrong
+copy at worst. Exemptions (EW5 — declared, never silent): `--ew-exempt a,b`
+(blocks whose rows are config / derived / index fallback) and, with
+`--blocks-dir <dir>`, `@ew-exempt <reason>` tags in each block's leading JSDoc
+(`@ew-exempt all` = the whole block is index/API-driven). Exempt dead texts are
+counted under `exempt` in the summary and never raise `dead-text`. Desktop
+viewport only (instrumentation is viewport-independent); `--max-pages` applies;
+needs playwright like `browse`.
+
 ## Cross-cutting
 
 - `<check>/check-crashed` (error) — a check module threw; the sweep continues

--- a/plugins/stardust/skills/qa/schemas/qa-report.schema.json
+++ b/plugins/stardust/skills/qa/schemas/qa-report.schema.json
@@ -41,7 +41,7 @@
         "type": "object",
         "required": ["check", "id", "severity", "path", "message"],
         "properties": {
-          "check": { "enum": ["routing", "content", "templates", "rendered", "visual", "metadata", "links", "a11y", "perf"] },
+          "check": { "enum": ["routing", "content", "templates", "rendered", "visual", "metadata", "links", "a11y", "perf", "editability"] },
           "id": { "type": "string", "description": "stable machine id within the check, e.g. broken-internal-link" },
           "severity": { "enum": ["error", "warn", "info"] },
           "path": { "type": "string", "description": "delivered path; empty string = fleet-level" },

--- a/plugins/stardust/skills/qa/scripts/checks/editability.mjs
+++ b/plugins/stardust/skills/qa/scripts/checks/editability.mjs
@@ -1,0 +1,82 @@
+/**
+ * qa/checks/editability.mjs — Experience Workspace inline-edit gate, one browser
+ * pass per page (desktop only — instrumentation is viewport-independent).
+ *
+ * Reproduces what the da.live canvas does when an author opens the page: the
+ * document response is intercepted and instrumented like
+ * editor-utils.getInstrumentedHTML (`data-prose-index` on every OUTERMOST
+ * h1-h6/p/ul/ol/pre/blockquote inside <main>, bare-text block cells re-wrapped as
+ * <p>), the live page's own scripts.js decorates it, sections settle, and each
+ * authored text is looked up by its index:
+ *   exactly one element  → editable
+ *   zero                 → dead      (rebuilt from textContent/innerHTML, synthesized, retagged)
+ *   several              → duplicated (clone slides; the editor attaches to the first)
+ *
+ * Findings: editability/dead-text (error, per block with dead non-exempt texts),
+ * editability/duplicated-index (warn, per block), editability/summary (info, per
+ * page), editability/probe-failed (warn). Exemptions (EW5): --ew-exempt a,b and,
+ * with --blocks-dir <dir>, `@ew-exempt <reason>` tags in each block's leading
+ * JSDoc. Shared instrument: skills/deploy/scripts/ew-editability-probe.mjs.
+ * Contract: deploy SKILL.md § Experience Workspace editability contract (EW1–EW10).
+ */
+import {
+  loadPlaywright, finding, pageUrl, pMap, arg,
+} from '../lib.mjs';
+import {
+  probeUrl, aggregate, readBlockExemptions, parseExemptList,
+} from '../../../deploy/scripts/ew-editability-probe.mjs';
+
+const VIEWPORT_WIDTH = 1440;
+const SETTLE_MS = 1500;
+const DECORATION_TIMEOUT = 15000;
+
+const quote = (d) => `<${d.tag}> "${d.text.slice(0, 40)}${d.text.length > 40 ? '…' : ''}"`;
+
+export async function run(ctx) {
+  const { base, inventory, opts } = ctx;
+  const findings = [];
+  const { chromium } = await loadPlaywright();
+  const browser = await chromium.launch();
+  const cliExempt = parseExemptList(arg('ew-exempt', ''));
+  const blocksDir = arg('blocks-dir', null);
+
+  await pMap(inventory.pages, async (p) => {
+    let bctx = null;
+    try {
+      const probe = await probeUrl(browser, pageUrl(base, p.path), {
+        width: VIEWPORT_WIDTH,
+        waitUntil: 'domcontentloaded', // hanging third-party tags never reach networkidle (browse.mjs)
+        settleMs: SETTLE_MS,
+        timeoutMs: DECORATION_TIMEOUT,
+      });
+      bctx = probe.ctx;
+      const { rows } = probe;
+      const names = [...new Set(rows.map((r) => r.block))];
+      const exemptions = readBlockExemptions(blocksDir, names, cliExempt);
+      const { blocks, totals } = aggregate(rows, { exemptions });
+      for (const b of blocks) {
+        if (b.dead) {
+          findings.push(finding('editability', 'dead-text', 'error', p.path,
+            `block "${b.block}": ${b.dead} of ${b.authored} authored text(s) not editable in Experience Workspace — ${b.deadItems.slice(0, 3).map(quote).join(', ')}${b.deadItems.length > 3 ? ', …' : ''}; MOVE the authored element into the wrapper (EW1)`,
+            { block: b.block, authored: b.authored, dead: b.dead, items: b.deadItems.slice(0, 8).map(({ tag, text }) => ({ tag, text })) }));
+        }
+        if (b.duplicated) {
+          findings.push(finding('editability', 'duplicated-index', 'warn', p.path,
+            `block "${b.block}": ${b.duplicated} authored text(s) carry their index on several elements (presentational clones) — the editor attaches to the first in DOM order; strip instrumentation from clones (EW4)`,
+            { block: b.block, items: b.dupItems.slice(0, 8).map(({ tag, text, hits }) => ({ tag, text, hits })) }));
+        }
+      }
+      findings.push(finding('editability', 'summary', 'info', p.path,
+        `authored ${totals.authored} · editable ${totals.editable} · dead ${totals.dead} · duplicated ${totals.duplicated} · exempt ${totals.exempt}`,
+        { totals, blocks: blocks.map(({ block, authored, editable, dead, duplicated, exempt, exemptReasons }) => ({ block, authored, editable, dead, duplicated, exempt, ...(exemptReasons.length ? { exemptReasons } : {}) })) }));
+    } catch (e) {
+      findings.push(finding('editability', 'probe-failed', 'warn', p.path,
+        `editability probe did not complete: ${String(e).slice(0, 200)}`));
+    } finally {
+      if (bctx) await bctx.close().catch(() => {});
+    }
+  }, opts.browserConcurrency || 3);
+
+  await browser.close();
+  return findings;
+}

--- a/plugins/stardust/skills/qa/scripts/qa.mjs
+++ b/plugins/stardust/skills/qa/scripts/qa.mjs
@@ -9,7 +9,7 @@
  *
  * Options:
  *   --base <url>            live host to sweep (required)
- *   --checks <list>         comma list: routing,content,templates,metadata,links,browse,perf (default: all)
+ *   --checks <list>         comma list: routing,content,templates,metadata,links,browse,perf,editability (default: all)
  *   --paths-file <txt>      inventory source: one path per line
  *   --template-map <json>   inventory + template assignments (stardust/template-map.json)
  *   --scrape <dir>          stardust scrape captures for verbatim fidelity
@@ -27,6 +27,11 @@
  *   --probe-externals       probe unique external link targets (skipped by
  *                           default — dominates sweep time on blog fleets;
  *                           the skip is reported as links/externals-skipped)
+ *   --ew-exempt <list>      editability: comma list of blocks whose authored rows are
+ *                           config / derived / index fallback (dead texts reported as
+ *                           exempt, not errors)
+ *   --blocks-dir <dir>      editability: local blocks root — `@ew-exempt <reason>`
+ *                           JSDoc tags in <dir>/<name>/<name>.js are honoured
  *   --fail-on <error|warn>  exit 1 threshold (default: error)
  *
  * Exit codes: 0 clean (below threshold), 1 findings at/above threshold, 2 infra error.
@@ -45,7 +50,7 @@ const BASE = (arg('base') || '').replace(/\/$/, '');
 if (!BASE) { console.error('qa: --base <live-url> is required'); process.exit(2); }
 
 const OUT = arg('out', 'stardust/qa');
-const CHECKS = (arg('checks', 'routing,content,templates,metadata,links,browse,perf')).split(',').map((s) => s.trim()).filter(Boolean);
+const CHECKS = (arg('checks', 'routing,content,templates,metadata,links,browse,perf,editability')).split(',').map((s) => s.trim()).filter(Boolean);
 const opts = {
   outDir: OUT,
   scrapeDir: arg('scrape', null),
@@ -67,6 +72,7 @@ const MODULES = {
   links: 'checks/links.mjs',
   browse: 'checks/browse.mjs',
   perf: 'checks/perf.mjs',
+  editability: 'checks/editability.mjs',
 };
 
 const started = Date.now();

--- a/plugins/stardust/skills/replica/SKILL.md
+++ b/plugins/stardust/skills/replica/SKILL.md
@@ -262,17 +262,16 @@ approval per the standard prototype approval flow (hands-off mode records
 - **Pages beyond the archetypes** go through `stardust:migrate` at
   **sibling tier** (`../migrate/reference/fidelity-tiers.md`): structural
   clone of the gated archetype + content-fidelity + delivery-lint +
-  media-reconcile. The archetype's source-fidelity gate is what the siblings
-  inherit — never re-author a sibling from scratch. Content-fidelity is
-  **measured per page at import time**
-  (`../migrate/reference/fidelity-tiers.md` § Content-count acceptance)
-  so dropped-content importer bugs surface while the importer is still
-  cheap to fix.
+  media-reconcile. Siblings inherit the archetype's source-fidelity gate —
+  never re-author one from scratch. Content-fidelity is
+  **measured per page at import time** (same file, § Content-count
+  acceptance) so importer bugs surface while cheap to fix.
 - **Delivery** via `stardust:deploy` per page. Bias the decode tier toward
   **template-slotted** for fixed-composition sections (deploy #95): replica
-  sections are by definition fixed compositions matched to a live original;
-  reconstruction freedom is risk with no payoff here. Repeat/authorable
-  groups (cards, listings) stay reconstructive.
+  sections are fixed compositions matched to a live original.
+  Repeat groups (cards, listings) stay reconstructive. **Blocks
+  obey the Experience Workspace editability contract (deploy § 8, EW1–EW10:
+  node-slotting, never value-slotting) and pass `block-roundtrip --ew`.**
 - **Site-wide rollout** via `stardust:rollout`, unchanged — its block dedup
   is what implements "same blocks across the whole site".
 - **The final gate runs against the PUBLISHED origin — not the harness**

--- a/plugins/stardust/skills/reskin/SKILL.md
+++ b/plugins/stardust/skills/reskin/SKILL.md
@@ -372,7 +372,10 @@ pipeline, unchanged:
   gated archetype. Content rules are the ones reskin already
   enforces — `../migrate/reference/content-preservation.md` is
   inherited wholesale.
-- **Ship via `stardust:deploy` / `stardust:rollout`**, unchanged.
+- **Ship via `stardust:deploy` / `stardust:rollout`**, unchanged. Blocks
+  written for donor modules obey the Experience Workspace editability
+  contract (deploy SKILL.md § 8, EW1–EW10) and pass the EW gate
+  (`block-roundtrip --ew`) before they are done.
 
 Reskin writes its own state under `stardust/reskin/` — `ledger.json`
 holds per-page status (`captured → mapped → rendered → gated`), gate

--- a/plugins/stardust/skills/rollout/SKILL.md
+++ b/plugins/stardust/skills/rollout/SKILL.md
@@ -118,7 +118,11 @@ Walk `plan.json.steps` in order (representative pages first). For each page:
 1. **Convert + push** the migrated HTML (`source.migratedHtml`) to AEM via the
    `deploy` methodology. **Pass the plan step into deploy's brief**: create only the
    blocks in `convert`; for each block in `reuse`, REUSE the existing block by its
-   `edsBlockName` (do not recreate).
+   `edsBlockName` (do not recreate). **The brief MUST carry the Experience Workspace
+   editability contract** (deploy SKILL.md § 8, EW1–EW10): every converted block
+   moves authored elements into wrappers (never rebuilds from text) and passes the
+   EW gate (`block-roundtrip --ew`) before it counts as delivered — a brief without
+   it skipped the contract on 27/27 blocks of a real site.
 
    **`content-pending` pages** (archetypes-only): no migrated HTML — skip the
    document push entirely (no shell/placeholder), record `content-pending`, surface

--- a/plugins/stardust/skills/stardust/reference/learnings.md
+++ b/plugins/stardust/skills/stardust/reference/learnings.md
@@ -37,6 +37,12 @@ One entry per learning, four fields:
 - proposed change: `skills/deploy/SKILL.md` § Runtime-detection probe — assert `blockWrapperClass` from `stardust/runtime-contract.json` before generating any block CSS
 - status: folded
 
+### Generated block text uneditable in Experience Workspace
+- failure class: silent-render (authored elements rebuilt from `textContent`/`innerHTML`, so the canvas's `data-prose-index` is lost; every fidelity gate green)
+- evidence: rwe.com 2026-09-03, `da.live/canvas` — 841/1452 authored texts editable over a 29-page sample; 20 stardust blocks 395/970; template-slotted blocks 0 %. Mechanism verified in da.live `editor-utils.js` + da-nx `quick-edit.js`: only elements still carrying their index after `decorate()` become editors; `cloneNode` keeps it (clone-based blocks worked), value-slotting does not. Wrapper selectors written `.x a` instead of `.x :where(a)` flipped link colour (specificity trap); the editor inserts two wrapper divs, so `>`/`:first-child` paths break while editing.
+- proposed change: `skills/deploy/SKILL.md` § 8 — named contract EW1–EW10 (move, wrapper-descendant selectors, CTA `<p>`, strip clones, declared exemptions), node-slotting in § 2b, edit-mode foundation in § 3, `block-roundtrip --ew` + `ew-editability-probe.mjs` gate; brief carries the contract (deploy IMPROVEMENTS #123)
+- status: folded
+
 ## Rules
 
 - **Entries are never deleted.** `folded` entries stay as the audit


### PR DESCRIPTION
## Summary

Implements the plugin improvement spec **"every generated text must be editable in Experience Workspace"** (written from the rwe.com migration, 2026-09-03). Hard property added to stardust output: any text an author wrote in a DA document is inline-editable in the da.live canvas once generated block JS has decorated the page, and the block looks the same while it is being edited.

**Field finding.** Over a 29-page covering sample only **841 / 1452** authored texts were editable; every template-slotted block was 0 %. The generated blocks were correct implementations of the skill's own guidance (value-slotting, `text(cell)`, clone-the-anchor) — the guidance was the bug. After the reference conversion on rwe: 1416 / 1452, every remaining one a declared exemption, 0 px visual change on 27 block instances.

**Mechanism** (verified in da.live `editor-utils.js`/`prose2aem.js` and da-nx `quick-edit.js`/`prose.js`): the canvas stamps `data-prose-index` on every outermost `h1–h6/p/ul/ol/pre/blockquote`, re-runs the page's own `loadPage()` over the instrumented body, and can only attach an editor to an element that still carries its index. `cloneNode` keeps the index (which is why clone-based blocks worked); the fix is **move**, not "avoid clone".

## Changes

**`skills/deploy/SKILL.md`** — § Target runtime documents the instrumentation; § 2b redefines template-slotted as **node-slotting** and bans value-slotting; § 3 ships three edit-mode foundation snippets (CTA repaint from `<strong>/<em>` marks under `.prosemirror-editor`, card-as-link inner anchor, `:where()` wrapper variants) + EW10; § 5 Buttons, #55, #62/#71, #70 and § Section heads rewritten to MOVE authored elements; the Step-7 brief carries the contract; § 8 gets a move-based scaffold (`wrapNode`, `labelWrap`, `stripInstrumentation`) followed by the named **Experience Workspace editability contract (EW1–EW10)** and the gate commands; Local QA + Checklist gain the EW gate, edit-mode simulation, static review and pixel-parity lines; anti-patterns 18 (value-slotting) and 19 (class on the authored element); References cite the da.live/da-nx sources.

**Scripts**
- New `deploy/scripts/ew-editability-probe.mjs` — instrument → decorate → count survivors; URL mode and `--content` harness mode; `--simulate-editor` performs the editor swap and reports font/colour/height drift; reads `@ew-exempt` JSDoc tags; exports the shared pieces.
- `block-roundtrip.mjs --ew` (default on, `--no-ew` to disable): `DEAD TEXT` / `DUPLICATED INDEX` are 🔴 (exit 2) alongside MISSING CTA/HEADING.
- `render-harness.mjs`: `--ew`, `--simulate-editor`, `--styles`/`--blocks-dir`, hides `body > header`.
- `section-schema.mjs` emits `editableTexts` per section; `content-inventory.mjs` (deploy + diff copies) export `editableInventory`; `content-diff` reports an `EDITABLE COUNT` advisory.
- **qa**: new `editability` check (`editability/dead-text` error, `editability/duplicated-index` warn, per-page summary; `--ew-exempt`, `--blocks-dir`), registered in `qa.mjs`, documented in `reference/checks.md`, schema enum updated.

**Other skills** — replica, rollout, reskin and migrate `fidelity-tiers.md` cite the contract and gate in every block-authoring handoff (the brief skipped it on 27/27 blocks because it did not carry it). New eval `evals/ew-editability`. Deploy `IMPROVEMENTS.md` #123; master `reference/learnings.md` example entry. CHANGELOG 0.19.0; `plugin.json` 0.18.5 → 0.19.0 (minor: new gate + new qa check).

## Verification

- Fixture (`/tmp/ew-fixture`): a value-slotting block → probe exit 1 (`dead=3`), `block-roundtrip` exit 2 with three `DEAD TEXT` 🔴; the move-based version → both exit 0, `--simulate-editor` drift 0, block Δh 0; `--no-ew` preserves the old behaviour; `@ew-exempt`-tagged version reports `exempt 3`, exit 0.
- rwe real pages, harness mode vs live URL agree exactly: home `authored=110 editable=104 dead=6` (columns video source, press ISO dates, breadcrumb — all in the spec's exemption list); `the-group` 104/102; `policy-statements` 57/56. With `--exempt columns,press,breadcrumb`: `dead=0`, exit 0.
- `qa.mjs --checks editability --max-pages 2` against the rwe preview: 0 errors with exemptions, 4 `dead-text` errors without.
- `render-harness --ew --simulate-editor` produces the edit-mode PNG; `section-schema` emits `editableTexts`; `content-diff` prints the advisory line.
- `node --check` on all 8 scripts; qa unit tests pass (2/2); `skills-ref validate` passes on deploy, qa, replica, rollout, reskin, migrate, stardust.

Spec: rwe repo `stardust/plugin-improvements/experience-workspace-editability.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
