### PR TITLE
feat(stardust): 0.19.6 — glyph-dense chrome noise floor, evidence-gated (P6)

### DIFF
--- a/plugins/stardust/.claude-plugin/plugin.json
+++ b/plugins/stardust/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stardust",
   "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "author": {
     "name": "Adobe"
   },

--- a/plugins/stardust/CHANGELOG.md
+++ b/plugins/stardust/CHANGELOG.md
@@ -4,6 +4,22 @@ This file starts at 0.14.0. Prior versions (0.3.0 – 0.13.1) are documented in
 git history only (plus the branch-scoped notes in
 `CHANGELOG-redesign-adobecom.md` and `CHANGELOG-delivery-media-fidelity.md`).
 
+## 0.19.6 — replica: glyph-dense chrome noise floor, evidence-gated (P6)
+
+- **`crop-compare.mjs` reports the diff TEXTURE** — the share of differing
+  pixels with ≥5 differing neighbours: thin-edge = glyph-antialiasing noise,
+  thick = blocks/bands (misalignment, missing paint). Reported in text and
+  `--json`; never changes the exit code.
+- **Gate doc, pass bar item 5:** a glyph-dense chrome band that fails the 2%
+  bar may be logged as a justified residual (`cause: "glyph-antialiasing"`)
+  — never a pass — only when all three hold and are attached as artifacts:
+  `chrome-parity.mjs` exit 0 for the region at 1px tolerance, crop-compare
+  texture thin-edge (≤15% thick), and a text-dense region (no imagery/icons).
+  Field evidence: a ~50-link footer bottomed out at ~5% with every metric
+  numerically identical; a hinted licensed face vs a self-hosted webfont
+  rasterise differently per glyph. The 2% bar is unchanged; residual logging
+  format gains the entry shape.
+
 ## 0.19.5 — deploy: link localization as a pipeline stage (P24)
 
 - **New `deploy/scripts/localize-links.mjs`** — dependency-free, idempotent.

