### PR TITLE
feat(stardust): 0.19.7 — sibling variance probe (P12)

### DIFF
--- a/plugins/stardust/.claude-plugin/plugin.json
+++ b/plugins/stardust/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stardust",
   "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "author": {
     "name": "Adobe"
   },

--- a/plugins/stardust/.claude-plugin/plugin.json
+++ b/plugins/stardust/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stardust",
   "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "author": {
     "name": "Adobe"
   },

--- a/plugins/stardust/CHANGELOG.md
+++ b/plugins/stardust/CHANGELOG.md
@@ -4,6 +4,27 @@ This file starts at 0.14.0. Prior versions (0.3.0 – 0.13.1) are documented in
 git history only (plus the branch-scoped notes in
 `CHANGELOG-redesign-adobecom.md` and `CHANGELOG-delivery-media-fidelity.md`).
 
+## 0.19.7 — sibling variance probe (P12)
+
+- **New `replica/scripts/sibling-variance.mjs`** — before cloning a gated
+  archetype onto its siblings, probe the template-defining computed values on
+  every sibling's LIVE page and diff against the archetype: per `--probe
+  name=<sel>` the match count, first match's box + computed group (background
+  layers incl. gradient scrims, colour, padding, font, radius), first heading
+  and image, list-style and `::before` mechanism, and the number of distinct
+  style families among matches; plus the top-level section list. Defaults
+  (first section, most-repeated class, `li`) when no probes are given.
+  Live-session hardening as the other replica instruments. Exit 0 constant,
+  2 variance found. Read-only — it never edits the clone.
+  Field evidence: eight "same-template" siblings varied in hero template
+  (441 vs 528px), scrim direction, bullet mechanism and terms shape — all
+  found late at the pixel gate.
+- **Fidelity tiers:** the sibling tier is "variance-probed" first; new
+  § Sibling variance probe — every delta is budgeted as a block VARIANT class
+  emitted on the sibling's content (blocks stay generic, never forked per
+  page); `gatesPassed` gains `variance-probe`, `_meta.json` gains
+  `variants[]`. Replica Phase 5 and migrate's A′ branch point at it.
+
 ## 0.19.6 — replica: glyph-dense chrome noise floor, evidence-gated (P6)
 
 - **`crop-compare.mjs` reports the diff TEXTURE** — the share of differing

--- a/plugins/stardust/CHANGELOG.md
+++ b/plugins/stardust/CHANGELOG.md
@@ -4,6 +4,22 @@ This file starts at 0.14.0. Prior versions (0.3.0 – 0.13.1) are documented in
 git history only (plus the branch-scoped notes in
 `CHANGELOG-redesign-adobecom.md` and `CHANGELOG-delivery-media-fidelity.md`).
 
+## 0.19.6 — replica: glyph-dense chrome noise floor, evidence-gated (P6)
+
+- **`crop-compare.mjs` reports the diff TEXTURE** — the share of differing
+  pixels with ≥5 differing neighbours: thin-edge = glyph-antialiasing noise,
+  thick = blocks/bands (misalignment, missing paint). Reported in text and
+  `--json`; never changes the exit code.
+- **Gate doc, pass bar item 5:** a glyph-dense chrome band that fails the 2%
+  bar may be logged as a justified residual (`cause: "glyph-antialiasing"`)
+  — never a pass — only when all three hold and are attached as artifacts:
+  `chrome-parity.mjs` exit 0 for the region at 1px tolerance, crop-compare
+  texture thin-edge (≤15% thick), and a text-dense region (no imagery/icons).
+  Field evidence: a ~50-link footer bottomed out at ~5% with every metric
+  numerically identical; a hinted licensed face vs a self-hosted webfont
+  rasterise differently per glyph. The 2% bar is unchanged; residual logging
+  format gains the entry shape.
+
 ## 0.19.5 — deploy: link localization as a pipeline stage (P24)
 
 - **New `deploy/scripts/localize-links.mjs`** — dependency-free, idempotent.

--- a/plugins/stardust/skills/migrate/SKILL.md
+++ b/plugins/stardust/skills/migrate/SKILL.md
@@ -178,7 +178,9 @@ For each page in scope, follow
 - **Render branch selection** (LLM judgment per T&M §
   Render path selection): A / A′ / B. **Declare the page's
   `fidelityTier`** from the branch — A → `archetype` (craft-gated),
-  A′ → `sibling` (canon-fork, the cheap default for breadth),
+  A′ → `sibling` (canon-fork, the cheap default for breadth — variance-probed
+  once per template before cloning, `reference/fidelity-tiers.md` § Sibling
+  variance probe; deltas become variant classes, never per-page forks),
   B/bodyless → `thin` — per `reference/fidelity-tiers.md`. Record
   `fidelityTier`, `archetypeSource`, and `gatesPassed[]` in
   `_meta.json` so coverage shows what was craft-gated vs cloned.

--- a/plugins/stardust/skills/migrate/reference/fidelity-tiers.md
+++ b/plugins/stardust/skills/migrate/reference/fidelity-tiers.md
@@ -17,7 +17,7 @@ trade so a reviewer can see, per page, what was and wasn't checked.
 | Tier | Render branch | Gates it MUST pass | When |
 |---|---|---|---|
 | **archetype** | Path A (approved prototype) | Full `prototype` gate stack: critique, audit, mobile-adapt, anti-template, content-sourcing, `:root` + data-attribute contracts | One representative page **per template**. The design canon. |
-| **sibling** | Path A′ (canon-fork) | Structural clone of the archetype + **content-fidelity** (verbatim source copy, no fabrication, **measured** — § Content-count acceptance) + **delivery-lint** + **media-reconcile**. NOT full craft. | Every other page of a template the archetype already covers. **The cheap default for breadth.** |
+| **sibling** | Path A′ (canon-fork) | **Variance-probed** (§ Sibling variance probe — run once per template BEFORE cloning) + structural clone of the archetype + **content-fidelity** (verbatim source copy, no fabrication, **measured** — § Content-count acceptance) + **delivery-lint** + **media-reconcile**. NOT full craft. | Every other page of a template the archetype already covers. **The cheap default for breadth.** |
 | **thin** | unique (graceful) | delivery-lint + media-reconcile + a declared `contentGap`. Renders metadata + hero + whatever real content exists (e.g. a PDF link). No fabricated filler. | Pages with little/no body content (PDF-only, redirect stubs, bodyless landing). |
 
 The point of the table: **archetype is craft-gated once per template; siblings
@@ -26,6 +26,46 @@ inherit that validated structure and only re-check the things that vary per page
 without dropping to zero gates. Make sibling-clone the path of least resistance —
 the reflex for "page N of an established template" should be *fork the archetype*,
 never *re-author from scratch*.
+
+## Sibling variance probe (template constancy is measured, not assumed)
+
+"Same template" is a hypothesis the crawl JSON cannot confirm: eight siblings
+of one gated archetype varied in ways no structure capture showed — a compact
+hero template (441 vs 528px, a wider card, a smaller logo), an INVERTED hero
+scrim (0.6→0.1 vs 0.1→0.5), tier lists split into two visual families
+(arrow-image `::before` rows vs plain discs), terms sections in three shapes
+(h2+paragraph, h2+list, inline-bold prefix), and three pages reusing another
+page's hero image (the source's own choice — replicate, don't "fix"). Every
+one surfaced late, at the pixel gate, as rework on an already-cloned page.
+
+**Before generating a template's siblings, run ONE automated probe of the
+template-defining computed values on every sibling's live page and diff
+against the archetype:**
+
+```bash
+node scripts/replica/sibling-variance.mjs "<archetype-live-url>" "<sibling-1>" "<sibling-2>" … \
+  --probe hero=".hero" --probe card=".offer-card" --probe tier="ul.tiers li" --width 1440
+# exit 0 = clone as-is; exit 2 = deltas printed per sibling — budget them
+```
+
+Per probe it compares match count, the first match's box and computed group
+(background layers incl. gradient scrims, colour, padding, font, radius), its
+first heading and image, list-style and `::before` mechanism, and the number
+of distinct style families among the matches; plus the top-level section
+list. Pass the archetype's own block selectors as probes — the defaults
+(first section, most-repeated class, `li`) are a fallback.
+
+Reading it: **every delta is first-class work, budgeted before the clone,
+not an edge case.** A hero height/scrim delta → a hero VARIANT class
+(`hero compact`, `hero scrim-inverted`); a second bullet mechanism → a list
+variant; a different terms shape → the terms block handles both shapes.
+Emit the variant on the sibling's generated content — the block stays
+generic (deploy SKILL.md § The one rule → same-pattern sections collapse into
+one block + variant classes); never fork a block per page. Record the probe's
+JSON next to the fan-out brief and list the variants in each sibling's
+`_meta.json` `variants[]`. The probe is read-only evidence — it never edits
+the clone — and it costs one live navigation per sibling, so run a
+template's siblings in one pass and reuse the JSON.
 
 ## Content-count acceptance (content-fidelity is measured, not asserted)
 
@@ -65,7 +105,8 @@ Every page row in `state.json` and `coverage/pages.json` carries:
 ```json
 "fidelityTier": "archetype" | "sibling" | "thin",
 "archetypeSource": "<slug>",        // for sibling/thin: which archetype it forked
