### PR TITLE
feat(stardust): 0.19.8 — impeccable dependency unpinned by design, with an update hint

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "name": "stardust",
       "source": "./plugins/stardust",
       "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-      "version": "0.18.1",
+      "version": "0.19.8",
       "category": "design",
       "keywords": [
         "design",

--- a/plugins/stardust/.claude-plugin/plugin.json
+++ b/plugins/stardust/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stardust",
   "description": "Redesign an existing website to make it better. Higher-level guided flow on top of impeccable.",
-  "version": "0.19.7",
+  "version": "0.19.8",
   "author": {
     "name": "Adobe"
   },
@@ -15,6 +15,9 @@
     "impeccable"
   ],
   "dependencies": [
-    "impeccable@impeccable"
+    {
+      "name": "impeccable",
+      "marketplace": "impeccable"
+    }
   ]
 }

--- a/plugins/stardust/.tessl-plugin/plugin.json
+++ b/plugins/stardust/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe/stardust",
-  "version": "0.18.1",
+  "version": "0.19.8",
   "description": "Redesign an existing website to make it better. Built on top of impeccable.",
   "skills": [
     "skills/stardust",

--- a/plugins/stardust/CHANGELOG.md
+++ b/plugins/stardust/CHANGELOG.md
@@ -4,6 +4,28 @@ This file starts at 0.14.0. Prior versions (0.3.0 – 0.13.1) are documented in
 git history only (plus the branch-scoped notes in
 `CHANGELOG-redesign-adobecom.md` and `CHANGELOG-delivery-media-fidelity.md`).
 
+## 0.19.8 — impeccable dependency: unpinned by design, with an update hint
+
+- **Dependency declaration** moves to the documented cross-marketplace object
+  form — `{ "name": "impeccable", "marketplace": "impeccable" }` — still with
+  NO version range, on purpose: impeccable's design craft should always be
+  the current one. (The root marketplace's `allowCrossMarketplaceDependenciesOn`
+  already lists `impeccable`.)
+- **New `stardust/scripts/impeccable-version-check.mjs`** — Claude Code only
+  announces plugin updates through marketplace auto-update, which is off by
+  default for third-party marketplaces, so a user can sit on an old
+  impeccable indefinitely. Setup step 1 now runs this check once per session
+  and surfaces its one line when a newer impeccable exists (installed
+  version from the plugin registry or `--local <dir>`; latest from the
+  upstream manifest with a 6s timeout, falling back to the cached
+  marketplace catalog; `--offline`, `--json`). Advisory only: always exits 0,
+  fails silently to "unknown" — the registry paths it reads are Claude Code
+  implementation details, not an API.
+- **Manifest drift fixed:** the adobe-skills marketplace entry and the Tessl
+  manifest both still said 0.18.1 while `plugin.json` was at 0.19.7 (the
+  validator warned; `plugin.json` wins at install, so users were unaffected,
+  but `claude plugin tag` requires agreement). All three now read 0.19.8.
+
 ## 0.19.7 — sibling variance probe (P12)
 
 - **New `replica/scripts/sibling-variance.mjs`** — before cloning a gated

--- a/plugins/stardust/skills/stardust/SKILL.md
+++ b/plugins/stardust/skills/stardust/SKILL.md
@@ -20,6 +20,18 @@ sub-commands that delegate the actual design work to **impeccable**.
    and tell the user:
    > Stardust requires impeccable. Install it from
    > <https://github.com/pbakaus/impeccable> and re-run the command.
+
+   **Version hint (advisory, never blocking).** Stardust deliberately pins
+   NO impeccable version — the design craft should always be the current
+   one — and Claude Code only announces plugin updates through marketplace
+   auto-update, which is off by default for third-party marketplaces such
+   as impeccable's. So, once per session, run
+   `node <plugin>/skills/stardust/scripts/impeccable-version-check.mjs`
+   (add `--local <impeccable-dir>` when impeccable lives in a harness skills
+   directory rather than the plugin registry) and surface its one output
+   line to the user verbatim when it reports a newer version; it prints the
+   two update commands. Any other outcome (current, unknown, offline) is
+   noise — do not mention it, and never stop or degrade a run over it.
 2. **Run impeccable's context loader once per session.** Execute the loader at
    `<harness>/skills/impeccable/scripts/load-context.mjs`. Its JSON output
    tells you whether `PRODUCT.md` and `DESIGN.md` exist at the project root

--- a/plugins/stardust/skills/stardust/scripts/impeccable-version-check.mjs
+++ b/plugins/stardust/skills/stardust/scripts/impeccable-version-check.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * skills/stardust/scripts/impeccable-version-check.mjs — "is a newer impeccable available?"
+ *
+ * Stardust depends on impeccable WITHOUT pinning a version (plugin.json declares
+ * the dependency with no range on purpose: impeccable's design craft should
+ * always be the current one). Claude Code only announces plugin updates through
+ * marketplace auto-update, which is OFF by default for third-party marketplaces
+ * such as impeccable's — so a user can sit on an old impeccable indefinitely
+ * with no signal. This check runs in stardust's Setup step 1 and prints ONE hint
+ * line when a newer impeccable exists. It is advisory: it never blocks a run,
+ * always exits 0, and fails silently (status "unknown") when anything it reads
+ * is missing — the registry/cache paths it consults are Claude Code
+ * implementation details, not a documented API.
+ *
+ * Sources, in order of authority for "latest":
+ *   1. upstream — the marketplace's git repo `.claude-plugin/plugin.json` on
+ *      HEAD (one fetch, 6s timeout; skipped with --offline or when it fails)
+ *   2. cached catalog — ~/.claude/plugins/marketplaces/<mkt>/.claude-plugin/marketplace.json
+ * "installed": ~/.claude/plugins/installed_plugins.json → plugins["impeccable@<mkt>"]
+ * (user scope preferred), or --local <dir> for a harness-directory install
+ * (reads <dir>/.claude-plugin/plugin.json or <dir>/package.json).
+ *
+ * Usage:
+ *   node skills/stardust/scripts/impeccable-version-check.mjs [--marketplace impeccable]
+ *        [--local <impeccable-dir>] [--offline] [--json]
+ *
+ * Output (text): one line —
+ *   "impeccable 4.1.3 installed — 4.2.2 available: claude plugin marketplace update impeccable && claude plugin update impeccable@impeccable"
+ *   "impeccable 4.2.2 installed — current"
+ *   "impeccable version check skipped (<reason>)"
+ * Exit code: always 0.
+ */
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+import os from 'os';
+
+const args = process.argv.slice(2);
+const opt = (n, d = null) => { const i = args.indexOf(`--${n}`); return i >= 0 ? args[i + 1] : d; };
+const MKT = opt('marketplace', 'impeccable');
+const PLUGIN = 'impeccable';
+const LOCAL = opt('local');
+const OFFLINE = args.includes('--offline');
+const JSON_OUT = args.includes('--json');
+const HOME = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+
+const readJson = (p) => { try { return JSON.parse(readFileSync(p, 'utf8')); } catch { return null; } };
+const semver = (v) => { const m = String(v || '').match(/^v?(\d+)\.(\d+)\.(\d+)/); return m ? m.slice(1, 4).map(Number) : null; };
+const cmp = (a, b) => { const x = semver(a); const y = semver(b); if (!x || !y) return null; for (let i = 0; i < 3; i += 1) if (x[i] !== y[i]) return x[i] - y[i]; return 0; };
+
+function installedVersion() {
+  if (LOCAL) {
+    const pj = readJson(path.join(LOCAL, '.claude-plugin', 'plugin.json')) || readJson(path.join(LOCAL, 'package.json'));
+    return pj?.version ? { version: pj.version, from: `local ${LOCAL}` } : null;
+  }
+  const reg = readJson(path.join(HOME, 'plugins', 'installed_plugins.json'));
+  const entry = reg?.plugins?.[`${PLUGIN}@${MKT}`];
+  if (!entry) return null;
+  const list = Array.isArray(entry) ? entry : [entry];
+  const pick = list.find((e) => e.scope === 'user') || list[0];
+  return pick?.version ? { version: pick.version, from: 'installed_plugins.json' } : null;
+}
+
+function marketplaceInfo() {
+  const known = readJson(path.join(HOME, 'plugins', 'known_marketplaces.json'));
+  const m = known?.[MKT];
+  if (!m) return { cached: null, repo: null };
+  const catalog = readJson(path.join(m.installLocation || '', '.claude-plugin', 'marketplace.json'));
+  const cached = catalog?.plugins?.find((p) => p.name === PLUGIN)?.version || null;
+  const repo = m.source?.source === 'github' ? m.source.repo : null;
+  return { cached, repo };
+}
+
+async function upstreamVersion(repo) {
+  if (!repo || OFFLINE || typeof fetch !== 'function') return null;
+  const ctl = new AbortController();
+  const t = setTimeout(() => ctl.abort(), 6000);
+  try {
+    const res = await fetch(`https://raw.githubusercontent.com/${repo}/HEAD/.claude-plugin/plugin.json`, { signal: ctl.signal });
+    if (!res.ok) return null;
+    return (await res.json())?.version || null;
+  } catch { return null; } finally { clearTimeout(t); }
+}
+
+const installed = installedVersion();
+const { cached, repo } = marketplaceInfo();
+const upstream = await upstreamVersion(repo);
+const latest = upstream || cached;
+const update = `claude plugin marketplace update ${MKT} && claude plugin update ${PLUGIN}@${MKT}`;
+
+let status; let line;
+if (!installed) { status = 'not-installed'; line = `impeccable not found in the plugin registry (${PLUGIN}@${MKT})${LOCAL ? '' : ' — pass --local <dir> for a harness-directory install'}`; }
+else if (!latest) { status = 'unknown'; line = `impeccable ${installed.version} installed — version check skipped (no marketplace catalog or upstream reachable)`; }
+else {
+  const c = cmp(latest, installed.version);
+  if (c === null) { status = 'unknown'; line = `impeccable ${installed.version} installed — cannot compare with "${latest}"`; }
+  else if (c > 0) { status = 'outdated'; line = `impeccable ${installed.version} installed — ${latest} available${upstream ? '' : ' (per cached catalog)'}: ${update}`; }
+  else { status = 'current'; line = `impeccable ${installed.version} installed — current${upstream ? '' : ' (per cached catalog; upstream not checked)'}`; }
+}
+
+if (JSON_OUT) console.log(JSON.stringify({ status, installed: installed?.version || null, installedFrom: installed?.from || null, cachedCatalog: cached, upstream, latest, marketplace: MKT, repo, updateCommand: status === 'outdated' ? update : null }));
+else console.log(line);
+process.exit(0);


### PR DESCRIPTION
## Summary

Answers "does stardust pin an impeccable version, and can it hint when a newer one exists?" — no pin (kept that way on purpose), and yes, advisory.

Stardust must always run on the current impeccable, so the dependency carries **no version range**. But Claude Code only announces plugin updates through marketplace auto-update, which is **off by default for third-party marketplaces** such as impeccable's — a user can sit on an old impeccable indefinitely with no signal (a maintainer machine today: installed 4.1.3, cached catalog 4.1.3, upstream 4.2.2). This PR adds a one-line advisory hint at stardust's Setup step and fixes a manifest version drift found on the way.

## Changes

- **`plugin.json` dependency** moves to the documented cross-marketplace object form `{ "name": "impeccable", "marketplace": "impeccable" }` (docs: plugin-dependencies § Depend on a plugin from another marketplace) — still **unpinned**. The root marketplace's `allowCrossMarketplaceDependenciesOn` already lists `impeccable`.
- **New `skills/stardust/scripts/impeccable-version-check.mjs`** (dependency-free). Installed version from `~/.claude/plugins/installed_plugins.json` (user scope preferred) or `--local <impeccable-dir>` for harness-directory installs; latest from the upstream repo's `.claude-plugin/plugin.json` (one fetch, 6s timeout) falling back to the cached marketplace catalog; `--offline`, `--json`. Prints ONE line and **always exits 0**; any missing input degrades to "unknown"/"not found" — the registry and cache paths are Claude Code implementation details, not an API, so the check must never block or degrade a run.
- **`skills/stardust/SKILL.md` Setup step 1**: run the check once per session; surface its line verbatim only when it reports a newer version (it includes the two update commands: `claude plugin marketplace update impeccable && claude plugin update impeccable@impeccable`); every other outcome is noise and is not mentioned.
- **Manifest drift fixed**: `.claude-plugin/marketplace.json` (stardust entry) and `.tessl-plugin/plugin.json` still said **0.18.1** while `plugin.json` was 0.19.7. `claude plugin validate .` warned about it; plugin.json wins at install so users were unaffected, but `claude plugin tag` requires the two to agree. All three now read **0.19.8** and both validators pass clean. (This touches the repo-root marketplace manifest, hence outside `plugins/stardust`.)
- CHANGELOG 0.19.8.

## Verification

- `node --check`; `claude plugin validate .` and `claude plugin validate plugins/stardust` → "Validation passed" (previously a version-mismatch warning).
- Script: outdated case → `impeccable 4.1.3 installed — 4.2.2 available: claude plugin marketplace update impeccable && claude plugin update impeccable@impeccable`, exit 0; `--json` carries status/installed/cachedCatalog/upstream/latest/updateCommand; `--offline` falls back to the cached catalog and says so; unknown marketplace and missing `CLAUDE_CONFIG_DIR` → "not found", exit 0; `--local` with a newer manifest → current, with an older one → outdated.

## Not done, deliberately

No `SessionStart` hook: it would run on every session regardless of stardust use, and there is no documented mechanism for a plugin to detect a dependency update — the Setup-step check is the least intrusive place. No version range added — the point is to track impeccable's current release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