--- a/plugins/stardust/skills/replica/reference/source-fidelity-gate.md
+++ b/plugins/stardust/skills/replica/reference/source-fidelity-gate.md
@@ -133,6 +133,28 @@ The prototype capture is re-taken every iteration.
      --region header=header --region footer=footer   # + --region strip=<sel>|<sel>
    ```
 
+   **Glyph-dense chrome has a pixel noise floor — the ONE justified way past
+   the 2% bar, and it is evidence-gated three ways.** A footer of ~50 links
+   bottomed out at ~5% pixel diff with family, size, line-height, weight,
+   colour, pitch and positions all numerically identical (recorded): per-glyph
+   antialiasing between a hinted licensed face and the self-hosted webfont
+   dominates, and raw pixel bars over-iterate against noise. A chrome band
+   that FAILS crop-compare may be logged as a **justified residual** —
+   never a pass — only when ALL three hold, and each is an artifact in the
+   residual entry (§ Residual logging format, `cause: "glyph-antialiasing"`):
+   (1) `chrome-parity.mjs` exits 0 for that region at tolerance 1px — every
+   paired text's metrics and position match, no MISSING/EXTRA, icons paired;
+   (2) `crop-compare.mjs` reports the diff **texture** as thin-edge (≤15% of
+   differing pixels have ≥5 differing neighbours) — glyph antialiasing is
+   thin, misalignment and missing paint are thick; (3) the region is
+   text-dense (link columns, nav rows) — a band with imagery or icons never
+   qualifies (parity's ICONS finding would not be quiet anyway). One or two
+   of the three is not enough: a quiet parity probe with a THICK texture is
+   a paint defect the probe does not model; a thin texture with parity
+   deltas is a real metric error hiding in noise. The 2% bar itself is
+   unchanged, and the residual is re-verified every gate round like any
+   other justified flag.
+
    **Chrome crops are ELEMENT-ANCHORED per side, never fixed-y — and
    "chrome" means every site-wide repeating band: header, sticky/quick-link
    strips, footer.** Recorded: the header measured 33.9% and a quick-links
@@ -588,7 +610,8 @@ Per archetype per breakpoint, in `stardust/replica/progress.json`:
         { "probe": "content", "flag": "🟠 font fork ×2", "why": "licensed kit substituted, R-policy fonts", "permanent": true }
       ],
       "residuals": [
-        { "band": "y 4500–5000", "pct": 6.2, "cause": "capture-state: 3 CDN-403 placeholder tiles", "flaggedFor": "delivery" }
+        { "band": "y 4500–5000", "pct": 6.2, "cause": "capture-state: 3 CDN-403 placeholder tiles", "flaggedFor": "delivery" },
+        { "region": "footer", "pct": 4.8, "cause": "glyph-antialiasing", "parity": "gates/home-1440/chrome-parity-iter3.json", "texture": { "thickPct": 6.1 }, "flaggedFor": "user" }
       ],
       "captureState": [ { "what": "product tiles 4–6 on placeholder data-URIs", "where": "carousel-2" } ]
     },

--- a/plugins/stardust/skills/replica/scripts/crop-compare.mjs
+++ b/plugins/stardust/skills/replica/scripts/crop-compare.mjs
@@ -24,6 +24,11 @@
  *     --pm-threshold <n> pixelmatch per-pixel color threshold (default 0.1)
  *     --json          machine-readable summary on stdout
  *
+ *   Also prints the diff TEXTURE (share of differing pixels with ≥5 differing
+ *   neighbours): thin-edge = glyph-antialiasing noise, thick = blocks/bands.
+ *   Reported only — it never changes the exit code (see the gate doc, pass bar
+ *   item 5, for the glyph-dense alternative pass it supports).
+ *
  * Example (header band, then footer band with per-side offsets):
  *   node skills/replica/scripts/crop-compare.mjs live.png proto.png \
  *     --y 0 --height 120 --out gates/home-1440/chrome-header-diff.png
@@ -91,6 +96,28 @@ const diff = new PNG({ width: w, height: h });
 const n = pixelmatch(ca.data, cb.data, diff.data, w, h, { threshold: pmThreshold });
 fs.writeFileSync(out, PNG.sync.write(diff));
 
+// Diff TEXTURE — separates glyph-antialiasing noise from real misalignment.
+// A differing pixel is "thick" when ≥5 of its 8 neighbours also differ: blocks,
+// bands and shifted shapes are thick; per-glyph antialiasing between two font
+// rasterisations (a hinted licensed face vs a self-hosted webfont) is thin —
+// numerically identical family/size/weight/colour/pitch/position can still
+// bottom out at ~5% pixel diff on a ~50-link footer. The share is REPORTED,
+// never used to pass: the alternative pass (source-fidelity-gate.md § Pass bar,
+// item 5 — glyph-dense regions) also needs chrome-parity.mjs quiet for the
+// region and a logged residual carrying both artifacts.
+const isRed = (x, y) => { if (x < 0 || y < 0 || x >= w || y >= h) return false; const i = (y * w + x) * 4; return diff.data[i] === 255 && diff.data[i + 1] < 100; };
+let thick = 0;
+for (let y = 0; y < h; y += 1) {
+  for (let x = 0; x < w; x += 1) {
+    if (!isRed(x, y)) continue;
+    let k = 0;
+    for (let dy = -1; dy <= 1; dy += 1) for (let dx = -1; dx <= 1; dx += 1) if ((dx || dy) && isRed(x + dx, y + dy)) k += 1;
+    if (k >= 5) thick += 1;
+  }
+}
+const thickPct = n ? (thick / n) * 100 : 0;
+const texture = n === 0 ? 'none' : thickPct <= 15 ? 'thin-edge (glyph-antialiasing texture)' : thickPct >= 40 ? 'thick (blocks/bands — misalignment or missing paint)' : 'mixed';
+
 const pct = (n / (w * h)) * 100;
 const pass = pct <= bar;
 if (asJson) {
@@ -98,8 +125,10 @@ if (asJson) {
     a: fileA, b: fileB, y: y0, yB: y1, height: h, width: w,
     diffPixels: n, diffPct: +pct.toFixed(2), matchPct: +(100 - pct).toFixed(2),
     threshold: bar, pass, diffImage: out,
+    texture: { thickPct: +thickPct.toFixed(1), label: texture },
   }));
 } else {
   console.log(`crop y${y0}${y1 !== y0 ? `/y${y1}` : ''}+${h}: ${n} px = ${pct.toFixed(2)}% diff → match ${(100 - pct).toFixed(2)}% — ${pass ? 'PASS' : `FAIL (bar ${bar}%)`}`);
+  if (n) console.log(`  texture: ${thickPct.toFixed(1)}% thick → ${texture}${!pass && thickPct <= 15 ? ' — glyph-dense region? run chrome-parity.mjs; if it is quiet, log as a justified residual (gate doc § Pass bar, item 5)' : ''}`);
 }
 process.exit(pass ? 0 : 2);


### PR DESCRIPTION
## Summary

Ledger entry **P6**, shipped at the user's request after being flagged as the one entry that loosens a gate. It is built so the 2% chrome crop bar itself is **unchanged**: a glyph-dense band that fails it may be logged as a **justified residual**, never a pass, and only with three pieces of evidence attached.

Field evidence: a ~50-link footer bottomed out at ~5% pixel diff with family, size, line-height, weight, colour, pitch and positions all numerically identical — per-glyph antialiasing between a hinted licensed face and the self-hosted webfont dominates, and a raw pixel bar over-iterates against noise.

## Changes

**`skills/replica/scripts/crop-compare.mjs`** — reports the diff **texture**: the share of differing pixels with ≥5 differing neighbours. Thin-edge (≤15% thick) is glyph-antialiasing texture; thick (≥40%) is blocks/bands — misalignment or missing paint. Printed in text mode with a hint when a FAIL is thin, and as `texture: {thickPct, label}` in `--json`. **Never changes the exit code.**

**`skills/replica/reference/source-fidelity-gate.md`** § Pass bar item 5 — the evidence gate. A failing chrome band may be logged as a residual with `cause: "glyph-antialiasing"` only when ALL three hold, each an artifact in the entry:
1. `chrome-parity.mjs` exits 0 for that region at 1px tolerance (every paired text's metrics and position match, no MISSING/EXTRA, icons paired);
2. crop-compare texture is thin-edge;
3. the region is text-dense — a band with imagery or icons never qualifies.

One or two of the three is not enough: a quiet parity probe with a thick texture is a paint defect the probe doesn't model; a thin texture with parity deltas is a real metric error hiding in noise. The residual is re-verified every gate round like any other justified flag. § Residual logging format gains the entry shape (`region`, `parity`, `texture`).

**Meta** — CHANGELOG 0.19.6; `plugin.json` 0.19.5 → 0.19.6.

## Verification

- `node --check` clean.
- Synthetic crops: text-like 1px strokes with a different antialias shade → 9.30% diff, **0.0% thick → thin-edge**, still FAIL (exit 2), hint printed. A 200×60 block shifted 30px → 3.00% diff, **99.8% thick → thick**, FAIL. `--json` carries `texture`.
- No site names in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