-"gatesPassed": ["delivery-lint", "media-reconcile", "content-fidelity", "content-count"],
+"gatesPassed": ["variance-probe", "delivery-lint", "media-reconcile", "content-fidelity", "content-count"],
+"variants": ["hero compact", "tiers disc"],   // sibling: variant classes the probe called for (empty = template-constant)
 "contentGap": "source is a PDF download; no HTML body"   // thin only
 ```
 

--- a/plugins/stardust/skills/replica/SKILL.md
+++ b/plugins/stardust/skills/replica/SKILL.md
@@ -51,8 +51,8 @@ eyeballing.
    (`node -e "import('pixelmatch').then(()=>process.exit(0))"`).
 4. Copy scripts into the project and run them from there, not from the
    plugin: this skill's whole `scripts/` dir (stitch-shot, pixel-compare,
-   crop-compare, chrome-parity, row-profile, anchor, gate.sh,
-   motion-observe) AND the whole `../diff/scripts/` dir (the diff scripts import
+   crop-compare, chrome-parity, row-profile, sibling-variance, anchor,
+   gate.sh, motion-observe) AND the whole `../diff/scripts/` dir (the diff scripts import
    diff-profiles.mjs, and ALL live-target hardening — including
    stitch-shot's — lives in its live-session.mjs; stitch-shot resolves it
    from `scripts/diff/` next to `scripts/replica/`, so keep the two dirs
@@ -266,7 +266,11 @@ approval per the standard prototype approval flow (hands-off mode records
   **sibling tier** (`../migrate/reference/fidelity-tiers.md`): structural
   clone of the gated archetype + content-fidelity + delivery-lint +
   media-reconcile. Siblings inherit the archetype's source-fidelity gate —
-  never re-author one from scratch. Content-fidelity is
+  never re-author one from scratch. **Template constancy is measured, not
+  assumed**: before cloning, run `scripts/replica/sibling-variance.mjs
+  <archetype> <siblings…> --probe <block>=<sel> …` once per template and
+  budget every delta as a block VARIANT class on the sibling's content (same
+  file, § Sibling variance probe). Content-fidelity is
   **measured per page at import time** (same file, § Content-count
   acceptance) so importer bugs surface while cheap to fix.
 - **Delivery** via `stardust:deploy` per page. Bias the decode tier toward

--- a/plugins/stardust/skills/replica/reference/source-fidelity-gate.md
+++ b/plugins/stardust/skills/replica/reference/source-fidelity-gate.md
@@ -133,6 +133,28 @@ The prototype capture is re-taken every iteration.
      --region header=header --region footer=footer   # + --region strip=<sel>|<sel>
    ```
 
+   **Glyph-dense chrome has a pixel noise floor — the ONE justified way past
+   the 2% bar, and it is evidence-gated three ways.** A footer of ~50 links
+   bottomed out at ~5% pixel diff with family, size, line-height, weight,
+   colour, pitch and positions all numerically identical (recorded): per-glyph
+   antialiasing between a hinted licensed face and the self-hosted webfont
+   dominates, and raw pixel bars over-iterate against noise. A chrome band
+   that FAILS crop-compare may be logged as a **justified residual** —
+   never a pass — only when ALL three hold, and each is an artifact in the
+   residual entry (§ Residual logging format, `cause: "glyph-antialiasing"`):
+   (1) `chrome-parity.mjs` exits 0 for that region at tolerance 1px — every
+   paired text's metrics and position match, no MISSING/EXTRA, icons paired;
+   (2) `crop-compare.mjs` reports the diff **texture** as thin-edge (≤15% of
+   differing pixels have ≥5 differing neighbours) — glyph antialiasing is
+   thin, misalignment and missing paint are thick; (3) the region is
+   text-dense (link columns, nav rows) — a band with imagery or icons never
+   qualifies (parity's ICONS finding would not be quiet anyway). One or two
+   of the three is not enough: a quiet parity probe with a THICK texture is
+   a paint defect the probe does not model; a thin texture with parity
+   deltas is a real metric error hiding in noise. The 2% bar itself is
+   unchanged, and the residual is re-verified every gate round like any
+   other justified flag.
+
    **Chrome crops are ELEMENT-ANCHORED per side, never fixed-y — and
    "chrome" means every site-wide repeating band: header, sticky/quick-link
    strips, footer.** Recorded: the header measured 33.9% and a quick-links
@@ -588,7 +610,8 @@ Per archetype per breakpoint, in `stardust/replica/progress.json`:
         { "probe": "content", "flag": "🟠 font fork ×2", "why": "licensed kit substituted, R-policy fonts", "permanent": true }
       ],
       "residuals": [
-        { "band": "y 4500–5000", "pct": 6.2, "cause": "capture-state: 3 CDN-403 placeholder tiles", "flaggedFor": "delivery" }
+        { "band": "y 4500–5000", "pct": 6.2, "cause": "capture-state: 3 CDN-403 placeholder tiles", "flaggedFor": "delivery" },
+        { "region": "footer", "pct": 4.8, "cause": "glyph-antialiasing", "parity": "gates/home-1440/chrome-parity-iter3.json", "texture": { "thickPct": 6.1 }, "flaggedFor": "user" }
       ],
       "captureState": [ { "what": "product tiles 4–6 on placeholder data-URIs", "where": "carousel-2" } ]
     },

--- a/plugins/stardust/skills/replica/scripts/crop-compare.mjs
+++ b/plugins/stardust/skills/replica/scripts/crop-compare.mjs
@@ -24,6 +24,11 @@
  *     --pm-threshold <n> pixelmatch per-pixel color threshold (default 0.1)
  *     --json          machine-readable summary on stdout
  *
+ *   Also prints the diff TEXTURE (share of differing pixels with ≥5 differing
+ *   neighbours): thin-edge = glyph-antialiasing noise, thick = blocks/bands.
+ *   Reported only — it never changes the exit code (see the gate doc, pass bar
+ *   item 5, for the glyph-dense alternative pass it supports).
+ *
  * Example (header band, then footer band with per-side offsets):
  *   node skills/replica/scripts/crop-compare.mjs live.png proto.png \
  *     --y 0 --height 120 --out gates/home-1440/chrome-header-diff.png
@@ -91,6 +96,28 @@ const diff = new PNG({ width: w, height: h });
 const n = pixelmatch(ca.data, cb.data, diff.data, w, h, { threshold: pmThreshold });
 fs.writeFileSync(out, PNG.sync.write(diff));
 
+// Diff TEXTURE — separates glyph-antialiasing noise from real misalignment.
+// A differing pixel is "thick" when ≥5 of its 8 neighbours also differ: blocks,
+// bands and shifted shapes are thick; per-glyph antialiasing between two font
+// rasterisations (a hinted licensed face vs a self-hosted webfont) is thin —
+// numerically identical family/size/weight/colour/pitch/position can still
+// bottom out at ~5% pixel diff on a ~50-link footer. The share is REPORTED,
+// never used to pass: the alternative pass (source-fidelity-gate.md § Pass bar,
+// item 5 — glyph-dense regions) also needs chrome-parity.mjs quiet for the
+// region and a logged residual carrying both artifacts.
+const isRed = (x, y) => { if (x < 0 || y < 0 || x >= w || y >= h) return false; const i = (y * w + x) * 4; return diff.data[i] === 255 && diff.data[i + 1] < 100; };
+let thick = 0;
+for (let y = 0; y < h; y += 1) {
+  for (let x = 0; x < w; x += 1) {
+    if (!isRed(x, y)) continue;
+    let k = 0;
+    for (let dy = -1; dy <= 1; dy += 1) for (let dx = -1; dx <= 1; dx += 1) if ((dx || dy) && isRed(x + dx, y + dy)) k += 1;
+    if (k >= 5) thick += 1;
+  }
+}
+const thickPct = n ? (thick / n) * 100 : 0;
+const texture = n === 0 ? 'none' : thickPct <= 15 ? 'thin-edge (glyph-antialiasing texture)' : thickPct >= 40 ? 'thick (blocks/bands — misalignment or missing paint)' : 'mixed';
+
 const pct = (n / (w * h)) * 100;
 const pass = pct <= bar;
 if (asJson) {
@@ -98,8 +125,10 @@ if (asJson) {
     a: fileA, b: fileB, y: y0, yB: y1, height: h, width: w,
     diffPixels: n, diffPct: +pct.toFixed(2), matchPct: +(100 - pct).toFixed(2),
     threshold: bar, pass, diffImage: out,
+    texture: { thickPct: +thickPct.toFixed(1), label: texture },
   }));
 } else {
   console.log(`crop y${y0}${y1 !== y0 ? `/y${y1}` : ''}+${h}: ${n} px = ${pct.toFixed(2)}% diff → match ${(100 - pct).toFixed(2)}% — ${pass ? 'PASS' : `FAIL (bar ${bar}%)`}`);
+  if (n) console.log(`  texture: ${thickPct.toFixed(1)}% thick → ${texture}${!pass && thickPct <= 15 ? ' — glyph-dense region? run chrome-parity.mjs; if it is quiet, log as a justified residual (gate doc § Pass bar, item 5)' : ''}`);
 }
 process.exit(pass ? 0 : 2);

--- a/plugins/stardust/skills/replica/scripts/sibling-variance.mjs
+++ b/plugins/stardust/skills/replica/scripts/sibling-variance.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+/**
+ * skills/replica/scripts/sibling-variance.mjs
+ *
+ * Live-variance probe for sibling fan-out: BEFORE cloning a gated archetype
+ * onto its "same-template" siblings, measure the template-defining computed
+ * values on each sibling's LIVE page and diff them against the archetype's.
+ * Vendor templates are not constant: eight siblings of one gated archetype
+ * varied in ways the crawl JSON never showed — a compact hero (441 vs 528px,
+ * wider card, smaller logo), an INVERTED hero scrim (0.6→0.1 vs 0.1→0.5), list
+ * bullets split into two visual families (arrow-image `::before` vs plain
+ * disc), terms sections in three shapes. Each delta found here is first-class
+ * work to budget — a block VARIANT class emitted by the sibling generator —
+ * not an edge case discovered at the pixel gate. The probe is read-only
+ * evidence; it changes nothing in the clone.
+ * Content is not variance: image and background url() FILENAMES are ignored
+ * (a sibling's own photo is the source's choice — replicate it); only the
+ * layer stack, geometry and computed styles are compared.
+ *
+ * Usage:
+ *   node skills/replica/scripts/sibling-variance.mjs <archetypeURL> <siblingURL> [<siblingURL>…] [options]
+ *     --probe <name>=<sel>   template-defining element to compare (repeatable). For
+ *                            each: match count, first match's rect + the computed
+ *                            group (background layers, colour, padding, font
+ *                            size/weight/line-height, radius), its first heading,
+ *                            its first image, list-style + `::before` mechanism,
+ *                            and — when the selector matches several elements —
+ *                            the number of distinct style clusters among them.
+ *                            Default when none given: hero = first section of
+ *                            --main; card = the most repeated element class in
+ *                            the page; li = "main li".
+ *     --main <sel>           content root (default main) — also probes the
+ *                            section list ([label, height] per top-level section)
+ *     --width <px>           viewport width                    (default 1440)
+ *     --tolerance <px>       ignore numeric deltas ≤ this      (default 2)
+ *     --consent <sel>        extra consent-accept selector
+ *     --dismiss <sel,…>      extra overlay-dismiss selectors
+ *     --headed               headed stealth real Chrome (bot-managed sites)
+ *     --locale <tag>         pin Accept-Language + locale
+ *     --json                 machine-readable output
+ *
+ * Exit codes: 0 every sibling matches the archetype within tolerance, 2 variance
+ * found (budget it), 1 error, 3 bot challenge (fail loud — never measured).
+ * Every URL is one live navigation: probe a template's siblings in ONE run and
+ * keep the JSON as the fan-out brief's evidence.
+ */
+
+/* eslint-disable import/no-extraneous-dependencies, import/extensions, no-await-in-loop, no-restricted-syntax, brace-style, object-curly-newline, max-len, no-plusplus, no-continue */
+import { chromium } from 'playwright';
+import { existsSync } from 'fs';
+import { dirname, resolve as resolvePath } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const LIVE_SESSION = ['../../diff/scripts/live-session.mjs', '../diff/live-session.mjs']
+  .map((p) => resolvePath(HERE, p)).find((p) => existsSync(p));
+if (!LIVE_SESSION) {
+  console.error('sibling-variance error: live-session.mjs not found (looked in ../../diff/scripts/ and ../diff/). Copy the diff skill\'s scripts dir alongside this one (replica SKILL.md § Setup).');
+  process.exit(1);
+}
+const { isLiveHttpUrl, launchStealthHeaded, newLiveContext, gotoLive, dismissOverlays, defaultWaitUntil } = await import(pathToFileURL(LIVE_SESSION).href);
+
+const HELP = `sibling-variance — diff template-defining computed values of live siblings against the archetype
+
+Usage: node sibling-variance.mjs <archetypeURL> <siblingURL> [<siblingURL>…] [options]
+  --probe <name>=<sel>  template-defining element (repeatable; defaults: hero, card, li)
+  --main <sel>          content root (default main)
+  --width <px>          viewport width (default 1440)
+  --tolerance <px>      ignore numeric deltas ≤ this (default 2)
+  --consent <sel>       extra consent-accept selector
+  --dismiss <sel,…>     extra overlay-dismiss selectors
+  --headed              headed stealth real Chrome
+  --locale <tag>        pin Accept-Language + locale
+  --json                machine-readable output
+  --help                this text
+
+Exit codes: 0 no variance, 2 variance found, 1 error, 3 bot challenge.`;
+
+function parseArgs(argv) {
+  const rest = argv.slice(2);
+  if (rest.includes('--help') || rest.includes('-h')) { console.log(HELP); process.exit(0); }
+  const pos = [];
+  const opts = { probes: [], main: 'main', width: 1440, tolerance: 2, consent: null, dismiss: [], headed: false, locale: null, json: false };
+  for (let i = 0; i < rest.length; i += 1) {
+    const a = rest[i];
+    if (a === '--probe') {
+      const spec = rest[i += 1] || '';
+      const m = spec.match(/^([\w-]+)=(.+)$/);
+      if (!m) { console.error(`bad --probe "${spec}" — expected name=<selector>\n\n${HELP}`); process.exit(1); }
+      opts.probes.push({ name: m[1], sel: m[2].trim() });
+    }
+    else if (a === '--main') { opts.main = rest[i += 1]; }
+    else if (a === '--width') { opts.width = Number(rest[i += 1]); }
+    else if (a === '--tolerance') { opts.tolerance = Number(rest[i += 1]); }
+    else if (a === '--consent') { opts.consent = rest[i += 1]; }
+    else if (a === '--dismiss') { opts.dismiss = (rest[i += 1] || '').split(',').map((s) => s.trim()).filter(Boolean); }
+    else if (a === '--headed') { opts.headed = true; }
+    else if (a === '--locale') { opts.locale = rest[i += 1]; }
+    else if (a === '--json') { opts.json = true; }
+    else if (a.startsWith('--')) { console.error(`unknown flag ${a}\n\n${HELP}`); process.exit(1); }
+    else pos.push(a);
+  }
+  if (pos.length < 2) { console.error(`need <archetypeURL> and at least one <siblingURL>\n\n${HELP}`); process.exit(1); }
+  return { archetype: pos[0], siblings: pos.slice(1), opts };
+}
+
+// ---------------------------------------------------------------- in-page probe
+
+/* eslint-disable no-undef */
+function probePage({ probes, main }) {
+  const root = document.querySelector(main) || document.body;
+  const rect = (el) => { const r = el.getBoundingClientRect(); return { w: Math.round(r.width), h: Math.round(r.height) }; };
+  const visible = (el) => el.getClientRects().length > 0;
+  const norm = (s) => (s || '').replace(/\s+/g, ' ').trim();
+  const fam = (cs) => (cs.fontFamily || '').split(',')[0].replace(/["']/g, '').trim().toLowerCase();
+  // url() filenames are CONTENT (a sibling's own photo — replicate, don't
+  // "fix"), never template: layers keep gradients verbatim and reduce every
+  // url(...) to a bare `url(…)` marker so only the LAYER STACK is compared.
+  const layers = (cs) => (cs.backgroundImage === 'none' ? [] : cs.backgroundImage.split(/,(?![^(]*\))/).map((l) => l.trim().replace(/url\([^)]*\)/g, 'url(…)')));
+
+  // default probes
+  const sections = [...root.querySelectorAll(':scope > section, :scope > .section')].filter(visible);
+  const firstSection = sections[0] || root.firstElementChild;
+  const classCounts = {};
+  for (const el of root.querySelectorAll('[class]')) {
+    if (!visible(el) || (el.children.length === 0 && !norm(el.textContent))) continue;
+    if (['LI', 'A', 'SPAN', 'P', 'IMG', 'SVG', 'PATH', 'BUTTON'].includes(el.tagName)) continue; // atoms, not units
+    const c = String(el.className).trim().split(/\s+/)[0];
+    if (c) classCounts[c] = (classCounts[c] || 0) + 1;
+  }
+  const cardClass = Object.entries(classCounts).filter(([, n]) => n >= 3).sort((a, b) => b[1] - a[1])[0]?.[0] || null;
+  const list = probes.length ? probes : [
+    { name: 'hero', el: firstSection, sel: '(first section)' },
+    ...(cardClass ? [{ name: 'card', sel: `.${cardClass}` }] : []),
+    { name: 'li', sel: `${main} li` },
+  ];
+
+  const signature = (el) => {
+    const cs = getComputedStyle(el);
+    const h = el.querySelector('h1, h2, h3, h4');
+    const img = el.querySelector('img');
+    const before = getComputedStyle(el, '::before');
+    const hcs = h ? getComputedStyle(h) : null;
+    return {
+      rect: rect(el),
+      backgroundLayers: layers(cs),
+      backgroundColor: cs.backgroundColor,
+      color: cs.color,
+      padding: [cs.paddingTop, cs.paddingRight, cs.paddingBottom, cs.paddingLeft].join(' '),
+      font: `${fam(cs)} ${cs.fontSize}/${cs.lineHeight} ${cs.fontWeight}`,
+      borderRadius: cs.borderRadius,
+      heading: h ? `${h.tagName.toLowerCase()} ${fam(hcs)} ${hcs.fontSize}/${hcs.lineHeight} ${hcs.fontWeight} ${hcs.color}` : null,
+      image: img ? rect(img) : null, // geometry only — the src is content
+      listStyle: cs.listStyleType !== 'none' || el.tagName === 'LI' ? cs.listStyleType : null,
+      before: (before.content && before.content !== 'none' && before.content !== 'normal') || before.backgroundImage !== 'none'
+        ? `content:${before.content.replace(/url\([^)]*\)/g, 'url(…)')} bg:${layers(before).join('|') || 'none'} ${Math.round(parseFloat(before.width) || 0)}x${Math.round(parseFloat(before.height) || 0)}`
+        : null,
+    };
+  };
+  const clusterKey = (s) => JSON.stringify({ ...s, rect: undefined, heading: s.heading ? s.heading.replace(/^h\d /, '') : null });
+
+  const out = {
+    sections: sections.map((el, i) => ({ label: String(el.className || '').split(/\s+/).filter((c) => c && c !== 'section').slice(0, 2).join('.') || `${el.tagName.toLowerCase()}[${i}]`, h: rect(el).h })),
+    probes: {},
+  };
+  for (const p of list) {
+    const els = p.el ? [p.el] : [...document.querySelectorAll(p.sel)].filter(visible);
+    if (!els.length) { out.probes[p.name] = { sel: p.sel, count: 0 }; continue; }
+    const sigs = els.slice(0, 40).map(signature);
+    const clusters = new Set(sigs.map(clusterKey)).size;
+    out.probes[p.name] = { sel: p.sel, count: els.length, first: sigs[0], clusters, text: norm(els[0].textContent).slice(0, 60) };
+  }
+  return out;
+}
+/* eslint-enable no-undef */
+
+// ------------------------------------------------------------------- diffing
+
+const px = (v) => { const m = String(v).match(/^-?[\d.]+(?=px$)/); return m ? parseFloat(m[0]) : null; };
+
+function diffValue(k, a, b, tol) {
+  if (JSON.stringify(a) === JSON.stringify(b)) return null;
+  if (a && b && typeof a === 'object' && !Array.isArray(a)) {
+    const d = Object.keys({ ...a, ...b }).map((kk) => diffValue(kk, a[kk], b[kk], tol)).filter(Boolean);
+    return d.length ? `${k}{${d.join(', ')}}` : null;
+  }
+  const pa = px(a); const pb = px(b);
+  if (pa !== null && pb !== null && Math.abs(pa - pb) <= tol) return null;
+  if (typeof a === 'number' && typeof b === 'number' && Math.abs(a - b) <= tol) return null;
+  // padding / font strings: compare token-wise with tolerance
+  if (typeof a === 'string' && typeof b === 'string' && a.split(' ').length === b.split(' ').length && a.split(' ').length > 1) {
+    const ta = a.split(' '); const tb = b.split(' ');
+    const diffTok = ta.some((t, i) => { const x = px(t); const y = px(tb[i]); return x !== null && y !== null ? Math.abs(x - y) > tol : t !== tb[i]; });
+    if (!diffTok) return null;
+  }
+  const show = (v) => (Array.isArray(v) ? `[${v.join(' | ')}]` : String(v));
+  return `${k} ${show(a)} → ${show(b)}`;
+}
+
+function compare(arch, sib, tol) {
+  const findings = [];
+  const sa = arch.sections.map((s) => s.label).join(' > '); const sb = sib.sections.map((s) => s.label).join(' > ');
+  if (arch.sections.length !== sib.sections.length) findings.push({ kind: 'SECTIONS', msg: `${arch.sections.length} vs ${sib.sections.length} top-level sections (archetype: ${sa || '-'}; sibling: ${sb || '-'}) — a different template family or an extra/missing section` });
+  else {
+    const hd = arch.sections.map((s, i) => (Math.abs(s.h - sib.sections[i].h) > tol ? `${s.label} ${s.h}→${sib.sections[i].h}` : null)).filter(Boolean);
+    if (hd.length) findings.push({ kind: 'SECTION HEIGHTS', msg: hd.join(', ') });
+  }
+  for (const [name, A] of Object.entries(arch.probes)) {
+    const B = sib.probes[name];
+    if (!B || !B.count) { if (A.count) findings.push({ kind: 'MISSING', probe: name, msg: `"${A.sel}" matches ${A.count} on the archetype, 0 on the sibling` }); continue; }
+    if (!A.count) { findings.push({ kind: 'EXTRA', probe: name, msg: `"${B.sel}" matches 0 on the archetype, ${B.count} on the sibling` }); continue; }
+    if (A.count !== B.count) findings.push({ kind: 'COUNT', probe: name, msg: `${A.count} → ${B.count} matches` });
+    if (A.clusters !== B.clusters) findings.push({ kind: 'CLUSTERS', probe: name, msg: `${A.clusters} → ${B.clusters} distinct style families among matches (a second visual family = a variant class)` });
+    const d = Object.keys(A.first).map((k) => diffValue(k, A.first[k], B.first[k], tol)).filter(Boolean);
+    if (d.length) findings.push({ kind: 'PROBE', probe: name, msg: d.join('; ') });
+  }
+  return findings;
+}
+
+// ---------------------------------------------------------------------- main
+
+async function probeUrl(browser, url, opts) {
+  const ctx = await newLiveContext(browser, { locale: opts.locale, viewport: { width: opts.width, height: 900 } });
+  const page = await ctx.newPage();
+  await gotoLive(page, url, { waitUntil: defaultWaitUntil(url), settleMs: isLiveHttpUrl(url) ? 2500 : 1200, solveWindow: opts.headed });
+  await dismissOverlays(page, { extra: [...(opts.consent ? [opts.consent] : []), ...opts.dismiss], lateWindowMs: isLiveHttpUrl(url) ? 6000 : 0 });
+  await page.evaluate(async () => {
+    const h = document.documentElement.scrollHeight;
+    for (let y = 0; y < h; y += 700) { window.scrollTo(0, y); await new Promise((r) => { setTimeout(r, 80); }); }
+    window.scrollTo(0, 0);
+    await new Promise((r) => { setTimeout(r, 400); });
+  });
+  await page.waitForTimeout(500);
+  const out = await page.evaluate(probePage, { probes: opts.probes, main: opts.main });
+  await ctx.close();
+  return out;
+}
+
+async function main() {
+  const { archetype, siblings, opts } = parseArgs(process.argv);
+  const browser = opts.headed ? await launchStealthHeaded(chromium) : await chromium.launch();
+  let varying = 0;
+  try {
+    const A = await probeUrl(browser, archetype, opts);
+    const results = [];
+    for (const url of siblings) {
+      const S = await probeUrl(browser, url, opts);
+      const findings = compare(A, S, opts.tolerance);
+      if (findings.length) varying += 1;
+      results.push({ url, findings, raw: S });
+    }
+    const probesVarying = [...new Set(results.flatMap((r) => r.findings.map((f) => f.probe || f.kind)))];
+    if (opts.json) {
+      console.log(JSON.stringify({ archetype, width: opts.width, tolerance: opts.tolerance, probes: Object.fromEntries(Object.entries(A.probes).map(([k, v]) => [k, v.sel])), archetypeRaw: A, siblings: results.map(({ url, findings, raw }) => ({ url, findings, raw })), summary: { siblings: siblings.length, varying, probesVarying } }, null, 2));
+    } else {
+      console.log(`sibling-variance @ ${opts.width}px, tolerance ${opts.tolerance}px\n  archetype: ${archetype}\n  probes: ${Object.entries(A.probes).map(([k, v]) => `${k}=${v.sel} (${v.count})`).join(', ')}\n  sections: ${A.sections.map((s) => `${s.label}:${s.h}`).join(' > ') || '-'}`);
+      for (const r of results) {
+        console.log(`\n■ ${r.url}: ${r.findings.length ? `${r.findings.length} delta(s)` : '✓ matches the archetype'}`);
+        for (const f of r.findings) console.log(`  ${f.kind.padEnd(16)}${f.probe ? `${f.probe}: ` : ''}${f.msg}`);
+      }
+      console.log(`\n${varying ? `✗ ${varying} of ${siblings.length} sibling(s) vary from the archetype in: ${probesVarying.join(', ')} — budget variant classes for these before cloning; do not assume template constancy.` : `✓ ${siblings.length} sibling(s) match the archetype within tolerance — clone.`}`);
+    }
+  } finally {
+    await browser.close();
+  }
+  process.exit(varying ? 2 : 0);
+}
+
+main().catch((e) => { console.error(`sibling-variance error: ${e.message}`); process.exit(e.name === 'BotChallengeError' ? 3 : 1); });


### PR DESCRIPTION
## Summary

Ledger entry **P12**, shipped at the user's request after being flagged as the entry that adds a probe to the cheap sibling path. **Stacked on #343 (0.19.6)** — merge that first; this PR then shows only its own commit.

"Same template" is a hypothesis the crawl JSON cannot confirm. Field evidence: eight siblings of one gated archetype varied in ways no structure capture showed — a compact hero template (441 vs 528px, wider card, smaller logo), an INVERTED hero scrim (0.6→0.1 vs 0.1→0.5), tier lists split into two visual families (arrow-image `::before` vs plain disc), terms sections in three shapes — all discovered late, at the pixel gate, as rework on already-cloned pages.

Guardrails: the probe is **read-only planning evidence**, run once per template before cloning; it never edits the clone. The doc frames every delta as "budget a block VARIANT class on the sibling's content" — blocks stay generic, never forked per page (the same rule deploy already enforces for same-pattern sections). Image and background `url()` filenames are **not** variance (a sibling's own photo is the source's choice — replicate it); only the layer stack, geometry and computed styles are compared.

## Changes

**New `skills/replica/scripts/sibling-variance.mjs`**
- `<archetypeURL> <siblingURL>…` with repeatable `--probe name=<sel>` (pass the archetype's own block selectors). Per probe: match count, the first match's box + computed group (background layer stack incl. gradient scrims, colour, padding, font, radius), first heading and image geometry, `list-style` and `::before` mechanism, and the number of distinct style families among the matches (a second family = a variant). Plus the top-level section list ([label, height]).
- Defaults when no probes are given: `hero` = first section of `--main`, `card` = the most repeated unit class, `li` = `main li`.
- Live-session hardening as the other replica instruments (UA + headers, challenge fail-loud exit 3, overlay dismissal, `--headed`, `--locale`); `--tolerance` (default 2px); `--json`. Exit 0 constant, 2 variance found.

**Docs**
- `migrate/reference/fidelity-tiers.md`: sibling tier is "variance-probed" first; new § Sibling variance probe with the command, what is compared, and how to read it (delta → variant class, emitted on content; never a per-page block fork; JSON kept as fan-out evidence). `gatesPassed` gains `variance-probe`; `_meta.json` gains `variants[]`.
- `replica/SKILL.md` Phase 5 and setup list; `migrate/SKILL.md` A′ branch pointer.
- CHANGELOG 0.19.7; `plugin.json` 0.19.6 → 0.19.7.

## Verification

- `node --check` clean.
- Three fixture pages. Sibling differing only in its hero photo → **✓ matches the archetype** (after making filenames content-neutral; the first cut flagged it, which is exactly the false positive the ledger warns about). Sibling with a compact hero (528→441), inverted scrim, wider card (360→420), disc bullets and a list-shaped terms section → SECTION HEIGHTS, hero rect + background layers, card rect, li COUNT + CLUSTERS 1→2 + `::before` mechanism — every planted delta, nothing else; exit 2. Same result with explicit `--probe` selectors and with the defaults (the default `card` probe found the repeated unit class). `--json` summary: `{siblings, varying, probesVarying}`.
- Run through the project-copy layout to exercise the live-session resolver.
- No site names in the diff.

With #343 and this PR, all 25 entries of the ledger are folded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
